### PR TITLE
Use their max ids to warm up all the nodes/rels

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ dependencies {
 }
 
 test {
+    systemProperties 'user.language': 'en', 'user.country': 'US'
     testLogging {
         exceptionFormat = 'full'
     }

--- a/src/test/java/apoc/warmup/WarmupTest.java
+++ b/src/test/java/apoc/warmup/WarmupTest.java
@@ -29,13 +29,22 @@ public class WarmupTest {
 
     @Test
     public void testWarmup() throws Exception {
-        db.execute("CREATE (n)-[:KNOWS]->(m)").close();
+        // Create enough nodes and relationships to span 2 pages
+        db.execute("UNWIND range(1, 300) AS i CREATE (n)-[:KNOWS]->(m)").close();
+        // Delete all relationships and their nodes, but ones with the minimum and maximum relationship ids, so
+        // they still span 2 pages
+        db.execute("MATCH ()-[r:KNOWS]->() " +
+                   "WITH [min(id(r)), max(id(r))] AS ids " +
+                   "MATCH (n)-[r:KNOWS]->(m) " +
+                   "WHERE NOT id(r) IN ids " +
+                   "DELETE n, m, r").close();
+
         TestUtil.testCall(db,"CALL apoc.warmup.run()", r ->
         {
-            assertEquals(2L, r.get("nodesTotal"));
-            assertEquals(1L, r.get("nodesLoaded"));
-            assertEquals(1L, r.get("relsTotal"));
-            assertEquals(1L, r.get("relsLoaded"));
+            assertEquals(4L, r.get("nodesTotal"));
+            assertEquals(2L, r.get("nodesLoaded"));
+            assertEquals(2L, r.get("relsTotal"));
+            assertEquals(2L, r.get("relsLoaded"));
         });
     }
 }


### PR DESCRIPTION
As reported in #131, instead of the node (or relationship) count, the maximum id needs to be used to try and load all pages: if some data has been deleted, the id space will be sparsed instead of sequential, and the count less than the actual maximum id.

I've also set the locale for the tests in the Gradle configuration, as some tests would fail on my machine due to number formats being different that the asserted ones using the French locale.