### PR TITLE
Additional option parameters for apoc.index.addAllNodes

### DIFF
--- a/src/main/java/apoc/index/FreeTextSearch.java
+++ b/src/main/java/apoc/index/FreeTextSearch.java
@@ -52,11 +52,12 @@ public class FreeTextSearch {
      *
      * @param index     The name of the index to create.
      * @param structure The labels of nodes to index, and the properties to index for each label.
+     * @param options   A list of options, e.g. "to_lower_case: false" or "analyzer: own.analyzer.Implementation"
      * @return a stream containing a single element that describes the created index.
      */
     @Procedure
     @PerformsWrites
-    @Description("apoc.index.addAllNodes('name',{label1:['prop1',...],...}) YIELD type, name, config - create a free text search index")
+    @Description("apoc.index.addAllNodes('name',{label1:['prop1',...],...}, {config}) YIELD type, name, config - create a free text search index")
     public Stream<IndexStats> addAllNodes(@Name("index") String index, @Name("structure") Map<String, List<String>> structure, @Name("options") Map<String,Object> options ) {
         if (structure.isEmpty()) {
             throw new IllegalArgumentException("No structure given.");

--- a/src/main/java/apoc/index/FreeTextSearch.java
+++ b/src/main/java/apoc/index/FreeTextSearch.java
@@ -57,7 +57,7 @@ public class FreeTextSearch {
     @Procedure
     @PerformsWrites
     @Description("apoc.index.addAllNodes('name',{label1:['prop1',...],...}) YIELD type, name, config - create a free text search index")
-    public Stream<IndexStats> addAllNodes(@Name("index") String index, @Name("structure") Map<String, List<String>> structure, @Name("options") Map<String,String> options ) {
+    public Stream<IndexStats> addAllNodes(@Name("index") String index, @Name("structure") Map<String, List<String>> structure, @Name("options") Map<String,Object> options ) {
         if (structure.isEmpty()) {
             throw new IllegalArgumentException("No structure given.");
         }
@@ -163,7 +163,7 @@ public class FreeTextSearch {
         return structure;
     }
 
-    private Index<Node> index(String index, Map<String, List<String>> structure, Map<String,String> options ) {
+    private Index<Node> index(String index, Map<String, List<String>> structure, Map<String,Object> options ) {
         Map<String, String> config = new HashMap<>(CONFIG);
         try (Transaction tx = db.beginTx()) {
             if (db.index().existsForNodes(index)) {
@@ -177,12 +177,15 @@ public class FreeTextSearch {
         try (Transaction tx = db.beginTx()) {
             updateConfigFromParameters(config, structure);
             for( String key : options.keySet() ) {
-                config.put( key, options.get( key ) );
+                config.put( key, "" + options.get( key ) );
             }
             log.info("Creating or updating index '%s' with config '%s'", index, config );
             Index<Node> nodeIndex = db.index().forNodes(index, config);
             tx.success();
             return nodeIndex;
+        } catch( Exception e ) {
+            log.error(e.toString());
+            return null;
         }
     }
 

--- a/src/main/java/apoc/index/FreeTextSearch.java
+++ b/src/main/java/apoc/index/FreeTextSearch.java
@@ -57,12 +57,12 @@ public class FreeTextSearch {
     @Procedure
     @PerformsWrites
     @Description("apoc.index.addAllNodes('name',{label1:['prop1',...],...}) YIELD type, name, config - create a free text search index")
-    public Stream<IndexStats> addAllNodes(@Name("index") String index, @Name("structure") Map<String, List<String>> structure) {
+    public Stream<IndexStats> addAllNodes(@Name("index") String index, @Name("structure") Map<String, List<String>> structure, @Name("options") Map<String,String> options ) {
         if (structure.isEmpty()) {
             throw new IllegalArgumentException("No structure given.");
         }
         return async(executor(), "Creating index '" + index + "'", result -> {
-            populate(index(index, structure), structure, result);
+            populate(index(index, structure, options ), structure, result);
         });
     }
 
@@ -163,7 +163,7 @@ public class FreeTextSearch {
         return structure;
     }
 
-    private Index<Node> index(String index, Map<String, List<String>> structure) {
+    private Index<Node> index(String index, Map<String, List<String>> structure, Map<String,String> options ) {
         Map<String, String> config = new HashMap<>(CONFIG);
         try (Transaction tx = db.beginTx()) {
             if (db.index().existsForNodes(index)) {
@@ -176,6 +176,10 @@ public class FreeTextSearch {
         }
         try (Transaction tx = db.beginTx()) {
             updateConfigFromParameters(config, structure);
+            for( String key : options.keySet() ) {
+                config.put( key, options.get( key ) );
+            }
+            log.info("Creating or updating index '%s' with config '%s'", index, config );
             Index<Node> nodeIndex = db.index().forNodes(index, config);
             tx.success();
             return nodeIndex;

--- a/src/main/java/apoc/index/FreeTextSearch.java
+++ b/src/main/java/apoc/index/FreeTextSearch.java
@@ -57,7 +57,6 @@ public class FreeTextSearch {
     @Procedure
     @PerformsWrites
     @Description("apoc.index.addAllNodes('name',{label1:['prop1',...],...}) YIELD type, name, config - create a free text search index")
-    @Deprecated
     public Stream<IndexStats> addAllNodes(@Name("index") String index, @Name("structure") Map<String, List<String>> structure ) {
         return addAllNodesExtended( index, structure, new HashMap<String,Object>(0) );
     }
@@ -72,11 +71,14 @@ public class FreeTextSearch {
      * @param structure The labels of nodes to index, and the properties to index for each label.
      * @param options   Additional options which can be evaluated by the index provider.
      * @return a stream containing a single element that describes the created index.
+     *
+     * @deprecated Will not be needed as of Neo4j 3.1.
      */
 
     @Procedure
     @PerformsWrites
     @Description("apoc.index.addAllNodes('name',{label1:['prop1',...],...}, {options}) YIELD type, name, config - create a free text search index with special options")
+    @Deprecated
     public Stream<IndexStats> addAllNodesExtended(@Name("index") String index, @Name("structure") Map<String, List<String>> structure, @Name("options") Map<String,Object> options ) {
         if (structure.isEmpty()) {
             throw new IllegalArgumentException("No structure given.");
@@ -183,13 +185,13 @@ public class FreeTextSearch {
         return structure;
     }
 
-    private Index<Node> index(String index, Map<String, List<String>> structure, Map<String,Object> options ) {
+    private Index<Node> index(String index, Map<String, List<String>> structure, final Map<String,Object> options ) {
         Map<String, String> config = new HashMap<>(CONFIG);
         try (Transaction tx = db.beginTx()) {
             if (db.index().existsForNodes(index)) {
                 Index<Node> old = db.index().forNodes(index);
-                config = new HashMap<>(db.index().getConfiguration(old));
-                log.info("Dropping existing index '%s', with config: %s", index, config);
+                Map<String,String> oldConfig = new HashMap<>(db.index().getConfiguration(old));
+                log.info("Dropping existing index '%s', with config: %s", index, oldConfig);
                 old.delete();
             }
             tx.success();
@@ -198,16 +200,14 @@ public class FreeTextSearch {
             updateConfigFromParameters(config, structure);
 
             /* add options to the parameters */
-            for( String key : options.keySet() ) {
-                config.put( key, "" + options.get( key ) ); // explicit conversion to String
-            }
+            options.forEach((k,v) -> {
+                config.put(k, String.valueOf(v)); // explicit conversion to String
+                }
+            );
             log.info("Creating or updating index '%s' with config '%s'", index, config );
             Index<Node> nodeIndex = db.index().forNodes(index, config);
             tx.success();
             return nodeIndex;
-        } catch( Exception e ) {
-            log.error(e.toString());
-            return null;
         }
     }
 

--- a/src/main/java/apoc/index/FreeTextSearch.java
+++ b/src/main/java/apoc/index/FreeTextSearch.java
@@ -58,7 +58,7 @@ public class FreeTextSearch {
     @PerformsWrites
     @Description("apoc.index.addAllNodes('name',{label1:['prop1',...],...}) YIELD type, name, config - create a free text search index")
     public Stream<IndexStats> addAllNodes(@Name("index") String index, @Name("structure") Map<String, List<String>> structure ) {
-        return addAllNodesExtended( index, structure, new HashMap<String,Object>(0) );
+        return addAllNodesExtended( index, structure, Collections.emptyMap() );
     }
 
     /**

--- a/src/main/java/apoc/index/FreeTextSearch.java
+++ b/src/main/java/apoc/index/FreeTextSearch.java
@@ -57,7 +57,7 @@ public class FreeTextSearch {
      */
     @Procedure
     @PerformsWrites
-    @Description("apoc.index.addAllNodes('name',{label1:['prop1',...],...}, {config}) YIELD type, name, config - create a free text search index")
+    @Description("apoc.index.addAllNodes('name',{label1:['prop1',...],...}, {options}) YIELD type, name, config - create a free text search index")
     public Stream<IndexStats> addAllNodes(@Name("index") String index, @Name("structure") Map<String, List<String>> structure, @Name("options") Map<String,Object> options ) {
         if (structure.isEmpty()) {
             throw new IllegalArgumentException("No structure given.");

--- a/src/main/java/apoc/index/analyzer/DynamicChainAnalyzer.java
+++ b/src/main/java/apoc/index/analyzer/DynamicChainAnalyzer.java
@@ -1,0 +1,23 @@
+package apoc.index.analyzer;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.core.LowerCaseFilter;
+import org.apache.lucene.analysis.core.WhitespaceTokenizer;
+
+public class DynamicChainAnalyzer extends Analyzer {
+
+    public DynamicChainAnalyzer() {
+        // default,
+        // TODO: need to obtain information about the GraphDB and IndexManager
+    }
+
+    @Override
+    protected Analyzer.TokenStreamComponents createComponents(final String fieldName) {
+        Tokenizer source = new WhitespaceTokenizer();
+        TokenStream filter = new LowerCaseFilter( source );
+        return new TokenStreamComponents( source, filter );
+    }
+
+}

--- a/src/test/java/apoc/index/FreeTextSearchTest.java
+++ b/src/test/java/apoc/index/FreeTextSearchTest.java
@@ -18,7 +18,6 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import java.util.*;
 
 import static apoc.index.FreeTextSearch.KEY;
-import static com.sun.tools.doclets.formats.html.markup.HtmlStyle.bar;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.CoreMatchers.*;

--- a/src/test/java/apoc/index/FreeTextSearchTest.java
+++ b/src/test/java/apoc/index/FreeTextSearchTest.java
@@ -1,5 +1,6 @@
 package apoc.index;
 
+import apoc.index.analyzer.DynamicChainAnalyzer;
 import apoc.util.TestUtil;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.Query;
@@ -307,7 +308,7 @@ public class FreeTextSearchTest {
             assertEquals( config.get("provider"), "lucene" );
             assertEquals( config.get("keysForLabel:Hacker"), "name" );
             assertEquals( config.get("labels"), "Hacker" );
-            assertEquals( config.get("analyzer"), "apoc.index.analyzer.DynamicQueueAnalyzer" );
+            assertEquals( config.get("analyzer"), DynamicChainAnalyzer.class.getName() );
         });
     }
 

--- a/src/test/java/apoc/index/FreeTextSearchTest.java
+++ b/src/test/java/apoc/index/FreeTextSearchTest.java
@@ -50,7 +50,7 @@ public class FreeTextSearchTest {
         execute("CREATE (:Person{name:'George Goldman', nick:'GeeGee'}), (:Person{name:'Cyrus Jones', age:103})");
 
         // when
-        execute("CALL apoc.index.addAllNodes('people', {Person:['name','nick']})");
+        execute("CALL apoc.index.addAllNodes('people', {Person:['name','nick']},{})");
 
         // then
         assertSingleNode("people", termQuery("GeeGee"), hasProperty("name", "George Goldman"));
@@ -64,7 +64,7 @@ public class FreeTextSearchTest {
     public void shouldRefuseToCreateIndexWithNoStructure() throws Exception {
         // when
         try {
-            execute("CALL apoc.index.addAllNodes('empty', {})");
+            execute("CALL apoc.index.addAllNodes('empty', {}, {})");
 
             fail("expected exception");
         }
@@ -86,7 +86,7 @@ public class FreeTextSearchTest {
         execute("CREATE (:Person{name:'Long John Silver', nick:'Cook'}), (:City{name:'London'})");
 
         // when
-        execute("CALL apoc.index.addAllNodes('stuff', {Person:['name','nick'], City:['name']})");
+        execute("CALL apoc.index.addAllNodes('stuff', {Person:['name','nick'], City:['name']},{})");
 
         // then
         assertSingleNode("stuff", termQuery("Long"), hasProperty("name", "Long John Silver"), hasLabel("Person"));
@@ -99,8 +99,8 @@ public class FreeTextSearchTest {
     public void shouldHandleRepeatedCalls() throws Exception {
         // given
         execute("CREATE (:Person{name:'George Goldman', nick:'GeeGee'}), (:Person{name:'Cyrus Jones', age:103})");
-        execute("CALL apoc.index.addAllNodes('people', {Person:['name','nick']})");
-        execute("CALL apoc.index.addAllNodes('people', {Person:['name','nick']})");
+        execute("CALL apoc.index.addAllNodes('people', {Person:['name','nick']},{})");
+        execute("CALL apoc.index.addAllNodes('people', {Person:['name','nick']},{})");
 
         // then
         assertSingle(search("people", "GeeGee"), hasProperty("name", "George Goldman"));
@@ -110,7 +110,7 @@ public class FreeTextSearchTest {
     public void shouldQueryFreeTextIndex() throws Exception {
         // given
         execute("CREATE (:Person{name:'George Goldman', nick:'GeeGee'}), (:Person{name:'Cyrus Jones', age:103})");
-        execute("CALL apoc.index.addAllNodes('people', {Person:['name','nick']})");
+        execute("CALL apoc.index.addAllNodes('people', {Person:['name','nick']},{})");
 
         // then
         assertSingle(search("people", "GeeGee"), hasProperty("name", "George Goldman"));
@@ -124,7 +124,7 @@ public class FreeTextSearchTest {
     public void shouldEnableSearchingBySpecificField() throws Exception {
         // given
         execute("CREATE (:Person{name:'Johnny'}), (:Product{name:'Johnny'})");
-        execute("CALL apoc.index.addAllNodes('stuff', {Person:['name'],Product:['name']})");
+        execute("CALL apoc.index.addAllNodes('stuff', {Person:['name'],Product:['name']},{})");
 
         // then
         assertSingle(search("stuff", "Person.name:Johnny"), hasLabel("Person"), not(hasLabel("Product")));
@@ -135,7 +135,7 @@ public class FreeTextSearchTest {
     public void shouldIndexNodesWithMultipleLabels() throws Exception {
         // given
         execute("CREATE (:Foo:Bar:Baz{name:'thing'})");
-        execute("CALL apoc.index.addAllNodes('stuff', {Foo:['name'], Baz:['name'], Axe:['name']})");
+        execute("CALL apoc.index.addAllNodes('stuff', {Foo:['name'], Baz:['name'], Axe:['name']},{})");
 
         // then
         assertSingle(search("stuff", "Foo.name:thing"));
@@ -151,7 +151,7 @@ public class FreeTextSearchTest {
         // given
         // create 90k nodes - this force 2 batches during indexing
         execute("UNWIND range(1,90000) as x CREATE (:Person{name:'person'+x})");
-        execute("CALL apoc.index.addAllNodes('people', {Person:['name']})");
+        execute("CALL apoc.index.addAllNodes('people', {Person:['name']},{})");
 
         // then
         assertSingle(search("people", "person89999"), hasProperty("name", "person89999"));
@@ -162,7 +162,7 @@ public class FreeTextSearchTest {
         // given
         db.execute("UNWIND {things} AS thing CREATE (:Thing{name:thing})", singletonMap("things",
                 asList("food", "feed", "foot", "fork", "foo", "bar", "ford"))).close();
-        execute("CALL apoc.index.addAllNodes('things',{Thing:['name']})");
+        execute("CALL apoc.index.addAllNodes('things',{Thing:['name']},{})");
 
         // when
         ResourceIterator<String> things = db.execute(
@@ -178,7 +178,7 @@ public class FreeTextSearchTest {
     public void shouldSearchInNumericRange() throws Exception {
         // given
         execute("UNWIND range(1, 10000) AS num CREATE (:Number{name:'The ' + num + 'th',number:num})");
-        execute("CALL apoc.index.addAllNodes('numbers', {Number:['name','number']})");
+        execute("CALL apoc.index.addAllNodes('numbers', {Number:['name','number']},{})");
 
         // when
         ResourceIterator<Object> names = db.execute(
@@ -193,7 +193,7 @@ public class FreeTextSearchTest {
     public void shouldLimitNumberOfResults() throws Exception {
         // given
         execute("UNWIND range(1, 10000) AS num CREATE (:Number{name:'The ' + num + 'th',number:num})");
-        execute("CALL apoc.index.addAllNodes('numbers', {Number:['name','number']})");
+        execute("CALL apoc.index.addAllNodes('numbers', {Number:['name','number']},{})");
 
         // when
         Result result = db.execute("CALL apoc.index.search('numbers', 'The')");
@@ -210,7 +210,7 @@ public class FreeTextSearchTest {
         String fred = "Fred Finished";
         Map params = singletonMap("names", Iterators.array(john, jim, fred));
         execute("UNWIND {names} as name CREATE (:Hacker{name:name})", params);
-        execute("CALL apoc.index.addAllNodes('hackerz', {Hacker:['name']})");
+        execute("CALL apoc.index.addAllNodes('hackerz', {Hacker:['name']},{})");
 
         // expect
         TestUtil.testResult(db, "CALL apoc.index.search('hackerz', 'D*') yield node, weight " +


### PR DESCRIPTION
e.g.

`CALL apoc.index.addAllNodes('name',{ Supplier: ["companyName", "description","address"], Product:  ["productName","address"] }, {to_lower_case: false, analyzer: "org.apache.lucene.analysis.core.WhitespaceAnalyzer", autoUpdate: true, queue: "asciifolding" } )`

Next steps: Add to trigger if autoUpdate is true, @sarmbruster had some ideas about this queue stuff.
