### PR TITLE
Added apoc.path procedures: subgraphNodes(), subgraphAll(), spanningTree()

### DIFF
--- a/src/main/java/apoc/algo/Cover.java
+++ b/src/main/java/apoc/algo/Cover.java
@@ -1,33 +1,21 @@
 package apoc.algo;
 
 import apoc.Description;
-import apoc.get.Get;
-import apoc.path.PathExplorer;
-import apoc.path.RelationshipTypeAndDirections;
-import apoc.result.PathResult;
 import apoc.result.RelationshipResult;
-import apoc.result.WeightedPathResult;
 import apoc.util.Util;
-import org.neo4j.graphalgo.CommonEvaluators;
-import org.neo4j.graphalgo.GraphAlgoFactory;
-import org.neo4j.graphalgo.PathFinder;
-import org.neo4j.graphalgo.WeightedPath;
-import org.neo4j.graphdb.*;
-import org.neo4j.graphdb.traversal.BranchState;
-import org.neo4j.helpers.collection.Pair;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
-import static org.neo4j.graphdb.traversal.Evaluators.atDepth;
 
 public class Cover {
 
@@ -45,5 +33,14 @@ public class Cover {
                                 .spliterator(),false)
                                 .filter(r -> nodeSet.contains(r.getEndNode()))
                                 .map(RelationshipResult::new)));
+    }
+
+    // non-parallelized utility method for use by other procedures
+    public Stream<Relationship> coverNodes(Collection<Node> nodes) {
+        return nodes.stream()
+                .flatMap(n ->
+                        StreamSupport.stream(n.getRelationships(Direction.OUTGOING)
+                                .spliterator(),false)
+                                .filter(r -> nodes.contains(r.getEndNode())));
     }
 }

--- a/src/main/java/apoc/path/PathExplorer.java
+++ b/src/main/java/apoc/path/PathExplorer.java
@@ -1,6 +1,7 @@
 package apoc.path;
 
 import apoc.Description;
+import apoc.result.NodeResult;
 import apoc.result.PathResult;
 import apoc.util.Util;
 import org.neo4j.graphdb.*;
@@ -43,17 +44,27 @@ public class PathExplorer {
 	@Description("apoc.path.expandConfig(startNode <id>|Node|list, {minLevel,maxLevel,uniqueness,relationshipFilter,labelFilter,uniqueness:'RELATIONSHIP_PATH',bfs:true}) yield path expand from start node following the given relationships from min to max-level adhering to the label filters")
 	public Stream<PathResult> expandConfig(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
 		List<Node> nodes = startToNodes(start);
-
+	
 		String uniqueness = (String) config.getOrDefault("uniqueness", UNIQUENESS.name());
 		String relationshipFilter = (String) config.getOrDefault("relationshipFilter", null);
 		String labelFilter = (String) config.getOrDefault("labelFilter", null);
 		long minLevel = Util.toLong(config.getOrDefault("minLevel", "-1"));
 		long maxLevel = Util.toLong(config.getOrDefault("maxLevel", "-1"));
 		boolean bfs = Util.toBoolean(config.getOrDefault("bfs",true));
-
+		
 		return explorePathPrivate(nodes, relationshipFilter, labelFilter, minLevel, maxLevel, bfs, getUniqueness(uniqueness));
 	}
-
+	
+	@Procedure("apoc.path.subgraphNodes")
+	@Description("apoc.path.subgraphNodes(startNode <id>|Node|list, {maxLevel,relationshipFilter,labelFilter,bfs:true}) yield path expand the subgraph nodes reachable from start node following relationships to max-level adhering to the label filters")
+	public Stream<NodeResult> subgraphNodes(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
+		Map<String, Object> configMap = new HashMap<>(config);
+		configMap.remove("minLevel");
+		configMap.put("uniqueness", "NODE_GLOBAL");
+		
+		return expandConfig(start, configMap).map( pathResult -> {return new NodeResult(pathResult.path.endNode());} );
+	}
+	
 	private Uniqueness getUniqueness(String uniqueness) {
 		for (Uniqueness u : Uniqueness.values()) {
 			if (u.name().equalsIgnoreCase(uniqueness)) return u;
@@ -90,7 +101,7 @@ public class PathExplorer {
 		}
 		throw new Exception("Unsupported data type for start parameter a Node or an Identifier (long) of a Node must be given!");
 	}
-
+	
 	private Stream<PathResult> explorePathPrivate(Iterable<Node> startNodes
 			, String pathFilter
 			, String labelFilter

--- a/src/main/java/apoc/path/PathExplorer.java
+++ b/src/main/java/apoc/path/PathExplorer.java
@@ -44,14 +44,14 @@ public class PathExplorer {
 	@Description("apoc.path.expandConfig(startNode <id>|Node|list, {minLevel,maxLevel,uniqueness,relationshipFilter,labelFilter,uniqueness:'RELATIONSHIP_PATH',bfs:true}) yield path expand from start node following the given relationships from min to max-level adhering to the label filters")
 	public Stream<PathResult> expandConfig(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
 		List<Node> nodes = startToNodes(start);
-	
+
 		String uniqueness = (String) config.getOrDefault("uniqueness", UNIQUENESS.name());
 		String relationshipFilter = (String) config.getOrDefault("relationshipFilter", null);
 		String labelFilter = (String) config.getOrDefault("labelFilter", null);
 		long minLevel = Util.toLong(config.getOrDefault("minLevel", "-1"));
 		long maxLevel = Util.toLong(config.getOrDefault("maxLevel", "-1"));
 		boolean bfs = Util.toBoolean(config.getOrDefault("bfs",true));
-		
+
 		return explorePathPrivate(nodes, relationshipFilter, labelFilter, minLevel, maxLevel, bfs, getUniqueness(uniqueness));
 	}
 	
@@ -64,7 +64,7 @@ public class PathExplorer {
 		
 		return expandConfig(start, configMap).map( pathResult -> {return new NodeResult(pathResult.path.endNode());} );
 	}
-	
+
 	private Uniqueness getUniqueness(String uniqueness) {
 		for (Uniqueness u : Uniqueness.values()) {
 			if (u.name().equalsIgnoreCase(uniqueness)) return u;
@@ -101,7 +101,7 @@ public class PathExplorer {
 		}
 		throw new Exception("Unsupported data type for start parameter a Node or an Identifier (long) of a Node must be given!");
 	}
-	
+
 	private Stream<PathResult> explorePathPrivate(Iterable<Node> startNodes
 			, String pathFilter
 			, String labelFilter

--- a/src/test/java/apoc/path/SubgraphTest.java
+++ b/src/test/java/apoc/path/SubgraphTest.java
@@ -1,0 +1,111 @@
+package apoc.path;
+
+import apoc.result.NodeResult;
+import apoc.util.TestUtil;
+import apoc.util.Util;
+import java.util.List;
+import java.util.Map;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+public class SubgraphTest {
+
+	private static GraphDatabaseService db;
+	
+	private static Long fullGraphCount;
+
+	public SubgraphTest() throws Exception {
+	}
+
+	@BeforeClass
+	public static void setUp() throws Exception {
+		db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+		TestUtil.registerProcedure(db, PathExplorer.class);
+		String movies = Util.readResourceFile("movies.cypher");
+		String bigbrother = "MATCH (per:Person) MERGE (bb:BigBrother {name : 'Big Brother' })  MERGE (bb)-[:FOLLOWS]->(per)";
+		try (Transaction tx = db.beginTx()) {
+			db.execute(movies);
+			db.execute(bigbrother);
+			tx.success();
+		}
+		
+		String getCounts = 
+			"match (n) \n" +
+			"return count(n) as graphCount";
+		try (Transaction tx = db.beginTx()) {
+			Result result = db.execute(getCounts);
+			
+			Map<String, Object> row = result.next();
+			fullGraphCount = (Long) row.get("graphCount");
+		}
+	}
+
+	@AfterClass
+	public static void tearDown() {
+		db.shutdown();
+	}
+
+	@Test
+	public void testFullSubgraph() throws Throwable {
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphNodes(m,{}) yield node return count(distinct node) as cnt";
+		TestUtil.testCall(db, query, (row) -> assertEquals(fullGraphCount, (Long) row.get("cnt")));
+	}
+	
+	@Test
+	public void testSugbraphWithMaxDepth() throws Throwable {
+		String controlQuery = "MATCH (m:Movie {title: 'The Matrix'})-[*0..3]-(subgraphNode) return collect(distinct subgraphNode) as subgraph";
+		List<NodeResult> subgraph;
+		try (Transaction tx = db.beginTx()) {
+			Result result = db.execute(controlQuery);
+			subgraph = (List<NodeResult>) result.next().get("subgraph");
+		}
+		
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphNodes(m,{maxLevel:3}) yield node return COLLECT(node) as subgraphNodes";
+		TestUtil.testCall(db, query, (row) -> {
+			List<NodeResult> subgraphNodes = (List<NodeResult>) row.get("subgraphNodes");
+			assertEquals(subgraph.size(), subgraphNodes.size());
+			assertTrue(subgraph.containsAll(subgraphNodes));
+		});
+	}
+	
+	@Test
+	public void testSugbraphWithLabelFilter() throws Throwable {
+		String controlQuery = "MATCH path = (:Person {name: 'Keanu Reeves'})-[*0..3]-(subgraphNode) where all(node in nodes(path) where node:Person) return collect(distinct subgraphNode) as subgraph";
+		List<NodeResult> subgraph;
+		try (Transaction tx = db.beginTx()) {
+			Result result = db.execute(controlQuery);
+			subgraph = (List<NodeResult>) result.next().get("subgraph");
+		}
+		
+		String query = "MATCH (k:Person {name: 'Keanu Reeves'}) CALL apoc.path.subgraphNodes(k,{maxLevel:3, labelFilter:'+Person'}) yield node return COLLECT(node) as subgraphNodes";
+		TestUtil.testCall(db, query, (row) -> {
+			List<NodeResult> subgraphNodes = (List<NodeResult>) row.get("subgraphNodes");
+			assertEquals(subgraph.size(), subgraphNodes.size());
+			assertTrue(subgraph.containsAll(subgraphNodes));
+		});
+	}
+	
+	@Test
+	public void testSugbraphWithRelationshipFilter() throws Throwable {
+		String controlQuery = "MATCH path = (:Person {name: 'Keanu Reeves'})-[:ACTED_IN*0..3]-(subgraphNode) return collect(distinct subgraphNode) as subgraph";
+		List<NodeResult> subgraph;
+		try (Transaction tx = db.beginTx()) {
+			Result result = db.execute(controlQuery);
+			subgraph = (List<NodeResult>) result.next().get("subgraph");
+		}
+		
+		String query = "MATCH (k:Person {name: 'Keanu Reeves'}) CALL apoc.path.subgraphNodes(k,{maxLevel:3, relationshipFilter:'ACTED_IN'}) yield node return COLLECT(node) as subgraphNodes";
+		TestUtil.testCall(db, query, (row) -> {
+			List<NodeResult> subgraphNodes = (List<NodeResult>) row.get("subgraphNodes");
+			assertEquals(subgraph.size(), subgraphNodes.size());
+			assertTrue(subgraph.containsAll(subgraphNodes));
+		});
+	}
+}


### PR DESCRIPTION
This is meant to fulfill feature requests #273 #274 and #275  