### PR TITLE
Fix the Help System

### DIFF
--- a/src/main/java/apoc/help/Help.java
+++ b/src/main/java/apoc/help/Help.java
@@ -9,7 +9,7 @@ import java.util.stream.Stream;
 public class Help {
 
     @Procedure("apoc.help")
-    @Description("Provides the description of the procedure")
+    @Description("Provides descriptions of available procedures. To narrow the results, supply a search string. To also search in the description text, append + to the end of the search string.")
     public Stream<HelpResult> info(@Name("proc") String name) throws Exception {
         boolean searchText = false;
 

--- a/src/main/java/apoc/help/Help.java
+++ b/src/main/java/apoc/help/Help.java
@@ -11,6 +11,16 @@ public class Help {
     @Procedure("apoc.help")
     @Description("Provides the description of the procedure")
     public Stream<HelpResult> info(@Name("proc") String name) throws Exception {
-        return HelpScanner.find(name);
+        boolean searchText = false;
+
+        if (name != null) {
+            name = name.trim();
+            if (name.endsWith("+")) {
+                name = name.substring(0, name.lastIndexOf('+')).trim();
+                searchText = true;
+            }
+        }
+
+        return HelpScanner.find(name, searchText);
     }
 }

--- a/src/main/java/apoc/help/HelpScanner.java
+++ b/src/main/java/apoc/help/HelpScanner.java
@@ -35,8 +35,14 @@ public class HelpScanner {
     public static Stream<HelpResult> find(String name) {
         if (name==null) return Stream.empty();
         return procedures.entrySet().stream()
-                .filter(e -> e.getKey().startsWith(name) || e.getKey().endsWith(name))
+                .filter(e -> search(e.getKey(), name))
                 .map(Map.Entry::getValue);
+    }
+
+    private static boolean search(String key, String name) {
+        // A better algorithm may be needed here (regex or Pattern)
+        if (key == null || name == null) return false;
+        return key.toLowerCase().contains(name.toLowerCase());
     }
 
     class MyClassVisitor extends ClassVisitor {

--- a/src/main/java/apoc/help/HelpScanner.java
+++ b/src/main/java/apoc/help/HelpScanner.java
@@ -110,7 +110,7 @@ public class HelpScanner {
     List<URL> getRootUrls() {
         List<URL> result = new ArrayList<>();
 
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        ClassLoader cl = HelpScanner.class.getClassLoader();
         while (cl != null) {
             if (cl instanceof URLClassLoader) {
                 URL[] urls = ((URLClassLoader) cl).getURLs();

--- a/src/main/java/apoc/help/HelpScanner.java
+++ b/src/main/java/apoc/help/HelpScanner.java
@@ -32,10 +32,10 @@ public class HelpScanner {
         new ClassReader(in).accept(cv, 0);
     }
 
-    public static Stream<HelpResult> find(String name) {
+    public static Stream<HelpResult> find(String name, boolean searchText) {
         if (name==null) return Stream.empty();
         return procedures.entrySet().stream()
-                .filter(e -> search(e.getKey(), name))
+                .filter(e -> search(e.getKey(), name) || (searchText && search(e.getValue(), name)))
                 .map(Map.Entry::getValue);
     }
 
@@ -43,6 +43,11 @@ public class HelpScanner {
         // A better algorithm may be needed here (regex or Pattern)
         if (key == null || name == null) return false;
         return key.toLowerCase().contains(name.toLowerCase());
+    }
+
+    private static boolean search(HelpResult value, String name) {
+        if (value == null) return false;
+        return search(value.text, name);
     }
 
     class MyClassVisitor extends ClassVisitor {


### PR DESCRIPTION
**Use the class's own ClassLoader to find the apoc jar file**

>When using thread's context class loader, it is not guaranteed to find the apoc jar. When using the class's own class loader, it is guaranteed, since this class comes from apoc jar itself.

>This ensures the help system always works.

**Enhance help to search whole procedure name, and be case insensitive**

>The original search was too restrictive as it only checked the beginning and end of the string, and moreover it was case sensitive. This makes the search more lenient by allowing one to search anywhere within the procedure name, and also ignores the case of the search terms.

>This gives more relevant results, such as searching for all procedures related to "meta" or getting information about "apoc.meta.subGraph" when searching for "graph".

**Add ability to search the description text by appending + to search term**

>When a + sign is found at the end of the search string, the help system also searches the descriptive text of the procedures. This is useful to return any procedures whose descriptions mention the search term.

>The change also trims the search string so any spaces at the beginning and end of the string are ignored.

**Better documentation for the apoc.help procedure**

>Includes instructions on searching the description text

_PS: Prefer if you auto-merge by preserving original commits (or you can fast-forward). Thanks :)_