### PR TITLE
[WIP] JS evaluation

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -290,6 +290,10 @@ call apoc.path.expand(p,"ACTED_IN>|PRODUCED<|FOLLOWS<","+Movie|Person",1,2) yiel
 return p, pp 
 ----
 
+=== Javascript evaluation
+call apoc.js.eval('1 + 1') => 2
+call apoc.js.evalWithParams('x + y', {x: 1, y: 2}) => 3
+call apoc.js.evalWithParams('n.getProperty("x")', {n: someNode}) // equivalent to n.x
 
 
 == Plans
@@ -311,7 +315,7 @@ return p, pp
 * parallel(fragment, params-list, result list)
 * (√) Graph Refactorings (WIP)
 * (√) Job Queue (WIP) See https://github.com/jakewins/neo4j-procedure-template/blob/batch/src/main/java/example/BatchedWrites.java[BatchedWriter from Jake/Max]
-* eval javascript
+* eval javascript (WIP)
 * Procedures in other languages (e.g. JS)
 
 == License

--- a/src/main/java/apoc/js/Eval.java
+++ b/src/main/java/apoc/js/Eval.java
@@ -1,0 +1,53 @@
+package apoc.js;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Stream;
+import javax.script.Bindings;
+import javax.script.ScriptContext;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import javax.script.SimpleScriptContext;
+import apoc.Description;
+import apoc.result.ObjectResult;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+
+
+/**
+ * @author tkroman
+ * @since 11.04.2016
+ */
+public class Eval {
+	private static final ScriptEngineManager scripting = new ScriptEngineManager();
+	private static final ScriptEngine js = scripting.getEngineByName("nashorn");
+
+	@Procedure
+	@Description("eval(1 + 41) => 42")
+	public Stream<ObjectResult> eval(final @Name("expr") String jsExpr) {
+		return evalWithParams(jsExpr, Collections.emptyMap());
+	}
+
+	@Procedure
+	@Description("evalWithParams(n.firstName + ' ' + n.lastName, { n: someNode }) => 'Jack Sparrow'")
+	public Stream<ObjectResult> evalWithParams(
+			final @Name("expr") String jsExpr,
+			final @Name("params") Map<String, Object> params) {
+		try {
+			SimpleScriptContext localCtx = createLocalContext(params);
+			Object eval = js.eval(jsExpr, localCtx);
+			return Stream.of(new ObjectResult(eval));
+		} catch (ScriptException e) {
+			throw new RuntimeException("Failed to evaluate " + jsExpr, e);
+		}
+	}
+
+	private SimpleScriptContext createLocalContext(final @Name("params") Map<String, Object> params) {
+		SimpleScriptContext localCtx = new SimpleScriptContext();
+		Bindings localBindings = js.createBindings();
+		localBindings.putAll(params);
+		localCtx.setBindings(localBindings, ScriptContext.ENGINE_SCOPE);
+		return localCtx;
+	}
+}

--- a/src/main/java/apoc/js/Eval.java
+++ b/src/main/java/apoc/js/Eval.java
@@ -5,12 +5,14 @@ import java.util.Map;
 import java.util.stream.Stream;
 import javax.script.Bindings;
 import javax.script.ScriptContext;
-import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import javax.script.SimpleScriptContext;
 import apoc.Description;
 import apoc.result.ObjectResult;
+import jdk.nashorn.api.scripting.NashornScriptEngine;
+import jdk.nashorn.api.scripting.NashornScriptEngineFactory;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
@@ -20,8 +22,10 @@ import org.neo4j.procedure.Procedure;
  * @since 11.04.2016
  */
 public class Eval {
-	private static final ScriptEngineManager scripting = new ScriptEngineManager();
-	private static final ScriptEngine js = scripting.getEngineByName("nashorn");
+	private static final NashornScriptEngineFactory FACTORY = new NashornScriptEngineFactory();
+	private static final NashornScriptEngine JS = (NashornScriptEngine) FACTORY.getScriptEngine("nashorn");
+
+	@Context public GraphDatabaseService db;
 
 	@Procedure
 	@Description("eval(1 + 41) => 42")
@@ -31,23 +35,41 @@ public class Eval {
 
 	@Procedure
 	@Description("evalWithParams(n.firstName + ' ' + n.lastName, { n: someNode }) => 'Jack Sparrow'")
-	public Stream<ObjectResult> evalWithParams(
-			final @Name("expr") String jsExpr,
-			final @Name("params") Map<String, Object> params) {
+	public Stream<ObjectResult> evalWithParams(final @Name("expr") String jsExpr, final @Name("params") Map<String, Object> params) {
 		try {
-			SimpleScriptContext localCtx = createLocalContext(params);
-			Object eval = js.eval(jsExpr, localCtx);
+			Object eval = JS.eval(jsExpr, freshLocalContext(params));
 			return Stream.of(new ObjectResult(eval));
 		} catch (ScriptException e) {
 			throw new RuntimeException("Failed to evaluate " + jsExpr, e);
 		}
 	}
 
-	private SimpleScriptContext createLocalContext(final @Name("params") Map<String, Object> params) {
-		SimpleScriptContext localCtx = new SimpleScriptContext();
-		Bindings localBindings = js.createBindings();
-		localBindings.putAll(params);
-		localCtx.setBindings(localBindings, ScriptContext.ENGINE_SCOPE);
+	@Procedure
+	@Description("compile('function id(x) { return x; };')")
+	public Stream<ObjectResult> compile(final @Name("function") String definition) {
+		try {
+			Object compiled = JS.compile(definition).eval(JS.getBindings(ScriptContext.GLOBAL_SCOPE));
+			return Stream.of(new ObjectResult(compiled.toString()));
+		} catch (ScriptException e) {
+			throw new RuntimeException("Failed to evaluate " + definition, e);
+		}
+	}
+
+	private ScriptContext freshLocalContext(final Map<String, Object> params) {
+		final ScriptContext localCtx = new SimpleScriptContext();
+		final Bindings engineScopeBindings = JS.createBindings();
+		final Bindings globalScopeBindings = JS.createBindings();
+		final Bindings presentEngineBindings = JS.getContext().getBindings(ScriptContext.GLOBAL_SCOPE);
+		final Bindings presentGlobalBindings = JS.getContext().getBindings(ScriptContext.ENGINE_SCOPE);
+		if (presentEngineBindings != null) {
+			engineScopeBindings.putAll(presentEngineBindings);
+		}
+		if (presentGlobalBindings != null) {
+			globalScopeBindings.putAll(presentGlobalBindings);
+		}
+		engineScopeBindings.putAll(params);
+		localCtx.setBindings(globalScopeBindings, ScriptContext.GLOBAL_SCOPE);
+		localCtx.setBindings(engineScopeBindings, ScriptContext.ENGINE_SCOPE);
 		return localCtx;
 	}
 }

--- a/src/main/java/apoc/result/Empty.java
+++ b/src/main/java/apoc/result/Empty.java
@@ -1,7 +1,5 @@
 package apoc.result;
 
-import apoc.meta.Meta;
-
 import java.util.stream.Stream;
 
 /**
@@ -11,5 +9,7 @@ import java.util.stream.Stream;
 public class Empty {
     public static Empty INSTANCE = new Empty();
 
-    public static Stream<Empty> stream(boolean value) { return value ? Stream.of(INSTANCE) : Stream.empty(); }
+    public static Stream<Empty> stream(boolean fillWithStub) {
+		return fillWithStub ? Stream.of(INSTANCE) : Stream.empty();
+	}
 }

--- a/src/main/java/apoc/result/GraphResult.java
+++ b/src/main/java/apoc/result/GraphResult.java
@@ -3,7 +3,6 @@ package apoc.result;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
-import java.util.Collection;
 import java.util.List;
 
 /**

--- a/src/main/java/apoc/result/LongResult.java
+++ b/src/main/java/apoc/result/LongResult.java
@@ -1,7 +1,5 @@
 package apoc.result;
 
-import java.util.stream.Stream;
-
 /**
  * @author mh
  * @since 26.02.16

--- a/src/test/java/apoc/js/EvalTest.java
+++ b/src/test/java/apoc/js/EvalTest.java
@@ -1,0 +1,104 @@
+package apoc.js;
+
+
+import apoc.util.TestUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.QueryExecutionException;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assert.*;
+
+
+public class EvalTest {
+	private GraphDatabaseService db;
+	public @Rule ExpectedException expected = ExpectedException.none();
+
+	@Before
+	public void sUp() throws Exception {
+		db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+		TestUtil.registerProcedure(db, Eval.class);
+	}
+
+	@After
+	public void tearDown() {
+		db.shutdown();
+	}
+
+	@Test
+	public void shouldEvalBasicExpressions() throws Exception {	// basic == context-independent
+		testCall(db,
+				"CALL apoc.js.eval('1 + 1') YIELD value as result",
+				row -> assertEquals(2, row.get("result"))
+		);
+
+		testCall(db,
+				"CALL apoc.js.eval('var z = 0; var o = 1; o / z;') YIELD value as result",
+				row -> assertEquals(Double.POSITIVE_INFINITY, row.get("result"))
+		);
+	}
+
+	@Test(expected = QueryExecutionException.class)
+	public void shouldCaptureJsExceptions() throws Exception {	// basic == context-independent
+		testCall(db,
+				"CALL apoc.js.eval('return 0') YIELD value as result",
+				row -> assertEquals(2, row.get("result"))
+		);
+	}
+
+	@Test
+	public void shouldWorkWithParams() throws Exception {	// basic == context-independent
+		testCall(db,
+				"CALL apoc.js.evalWithParams('var v = x; x', { x : 1 }) YIELD value as result",
+				row -> assertEquals(1L, row.get("result"))
+		);
+
+		String expr =
+				"String.prototype.capitalize = function() {\n" +
+				"    return this.charAt(0).toUpperCase() + this.slice(1);\n" +
+				"}; \n" +
+				"var fullName = ln.capitalize() + \\', \\' + fn.capitalize();\n" +
+				"fullName";
+		testCall(db,
+				"CALL apoc.js.evalWithParams('" + expr + "', { fn: 'john', ln: 'doe' }) YIELD value as result",
+				row -> assertEquals("Doe, John", row.get("result"))
+		);
+	}
+
+	@Test
+	public void shouldNotClogGlobalContext() throws Exception {	// basic == context-independent
+
+		// given
+		String expr =
+				"String.prototype.capitalize = function() {\n" +
+						"    return this.charAt(0).toUpperCase() + this.slice(1);\n" +
+						"}; \n" +
+						"var fullName = ln.capitalize() + \\', \\' + fn.capitalize();\n" +
+						"fullName";
+
+		// when
+		testCall(db,
+				"CALL apoc.js.evalWithParams('" + expr + "', { fn: 'john', ln: 'doe' }) YIELD value as result",
+				row -> assertEquals("Doe, John", row.get("result"))
+		);
+
+		// then: subsequent calls shouldn't see prev. calls' bindings, if any.
+		expected.expect(QueryExecutionException.class);
+		expected.expectMessage("Failed to evaluate fullName");
+		testCall(db,
+				"CALL apoc.js.eval('fullName') YIELD value as result",
+				row -> assertEquals("Doe, John", row.get("result"))
+		);
+
+		expected.expect(QueryExecutionException.class);
+		expected.expectMessage("Failed to evaluate capitalize");
+		testCall(db,
+				"CALL apoc.js.eval('\"str\".capitalize()') YIELD value as result",
+				row -> assertEquals("Doe, John", row.get("result"))
+				);
+	}
+}

--- a/src/test/java/apoc/js/EvalTest.java
+++ b/src/test/java/apoc/js/EvalTest.java
@@ -125,4 +125,27 @@ public class EvalTest {
 				row -> assertTrue((Boolean) row.get("result"))
 		);
 	}
+
+	@Test
+	public void shouldSaveCompiledProcedures() throws Exception {	// basic == context-independent
+		testCall(db,
+				"CALL apoc.js.compile('function id(n) { return n.getId(); }')",
+				row -> assertEquals("function id(n) { return n.getId(); }", row.get("value"))
+		);
+	}
+
+	@Test
+	public void compiledJsFucntionsAreVisibleAcrossCalls() throws Exception {	// basic == context-independent
+
+		// given
+		testCall(db,
+				"CALL apoc.js.compile('function testCall() { return \"testCall\"; }')",
+				row -> {}
+		);
+
+		// when
+		testCall(db,
+				"CALL apoc.js.eval('testCall()')",
+				row -> assertEquals("testCall", row.get("value")));
+	}
 }


### PR DESCRIPTION
My take at JS evaluation. 
Some questions I'd like to discuss, though.
I'm not sure about the security implications (file access etc).
Another question: should we populate the global script engine context with shortcuts for methods like `n.foo(bar)` for nodes/rels etc. so users could do 

```
CALL evalWithParams('n.x', {n: someNode})
```

instead of

```
CALL evalWithParams('n.getProperty("x")', {n: someNode})
```
?

Next possible thing on the TODO-list would be adding compiled script support, something like this:

```
CALL apoc.js.compile('function id(n) { return n.getId() } ')
CALL apoc.js.call(id(n), {n: personNode})
```
This can potentially allow for 'unlimited' extensibility in runtime without restarts at all.