### PR TITLE
apoc.date.formatTimeZone procedure

### DIFF
--- a/docs/datetime.adoc
+++ b/docs/datetime.adoc
@@ -6,10 +6,12 @@
 
 * `apoc.date.parseDefault('2015-03-25 03:15:59','s')` get Unix time equivalent of given date (in seconds)
 * `apoc.date.parse('2015/03/25 03-15-59','s','yyyy/MM/dd HH/mm/ss')` same as previous, but accepts custom datetime format
-* `apoc.date.formatDefault(12345,'s')` get string representation of date corresponding to given Unix time (in seconds)
+* `apoc.date.formatDefault(12345,'s')` get string representation of date corresponding to given Unix time (in seconds) in UTC time zone
 * `apoc.date.format(12345,'s', 'yyyy/MM/dd HH/mm/ss')` the same as previous, but accepts custom datetime format
+* `apoc.date.formatTimeZone(12345,'s', 'yyyy/MM/dd HH/mm/ss', 'ABC')` the same as previous, but accepts custom time zone
 
 * possible unit values: `ms,s,m,h,d` and their long forms.
+* possible time zone values: Either an abbreviation such as `PST`, a full name such as `America/Los_Angeles`, or a custom ID such as `GMT-8:00`. Full names are recommended.
 
 == Reading separate datetime fields:
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -371,11 +371,13 @@ TODO:
 
 | apoc.date.parseDefault('2015-03-25 03:15:59','ms') | get Unix time equivalent of given date (in milliseconds)
 | apoc.date.parse('2015/03/25 03-15-59','ms','yyyy/MM/dd HH/mm/ss') | same as previous, but accepts custom datetime format
-| apoc.date.formatDefault(12345,'ms') | get string representation of date corresponding to given time in milliseconds
+| apoc.date.formatDefault(12345,'ms') | get string representation of date corresponding to given time in milliseconds in UTC time zone
 | apoc.date.format(12345,'ms', 'yyyy/MM/dd HH/mm/ss') | the same as previous, but accepts custom datetime format
+| apoc.date.formatTimeZone(12345,'s', 'yyyy/MM/dd HH/mm/ss', 'ABC') | the same as previous, but accepts custom time zone
 |===
 
 * possible unit values: `ms,s,m,h,d` and their long forms `millis,milliseconds,seconds,minutes,hours,days`.
+* possible time zone values: Either an abbreviation such as `PST`, a full name such as `America/Los_Angeles`, or a custom ID such as `GMT-8:00`. Full names are recommended.
 
 ==== Reading separate datetime fields:
 

--- a/src/main/java/apoc/date/Date.java
+++ b/src/main/java/apoc/date/Date.java
@@ -88,9 +88,15 @@ public class Date {
 	}
 
 	@Procedure
-	@Description("apoc.date.format(12345,'ms|s|m|h|d','yyyy-MM-dd') get string representation of time value in the specified unit using specified format")
+	@Description("apoc.date.format(12345,'ms|s|m|h|d','yyyy-MM-dd') get string representation of time value in the specified unit using specified format and UTC time zone")
 	public Stream<StringResult> format(final @Name("time") long time, @Name("unit") String unit, @Name("format") String format) {
-		return parse(unit(unit).toMillis(time), format);
+		return parse(unit(unit).toMillis(time), format, null);
+	}
+
+	@Procedure
+	@Description("apoc.date.formatTimeZone(12345,'ms|s|m|h|d','yyyy-MM-dd HH:mm:ss zzz', 'ABC') get string representation of time value in the specified unit using specified format and specified time zone")
+	public Stream<StringResult> formatTimeZone(final @Name("time") long time, @Name("unit") String unit, @Name("format") String format, @Name("timezone") String timezone) {
+		return parse(unit(unit).toMillis(time), format, timezone);
 	}
 
 	@Procedure
@@ -102,22 +108,28 @@ public class Date {
 	@Procedure
 	@Description("apoc.date.parse('2012-12-23','ms|s|m|h|d','yyyy-MM-dd') parse date string using the specified format into the specified time unit")
 	public Stream<LongResult> parse(@Name("time") String time, @Name("unit") String unit, @Name("format") String format) {
-		Long value = parseOrThrow(time, getFormat(format));
+		Long value = parseOrThrow(time, getFormat(format, null));
 		Long valueInUnit = value == null ? null : unit(unit).convert(value, TimeUnit.MILLISECONDS);
 		return Stream.of(new LongResult(valueInUnit));
 	}
 
 	public Stream<StringResult> parse(final @Name("millis") long millis, final @Name("pattern") String pattern) {
+		return parse(millis, pattern, null);
+	}
+
+	private Stream<StringResult> parse(final @Name("millis") long millis, final @Name("pattern") String pattern, final @Name("timezone") String timezone) {
 		if (millis < 0) {
 			throw new IllegalArgumentException("The time argument should be >= 0, got: " + millis);
 		}
-		return Stream.of(new StringResult(getFormat(pattern).format(new java.util.Date(millis))));
+		return Stream.of(new StringResult(getFormat(pattern, timezone).format(new java.util.Date(millis))));
 	}
 
-	private static DateFormat getFormat(final String pattern) {
+	private static DateFormat getFormat(final String pattern, final String timezone) {
 		String actualPattern = getPattern(pattern);
 		SimpleDateFormat format = new SimpleDateFormat(actualPattern);
-		if (!(containsTimeZonePattern(actualPattern))) {
+		if (timezone != null) {
+			format.setTimeZone(TimeZone.getTimeZone(timezone));
+		} else if (!(containsTimeZonePattern(actualPattern))) {
 			format.setTimeZone(TimeZone.getTimeZone(UTC_ZONE_ID));
 		}
 		return format;

--- a/src/test/java/apoc/date/DateTest.java
+++ b/src/test/java/apoc/date/DateTest.java
@@ -133,10 +133,33 @@ public class DateTest {
 				});
 	}
 
+	@Test public void testFromUnixtimeWithCorrectFormatAndTimeZone() throws Exception {
+		String pattern = "HH:mm:ss/yyyy";
+		String timezone = "America/New_York";
+		SimpleDateFormat customFormat = formatInCustomTimeZone(pattern, timezone);
+		testCall(db,
+				"CALL apoc.date.formatTimeZone(0,'s',{pattern},{timezone})",
+				map("pattern",pattern,"timezone",timezone),
+				row -> {
+					try {
+						assertEquals(new java.util.Date(0L), customFormat.parse((String) row.get("value")));
+					} catch (ParseException e) {
+						throw new RuntimeException(e);
+					}
+				});
+	}
+
 	@Test public void testFromUnixtimeWithIncorrectPatternFormat() throws Exception {
 		expected.expect(instanceOf(QueryExecutionException.class));
 		testCall(db,
 				"CALL apoc.date.format(0,'s','HH:mm:ss/yyyy/neo4j')",
+				row -> {});
+	}
+
+	@Test public void testFromUnixtimeWithIncorrectPatternFormatAndTimeZone() throws Exception {
+		expected.expect(instanceOf(QueryExecutionException.class));
+		testCall(db,
+				"CALL apoc.date.formatTimeZone(0,'s','HH:mm:ss/yyyy/neo4j','Neo4j/Apoc')",
 				row -> {});
 	}
 
@@ -244,6 +267,12 @@ public class DateTest {
 	private SimpleDateFormat formatInUtcZone(final String pattern) {
 		SimpleDateFormat customFormat = new SimpleDateFormat(pattern);
 		customFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+		return customFormat;
+	}
+
+	private SimpleDateFormat formatInCustomTimeZone(final String pattern, final String timezone) {
+		SimpleDateFormat customFormat = new SimpleDateFormat(pattern);
+		customFormat.setTimeZone(TimeZone.getTimeZone(timezone));
 		return customFormat;
 	}
 }

--- a/src/test/java/apoc/date/DateTest.java
+++ b/src/test/java/apoc/date/DateTest.java
@@ -84,7 +84,7 @@ public class DateTest {
 	}
 
 	@Test public void testToUnixtimeWithCorrectFormat() throws Exception {
-		String pattern = "HH:mm:ss/yyyy";
+		String pattern = "MM/dd/yyyy HH:mm:ss";
 		SimpleDateFormat customFormat = formatInUtcZone(pattern);
 		String reference = customFormat.format(new java.util.Date(0L));
 		testCall(db,
@@ -96,7 +96,7 @@ public class DateTest {
 	@Test public void testToUnixtimeWithIncorrectPatternFormat() throws Exception {
 		expected.expect(instanceOf(QueryExecutionException.class));
 		testCall(db,
-				"CALL apoc.date.parse('12:12:12/1945','s','HH:mm:ss/yyyy/neo4j')",
+				"CALL apoc.date.parse('12/12/1945 12:12:12','s','MM/dd/yyyy HH:mm:ss/neo4j')",
 				row -> assertEquals(Instant.EPOCH, Instant.ofEpochSecond((long) row.get("value"))));
 	}
 
@@ -119,7 +119,7 @@ public class DateTest {
 	}
 
 	@Test public void testFromUnixtimeWithCorrectFormat() throws Exception {
-		String pattern = "HH:mm:ss/yyyy";
+		String pattern = "MM/dd/yyyy HH:mm:ss";
 		SimpleDateFormat customFormat = formatInUtcZone(pattern);
 		testCall(db,
 				"CALL apoc.date.format(0,'s',{pattern})",
@@ -134,7 +134,7 @@ public class DateTest {
 	}
 
 	@Test public void testFromUnixtimeWithCorrectFormatAndTimeZone() throws Exception {
-		String pattern = "HH:mm:ss/yyyy";
+		String pattern = "MM/dd/yyyy HH:mm:ss";
 		String timezone = "America/New_York";
 		SimpleDateFormat customFormat = formatInCustomTimeZone(pattern, timezone);
 		testCall(db,
@@ -152,14 +152,14 @@ public class DateTest {
 	@Test public void testFromUnixtimeWithIncorrectPatternFormat() throws Exception {
 		expected.expect(instanceOf(QueryExecutionException.class));
 		testCall(db,
-				"CALL apoc.date.format(0,'s','HH:mm:ss/yyyy/neo4j')",
+				"CALL apoc.date.format(0,'s','MM/dd/yyyy HH:mm:ss/neo4j')",
 				row -> {});
 	}
 
 	@Test public void testFromUnixtimeWithIncorrectPatternFormatAndTimeZone() throws Exception {
 		expected.expect(instanceOf(QueryExecutionException.class));
 		testCall(db,
-				"CALL apoc.date.formatTimeZone(0,'s','HH:mm:ss/yyyy/neo4j','Neo4j/Apoc')",
+				"CALL apoc.date.formatTimeZone(0,'s','MM/dd/yyyy HH:mm:ss/neo4j','Neo4j/Apoc')",
 				row -> {});
 	}
 


### PR DESCRIPTION
This is an implementation for the feature request #42 _Date.java format with custom time zone_

~~**Note: 100% untested code**~~

A simplified test was done to help get the Travis build passing:

```
import java.text.SimpleDateFormat;
import java.util.TimeZone;
public class HelloWorld{
    
    private static long time_epoch = 0L; //the epoch

    public static void main(String []args) throws java.text.ParseException{
        String pattern = "MM/dd/yyyy HH:mm:ss";
        String timezone = "America/New_York";
        String apocProceduceOutput = formatTimeZone(pattern, timezone);
        SimpleDateFormat customFormat = formatInCustomTimeZone(pattern, timezone);
        java.util.Date date1 = new java.util.Date(time_epoch);
        java.util.Date date2 = customFormat.parse(apocProceduceOutput);
        System.out.println(date1);
        System.out.println(date2);
        System.out.println(date1.equals(date2));
    }
     
    private static String formatTimeZone(String pattern, String timezone) {
        SimpleDateFormat format = new SimpleDateFormat(pattern);
        format.setTimeZone(TimeZone.getTimeZone(timezone));
        String formatted = format.format(new java.util.Date(time_epoch));
        System.out.println(formatted);
        return formatted;
    }
     
    private static SimpleDateFormat formatInCustomTimeZone(final String pattern, final String timezone) {
		SimpleDateFormat customFormat = new SimpleDateFormat(pattern);
		customFormat.setTimeZone(TimeZone.getTimeZone(timezone));
		return customFormat;
	}
}
```
Output:
```
12/31/1969 19:00:00
Thu Jan 01 00:00:00 UTC 1970
Thu Jan 01 00:00:00 UTC 1970
true
```