### PR TITLE
Remove runtime=compiled in NodeCounter Cypher statement

### DIFF
--- a/src/main/java/apoc/algo/pagerank/NodeCounter.java
+++ b/src/main/java/apoc/algo/pagerank/NodeCounter.java
@@ -7,7 +7,7 @@ public class NodeCounter
 {
     public int getNodeCount( GraphDatabaseService db )
     {
-        Result result = db.execute( "CYPHER runtime=compiled MATCH (n) RETURN max(id(n)) AS maxId" );
+        Result result = db.execute( "MATCH (n) RETURN max(id(n)) AS maxId" );
         return ((Number) result.next().get( "maxId" )).intValue() + 1;
 //        NeoStores neoStore = ((GraphDatabaseAPI) db).getDependencyResolver().resolveDependency(NeoStores.class);
 //        return (int) neoStore.getNodeStore().getHighId();
@@ -15,7 +15,7 @@ public class NodeCounter
 
     public int getRelationshipCount( GraphDatabaseService db )
     {
-        Result result = db.execute( "CYPHER runtime=compiled MATCH ()-[r]->() RETURN max(id(r)) AS maxId" );
+        Result result = db.execute( "MATCH ()-[r]->() RETURN max(id(r)) AS maxId" );
         return ((Number) result.next().get( "maxId" )).intValue() + 1;
 //        NeoStores neoStore = ((GraphDatabaseAPI) db).getDependencyResolver().resolveDependency(NeoStores.class);
 //        return (int) neoStore.getRelationshipStore().getHighId();


### PR DESCRIPTION
runtime=compiled option was removed in Neo4j 3.0.3 and using
this results in a Cypher syntax error