### PR TITLE
Fix the partitioning logic in mapParallel partitionSubList

### DIFF
--- a/src/main/java/apoc/cypher/Cypher.java
+++ b/src/main/java/apoc/cypher/Cypher.java
@@ -186,9 +186,9 @@ public class Cypher {
     public Stream<List<Object>> partitionSubList(@Name("list") List<Object> data, int partitions) {
         List<Object> list = new ArrayList<>(data);
         int total = list.size();
-        int batchSize = Math.max(total / partitions, 1);
+        int batchSize = Math.max((int) Math.ceil(((double)total) / ((double)partitions)), 1);
         return IntStream.rangeClosed(0, partitions).parallel()
-                .mapToObj((part) -> list.subList(part * batchSize, Math.min((part + 1) * batchSize, total)))
+                .mapToObj((part) -> list.subList(Math.min(part * batchSize, total), Math.min((part + 1) * batchSize, total)))
                 .filter(partition -> !partition.isEmpty());
     }
 


### PR DESCRIPTION
The original partitioning logic is wrong and causes `AssertionError` when doing `testMapParallel`. The fix is to get ceiling of the quotient so that the partitions will always cover the total number of items in the list. In addition, the `subList` call had to include another `Math.min` call to avoid `IndexOutOfBoundsException`.

**Example:**
Total: 1000
Partitions: 400

_Incorrect batch size logic:_ 1000/400 = (int)2
With each batch having 2 list elements, the `subList` can only reach up to (2*400=) 800 elements.

_Correct batch size logic:_ 1000/400 = 2.5; ceiling of 2.5 = 3
With each batch having 3 list elements, the `subList` can reach up to (3*400=) 1200 elements, enough to cover the total of 1000 elements in the list.