### PR TITLE
make XmlGraphMLWriter.newLine system agnostic

### DIFF
--- a/src/main/java/apoc/export/graphml/XmlGraphMLWriter.java
+++ b/src/main/java/apoc/export/graphml/XmlGraphMLWriter.java
@@ -176,6 +176,6 @@ public class XmlGraphMLWriter {
     }
 
     private void newLine(XMLStreamWriter writer) throws XMLStreamException {
-        writer.writeCharacters("\n");
+        writer.writeCharacters(System.getProperty("line.separator"));
     }
 }


### PR DESCRIPTION
This resolves 3 of the 4 failing tests in the suite when trying to build on a windows machine. ref: #171 