### PR TITLE
Fixed wrong documentation for `apoc.index.addNodeByLabel`

### DIFF
--- a/docs/guide.html
+++ b/docs/guide.html
@@ -334,7 +334,7 @@ Please note that there are (case-sensitive) <a href="http://neo4j.com/docs/devel
 <td class="tableblock halign-left valign-top"><p class="tableblock">add node to an index for each label it has</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.index.addNodeByLabel(node,'Label',['prop1',&#8230;&#8203;])</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.index.addNodeByLabel('Label',node,['prop1',&#8230;&#8203;])</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">add node to an index for the given label</p></td>
 </tr>
 <tr>
@@ -2377,7 +2377,7 @@ Please note that there are (case-sensitive) <a href="http://neo4j.com/docs/devel
 <td class="tableblock halign-left valign-top"><p class="tableblock">add node to an index for each label it has</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.index.addNodeByLabel(node,'Label',['prop1',&#8230;&#8203;])</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.index.addNodeByLabel('Label',node,['prop1',&#8230;&#8203;])</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">add node to an index for the given label</p></td>
 </tr>
 <tr>

--- a/docs/index.html
+++ b/docs/index.html
@@ -953,7 +953,7 @@ Please note that there are (case-sensitive) <a href="http://neo4j.com/docs/devel
 <td class="tableblock halign-left valign-top"><p class="tableblock">add node to an index for each label it has</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.index.addNodeByLabel(node,'Label',['prop1',&#8230;&#8203;])</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.index.addNodeByLabel('Label',node,['prop1',&#8230;&#8203;])</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">add node to an index for the given label</p></td>
 </tr>
 <tr>
@@ -2899,7 +2899,7 @@ Please note that there are (case-sensitive) <a href="http://neo4j.com/docs/devel
 <td class="tableblock halign-left valign-top"><p class="tableblock">add node to an index for each label it has</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.index.addNodeByLabel(node,'Label',['prop1',&#8230;&#8203;])</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.index.addNodeByLabel('Label',node,['prop1',&#8230;&#8203;])</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">add node to an index for the given label</p></td>
 </tr>
 <tr>
@@ -5709,7 +5709,7 @@ RETURN count(*)
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2016-11-08 22:45:40 +01:00
+Last updated 2016-11-30 15:06:18 +09:00
 </div>
 </div>
 </body>

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -77,7 +77,7 @@ NOTE: Please note that there are (case-sensitive) http://neo4j.com/docs/develope
 |===
 | apoc.index.addAllNodes('index-name',{label1:['prop1',...],...}) | add all nodes to this full text index with the given fields, additionally populates a 'search' index field with all of them in one place
 | apoc.index.addNode(node,['prop1',...]) | add node to an index for each label it has
-| apoc.index.addNodeByLabel(node,'Label',['prop1',...]) | add node to an index for the given label
+| apoc.index.addNodeByLabel('Label',node,['prop1',...]) | add node to an index for the given label
 | apoc.index.addRelationship(rel,['prop1',...]) | add relationship to an index for its type
 |===
 

--- a/src/main/java/apoc/index/FulltextIndex.java
+++ b/src/main/java/apoc/index/FulltextIndex.java
@@ -190,10 +190,10 @@ public class FulltextIndex {
         }
     }
 
-    // CALL apoc.index.addNode(joe, 'Person', ['name','age','city'])
+    // CALL apoc.index.addNodeByLabel('Person', joe, ['name','age','city'])
     @Procedure
     @PerformsWrites
-    @Description("apoc.index.addNodeByLabel(node,'Label',['prop1',...]) add node to an index for the given label")
+    @Description("apoc.index.addNodeByLabel('Label',node,['prop1',...]) add node to an index for the given label")
     public void addNodeByLabel(@Name("label") String label, @Name("node") Node node, @Name("properties") List<String> propKeys) {
         indexContainer(node, propKeys, getNodeIndex(label,FULL_TEXT));
     }


### PR DESCRIPTION
The signature of `apoc.index.addNodeByLabel` should be `apoc.index.addNodeByLabel('Label',node,['prop1',…​])`.
