### PR TITLE
adding schema.properties.distinct

### DIFF
--- a/src/main/java/apoc/schema/Properties.java
+++ b/src/main/java/apoc/schema/Properties.java
@@ -1,0 +1,64 @@
+package apoc.schema;
+
+import apoc.Description;
+import apoc.result.ListResult;
+import org.apache.lucene.index.Fields;
+import org.apache.lucene.index.MultiFields;
+import org.apache.lucene.index.Terms;
+import org.apache.lucene.index.TermsEnum;
+import org.apache.lucene.search.Sort;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
+import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;
+import org.neo4j.kernel.api.impl.schema.reader.SimpleIndexReader;
+import org.neo4j.kernel.api.impl.schema.reader.SortedIndexReader;
+import org.neo4j.kernel.api.index.IndexDescriptor;
+import org.neo4j.kernel.impl.api.KernelStatement;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.stream.Stream;
+
+public class Properties {
+
+    @Context
+    public GraphDatabaseAPI db;
+    @Context
+    public KernelTransaction tx;
+
+
+    public Properties(GraphDatabaseAPI db) {
+        this.db = db;
+    }
+
+    public Properties() {
+    }
+
+    @Procedure("apoc.schema.properties.distinct")
+    @Description("apoc.schema.properties.distinct(label, key) - quickly returns all distinct values for a given key")
+    public Stream<ListResult> distinct(@Name("label") String label, @Name("key")  String key) throws SchemaRuleNotFoundException, IndexNotFoundKernelException, IOException {
+        KernelStatement stmt = (KernelStatement) tx.acquireStatement();
+        ReadOperations reads = stmt.readOperations();
+
+        IndexDescriptor descriptor = reads.indexGetForLabelAndPropertyKey(reads.labelGetForName(label), reads.propertyKeyGetForName(key));
+        SimpleIndexReader reader = (SimpleIndexReader) stmt.getStoreStatement().getIndexReader(descriptor);
+        SortedIndexReader sortedIndexReader = new SortedIndexReader(reader, 0, Sort.INDEXORDER);
+
+        Fields fields = MultiFields.getFields(sortedIndexReader.getIndexSearcher().getIndexReader());
+
+        Terms terms = fields.terms("string");
+        TermsEnum termsEnum = terms.iterator();
+        ArrayList<String> values = new ArrayList<>();
+        while((termsEnum.next()) != null){
+            values.add(termsEnum.term().utf8ToString());
+        }
+
+        return Stream.of(new ListResult(values));
+    }
+
+}

--- a/src/main/java/org/neo4j/kernel/api/impl/schema/reader/SortedIndexReader.java
+++ b/src/main/java/org/neo4j/kernel/api/impl/schema/reader/SortedIndexReader.java
@@ -1,50 +1,24 @@
 package org.neo4j.kernel.api.impl.schema.reader;
 
-import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Query;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.index.*;
+import org.apache.lucene.search.*;
+import org.apache.lucene.util.ArrayUtil;
+import org.apache.lucene.util.DocIdSetBuilder;
+import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.graphdb.index.IndexHits;
+import org.neo4j.helpers.collection.ArrayIterator;
+import org.neo4j.helpers.collection.PrefetchingIterator;
+import org.neo4j.index.impl.lucene.legacy.AbstractIndexHits;
+import org.neo4j.index.impl.lucene.legacy.EmptyIndexHits;
 import org.neo4j.kernel.api.impl.index.collector.DocValuesAccess;
 import org.neo4j.kernel.api.impl.schema.LuceneDocumentStructure;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-
-import org.apache.lucene.document.Document;
-import org.apache.lucene.index.DocValuesType;
-import org.apache.lucene.index.FieldInfo;
-import org.apache.lucene.index.LeafReader;
-import org.apache.lucene.index.LeafReaderContext;
-import org.apache.lucene.index.NumericDocValues;
-import org.apache.lucene.index.ReaderUtil;
-import org.apache.lucene.search.Collector;
-import org.apache.lucene.search.ConstantScoreScorer;
-import org.apache.lucene.search.DocIdSet;
-import org.apache.lucene.search.DocIdSetIterator;
-import org.apache.lucene.search.LeafCollector;
-import org.apache.lucene.search.ScoreDoc;
-import org.apache.lucene.search.Scorer;
-import org.apache.lucene.search.SimpleCollector;
-import org.apache.lucene.search.Sort;
-import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.TopFieldCollector;
-import org.apache.lucene.search.TopScoreDocCollector;
-import org.apache.lucene.util.ArrayUtil;
-import org.apache.lucene.util.DocIdSetBuilder;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import org.neo4j.collection.primitive.PrimitiveLongCollections;
-import org.neo4j.graphdb.index.IndexHits;
-import org.neo4j.helpers.collection.ArrayIterator;
-import org.neo4j.helpers.collection.PrefetchingIterator;
-import org.neo4j.index.impl.lucene.legacy.AbstractIndexHits;
-import org.neo4j.index.impl.lucene.legacy.EmptyIndexHits;
+import java.util.*;
 
 
 /**
@@ -84,7 +58,7 @@ public class SortedIndexReader {
         }
     }
 
-    private IndexSearcher getIndexSearcher() {
+    public IndexSearcher getIndexSearcher() {
         try {
             return (IndexSearcher) method.invoke(reader);
         } catch (IllegalAccessException | InvocationTargetException e) {

--- a/src/test/java/apoc/schema/DistinctPropertiesTest.java
+++ b/src/test/java/apoc/schema/DistinctPropertiesTest.java
@@ -1,0 +1,42 @@
+package apoc.schema;
+
+import apoc.util.TestUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assert.assertEquals;
+import static java.util.Arrays.asList;
+
+public class DistinctPropertiesTest {
+    private GraphDatabaseService db;
+
+    @Before
+    public void setUp() throws Exception {
+        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        TestUtil.registerProcedure(db,Properties.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
+    }
+
+    @Test
+    public void testDistinctProperties() throws Exception {
+        db.execute("CREATE INDEX ON :Foo(bar)").close();
+        db.execute("CREATE (f:Foo {bar:'one'}), (f2a:Foo {bar:'two'}), (f2b:Foo {bar:'two'})").close();
+        String label = "Foo";
+        String key = "bar";
+
+        testCall(db,"CALL apoc.schema.properties.distinct({label}, {key})",
+                map("label",label,"key",key),
+                (row) -> assertEquals(asList("one","two"), row.get("value"))
+        );
+    }
+
+}


### PR DESCRIPTION
Leverages lucene index to get the indexed terms, as a replacement for queries such as:

`MATCH (c:Customer) RETURN DISTINCT c.ethnicity;`