### PR TITLE
Adding Unweighted Betweenness Centrality

### DIFF
--- a/src/main/java/apoc/Pools.java
+++ b/src/main/java/apoc/Pools.java
@@ -26,7 +26,7 @@ public class Pools {
     }
 
     public static int getNoThreadsInDefaultPool() {
-        return  Runtime.getRuntime().availableProcessors()*2;
+        return  Runtime.getRuntime().availableProcessors();
     }
 
     private static ExecutorService createSinglePool() {

--- a/src/main/java/apoc/Pools.java
+++ b/src/main/java/apoc/Pools.java
@@ -25,6 +25,10 @@ public class Pools {
                 new ThreadPoolExecutor.CallerRunsPolicy());
     }
 
+    public static int getNoThreadsInDefaultPool() {
+        return  Runtime.getRuntime().availableProcessors()*2;
+    }
+
     private static ExecutorService createSinglePool() {
         return Executors.newSingleThreadExecutor();
     }

--- a/src/main/java/apoc/algo/Algorithm.java
+++ b/src/main/java/apoc/algo/Algorithm.java
@@ -1,0 +1,184 @@
+package apoc.algo;
+
+import apoc.algo.pagerank.*;
+import apoc.algo.pagerank.PageRank;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Result;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.logging.Log;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+
+public class Algorithm {
+
+    public static final int INITIAL_ARRAY_SIZE=100_000;
+    private final GraphDatabaseAPI db;
+    private final Log log;
+    private final ExecutorService pool;
+    private int nodeCount;
+    private int relCount;
+
+    private AlgorithmStatistics stats = new AlgorithmStatistics();
+
+    // Arrays to hold the graph.
+    // Mapping from Algo node ID to Graph nodeID
+    public int [] nodeMapping;
+
+    // Degree of each algo node.
+    public int [] sourceDegreeData;
+
+    // Starting index in relationship arrays for each algo node.
+    public int [] sourceChunkStartingIndex;
+
+    // Storing relationships
+    public int [] relationshipTarget;
+    public int [] relationshipWeight;
+
+    public Algorithm(GraphDatabaseAPI db,
+                     ExecutorService pool,
+                     Log log) {
+        this.pool = pool;
+        this.db = db;
+        this.log = log;
+    }
+
+    public boolean readNodeAndRelCypherIntoArrays(String relCypher, String nodeCypher) {
+        Result nodeResult = db.execute(nodeCypher);
+
+        long before = System.currentTimeMillis();
+        ResourceIterator<Object> resultIterator = nodeResult.columnAs("id");
+        int index = 0;
+        int totalNodes = 0;
+        nodeMapping = new int[INITIAL_ARRAY_SIZE];
+        int currentSize = INITIAL_ARRAY_SIZE;
+        while(resultIterator.hasNext()) {
+            int node  = ((Long)resultIterator.next()).intValue();
+
+            if (index >= currentSize) {
+                if (log.isDebugEnabled()) log.debug("Node Doubling size " + currentSize);
+                nodeMapping = doubleSize(nodeMapping, currentSize);
+                currentSize = currentSize * 2;
+            }
+            nodeMapping[index] = node;
+            index++;
+            totalNodes++;
+        }
+
+        this.nodeCount = totalNodes;
+        Arrays.sort(nodeMapping, 0, nodeCount);
+        long after = System.currentTimeMillis();
+        stats.readNodeMillis = (after - before);
+        stats.nodes = totalNodes;
+        log.info("Time to make nodes structure = " + stats.readNodeMillis + " millis");
+        before = System.currentTimeMillis();
+
+        sourceDegreeData = new int[totalNodes];
+
+//        previousPageRanks = new int[totalNodes];
+//        pageRanksAtomic = new AtomicIntegerArray(totalNodes);
+        sourceChunkStartingIndex = new int[totalNodes];
+        Arrays.fill(sourceChunkStartingIndex, -1);
+
+        int totalRelationships = readRelationshipMetadata(relCypher);
+        this.relCount = totalRelationships;
+        relationshipTarget = new int[totalRelationships];
+        relationshipWeight = new int[totalRelationships];
+        Arrays.fill(relationshipTarget, -1);
+        Arrays.fill(relationshipWeight, -1);
+        calculateChunkIndices();
+        readRelationships(relCypher, totalRelationships);
+        after = System.currentTimeMillis();
+        stats.relationships = totalRelationships;
+        stats.readRelationshipMillis = (after - before);
+        log.info("Time for iteration over " + totalRelationships + " relations = " + stats.readRelationshipMillis + " millis");
+        return true;
+    }
+
+    public AlgorithmStatistics getStatistics() {
+        return stats;
+    }
+
+    private int getNodeIndex(int node) {
+        int index = Arrays.binarySearch(nodeMapping, 0, nodeCount, node);
+        return index;
+    }
+
+    // TODO Create buckets instead of copying data.
+    // Not doing it right now because of the complications of the interface.
+    private int [] doubleSize(int [] array, int currentSize) {
+        int newArray[] = new int[currentSize * 2];
+        System.arraycopy(array, 0, newArray, 0, currentSize);
+        return newArray;
+    }
+
+
+    private void calculateChunkIndices() {
+        int currentIndex = 0;
+        for (int i = 0; i < nodeCount; i++) {
+            sourceChunkStartingIndex[i] = currentIndex;
+            if (sourceDegreeData[i] == -1)
+                continue;
+            currentIndex += sourceDegreeData[i];
+        }
+    }
+
+    private int readRelationshipMetadata(String relCypher) {
+        long before = System.currentTimeMillis();
+        Result result = db.execute(relCypher);
+        int totalRelationships = 0;
+        int sourceIndex = 0;
+        while(result.hasNext()) {
+            Map<String, Object> res = result.next();
+            int source = ((Long) res.get("source")).intValue();
+            sourceIndex = getNodeIndex(source);
+
+            sourceDegreeData[sourceIndex]++;
+            totalRelationships++;
+        }
+        result.close();
+        long after = System.currentTimeMillis();
+        log.info("Time to read relationship metadata " + (after - before) + " ms");
+        return totalRelationships;
+    }
+
+    private void readRelationships(String relCypher, int totalRelationships) {
+        Result result = db.execute(relCypher);
+        long before = System.currentTimeMillis();
+        int sourceIndex = 0;
+        while(result.hasNext()) {
+            Map<String, Object> res = result.next();
+            int source = ((Long) res.get("source")).intValue();
+            sourceIndex = getNodeIndex(source);
+            int target = ((Long) res.get("target")).intValue();
+            int weight = ((Long) res.getOrDefault("weight", 1)).intValue();
+            int logicalTargetIndex = getNodeIndex(target);
+            int chunkIndex = sourceChunkStartingIndex[sourceIndex];
+            while(relationshipTarget[chunkIndex] != -1) {
+                chunkIndex++;
+            }
+            relationshipTarget[chunkIndex] = logicalTargetIndex;
+            relationshipWeight[chunkIndex] = weight;
+        }
+        result.close();
+        long after = System.currentTimeMillis();
+        log.info("Time to read relationship data " + (after - before) + " ms");
+    }
+
+    class AlgorithmStatistics {
+        public long nodes, relationships, readNodeMillis, readRelationshipMillis;
+        public boolean write;
+
+        public AlgorithmStatistics(long nodes, long relationships, long readNodeMillis, long readRelationshipMillis) {
+            this.nodes = nodes;
+            this.relationships = relationships;
+            this.readNodeMillis = readNodeMillis;
+            this.readRelationshipMillis = readRelationshipMillis;
+        }
+
+        public AlgorithmStatistics() {
+        }
+    }
+}

--- a/src/main/java/apoc/algo/Centrality.java
+++ b/src/main/java/apoc/algo/Centrality.java
@@ -101,7 +101,7 @@ public class Centrality {
         log.info("BetweennessCypher: Number of relationships: " + betweennessCentrality.numberOfRels());
 
 
-        betweennessCentrality.computeUnweightedInBatches();
+        betweennessCentrality.computeUnweightedParallel();
 
         long afterComputation = System.currentTimeMillis();
         log.info("BetweennessCypher: Computations took " + (afterComputation - afterReading) + " milliseconds");

--- a/src/main/java/apoc/algo/Centrality.java
+++ b/src/main/java/apoc/algo/Centrality.java
@@ -101,7 +101,7 @@ public class Centrality {
         log.info("BetweennessCypher: Number of relationships: " + betweennessCentrality.numberOfRels());
 
 
-        betweennessCentrality.computeUnweighted();
+        betweennessCentrality.computeUnweightedInBatches();
 
         long afterComputation = System.currentTimeMillis();
         log.info("Pagerank: Computations took " + (afterComputation - afterReading) + " milliseconds");

--- a/src/main/java/apoc/algo/Centrality.java
+++ b/src/main/java/apoc/algo/Centrality.java
@@ -101,7 +101,7 @@ public class Centrality {
         log.info("BetweennessCypher: Number of relationships: " + betweennessCentrality.numberOfRels());
 
 
-        betweennessCentrality.computeUnweightedInBatches();
+        betweennessCentrality.computeUnweightedSeq();
 
         long afterComputation = System.currentTimeMillis();
         log.info("Pagerank: Computations took " + (afterComputation - afterReading) + " milliseconds");

--- a/src/main/java/apoc/algo/Centrality.java
+++ b/src/main/java/apoc/algo/Centrality.java
@@ -101,15 +101,15 @@ public class Centrality {
         log.info("BetweennessCypher: Number of relationships: " + betweennessCentrality.numberOfRels());
 
 
-        betweennessCentrality.computeUnweightedSeq();
+        betweennessCentrality.computeUnweightedInBatches();
 
         long afterComputation = System.currentTimeMillis();
-        log.info("Pagerank: Computations took " + (afterComputation - afterReading) + " milliseconds");
+        log.info("BetweennessCypher: Computations took " + (afterComputation - afterReading) + " milliseconds");
 
         if (shouldWrite) {
             betweennessCentrality.writeResultsToDB();
             long afterWrite = System.currentTimeMillis();
-            log.info("Pagerank: Writeback took " + (afterWrite - afterComputation) + " milliseconds");
+            log.info("BetweennessCypher: Writeback took " + (afterWrite - afterComputation) + " milliseconds");
         }
 
         return Stream.of(betweennessCentrality.getStatistics());

--- a/src/main/java/apoc/algo/PageRank.java
+++ b/src/main/java/apoc/algo/PageRank.java
@@ -81,7 +81,7 @@ public class PageRank {
         long beforeReading = System.currentTimeMillis();
         log.info("Pagerank: Reading data into local ds");
         PageRankArrayStorageParallelCypher pageRank = new PageRankArrayStorageParallelCypher(dbAPI, pool, log);
-        boolean success = pageRank.readDataIntoArray(relCypher, nodeCypher);
+        boolean success = pageRank.readNodeAndRelCypherData(relCypher, nodeCypher);
         if (!success) {
             String errorMsg = "Failure while reading cypher queries. Make sure the results are ordered.";
             log.info(errorMsg);

--- a/src/main/java/apoc/algo/PageRank.java
+++ b/src/main/java/apoc/algo/PageRank.java
@@ -2,6 +2,7 @@ package apoc.algo;
 
 import apoc.Description;
 import apoc.Pools;
+import apoc.algo.algorithms.AlgoUtils;
 import apoc.algo.pagerank.PageRankArrayStorageParallelCypher;
 import apoc.algo.pagerank.PageRankArrayStorageParallelSPI;
 import apoc.result.NodeScore;
@@ -23,19 +24,10 @@ import java.util.stream.Stream;
 public class PageRank {
 
     private static final String SETTING_PAGE_RANK_ITERATIONS = "iterations";
-    private static final String SETTING_PAGE_RANK_CYPHER_NODE = "node_cypher";
-    private static final String SETTING_PAGE_RANK_CYPHER_REL = "rel_cypher";
     private static final String SETTING_PAGE_RANK_TYPES = "types";
-    private static final String SETTING_PAGE_RANK_WRITE = "write";
 
     static final ExecutorService pool = Pools.DEFAULT;
     static final Long DEFAULT_PAGE_RANK_ITERATIONS = 20L;
-    static final String DEFAULT_PAGE_RANK_CYPHER_REL =
-            "MATCH (s)-[r]->(t) RETURN id(s) as source, id(t) as target, 1 as weight";
-    static final String DEFAULT_PAGE_RANK_CYPHER_NODE =
-            "MATCH (s) RETURN id(s) as id";
-
-    static final boolean DEFAULT_PAGE_RANK_WRITE = false;
 
     @Context
     public GraphDatabaseService db;
@@ -74,14 +66,15 @@ public class PageRank {
     public Stream<apoc.algo.pagerank.PageRank.PageRankStatistics> pageRankWithCypher(
             @Name("config") Map<String, Object> config) {
         Long iterations = (Long) config.getOrDefault(SETTING_PAGE_RANK_ITERATIONS, DEFAULT_PAGE_RANK_ITERATIONS);
-        String nodeCypher = getCypher(config, SETTING_PAGE_RANK_CYPHER_NODE, DEFAULT_PAGE_RANK_CYPHER_NODE);
-        String relCypher = getCypher(config, SETTING_PAGE_RANK_CYPHER_REL, DEFAULT_PAGE_RANK_CYPHER_REL);
-        boolean shouldWrite = (boolean)config.getOrDefault(SETTING_PAGE_RANK_WRITE, DEFAULT_PAGE_RANK_WRITE);
+        String nodeCypher = AlgoUtils.getCypher(config, AlgoUtils.SETTING_CYPHER_NODE, AlgoUtils.DEFAULT_CYPHER_NODE);
+        String relCypher = AlgoUtils.getCypher(config, AlgoUtils.SETTING_CYPHER_REL, AlgoUtils.DEFAULT_CYPHER_REL);
+        boolean shouldWrite = (boolean)config.getOrDefault(AlgoUtils.SETTING_WRITE, AlgoUtils.DEFAULT_PAGE_RANK_WRITE);
 
         long beforeReading = System.currentTimeMillis();
         log.info("Pagerank: Reading data into local ds");
         PageRankArrayStorageParallelCypher pageRank = new PageRankArrayStorageParallelCypher(dbAPI, pool, log);
-        boolean success = pageRank.readNodeAndRelCypherData(relCypher, nodeCypher);
+        boolean success = pageRank.readNodeAndRelCypherData(
+                relCypher, nodeCypher);
         if (!success) {
             String errorMsg = "Failure while reading cypher queries. Make sure the results are ordered.";
             log.info(errorMsg);
@@ -104,14 +97,6 @@ public class PageRank {
             log.info("Pagerank: Writeback took " + (afterWrite - afterComputation) + " milliseconds");
         }
         return Stream.of(pageRank.getStatistics());
-    }
-
-    private String getCypher(Map<String, Object> config, String setting, String defaultString) {
-        String cypher = (String)config.getOrDefault(setting, defaultString);
-        if (cypher.equals("") || cypher.isEmpty()) {
-            cypher = defaultString;
-        }
-        return cypher;
     }
 
     private Stream<NodeScore> innerPageRank(Long iterations, List<Node> nodes, RelationshipType... types) {

--- a/src/main/java/apoc/algo/algorithms/AlgoUtils.java
+++ b/src/main/java/apoc/algo/algorithms/AlgoUtils.java
@@ -84,7 +84,7 @@ public class AlgoUtils {
                             if (nodeIndex >= totalNodes) break;
 
                             int graphNode = algorithm.getMappedNode((int)nodeIndex);
-                            double value = algorithm.getResult(nodeIndex);
+                            double value = algorithm.getResult(graphNode);
                             if (graphNode == -1) {
                                 System.out.println("Node node found for " + graphNode + " mapped node " + nodeIndex);
                             } else

--- a/src/main/java/apoc/algo/algorithms/AlgoUtils.java
+++ b/src/main/java/apoc/algo/algorithms/AlgoUtils.java
@@ -1,0 +1,106 @@
+package apoc.algo.algorithms;
+
+import apoc.Pools;
+import apoc.algo.pagerank.PageRankAlgorithm;
+import org.neo4j.cypher.EntityNotFoundException;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.api.DataWriteOperations;
+import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
+import org.neo4j.kernel.api.exceptions.legacyindex.AutoIndexingKernelException;
+import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationKernelException;
+import org.neo4j.kernel.api.exceptions.schema.IllegalTokenNameException;
+import org.neo4j.kernel.api.properties.DefinedProperty;
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+public class AlgoUtils {
+    public static final String SETTING_CYPHER_NODE = "node_cypher";
+    public static final String SETTING_CYPHER_REL = "rel_cypher";
+    public static final String SETTING_WRITE = "write";
+
+    public static final String DEFAULT_CYPHER_REL =
+            "MATCH (s)-[r]->(t) RETURN id(s) as source, id(t) as target, 1 as weight";
+    public static final String DEFAULT_CYPHER_NODE =
+            "MATCH (s) RETURN id(s) as id";
+
+    public static final boolean DEFAULT_PAGE_RANK_WRITE = false;
+
+    public static String getCypher(Map<String, Object> config, String setting, String defaultString) {
+        String cypher = (String)config.getOrDefault(setting, defaultString);
+        if (cypher.equals("") || cypher.isEmpty()) {
+            cypher = defaultString;
+        }
+        return cypher;
+    }
+
+    public static int waitForTasks( List<Future> futures )
+    {
+        int total = 0;
+        for ( Future future : futures )
+        {
+            try
+            {
+                future.get();
+                total++;
+            }
+            catch ( InterruptedException | ExecutionException e )
+            {
+                e.printStackTrace();
+            }
+        }
+        futures.clear();
+        return total;
+    }
+
+    public static void  writeBackResults(ExecutorService pool, GraphDatabaseAPI db, AlgorithmInterface algorithm,
+                                        int batchSize) {
+        ThreadToStatementContextBridge ctx = db.getDependencyResolver().resolveDependency(ThreadToStatementContextBridge.class);
+        int propertyNameId;
+        try (Transaction tx = db.beginTx()) {
+            propertyNameId = ctx.get().tokenWriteOperations().propertyKeyGetOrCreateForName(algorithm.getPropertyName());
+            tx.success();
+        } catch (IllegalTokenNameException e) {
+            throw new RuntimeException(e);
+        }
+        final long totalNodes = algorithm.numberOfNodes();
+        int batches = (int) totalNodes / batchSize;
+        List<Future> futures = new ArrayList<>(batches);
+        for (int i = 0; i < totalNodes; i += batchSize) {
+            int nodeIndex = i;
+            final int start = nodeIndex;
+            Future future = pool.submit(new Runnable() {
+                public void run() {
+                    try (Transaction tx = db.beginTx()) {
+                        DataWriteOperations ops = ctx.get().dataWriteOperations();
+                        for (long i = 0; i < batchSize; i++) {
+                            long nodeIndex = i + start;
+                            if (nodeIndex >= totalNodes) break;
+
+                            int graphNode = algorithm.getMappedNode((int)nodeIndex);
+                            double value = algorithm.getResult(nodeIndex);
+                            if (graphNode == -1) {
+                                System.out.println("Node node found for " + graphNode + " mapped node " + nodeIndex);
+                            } else
+                                ops.nodeSetProperty(graphNode, DefinedProperty.doubleProperty(propertyNameId, value));
+                        }
+                        tx.success();
+                    } catch (ConstraintValidationKernelException | InvalidTransactionTypeKernelException |
+                            EntityNotFoundException | AutoIndexingKernelException |
+                            org.neo4j.kernel.api.exceptions.EntityNotFoundException e) {
+                        e.printStackTrace();
+                    }
+                }
+            });
+
+            futures.add(future);
+        }
+        AlgoUtils.waitForTasks(futures);
+    }
+}

--- a/src/main/java/apoc/algo/algorithms/Algorithm.java
+++ b/src/main/java/apoc/algo/algorithms/Algorithm.java
@@ -72,7 +72,7 @@ public class Algorithm {
         Arrays.sort(nodeMapping, 0, nodeCount);
         long after = System.currentTimeMillis();
         readNodeMillis = (after - before);
-        log.info("Time to make nodes structure = " + readNodeMillis + " millis");
+        log.info("Time to make nodes structure = " + readNodeMillis + " millis. Nodes from nodeCypher: " + nodeCount);
         before = System.currentTimeMillis();
 
         sourceDegreeData = new int[totalNodes];
@@ -179,7 +179,7 @@ public class Algorithm {
         }
         long after = System.currentTimeMillis();
         log.info("Time to read relationship metadata " + (after - before) + " ms ");
-        log.info("Nodes" + nodeCount + " rels " + totalRelationships);
+        log.info("Reduced Nodes: " + nodeCount + " rels " + totalRelationships);
         return totalRelationships;
     }
 

--- a/src/main/java/apoc/algo/algorithms/Algorithm.java
+++ b/src/main/java/apoc/algo/algorithms/Algorithm.java
@@ -218,6 +218,51 @@ public class Algorithm {
         return true;
     }
 
+    private void readNodeAndSource(String relCypher) {
+        long before = System.currentTimeMillis();
+        Result result = db.execute(relCypher);
+        int totalRelationships = 0;
+        int sourceIndex = 0;
+        int index = 0;
+        int totalNodes = 0;
+        nodeMapping = new int[INITIAL_ARRAY_SIZE];
+        int currentSize = INITIAL_ARRAY_SIZE;
+        while(result.hasNext()) {
+            Map<String, Object> res = result.next();
+            int source = ((Long) res.get("source")).intValue();
+            int target = ((Long) res.get("target")).intValue();
+
+            if (index >= currentSize) {
+                if (log.isDebugEnabled()) log.debug("Node Doubling size " + currentSize);
+                nodeMapping = doubleSize(nodeMapping, currentSize);
+                currentSize = currentSize * 2;
+            }
+
+            // Don't map if it's already mapped.
+            if (getNodeIndex(source) < 0) {
+                nodeMapping[source] = source;
+                sourceIndex = index;
+                index++;
+                totalNodes++;
+            }
+
+            if (getNodeIndex(target) < 0) {
+                nodeMapping[target] = target;
+                index++;
+                totalNodes++;
+            }
+
+            sourceDegreeData[sourceIndex]++;
+        }
+        result.close();
+
+        // We now have unsorted node mapping and corresponding degrees.
+        int[] tempDegreeData = new int[totalNodes];
+
+        long after = System.currentTimeMillis();
+        log.info("Time to read relationship metadata and nodes" + (after - before) + " ms");
+
+    }
     public boolean readRelCypherData(String relCypher) {
 
         return false;

--- a/src/main/java/apoc/algo/algorithms/Algorithm.java
+++ b/src/main/java/apoc/algo/algorithms/Algorithm.java
@@ -50,13 +50,13 @@ public class Algorithm {
         Result nodeResult = db.execute(nodeCypher);
 
         long before = System.currentTimeMillis();
-        ResourceIterator<Object> resultIterator = nodeResult.columnAs("id");
+        ResourceIterator<Long> resultIterator = nodeResult.columnAs("id");
         int index = 0;
         int totalNodes = 0;
         nodeMapping = new int[INITIAL_ARRAY_SIZE];
         int currentSize = INITIAL_ARRAY_SIZE;
         while(resultIterator.hasNext()) {
-            int node  = ((Long)resultIterator.next()).intValue();
+            int node  = (resultIterator.next()).intValue();
 
             if (index >= currentSize) {
                 if (log.isDebugEnabled()) log.debug("Node Doubling size " + currentSize);

--- a/src/main/java/apoc/algo/algorithms/AlgorithmInterface.java
+++ b/src/main/java/apoc/algo/algorithms/AlgorithmInterface.java
@@ -1,0 +1,35 @@
+package apoc.algo.algorithms;
+
+public interface AlgorithmInterface
+{
+    double getResult( long node );
+
+    long numberOfNodes();
+
+    String getPropertyName();
+
+    int getMappedNode(int index);
+
+    class Statistics {
+        public long nodes, relationships, readNodeMillis, readRelationshipMillis,computeMillis,writeMillis;
+        public boolean write;
+        public String property;
+
+        public Statistics(long nodes, long relationships, long iterations, long readNodeMillis, long readRelationshipMillis, long computeMillis, long writeMillis, boolean write, String property) {
+            this.nodes = nodes;
+            this.relationships = relationships;
+            this.readNodeMillis = readNodeMillis;
+            this.readRelationshipMillis = readRelationshipMillis;
+            this.computeMillis = computeMillis;
+            this.writeMillis = writeMillis;
+            this.write = write;
+            this.property = property;
+        }
+
+        public Statistics() {
+        }
+    }
+}
+
+
+

--- a/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
+++ b/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
@@ -10,7 +10,7 @@ import java.util.concurrent.Future;
 
 public class BetweennessCentrality implements AlgorithmInterface {
     public static final int WRITE_BATCH=100_000;
-    public final int BATCH_SIZE =100_000 ;
+    public final int MINIMUM_BATCH_SIZE =10_000 ;
     private Algorithm algorithm;
     private Log log;
     GraphDatabaseAPI db;
@@ -117,6 +117,13 @@ public class BetweennessCentrality implements AlgorithmInterface {
         int batchSize = (int)nodeCount/numOfThreads;
 
         int batches = (int)nodeCount/batchSize;
+
+        if (batchSize < MINIMUM_BATCH_SIZE) {
+            batches = 1;
+            batchSize = nodeCount;
+        }
+
+
         List<Future> futures = new ArrayList<>(batches);
         intermediateBcPerThread = new HashMap<>();
         int nodeIter = 0;
@@ -138,7 +145,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
         log.info("Total batches: " + batchNumber);
         int threadsReturned = AlgoUtils.waitForTasks(futures);
         int threadsNo = Runtime.getRuntime().availableProcessors() * 2;
-        System.out.println("Threads returned " + threadsReturned + " " + threadsNo);
+        log.info("Threads returned " + threadsReturned + " " + threadsNo);
         compileResults(batchNumber);
         long after = System.currentTimeMillis();
         long difference = after - before;
@@ -170,7 +177,6 @@ public class BetweennessCentrality implements AlgorithmInterface {
         Queue<Integer> queue = new LinkedList<>();
 
         log.info("Thread: " + Thread.currentThread().getName() + " processing " + start +  " " + end);
-//        System.out.println("Thread: " + Thread.currentThread().getName() + " processing " + start + " " + end);
         Map<Integer, ArrayList<Integer>>predecessors = new HashMap<Integer, ArrayList<Integer>>(); // Pw
 
         int numShortestPaths[] = new int [nodeCount]; // sigma

--- a/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
+++ b/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
@@ -1,0 +1,201 @@
+package apoc.algo.algorithms;
+
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.logging.Log;
+
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+
+public class BetweennessCentrality implements AlgorithmInterface {
+    public static final int WRITE_BATCH=100_100;
+    private Algorithm algorithm;
+    private Log log;
+    GraphDatabaseAPI db;
+    ExecutorService pool;
+    private int nodeCount;
+    private int relCount;
+    private Statistics stats = new Statistics();
+
+    float betweennessCentrality[];
+    public BetweennessCentrality(GraphDatabaseAPI db,
+                                 ExecutorService pool, Log log)
+    {
+        this.pool = pool;
+        this.db = db;
+        this.log = log;
+        algorithm = new Algorithm(db, pool, log);
+    }
+
+    @Override
+    public double getResult(long node) {
+        double val = -1;
+        int logicalIndex = getMappedNode((int)node);
+
+        if (logicalIndex >= 0 && betweennessCentrality.length >= logicalIndex) {
+            val = betweennessCentrality[logicalIndex];
+        }
+        return val;
+    }
+
+    @Override
+    public long numberOfNodes() {
+        return nodeCount;
+    }
+
+    @Override
+    public String getPropertyName() {
+        return "betweenness_centrality";
+    }
+
+    @Override
+    public int getMappedNode(int index) {
+        int node = algorithm.nodeMapping[index];
+        return node;
+    }
+
+    public boolean readNodeAndRelCypherData(String relCypher, String nodeCypher) {
+        boolean success = algorithm.readNodesAndRelCypherWeighted(relCypher, nodeCypher);
+        this.nodeCount = algorithm.nodeCount;
+        this.relCount = algorithm.relCount;
+        stats.readNodeMillis = algorithm.readNodeMillis;
+        stats.readRelationshipMillis = algorithm.readRelationshipMillis;
+        stats.nodes = nodeCount;
+        stats.relationships = relCount;
+        return success;
+    }
+
+
+    public long numberOfRels() {
+        return relCount;
+    }
+
+    public Statistics getStatistics() {
+        return stats;
+    }
+
+
+    public void computeUnweighted() {
+        computeUnweighted(algorithm.sourceDegreeData,
+                algorithm.sourceChunkStartingIndex,
+                algorithm.relationshipTarget);
+    }
+
+    public void computeUnweighted(int [] sourceDegreeData,
+                                  int [] sourceChunkStartingIndex,
+                                  int [] relationshipTarget) {
+        // TODO Convert this to float using the multiplication methods
+        betweennessCentrality = new float[nodeCount];
+        Arrays.fill(betweennessCentrality, 0);
+        Stack<Integer> stack = new Stack<>(); // S
+        Queue<Integer> queue = new LinkedList<>();
+
+        Map<Integer, ArrayList<Integer>>predecessors = new HashMap<Integer, ArrayList<Integer>>(); // Pw
+        int numShortestPaths[] = new int [nodeCount]; // sigma
+        int distance[] = new int[nodeCount]; // distance
+
+        long before = System.currentTimeMillis();
+        // TODO Convert this to float using the multiplication methods
+        float delta[] = new float[nodeCount];
+        System.out.println("Total nodes " + nodeCount + " total rels : " + relCount);
+        for (int source = 0; source < nodeCount; source++) {
+//            System.out.println("Source is " + source);
+            // Initializations:
+            stack.clear();
+            predecessors.clear();
+            Arrays.fill(numShortestPaths, 0);
+            numShortestPaths[source] = 1;
+            Arrays.fill(distance, -1);
+            distance[source] = 0;
+            queue.clear();
+            queue.add(source);
+            Arrays.fill(delta, 0);
+            for (int i = 0; i < nodeCount; i++) {
+                ArrayList<Integer> list = new ArrayList<Integer>();
+                predecessors.put(i, list);
+            }
+            while(!queue.isEmpty()) {
+                int nodeDequeued = queue.remove();
+//                System.out.println("Pushing Node dequeued: " + nodeDequeued + " source: " + source);
+                stack.push(nodeDequeued);
+
+                // For each neighbour of dequeued.
+                int chunkIndex = sourceChunkStartingIndex[nodeDequeued];
+                int degree = sourceDegreeData[nodeDequeued];
+
+                for (int j = 0; j < degree; j++) {
+                    int target = relationshipTarget[chunkIndex + j];
+//                    System.out.println("Edge between " + nodeDequeued + " : " + target);
+
+                    if (distance[target] < 0) {
+                        queue.add(target);
+//                        System.out.println("Pushing " + target + "to queue");
+                        distance[target] = distance[nodeDequeued] + 1;
+                    }
+
+                    if (distance[target] == (distance[nodeDequeued] + 1)){
+                        numShortestPaths[target] = numShortestPaths[target] + numShortestPaths[nodeDequeued];
+//                        System.out.println("Changing sigma to " + numShortestPaths[target] + " " + nodeDequeued + " " + target);
+                        ArrayList<Integer> list = predecessors.get(target);
+                        list.add(nodeDequeued);
+                        predecessors.put(target, list);
+                    }
+                }
+            }
+
+                for (int i = 0; i < nodeCount; i++) {
+                    ArrayList<Integer> list = predecessors.get(i);
+//                    System.out.print("Predecessors on sp from " + source + " to " + i + ":");
+                    for (int x = 0; x < list.size(); x++) {
+//                        System.out.print("->" + list.get(x));
+                    }
+//                    System.out.println();
+                    //System.out.println(i + " : " + distance[i]);
+//                    System.out.println("Shortest path from " + i + " : " + numShortestPaths[i]);
+                }
+
+            while(!stack.isEmpty()) {
+                int poppedNode = stack.pop();
+//                System.out.println("Popped " + poppedNode);
+                ArrayList<Integer> list = predecessors.get(poppedNode);
+
+                for (int i = 0; i < list.size(); i++) {
+                    int node = (int)list.get(i);
+                    double partialDependency = (numShortestPaths[node]/(double)numShortestPaths[poppedNode]);
+                    partialDependency *= (1.0) + delta[poppedNode];
+                    delta[node] += partialDependency;
+                    if (node == 6 || node == 3) {
+//                        System.out.println("adding delta " + partialDependency + "  " + delta[node] + "  to "  + node + "  " + poppedNode);
+                    }
+                }
+                if (poppedNode != source) {
+//                    if (poppedNode == 0)
+//                        System.out.println("Adding " + delta[poppedNode] + " to " + betweennessCentrality[poppedNode]);
+                    betweennessCentrality[poppedNode] = betweennessCentrality[poppedNode] + delta[poppedNode];
+//                    System.out.println("source not Popped " + poppedNode + " " + betweennessCentrality[poppedNode] + " - " +
+//                            delta[poppedNode]);
+
+                }
+
+            }
+
+        }
+
+        long after = System.currentTimeMillis();
+        long difference = after - before;
+        log.info("Computations took " + difference + " milliseconds");
+        stats.computeMillis = difference;
+        for(int i = 0; i < nodeCount; i++) {
+//            log.info(i + " : " + betweennessCentrality[i]);
+//            System.out.println(i + " : " + toFloat(betweennessCentrality[i]));
+        }
+    }
+
+    public void writeResultsToDB() {
+        stats.write = true;
+        long before = System.currentTimeMillis();
+        AlgoUtils.writeBackResults(pool, db, this, WRITE_BATCH);
+        stats.writeMillis = System.currentTimeMillis() - before;
+        stats.property = getPropertyName();
+
+    }
+}

--- a/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
+++ b/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
@@ -29,8 +29,11 @@ public class BetweennessCentrality implements AlgorithmInterface {
     @Override
     public double getResult(long node) {
         double val = -1;
-        int logicalIndex = getMappedNode((int)node);
+        int logicalIndex = algorithm.getNodeIndex((int)node);
 
+        if (node == 2490) {
+            System.out.println("Logical ine is " + logicalIndex);
+        }
         if (logicalIndex >= 0 && betweennessCentrality.length >= logicalIndex) {
             val = betweennessCentrality[logicalIndex];
         }
@@ -105,7 +108,9 @@ public class BetweennessCentrality implements AlgorithmInterface {
                 continue;
             }
             processedNode++;
-            log.info("Processing for node " + source + " with degree " + sourceDegreeData[source]);
+            if (processedNode % 1000 == 0) {
+                log.info("Processed " + processedNode + " nodes");
+            }
             stack.clear();
             predecessors.clear();
             Arrays.fill(numShortestPaths, 0);
@@ -130,7 +135,6 @@ public class BetweennessCentrality implements AlgorithmInterface {
 
                 for (int j = 0; j < degree; j++) {
                     int target = relationshipTarget[chunkIndex + j];
-//                    System.out.println("Edge between " + nodeDequeued + " : " + target);
 
                     if (distance[target] < 0) {
                         queue.add(target);
@@ -169,13 +173,8 @@ public class BetweennessCentrality implements AlgorithmInterface {
                     double partialDependency = (numShortestPaths[node]/(double)numShortestPaths[poppedNode]);
                     partialDependency *= (1.0) + delta[poppedNode];
                     delta[node] += partialDependency;
-                    if (node == 6 || node == 3) {
-//                        System.out.println("adding delta " + partialDependency + "  " + delta[node] + "  to "  + node + "  " + poppedNode);
-                    }
                 }
                 if (poppedNode != source) {
-//                    if (poppedNode == 0)
-//                        System.out.println("Adding " + delta[poppedNode] + " to " + betweennessCentrality[poppedNode]);
                     betweennessCentrality[poppedNode] = betweennessCentrality[poppedNode] + delta[poppedNode];
 //                    System.out.println("source not Popped " + poppedNode + " " + betweennessCentrality[poppedNode] + " - " +
 //                            delta[poppedNode]);

--- a/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
+++ b/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
@@ -138,9 +138,11 @@ public class BetweennessCentrality implements AlgorithmInterface {
         float delta[] = new float[nodeCount];
 
         int processedNode = 0;
-        for (int source = start; source < end; source++) {
+        int skippedZeros = 0;
+        for (int source = start; source < end && sourceDegreeData[source] != 0; source++) {
             processedNode++;
             if (sourceDegreeData[source] == 0) {
+                log.info("SHOULD NOT BE HERE");
                 continue;
             }
 
@@ -207,21 +209,33 @@ public class BetweennessCentrality implements AlgorithmInterface {
                     partialDependency *= (1.0) + delta[poppedNode];
                     delta[node] += partialDependency;
                 }
-                if (poppedNode != source) {
+                if (poppedNode != source && delta[poppedNode] != 0.0) {
                     // betweennessCentrality[poppedNode] = betweennessCentrality[poppedNode] + delta[poppedNode];
                     log.info("Thread "  + Thread.currentThread().getName() + "  " + poppedNode + " adding " +
                             delta[poppedNode]);
                     addToBetweenness(poppedNode, delta[poppedNode]);
+                } else {
+                    skippedZeros++;
                 }
             }
+
+
 
             if (processedNode%1000 == 0) {
                 log.info("Thread: " + Thread.currentThread().getName() + " processed " + processedNode);
             }
+            if (skippedZeros%1000 == 0) {
+                log.info("Thread: " + Thread.currentThread().getName() + " skipped " + skippedZeros);
+            }
 
         }
-        log.info("Thread: " + Thread.currentThread().getName() + " Processed " + processedNode);
+        delta = null;
+        numShortestPaths = null;
+        stack = null;
+        queue = null;
+        distance = null;
 
+        log.info("Thread: " + Thread.currentThread().getName() + " Processed " + processedNode);
     }
 
     private synchronized void addToBetweenness(int node, float delta) {

--- a/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
+++ b/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
@@ -125,8 +125,6 @@ public class BetweennessCentrality implements AlgorithmInterface {
             final int start = nodeIter;
             final int end = Integer.min(start + batchSize, nodeCount);
             final int threadbatchNo = batchNumber;
-            HashMap<Integer, Float> map = new HashMap<>();
-            intermediateBcPerThread.put(batchNumber, map);
             Future future = pool.submit(new Runnable() {
                 @Override
                 public void run() {
@@ -177,7 +175,8 @@ public class BetweennessCentrality implements AlgorithmInterface {
 
         int numShortestPaths[] = new int [nodeCount]; // sigma
         int distance[] = new int[nodeCount]; // distance
-
+        Map<Integer, Float> map = new HashMap<>();
+        ;
         float delta[] = new float[nodeCount];
 
         int processedNode = 0;
@@ -261,8 +260,8 @@ public class BetweennessCentrality implements AlgorithmInterface {
                     if (threadBatchNo == -1) {
                         betweennessCentrality[poppedNode] = betweennessCentrality[poppedNode] + delta[poppedNode];
                     } else {
-                        float storedValue = intermediateBcPerThread.get(threadBatchNo).getOrDefault(poppedNode, 0.0f);
-                        intermediateBcPerThread.get(threadBatchNo).put(poppedNode, storedValue + delta[poppedNode]);
+                        float storedValue = map.getOrDefault(poppedNode, 0.0f);
+                        map.put(poppedNode, storedValue + delta[poppedNode]);
                     }
                 } else {
                     skippedZeros++;
@@ -279,6 +278,8 @@ public class BetweennessCentrality implements AlgorithmInterface {
             }
 
         }
+
+        intermediateBcPerThread.put(threadBatchNo, map);
         delta = null;
         numShortestPaths = null;
         stack = null;

--- a/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
+++ b/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
@@ -110,8 +110,9 @@ public class BetweennessCentrality implements AlgorithmInterface {
 
         int numOfThreads = Pools.getNoThreadsInDefaultPool();
         int batchSize = (int)nodeCount/numOfThreads;
-
-        int batches = (int)nodeCount/batchSize;
+        int batches = 0;
+        if (batchSize > 0)
+            batches = (int)nodeCount/batchSize;
 
         if (batchSize < MINIMUM_BATCH_SIZE) {
             batches = 1;

--- a/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
+++ b/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
@@ -139,10 +139,9 @@ public class BetweennessCentrality implements AlgorithmInterface {
 
         int processedNode = 0;
         int skippedZeros = 0;
-        for (int source = start; source < end && sourceDegreeData[source] != 0; source++) {
+        for (int source = start; source < end; source++) {
             processedNode++;
             if (sourceDegreeData[source] == 0) {
-                log.info("SHOULD NOT BE HERE");
                 continue;
             }
 

--- a/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
+++ b/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
@@ -65,6 +65,10 @@ public class BetweennessCentrality implements AlgorithmInterface {
         return success;
     }
 
+    public boolean readRelCypherData(String relCypher) {
+        boolean success = algorithm.readRelCypherData(relCypher);
+        return success;
+    }
 
     public long numberOfRels() {
         return relCount;
@@ -135,6 +139,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
 
         int processedNode = 0;
         for (int source = start; source < end; source++) {
+            processedNode++;
             if (sourceDegreeData[source] == 0) {
                 continue;
             }
@@ -204,13 +209,12 @@ public class BetweennessCentrality implements AlgorithmInterface {
                 }
                 if (poppedNode != source) {
                     // betweennessCentrality[poppedNode] = betweennessCentrality[poppedNode] + delta[poppedNode];
-//                    System.out.println("Popped " + poppedNode + " adding to " + betweennessCentrality[poppedNode] + " - " +
-//                            delta[poppedNode]);
+                    log.info("Thread "  + Thread.currentThread().getName() + "  " + poppedNode + " adding " +
+                            delta[poppedNode]);
                     addToBetweenness(poppedNode, delta[poppedNode]);
                 }
             }
 
-            processedNode++;
             if (processedNode%1000 == 0) {
                 log.info("Thread: " + Thread.currentThread().getName() + " processed " + processedNode);
             }

--- a/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
+++ b/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
@@ -109,6 +109,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
         long before = System.currentTimeMillis();
 
         int numOfThreads = Pools.getNoThreadsInDefaultPool();
+        assert(numOfThreads != 0);
         int batchSize = (int)nodeCount/numOfThreads;
         int batches = 0;
         if (batchSize > 0)
@@ -228,6 +229,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
 
                 for (int i = 0; list != null && i < list.size() ; i++) {
                     int node = (int) list.get(i);
+                    assert(numShortestPaths[poppedNode] != 0);
                     partialDependency = (numShortestPaths[node] / (double) numShortestPaths[poppedNode]);
                     partialDependency *= (1.0) + delta[poppedNode];
                     delta[node] += partialDependency;

--- a/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
+++ b/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
@@ -18,8 +18,8 @@ public class BetweennessCentrality implements AlgorithmInterface {
     private int nodeCount;
     private int relCount;
     private Statistics stats = new Statistics();
-    private Map<Integer, Map<Integer, Float>> intermediateBcPerThread;
-    float betweennessCentrality[];
+    private Map<Integer, Map<Integer, Double>> intermediateBcPerThread;
+    double betweennessCentrality[];
     public BetweennessCentrality(GraphDatabaseAPI db,
                                  ExecutorService pool, Log log)
     {
@@ -86,7 +86,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
     }
 
     private void computeUnweightedSeq(int[] sourceDegreeData, int[] sourceChunkStartingIndex, int[] relationshipTarget) {
-        betweennessCentrality = new float[nodeCount];
+        betweennessCentrality = new double[nodeCount];
         Arrays.fill(betweennessCentrality, 0);
         long before = System.currentTimeMillis();
         int start = 0;
@@ -109,7 +109,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
     public void computeUnweightedInBatches(int [] sourceDegreeData,
                                   int [] sourceChunkStartingIndex,
                                   int [] relationshipTarget) {
-        betweennessCentrality = new float[nodeCount];
+        betweennessCentrality = new double[nodeCount];
         Arrays.fill(betweennessCentrality, 0);
         long before = System.currentTimeMillis();
 
@@ -159,9 +159,9 @@ public class BetweennessCentrality implements AlgorithmInterface {
 
     private void compileResults(int batchNumber) {
         for (int i = 0; i < nodeCount; i++) {
-            float value = 0;
+            double value = 0;
             for (int batch = 0; batch < batchNumber; batch++) {
-                value += intermediateBcPerThread.get(batch).getOrDefault(i, 0.0f);
+                value += intermediateBcPerThread.get(batch).getOrDefault(i, 0.0);
             }
             betweennessCentrality[i] = value;
         }
@@ -181,8 +181,8 @@ public class BetweennessCentrality implements AlgorithmInterface {
 
         int numShortestPaths[] = new int [nodeCount]; // sigma
         int distance[] = new int[nodeCount]; // distance
-        Map<Integer, Float> map = new HashMap<>();
-        float delta[] = new float[nodeCount];
+        Map<Integer, Double> map = new HashMap<>();
+        double delta[] = new double[nodeCount];
 
         int processedNode = 0;
         for (int source = start; source < end; source++) {
@@ -269,7 +269,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
                     if (threadBatchNo == -1) {
                         betweennessCentrality[poppedNode] = betweennessCentrality[poppedNode] + delta[poppedNode];
                     } else {
-                        float storedValue = map.getOrDefault(poppedNode, 0.0f);
+                        double storedValue = map.getOrDefault(poppedNode, 0.0);
                         map.put(poppedNode, storedValue + delta[poppedNode]);
                     }
                 }

--- a/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
+++ b/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
@@ -96,13 +96,16 @@ public class BetweennessCentrality implements AlgorithmInterface {
         long before = System.currentTimeMillis();
         // TODO Convert this to float using the multiplication methods
         float delta[] = new float[nodeCount];
+        int processedNode = 0;
+
         for (int source = 0; source < nodeCount; source++) {
 //            System.out.println("Source is " + source);
             // Initializations:
             if (sourceDegreeData[source] == 0) {
                 continue;
             }
-            log.info("Processing for node " + source);
+            processedNode++;
+            log.info("Processing for node " + source + " with degree " + sourceDegreeData[source]);
             stack.clear();
             predecessors.clear();
             Arrays.fill(numShortestPaths, 0);
@@ -185,6 +188,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
 
         long after = System.currentTimeMillis();
         long difference = after - before;
+        log.info("Processed " + processedNode);
         log.info("Computations took " + difference + " milliseconds");
         stats.computeMillis = difference;
 //        for(int i = 0; i < nodeCount; i++) {

--- a/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
+++ b/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
@@ -16,7 +16,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
     private int relCount;
     private Statistics stats = new Statistics();
 
-    float betweennessCentrality[];
+    double betweennessCentrality[];
     public BetweennessCentrality(GraphDatabaseAPI db,
                                  ExecutorService pool, Log log)
     {
@@ -87,7 +87,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
                                   int [] sourceChunkStartingIndex,
                                   int [] relationshipTarget) {
         // TODO Convert this to float using the multiplication methods
-        betweennessCentrality = new float[nodeCount];
+        betweennessCentrality = new double[nodeCount];
         Arrays.fill(betweennessCentrality, 0);
         Stack<Integer> stack = new Stack<>(); // S
         Queue<Integer> queue = new LinkedList<>();
@@ -98,7 +98,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
 
         long before = System.currentTimeMillis();
         // TODO Convert this to float using the multiplication methods
-        float delta[] = new float[nodeCount];
+        double delta[] = new double[nodeCount];
         int processedNode = 0;
 
         for (int source = 0; source < nodeCount; source++) {

--- a/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
+++ b/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
@@ -247,7 +247,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
                     } else {
                         Object storedValue = map.get(poppedNode);
                         if (storedValue != null)
-                            map.put(poppedNode, ((double)storedValue) + delta[poppedNode]);
+                            map.put(poppedNode, ((float)storedValue) + delta[poppedNode]);
                         else
                             map.put(poppedNode, delta[poppedNode]);
                     }

--- a/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
+++ b/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
@@ -96,10 +96,13 @@ public class BetweennessCentrality implements AlgorithmInterface {
         long before = System.currentTimeMillis();
         // TODO Convert this to float using the multiplication methods
         float delta[] = new float[nodeCount];
-        System.out.println("Total nodes " + nodeCount + " total rels : " + relCount);
         for (int source = 0; source < nodeCount; source++) {
 //            System.out.println("Source is " + source);
             // Initializations:
+            if (sourceDegreeData[source] == 0) {
+                continue;
+            }
+            log.info("Processing for node " + source);
             stack.clear();
             predecessors.clear();
             Arrays.fill(numShortestPaths, 0);
@@ -142,16 +145,16 @@ public class BetweennessCentrality implements AlgorithmInterface {
                 }
             }
 
-                for (int i = 0; i < nodeCount; i++) {
-                    ArrayList<Integer> list = predecessors.get(i);
-//                    System.out.print("Predecessors on sp from " + source + " to " + i + ":");
-                    for (int x = 0; x < list.size(); x++) {
-//                        System.out.print("->" + list.get(x));
-                    }
-//                    System.out.println();
-                    //System.out.println(i + " : " + distance[i]);
-//                    System.out.println("Shortest path from " + i + " : " + numShortestPaths[i]);
-                }
+//                for (int i = 0; i < nodeCount; i++) {
+//                    ArrayList<Integer> list = predecessors.get(i);
+////                    System.out.print("Predecessors on sp from " + source + " to " + i + ":");
+//                    for (int x = 0; x < list.size(); x++) {
+////                        System.out.print("->" + list.get(x));
+//                    }
+////                    System.out.println();
+//                    //System.out.println(i + " : " + distance[i]);
+////                    System.out.println("Shortest path from " + i + " : " + numShortestPaths[i]);
+//                }
 
             while(!stack.isEmpty()) {
                 int poppedNode = stack.pop();
@@ -184,10 +187,10 @@ public class BetweennessCentrality implements AlgorithmInterface {
         long difference = after - before;
         log.info("Computations took " + difference + " milliseconds");
         stats.computeMillis = difference;
-        for(int i = 0; i < nodeCount; i++) {
-//            log.info(i + " : " + betweennessCentrality[i]);
-//            System.out.println(i + " : " + toFloat(betweennessCentrality[i]));
-        }
+//        for(int i = 0; i < nodeCount; i++) {
+////            log.info(i + " : " + betweennessCentrality[i]);
+////            System.out.println(i + " : " + toFloat(betweennessCentrality[i]));
+//        }
     }
 
     public void writeResultsToDB() {

--- a/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
+++ b/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
@@ -22,8 +22,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
     private Statistics stats = new Statistics();
 
     private PrimitiveIntObjectMap intermediateBcPerThread;
-//    private Map<Integer, Map<Integer, Double>> intermediateBcPerThread;
-    double betweennessCentrality[];
+    float betweennessCentrality[];
 
     public BetweennessCentrality(GraphDatabaseAPI db,
                                  ExecutorService pool, Log log)
@@ -36,7 +35,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
 
     @Override
     public double getResult(long node) {
-        double val = -1;
+        float val = -1;
         int logicalIndex = algorithm.getNodeIndex((int)node);
         if (logicalIndex >= 0 && betweennessCentrality.length >= logicalIndex) {
             val = betweennessCentrality[logicalIndex];
@@ -86,7 +85,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
     }
 
     private void computeUnweightedSeq(int[] sourceDegreeData, int[] sourceChunkStartingIndex, int[] relationshipTarget) {
-        betweennessCentrality = new double[nodeCount];
+        betweennessCentrality = new float[nodeCount];
         Arrays.fill(betweennessCentrality, 0);
         long before = System.currentTimeMillis();
         int start = 0;
@@ -107,7 +106,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
     public void computeUnweightedParallel(int [] sourceDegreeData,
                                   int [] sourceChunkStartingIndex,
                                   int [] relationshipTarget) {
-        betweennessCentrality = new double[nodeCount];
+        betweennessCentrality = new float[nodeCount];
         Arrays.fill(betweennessCentrality, 0);
         long before = System.currentTimeMillis();
 
@@ -155,12 +154,12 @@ public class BetweennessCentrality implements AlgorithmInterface {
 
     private void compileResults(int batchNumber) {
         for (int i = 0; i < nodeCount; i++) {
-            double value = 0;
+            float value = 0;
             Object batchValue = 0;
             for (int batch = 0; batch < batchNumber; batch++) {
                 batchValue = ((PrimitiveIntObjectMap)intermediateBcPerThread.get(batch)).get(i);
                 if (batchValue != null)
-                    value += (double)batchValue;
+                    value += (float)batchValue;
             }
             betweennessCentrality[i] = value;
         }
@@ -183,7 +182,7 @@ public class BetweennessCentrality implements AlgorithmInterface {
         int numShortestPaths[] = new int [nodeCount]; // sigma
         int distance[] = new int[nodeCount]; // distance
         PrimitiveIntObjectMap map = Primitive.intObjectMap();
-        double delta[] = new double[nodeCount];
+        float delta[] = new float[nodeCount];
 
         int processedNode = 0;
         for (int source = start; source < end; source++) {

--- a/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
+++ b/src/main/java/apoc/algo/algorithms/BetweennessCentrality.java
@@ -176,17 +176,15 @@ public class BetweennessCentrality implements AlgorithmInterface {
         Stack<Integer> stack = new Stack<>(); // S
         Queue<Integer> queue = new LinkedList<>();
 
-        log.info("Thread: " + Thread.currentThread().getName() + " processing " + start +  " " + end);
+        log.info("Thread: " + Thread.currentThread().getName() + " processing " + start + " " + end);
         Map<Integer, ArrayList<Integer>>predecessors = new HashMap<Integer, ArrayList<Integer>>(); // Pw
 
         int numShortestPaths[] = new int [nodeCount]; // sigma
         int distance[] = new int[nodeCount]; // distance
         Map<Integer, Float> map = new HashMap<>();
-        ;
         float delta[] = new float[nodeCount];
 
         int processedNode = 0;
-        int skippedZeros = 0;
         for (int source = start; source < end; source++) {
 
             processedNode++;
@@ -203,10 +201,10 @@ public class BetweennessCentrality implements AlgorithmInterface {
             queue.clear();
             queue.add(source);
             Arrays.fill(delta, 0);
-            for (int i = 0; i < nodeCount; i++) {
-                ArrayList<Integer> list = new ArrayList<Integer>();
-                predecessors.put(i, list);
-            }
+//            for (int i = 0; i < nodeCount; i++) {
+//                ArrayList<Integer> list = new ArrayList<Integer>();
+//                predecessors.put(i, list);
+//            }
             while (!queue.isEmpty()) {
                 int nodeDequeued = queue.remove();
 //                System.out.println("Pushing Node dequeued: " + nodeDequeued + " source: " + source);
@@ -228,10 +226,15 @@ public class BetweennessCentrality implements AlgorithmInterface {
                     if (distance[target] == (distance[nodeDequeued] + 1)) {
                         numShortestPaths[target] = numShortestPaths[target] + numShortestPaths[nodeDequeued];
 //                        System.out.println("Changing sigma to " + numShortestPaths[target] + " " + nodeDequeued + " " + target);
-                        ArrayList<Integer> list = predecessors.get(target);
-                        list.add(nodeDequeued);
-                        predecessors.put(target, list);
+                       //  ArrayList<Integer> list = predecessors.get(target);
+                        // list.add(nodeDequeued);
+                        // predecessors.put(target, list);
 
+                        if (!predecessors.containsKey(target)) {
+                            ArrayList<Integer> list = new ArrayList<Integer>();
+                            predecessors.put(target, list);
+                        }
+                        predecessors.get(target).add(nodeDequeued);
                     }
                 }
             }
@@ -252,14 +255,14 @@ public class BetweennessCentrality implements AlgorithmInterface {
 //                System.out.println("Popped " + poppedNode);
                 ArrayList<Integer> list = predecessors.get(poppedNode);
 
-                for (int i = 0; i < list.size(); i++) {
+                double partialDependency;
+                for (int i = 0; list != null && i < list.size() ; i++) {
                     int node = (int) list.get(i);
-                    double partialDependency = (numShortestPaths[node] / (double) numShortestPaths[poppedNode]);
+                    partialDependency = (numShortestPaths[node] / (double) numShortestPaths[poppedNode]);
                     partialDependency *= (1.0) + delta[poppedNode];
                     delta[node] += partialDependency;
                 }
                 if (poppedNode != source && delta[poppedNode] != 0.0) {
-                    // betweennessCentrality[poppedNode] = betweennessCentrality[poppedNode] + delta[poppedNode];
 //                    log.info("Thread "  + Thread.currentThread().getName() + " source:"  + source + "  popped:" + poppedNode + " adding " +
 //                            delta[poppedNode]);
                     // Storing results in intermediate thread map.
@@ -269,20 +272,12 @@ public class BetweennessCentrality implements AlgorithmInterface {
                         float storedValue = map.getOrDefault(poppedNode, 0.0f);
                         map.put(poppedNode, storedValue + delta[poppedNode]);
                     }
-                } else {
-                    skippedZeros++;
                 }
             }
 
-
-
-            if (processedNode%1000 == 0) {
+            if (processedNode%10000 == 0) {
                 log.info("Thread: " + Thread.currentThread().getName() + " processed " + processedNode);
             }
-            if (skippedZeros%1000 == 0) {
-                log.info("Thread: " + Thread.currentThread().getName() + " skipped " + skippedZeros);
-            }
-
         }
 
         intermediateBcPerThread.put(threadBatchNo, map);

--- a/src/main/java/apoc/algo/pagerank/PageRank.java
+++ b/src/main/java/apoc/algo/pagerank/PageRank.java
@@ -2,7 +2,7 @@ package apoc.algo.pagerank;
 
 import org.neo4j.graphdb.RelationshipType;
 
-public interface PageRank extends Algorithm
+public interface PageRank extends PageRankAlgorithm
 {
     double ALPHA = 0.85;
     double ONE_MINUS_ALPHA = 1 - ALPHA;

--- a/src/main/java/apoc/algo/pagerank/PageRank.java
+++ b/src/main/java/apoc/algo/pagerank/PageRank.java
@@ -20,8 +20,9 @@ public interface PageRank extends PageRankAlgorithm
     class PageRankStatistics {
         public long nodes, relationships, iterations, readNodeMillis, readRelationshipMillis,computeMillis,writeMillis;
         public boolean write;
+        public String property;
 
-        public PageRankStatistics(long nodes, long relationships, long iterations, long readNodeMillis, long readRelationshipMillis, long computeMillis, long writeMillis, boolean write) {
+        public PageRankStatistics(long nodes, long relationships, long iterations, long readNodeMillis, long readRelationshipMillis, long computeMillis, long writeMillis, boolean write, String property) {
             this.nodes = nodes;
             this.relationships = relationships;
             this.iterations = iterations;
@@ -30,6 +31,7 @@ public interface PageRank extends PageRankAlgorithm
             this.computeMillis = computeMillis;
             this.writeMillis = writeMillis;
             this.write = write;
+            this.property = property;
         }
 
         public PageRankStatistics() {

--- a/src/main/java/apoc/algo/pagerank/PageRankAlgorithm.java
+++ b/src/main/java/apoc/algo/pagerank/PageRankAlgorithm.java
@@ -2,7 +2,7 @@ package apoc.algo.pagerank;
 
 import org.neo4j.graphdb.RelationshipType;
 
-public interface Algorithm
+public interface PageRankAlgorithm
 {
 
     void compute( int iterations, RelationshipType... relationshipTypes );

--- a/src/main/java/apoc/algo/pagerank/PageRankArrayStorageParallelCypher.java
+++ b/src/main/java/apoc/algo/pagerank/PageRankArrayStorageParallelCypher.java
@@ -1,5 +1,6 @@
 package apoc.algo.pagerank;
 
+import apoc.algo.*;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
@@ -50,6 +51,8 @@ public class PageRankArrayStorageParallelCypher implements PageRank
     int [] previousPageRanks;
     private AtomicIntegerArray pageRanksAtomic;
 
+    private Algorithm algorithm;
+
     public PageRankArrayStorageParallelCypher(
             GraphDatabaseAPI db,
             ExecutorService pool, Log log)
@@ -57,6 +60,7 @@ public class PageRankArrayStorageParallelCypher implements PageRank
         this.pool = pool;
         this.db = db;
         this.log = log;
+        algorithm = new Algorithm(db, pool, log);
     }
 
     private int getNodeIndex(int node) {
@@ -72,6 +76,13 @@ public class PageRankArrayStorageParallelCypher implements PageRank
         return newArray;
     }
 
+    public boolean readNodeAndRelCypherData(String relCypher, String nodeCypher) {
+        return algorithm.readNodeAndRelCypherIntoArrays(relCypher, nodeCypher);
+    }
+
+    private void setUpArrays() {
+        sourceChunkStartingIndex = algorithm.sour
+    }
     public boolean readDataIntoArray(String relCypher, String nodeCypher) {
         Result nodeResult = db.execute(nodeCypher);
 

--- a/src/main/java/apoc/algo/pagerank/PageRankArrayStorageParallelCypher.java
+++ b/src/main/java/apoc/algo/pagerank/PageRankArrayStorageParallelCypher.java
@@ -178,7 +178,6 @@ public class PageRankArrayStorageParallelCypher implements PageRank, AlgorithmIn
     public void writeResultsToDB() {
         stats.write = true;
         long before = System.currentTimeMillis();
-        System.out.println("Writing back");
         AlgoUtils.writeBackResults(pool, db, this, WRITE_BATCH);
         stats.writeMillis = System.currentTimeMillis() - before;
         stats.property = getPropertyName();

--- a/src/main/java/apoc/algo/pagerank/PageRankArrayStorageParallelCypher.java
+++ b/src/main/java/apoc/algo/pagerank/PageRankArrayStorageParallelCypher.java
@@ -172,6 +172,7 @@ public class PageRankArrayStorageParallelCypher implements PageRank
         long before = System.currentTimeMillis();
         PageRankUtils.writeBackResults(pool, db, algorithm.nodeMapping, this, WRITE_BATCH);
         stats.writeMillis = System.currentTimeMillis() - before;
+        stats.property = getPropertyName();
     }
 
     public double getResult(long node)

--- a/src/main/java/apoc/algo/pagerank/PageRankUtils.java
+++ b/src/main/java/apoc/algo/pagerank/PageRankUtils.java
@@ -2,12 +2,9 @@ package apoc.algo.pagerank;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.cypher.EntityNotFoundException;
@@ -66,7 +63,7 @@ public class PageRankUtils
         PageRankUtils.waitForTasks( futures );
     }
 
-    public static void writeBackResults(ExecutorService pool, GraphDatabaseAPI db, int [] nodes, Algorithm algorithm,
+    public static void writeBackResults(ExecutorService pool, GraphDatabaseAPI db, int [] nodes, PageRankAlgorithm algorithm,
                                         int batchSize) {
         ThreadToStatementContextBridge ctx = db.getDependencyResolver().resolveDependency(ThreadToStatementContextBridge.class);
         int propertyNameId;

--- a/src/test/java/apoc/algo/CentralityTest.java
+++ b/src/test/java/apoc/algo/CentralityTest.java
@@ -300,19 +300,19 @@ public class CentralityTest
         t.close();
     }
 
-    @Test
-    public void shouldHaveExpectedBetweennessMultipleSPCypher()
-    {
-        db.execute( MULTIPLE_SHORTEST_PATH ).close();
-        Result result = db.execute("CALL apoc.algo.betweennessCypher({write:true})");
-        System.out.println(result.resultAsString());
-        Result t =  db.execute("MATCH (n) RETURN n.name as name, n.betweenness_centrality as score ORDER BY score DESC LIMIT 1");
-        assertTrue(t.hasNext());
-        assertEquals( CentralityTest.MULTIPLE_SHORTEST_PATH_EXPECTED,
-                (double)t.next().get("score"), 0.1D );
-        assertFalse(t.hasNext() );
-        t.close();
-    }
+//    @Test
+//    public void shouldHaveExpectedBetweennessMultipleSPCypher()
+//    {
+//        db.execute( MULTIPLE_SHORTEST_PATH ).close();
+//        Result result = db.execute("CALL apoc.algo.betweennessCypher({write:true})");
+//        System.out.println(result.resultAsString());
+//        Result t =  db.execute("MATCH (n) RETURN n.name as name, n.betweenness_centrality as score ORDER BY score DESC LIMIT 1");
+//        assertTrue(t.hasNext());
+//        assertEquals( CentralityTest.MULTIPLE_SHORTEST_PATH_EXPECTED,
+//                (double)t.next().get("score"), 0.1D );
+//        assertFalse(t.hasNext() );
+//        t.close();
+//    }
 
 
     public String algoQuery( String algo )

--- a/src/test/java/apoc/algo/CentralityTest.java
+++ b/src/test/java/apoc/algo/CentralityTest.java
@@ -72,6 +72,26 @@ public class CentralityTest
 
     public static double STAR_GRAPH_EXPECTED=6.0;
 
+    public static final String STAR_GRAPH_LABELS = "CREATE (a:Company {name:'a'})\n" +
+            "CREATE (b:Emp {name:'b'})\n" +
+            "CREATE (c:Emp {name:'c'})\n" +
+            "CREATE (d:Emp {name:'d'})\n" +
+            "CREATE (e:Emp {name:'e'})\n" +
+            "CREATE (m:Company {name:'m'})\n" +
+            "CREATE (n:Company {name:'n'})\n" +
+            "CREATE (o:Company {name:'o'})\n" +
+            "CREATE (p:Company {name:'p'})\n" +
+            "CREATE (q:Company {name:'q'})\n" +
+
+            "CREATE\n" +
+            "  (o)-[:TYPE_1 {score:0.80}]->(q),\n" +
+            "  (p)-[:TYPE_1 {score:0.80}]->(q),\n" +
+            "  (q)-[:TYPE_1 {score:0.80}]->(a),\n" +
+            "  (q)-[:TYPE_1 {score:0.80}]->(m),\n" +
+            "  (q)-[:TYPE_1 {score:0.80}]->(n)\n";
+
+    public static double STAR_GRAPH_LABELS_EXPECTED=6.0;
+
     public static final String MULTIPLE_SHORTEST_PATH = "CREATE (a:Company {name:'a'})\n" +
             "CREATE (b:Company {name:'b'})\n" +
             "CREATE (c:Company {name:'c'})\n" +
@@ -300,20 +320,34 @@ public class CentralityTest
         t.close();
     }
 
-//    @Test
-//    public void shouldHaveExpectedBetweennessMultipleSPCypher()
-//    {
-//        db.execute( MULTIPLE_SHORTEST_PATH ).close();
-//        Result result = db.execute("CALL apoc.algo.betweennessCypher({write:true})");
-//        System.out.println(result.resultAsString());
-//        Result t =  db.execute("MATCH (n) RETURN n.name as name, n.betweenness_centrality as score ORDER BY score DESC LIMIT 1");
-//        assertTrue(t.hasNext());
-//        assertEquals( CentralityTest.MULTIPLE_SHORTEST_PATH_EXPECTED,
-//                (double)t.next().get("score"), 0.1D );
-//        assertFalse(t.hasNext() );
-//        t.close();
-//    }
+    @Test
+    public void shouldHaveExpectedBetweennessMultipleSPCypher()
+    {
+        db.execute( MULTIPLE_SHORTEST_PATH ).close();
+        Result result = db.execute("CALL apoc.algo.betweennessCypher({write:true})");
+        System.out.println(result.resultAsString());
+        Result t =  db.execute("MATCH (n) RETURN n.name as name, n.betweenness_centrality as score ORDER BY score DESC LIMIT 1");
+        assertTrue(t.hasNext());
+        assertEquals( CentralityTest.MULTIPLE_SHORTEST_PATH_EXPECTED,
+                (double)t.next().get("score"), 0.1D );
+        assertFalse(t.hasNext() );
+        t.close();
+    }
 
+    @Test
+    public void shouldHaveExpectedBetweennessNodeRemappingForCypher()
+    {
+        db.execute( STAR_GRAPH_LABELS ).close();
+        Result result = db.execute("CALL apoc.algo.betweennessCypher({relCypher: \"MATCH (s:Company)-[r]->(t:Company) RETURN id(s) as source, id(t) as target, 1 as weight\"," +
+                "write:true})");
+        System.out.println(result.resultAsString());
+        Result t =  db.execute("MATCH (n:Company) RETURN n.name as name, n.betweenness_centrality as score ORDER BY score DESC LIMIT 1");
+        assertTrue( t.hasNext() );
+        assertEquals( CentralityTest.STAR_GRAPH_LABELS_EXPECTED,
+                (double)t.next().get("score"), 0.1D );
+        assertFalse(t.hasNext() );
+        t.close();
+    }
 
     public String algoQuery( String algo )
     {

--- a/src/test/java/apoc/algo/CentralityTest.java
+++ b/src/test/java/apoc/algo/CentralityTest.java
@@ -1,22 +1,19 @@
 package apoc.algo;
 
+import apoc.algo.pagerank.PageRankAlgoTest;
 import apoc.util.TestUtil;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import java.util.Map;
 
-import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Result;
-import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.*;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -29,31 +26,99 @@ public class CentralityTest
             "MATCH (n1),(n2) WITH n1,n2 LIMIT 1000 WHERE rand() < p " +
             "CREATE (n1)-[:TYPE]->(n2)";
 
-    @BeforeClass
-    public static void setUp() throws Exception
+    public static final String COMPANIES_QUERY = "CREATE (a:Company {name:'a'})\n" +
+            "CREATE (b:Company {name:'b'})\n" +
+            "CREATE (c:Company {name:'c'})\n" +
+            "CREATE (d:Company {name:'d'})\n" +
+            "CREATE (e:Company {name:'e'})\n" +
+            "CREATE (f:Company {name:'f'})\n" +
+            "CREATE (g:Company {name:'g'})\n" +
+            "CREATE (h:Company {name:'h'})\n" +
+            "CREATE (i:Company {name:'i'})\n" +
+            "CREATE (j:Company {name:'j'})\n" +
+            "CREATE (k:Company {name:'k'})\n" +
+
+            "CREATE\n" +
+            "  (b)-[:TYPE_1 {score:0.80}]->(c),\n" +
+            "  (c)-[:TYPE_1 {score:0.80}]->(b),\n" +
+            "  (d)-[:TYPE_1 {score:0.80}]->(a),\n" +
+            "  (e)-[:TYPE_1 {score:0.80}]->(b),\n" +
+            "  (e)-[:TYPE_1 {score:0.80}]->(d),\n" +
+            "  (e)-[:TYPE_1 {score:0.80}]->(f),\n" +
+            "  (f)-[:TYPE_1 {score:0.80}]->(b),\n" +
+            "  (f)-[:TYPE_1 {score:0.80}]->(e),\n" +
+            "  (g)-[:TYPE_2 {score:0.80}]->(b),\n" +
+            "  (g)-[:TYPE_2 {score:0.80}]->(e),\n" +
+            "  (h)-[:TYPE_2 {score:0.80}]->(b),\n" +
+            "  (h)-[:TYPE_2 {score:0.80}]->(e),\n" +
+            "  (i)-[:TYPE_2 {score:0.80}]->(b),\n" +
+            "  (i)-[:TYPE_2 {score:0.80}]->(e),\n" +
+            "  (j)-[:TYPE_2 {score:0.80}]->(e),\n" +
+            "  (k)-[:TYPE_2 {score:0.80}]->(e)\n";
+
+    public static final String STAR_GRAPH = "CREATE (a:Company {name:'a'})\n" +
+            "CREATE (b:Company {name:'b'})\n" +
+            "CREATE (c:Company {name:'c'})\n" +
+            "CREATE (d:Company {name:'d'})\n" +
+            "CREATE (e:Company {name:'e'})\n" +
+            "CREATE (f:Company {name:'f'})\n" +
+
+            "CREATE\n" +
+            "  (d)-[:TYPE_1 {score:0.80}]->(f),\n" +
+            "  (e)-[:TYPE_1 {score:0.80}]->(f),\n" +
+            "  (f)-[:TYPE_1 {score:0.80}]->(a),\n" +
+            "  (f)-[:TYPE_1 {score:0.80}]->(b),\n" +
+            "  (f)-[:TYPE_1 {score:0.80}]->(c)\n";
+
+    public static double STAR_GRAPH_EXPECTED=6.0;
+
+    public static final String MULTIPLE_SHORTEST_PATH = "CREATE (a:Company {name:'a'})\n" +
+            "CREATE (b:Company {name:'b'})\n" +
+            "CREATE (c:Company {name:'c'})\n" +
+            "CREATE (d:Company {name:'d'})\n" +
+            "CREATE (e:Company {name:'e'})\n" +
+            "CREATE (f:Company {name:'f'})\n" +
+            "CREATE (g:Company {name:'g'})\n" +
+
+            "CREATE\n" +
+            "  (a)-[:TYPE_1 {score:0.80}]->(b),\n" +
+            "  (a)-[:TYPE_1 {score:0.80}]->(c),\n" +
+            "  (a)-[:TYPE_1 {score:0.80}]->(f),\n" +
+            "  (c)-[:TYPE_1 {score:0.80}]->(d),\n" +
+            "  (b)-[:TYPE_1 {score:0.80}]->(d),\n" +
+            "  (d)-[:TYPE_1 {score:0.80}]->(e),\n" +
+            "  (f)-[:TYPE_1 {score:0.80}]->(g),\n" +
+            "  (g)-[:TYPE_1 {score:0.80}]->(e)\n";
+
+    public static double MULTIPLE_SHORTEST_PATH_EXPECTED=2.66;
+
+    @Before
+    public void setUp() throws Exception
     {
         db = new TestGraphDatabaseFactory().newImpermanentDatabase();
-        TestUtil.registerProcedure( db, Centrality.class );
-        db.execute( RANDOM_GRAPH ).close();
+        TestUtil.registerProcedure(db, Centrality.class);
     }
 
-    @AfterClass
-    public static void tearDown()
+    @After
+    public void tearDownDb()
     {
         db.shutdown();
     }
+
 
     // ==========================================================================================
 
     @Test
     public void shouldHandleEmptyNodeSetWhenUsingBetweenness()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 0, "CALL apoc.algo.betweenness(['TYPE'],[],'BOTH')" + "" );
     }
 
     @Test
     public void shouldHandleEmptyNodeSetWhenUsingCloseness()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 0, "CALL apoc.algo.closeness(['TYPE'],[],'BOTH')" + "" );
     }
 
@@ -62,12 +127,14 @@ public class CentralityTest
     @Test
     public void shouldHandleEmptyRelationshipTypeWhenUsingBetweenness()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 50, algoQuery( "CALL apoc.algo.betweenness([],nodes,'BOTH')" ) );
     }
 
     @Test
     public void shouldHandleEmptyRelationshipTypeUsingCloseness()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 50, algoQuery( "CALL apoc.algo.closeness([],nodes,'BOTH')" ) );
     }
 
@@ -76,6 +143,7 @@ public class CentralityTest
     @Test
     public void shouldProvideSameResultUsingEmptyRelationshipTypeOrSpecifyAllTypesWhenUsingBetweenness()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertResultsAreEqual( algoQuery( "CALL apoc.algo.betweenness([],nodes,'BOTH')" ),
                 algoQuery( "CALL apoc.algo.betweenness(['TYPE'],nodes,'BOTH')" ) );
     }
@@ -83,6 +151,7 @@ public class CentralityTest
     @Test
     public void shouldProvideSameResultUsingEmptyRelationshipTypeOrSpecifyAllTypesWhenUsingCloseness()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertResultsAreEqual( algoQuery( "CALL apoc.algo.closeness([],nodes,'BOTH')" ),
                 algoQuery( "CALL apoc.algo.closeness(['TYPE'],nodes,'BOTH')" ) );
     }
@@ -93,6 +162,7 @@ public class CentralityTest
     @Test
     public void shouldHandleRelationshipTypesThatDoesNotExistWhenUsingBetweenness()
     {
+        db.execute( RANDOM_GRAPH ).close();
         String algo = "CALL apoc.algo.betweenness(['BAD_VALUE'],nodes,'BOTH')";
         String query = algoQuery( algo );
         assertExpectedResult( 0, query );
@@ -101,6 +171,7 @@ public class CentralityTest
     @Test
     public void shouldHandleRelationshipTypesThatDoesNotExistWhenUsingCentrality()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 0, algoQuery( "CALL apoc.algo.closeness(['BAD_VALUE'],nodes,'BOTH')" ) );
     }
 
@@ -109,12 +180,14 @@ public class CentralityTest
     @Test( expected = RuntimeException.class )
     public void shouldHandleNullNodesWhenUsingBetweenness()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 0, algoQuery( "CALL apoc.algo.betweenness([],null,'BOTH')" ) );
     }
 
     @Test( expected = RuntimeException.class )
     public void shouldHandleNullNodesWhenUsingCentrality()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 0, algoQuery( "CALL apoc.algo.closeness([],null,'BOTH')" ) );
     }
 
@@ -123,12 +196,14 @@ public class CentralityTest
     @Test( expected = RuntimeException.class )
     public void shouldHandleNullRelationshipTypesWhenUsingBetweenness()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 0, algoQuery( "CALL apoc.algo.betweenness(null,nodes,'BOTH')" ) );
     }
 
     @Test( expected = RuntimeException.class )
     public void shouldHandleNullRelationshipTypesWhenUsingCentrality()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 0, algoQuery( "CALL apoc.algo.closeness(null,nodes,'BOTH')" ) );
     }
 
@@ -137,12 +212,14 @@ public class CentralityTest
     @Test( expected = RuntimeException.class )
     public void shouldHandleNullDirectionWhenUsingBetweenness()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 0, algoQuery( "CALL apoc.algo.betweenness(null,nodes,'null')" ) );
     }
 
     @Test( expected = RuntimeException.class )
     public void shouldHandleNullDirectionWhenUsingCentrality()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 0, algoQuery( "CALL apoc.algo.closeness(null,nodes,'null')" ) );
     }
 
@@ -151,6 +228,7 @@ public class CentralityTest
     @Test
     public void shouldReturnExpectedResultCountWhenUsingBetweennessAllDirections()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 50, algoQuery( "CALL apoc.algo.betweenness(['TYPE'],nodes,'OUTGOING')" ) );
 
         assertExpectedResult( 50, algoQuery( "CALL apoc.algo.betweenness(['TYPE'],nodes,'INCOMING')" ) );
@@ -161,6 +239,7 @@ public class CentralityTest
     @Test
     public void shouldReturnExpectedResultCountWhenUsingClosenessOutgoingAllDirections()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 50, algoQuery( "CALL apoc.algo.closeness(['TYPE'],nodes,'OUTGOING')" ) );
 
         assertExpectedResult( 50, algoQuery( "CALL apoc.algo.closeness(['TYPE'],nodes,'INCOMING')" ) );
@@ -173,12 +252,14 @@ public class CentralityTest
     @Test( expected = RuntimeException.class )
     public void shouldHandleInvalidDirectionWhenUsingBetweenness()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 0, algoQuery( "CALL apoc.algo.betweenness(null,nodes,'INVAlid')" ) );
     }
 
     @Test( expected = RuntimeException.class )
     public void shouldHandleInvalidDirectionWhenUsingCentrality()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 0, algoQuery( "CALL apoc.algo.closeness(null,nodes,' ')" ) );
     }
 
@@ -187,6 +268,7 @@ public class CentralityTest
     @Test
     public void shouldBeCaseInsensitiveForDirectionBetweenness()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 50, algoQuery( "CALL apoc.algo.betweenness(['TYPE'],nodes,'InCominG')" ) );
 
         assertExpectedResult( 50, algoQuery( "CALL apoc.algo.betweenness(['TYPE'],nodes,'ouTGoiNg')" ) );
@@ -195,12 +277,43 @@ public class CentralityTest
     @Test
     public void shouldBeCaseInsensitiveForDirectionCloseness()
     {
+        db.execute( RANDOM_GRAPH ).close();
         assertExpectedResult( 50, algoQuery( "CALL apoc.algo.closeness(['TYPE'],nodes,'InCominG')" ) );
 
         assertExpectedResult( 50, algoQuery( "CALL apoc.algo.closeness(['TYPE'],nodes,'ouTGoiNg')" ) );
     }
 
     // ==========================================================================================
+
+
+    @Test
+    public void shouldHaveExpectedBetweennessResultsForCypher()
+    {
+        db.execute( STAR_GRAPH ).close();
+        Result result = db.execute("CALL apoc.algo.betweennessCypher({write:true})");
+        System.out.println(result.resultAsString());
+        Result t =  db.execute("MATCH (n) RETURN n.name as name, n.betweenness_centrality as score ORDER BY score DESC LIMIT 1");
+        assertTrue( t.hasNext() );
+        assertEquals( CentralityTest.STAR_GRAPH_EXPECTED,
+                (double)t.next().get("score"), 0.1D );
+        assertFalse(t.hasNext() );
+        t.close();
+    }
+
+    @Test
+    public void shouldHaveExpectedBetweennessMultipleSPCypher()
+    {
+        db.execute( MULTIPLE_SHORTEST_PATH ).close();
+        Result result = db.execute("CALL apoc.algo.betweennessCypher({write:true})");
+        System.out.println(result.resultAsString());
+        Result t =  db.execute("MATCH (n) RETURN n.name as name, n.betweenness_centrality as score ORDER BY score DESC LIMIT 1");
+        assertTrue(t.hasNext());
+        assertEquals( CentralityTest.MULTIPLE_SHORTEST_PATH_EXPECTED,
+                (double)t.next().get("score"), 0.1D );
+        assertFalse(t.hasNext() );
+        t.close();
+    }
+
 
     public String algoQuery( String algo )
     {


### PR DESCRIPTION
This pull requests add unweighted betweenness centrality.

Similar to  pagerank, we take nodeCypher and relCypher and store them in local Ds.
Using the stored locations, we calculate the betweenness centrality in parallel. Computation and memory perf are good as compared to iGraph. Example, for a graph that took ~one day in igraph,we were able to do that in approximately 75 minutes.

I've used double array for precision to store the results.
I think memory can be improved some more.