### PR TITLE
Add `apoc.script.engines` and `apoc.script.eval`.

### DIFF
--- a/src/main/java/apoc/script/EnginesResult.java
+++ b/src/main/java/apoc/script/EnginesResult.java
@@ -1,0 +1,70 @@
+package apoc.script;
+
+import javax.script.ScriptEngineFactory;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * @author Victor Borja vborja@apache.org
+ * @since 12.06.16
+ */
+public class EnginesResult {
+
+    public final String name;
+    public final String version;
+    public final String languageName;
+    public final String languageVersion;
+    public final String names;
+
+    public EnginesResult(ScriptEngineFactory factory) {
+        this.name = factory.getEngineName();
+        this.version = factory.getEngineVersion();
+        this.languageName = factory.getLanguageName();
+        this.languageVersion = factory.getLanguageVersion();
+        this.names = factory.getNames().stream().collect(Collectors.joining(","));
+    }
+
+    public EnginesResult(Map<String, Object> row) {
+        this.name = (String) row.get("name");
+        this.version = (String) row.get("version");
+        this.languageName = (String) row.get("languageName");
+        this.languageVersion = (String) row.get("languageVersion");
+        this.names = (String) row.get("names");
+    }
+
+    @Override
+    public String toString() {
+        return "EnginesResult{" +
+                "name='" + name + '\'' +
+                ", version='" + version + '\'' +
+                ", languageName='" + languageName + '\'' +
+                ", languageVersion='" + languageVersion + '\'' +
+                ", names='" + names + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        EnginesResult that = (EnginesResult) o;
+
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (version != null ? !version.equals(that.version) : that.version != null) return false;
+        if (languageName != null ? !languageName.equals(that.languageName) : that.languageName != null) return false;
+        if (languageVersion != null ? !languageVersion.equals(that.languageVersion) : that.languageVersion != null)
+            return false;
+        return names != null ? names.equals(that.names) : that.names == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (version != null ? version.hashCode() : 0);
+        result = 31 * result + (languageName != null ? languageName.hashCode() : 0);
+        result = 31 * result + (languageVersion != null ? languageVersion.hashCode() : 0);
+        result = 31 * result + (names != null ? names.hashCode() : 0);
+        return result;
+    }
+}

--- a/src/main/java/apoc/script/Script.java
+++ b/src/main/java/apoc/script/Script.java
@@ -1,0 +1,68 @@
+package apoc.script;
+
+import apoc.Description;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.UserFunction;
+
+import javax.naming.Binding;
+import javax.script.Bindings;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * @author Victor Borja vborja@apache.org
+ * @since 12.06.16
+ */
+public class Script {
+
+    final static ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
+
+    @Procedure
+    @Description("apoc.script.engines() YIELD name, version, languageName, languageVersion, names - List available scripting engines.")
+    public Stream<EnginesResult> engines() {
+        return scriptEngineManager.getEngineFactories()
+                .stream()
+                .map(EnginesResult::new);
+    }
+
+    @UserFunction
+    @Description("apoc.script.eval(engineName, code, params) -- Evaluate a script on an engine")
+    public Object eval(@Name("engineName") String engineName, @Name("code") String code, @Name("params") Map<String, Object> params) throws ScriptException {
+        ScriptEngine engine = getEngine(engineName);
+        Bindings bindings = createBindings(engine, params);
+        return engine.eval(code, bindings);
+    }
+
+    @UserFunction
+    @Description("apoc.script.evalToBindings(engineName, code, params, bindings) -- Evaluate a script on an engine")
+    public Map<String, Object> evalToBindings(@Name("engineName") String engineName, @Name("code") String code, @Name("params") Map<String, Object> params, @Name("bindings") List<String> resultNames) throws ScriptException {
+        ScriptEngine engine = getEngine(engineName);
+        Bindings bindings = createBindings(engine, params);
+        engine.eval(code, bindings);
+        Map<String, Object> result = new HashMap();
+        for (String resultName : resultNames) {
+            result.put(resultName, bindings.get(resultName));
+        }
+        return result;
+    }
+
+    private ScriptEngine getEngine(String engineName) {
+        ScriptEngine engine = scriptEngineManager.getEngineByName(engineName);
+        if (engine == null) {
+            throw new RuntimeException("No script engine with name "+engineName+" available");
+        }
+        return engine;
+    }
+
+    private Bindings createBindings(ScriptEngine engine, Map<String, Object> params) {
+        Bindings bindings = engine.createBindings();
+        bindings.putAll(params);
+        return bindings;
+    }
+
+}

--- a/src/test/java/apoc/script/ScriptTest.java
+++ b/src/test/java/apoc/script/ScriptTest.java
@@ -1,0 +1,110 @@
+package apoc.script;
+
+import apoc.util.TestUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Result;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import javax.script.ScriptEngineManager;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testResult;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+
+/**
+ * @author Victor Borja vborja@apache.org
+ * @since 12.06.16
+ */
+public class ScriptTest {
+
+    private static GraphDatabaseService db;
+
+    // Test with Oracle nashorn available on JVM 8
+    private static final String NASHORN = "nashorn";
+
+    @Rule
+    public ExpectedException thrown= ExpectedException.none();
+
+
+    @BeforeClass
+    public static void setUp() throws Exception
+    {
+        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        TestUtil.registerProcedure( db, Script.class );
+    }
+
+    @AfterClass
+    public static void tearDown()
+    {
+        db.shutdown();
+    }
+
+
+    @Test
+    public void testOracleVMHasNashornAvailable() throws Exception {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        if (null == sem.getEngineByName(NASHORN)) {
+            return; /* Skip test, not on Oracle JVM */
+        }
+        String fullName = sem.getEngineByName(NASHORN).getFactory().getEngineName();
+        testCall(db, "CALL apoc.script.engines()", map(),
+                (Map<String, Object> map) -> assertEquals(fullName, map.get("name")));
+    }
+
+    @Test
+    public void testDefaultEngines() throws Exception {
+        testResult(db,
+                "CALL apoc.script.engines()",
+                map(),
+                this::assertDefaultEngines);
+    }
+
+    private void assertDefaultEngines(Result enginesResult) {
+        assertArrayEquals(new String[]{"name", "version", "languageName", "languageVersion", "names"}, enginesResult.columns().toArray());
+        ScriptEngineManager sem = new ScriptEngineManager();
+        Stream<EnginesResult> expected = sem.getEngineFactories().stream().map(EnginesResult::new);
+        Stream<EnginesResult> actual = enginesResult.stream().map(EnginesResult::new);
+        assertArrayEquals("should list current vm loaded scripting engines", expected.toArray(), actual.toArray());
+    }
+
+    @Test
+    public void testEvalJsWithParamsReturningFloat() {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        if (null == sem.getEngineByName(NASHORN)) {
+            return; /* Skip test, not on Oracle JVM */
+        }
+
+        testCall(db,
+                "RETURN apoc.script.eval({engine}, {code}, {params}) AS answer",
+                map("engine", NASHORN, "code", "21 * two", "params", map("two", 2)),
+                row -> assertEquals(42.0, row.get("answer")));
+    }
+
+    @Test
+    public void testEvalJsToBindings() {
+        ScriptEngineManager sem = new ScriptEngineManager();
+        if (null == sem.getEngineByName(NASHORN)) {
+            return; /* Skip test, not on Oracle JVM */
+        }
+
+        testCall(db,
+                "RETURN apoc.script.evalToBindings({engine}, {code}, {params}, ['x']) AS bindings",
+                map("engine", NASHORN, "code", "var x = 10 * two", "params", map("two", 2)),
+                row -> {
+                    Map<String, Object> bindings = (Map<String, Object>) row.get("bindings");
+                    assertEquals(20.0, bindings.get("x"));
+                });
+    }
+
+
+}


### PR DESCRIPTION
This branch implements a couple of user-functions to let you
call any JSR 223 (javax.script) language from within cypher.

By default Oracle's JDK includes the Nashorn Javascript engine,
so if you are running neo4j with it, you can at least eval
some javascript code.

You can also drop other languages jars into the plugin/
directory (be sure they have or you provide a JSR-223 factory)

`apoc.script` can be useful for calling one-shot java utilities
without having to create full server plugins for them.

Currently there is no way to load scripts from fileystem, and
perhaps never will, as the idea is that scripts should be just
simple one-liners.

This branch is based on the `3.1` branch.

Closes #202