### PR TITLE
Updated apoc.periodic.iterate example.

### DIFF
--- a/docs/periodic.adoc
+++ b/docs/periodic.adoc
@@ -25,7 +25,7 @@ So if you were to add an `:Actor` label to several million `:Person` nodes, you 
 ----
 CALL apoc.periodic.iterate(
 "MATCH (p:Person) WHERE (p)-[:ACTED_IN]->() RETURN p",
-"SET p:Actor", {batchSize:10000, parallel:true})
+"WITH {p} as p SET p:Actor", {batchSize:10000, parallel:true})
 ----
 
 Which would take 10k people from the stream and update them in a single transaction, executing the *second* statement for each person.
@@ -38,7 +38,7 @@ If you do more complex operations like updating or removing relationships, eithe
 ----
 CALL apoc.periodic.iterate(
 "MATCH (o:Order) WHERE o.date > '2016-10-13' RETURN o",
-"MATCH (o)-[:HAS_ITEM]->(i) WITH o, sum(i.value) as value SET o.value = value", {batchSize:100, parallel:true})
+"with {o} as o MATCH (o)-[:HAS_ITEM]->(i) WITH o, sum(i.value) as value SET o.value = value", {batchSize:100, parallel:true})
 ----
 
 The stream of other data can also come from another source, like a different database, CSV or JSON file.


### PR DESCRIPTION
Updated apoc.periodic.iterate example. Fixed the example as there was a small bug in it. 
In the second statement need to treat `p` as a parameter so had to add the following. 
`with {p} as p ...`. 
Same thing for the other example as well.  
I have tested this and it works.