### PR TITLE
Added new apoc.path procedures: subgraphNodes(), subgraphAll(), and spanningTree()

### DIFF
--- a/docs/expand.adoc
+++ b/docs/expand.adoc
@@ -1,8 +1,18 @@
 = Expand paths
 
-expand from start node following the given relationships from min to max-level adhering to the label filters
+Expand from start node following the given relationships from min to max-level adhering to the label filters. Several variations exist:
 
-== Usage
+`apoc.path.expand()` expands paths using Cypher's default expansion modes (bfs and 'RELATIONSHIP_PATH' uniqueness)
+
+`apoc.path.expandConfig()` allows more flexible configuration of parameters and expansion modes
+
+`apoc.path.subgraphNodes()` expands to nodes of a subgraph
+
+`apoc.path.subgraphAll()` expands to nodes of a subgraph and also returns all relationships in the subgraph
+
+`apoc.path.spanningTree()` expands to paths collectively forming a spanning tree
+
+== Expand
 
 [source,cypher]
 ----
@@ -11,7 +21,7 @@ CALL apoc.path.expand(startNode <id>|Node, relationshipFilter, labelFilter, minL
 CALL apoc.path.expand(startNode <id>|Node|list, 'TYPE|TYPE_OUT>|<TYPE_IN', '+YesLabel|-NoLabel', minLevel, maxLevel ) yield path
 ----
 
-Relationship Filter
+==== Relationship Filter
 
 Syntax: `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`
 
@@ -23,7 +33,7 @@ Syntax: `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`
 | KNOWS  | KNOWS | BOTH
 |===
 
-Label Filter
+==== Label Filter
 
 Syntax: `[+-/]LABEL1|LABEL2|...`
 
@@ -35,7 +45,8 @@ Syntax: `[+-/]LABEL1|LABEL2|...`
 | /Friend | Friend | stop traversal after reaching a friend (but include him)
 |===
 
-== Examples
+
+.Examples
 
 [source,cypher]
 ----
@@ -75,7 +86,32 @@ Takes an additional config to provide configuration options:
  bfs: true|false}
 ----
 
-So you can turn this cypher query:
+
+.Uniqueness
+
+Uniqueness of nodes and relationships guides the expansion and the results returned.
+Uniqueness is only configurable using `expandConfig()`.
+
+`subgraphNodes()`, `subgraphAll()`, and `spanningTree()` all use 'NODE_GLOBAL' uniqueness.
+
+[opts=header,cols="m,a"]
+|===
+| value | description
+| RELATIONSHIP_PATH | For each returned node there's a (relationship wise) unique path from the start node to it. This is Cypher's default expansion mode.
+| NODE_GLOBAL | A node cannot be traversed more than once. This is what the legacy traversal framework does.
+| NODE_LEVEL | Entities on the same level are guaranteed to be unique.
+| NODE_PATH | For each returned node there's a unique path from the start node to it.
+| NODE_RECENT | This is like NODE_GLOBAL, but only guarantees uniqueness among the most recent visited nodes, with a configurable count. Traversing a huge graph is quite memory intensive in that it keeps track of all the nodes it has visited.
+For huge graphs a traverser can hog all the memory in the JVM, causing OutOfMemoryError. Together with this Uniqueness you can supply a count, which is the number of most recent visited nodes. This can cause a node to be visited more than once, but scales infinitely.
+| RELATIONSHIP_GLOBAL | A relationship cannot be traversed more than once, whereas nodes can.
+| RELATIONSHIP_LEVEL | Entities on the same level are guaranteed to be unique.
+| RELATIONSHIP_RECENT | Same as for NODE_RECENT, but for relationships.
+| NONE | No restriction (the user will have to manage it)
+|===
+
+.Examples
+
+You can turn this cypher query:
 
 [source,cypher]
 ----
@@ -91,4 +127,78 @@ into this procedure call, with changed semantics for uniqueness and bfs (which i
 MATCH (user:User) WHERE user.id = 460
 CALL apoc.path.expandConfig(user,{relationshipFilter:"RATED",minLevel:3,maxLevel:3,bfs:false,uniqueness:"NONE"}) YIELD path
 RETURN count(*);
+----
+
+== Expand to nodes in a subgraph
+
+----
+apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true}) yield node
+----
+
+Expand to subgraph nodes reachable from the start node following relationships to max-level adhering to the label filters.
+
+Accepts the same `config` values as in `expandConfig()`, though `uniqueness` and `minLevel` are not configurable.
+
+.Examples
+
+Expand to all nodes of a connected subgraph:
+
+[source,cypher]
+----
+MATCH (user:User) WHERE user.id = 460
+CALL apoc.path.subgraphNodes(user, {}) YIELD node
+RETURN node;
+----
+
+Expand to all nodes reachable by :FRIEND relationships:
+
+[source,cypher]
+----
+MATCH (user:User) WHERE user.id = 460
+CALL apoc.path.subgraphNodes(user, {relationshipFilter:'FRIEND'}) YIELD node
+RETURN node;
+----
+
+== Expand to a subgraph and return all nodes and relationships within the subgraph
+
+----
+apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true}) yield nodes, relationships
+----
+
+Expand to subgraph nodes reachable from the start node following relationships to max-level adhering to the label filters.
+Returns the collection of nodes in the subgraph, and the collection of relationships between all subgraph nodes.
+
+Accepts the same `config` values as in `expandConfig()`, though `uniqueness` and `minLevel` are not configurable.
+
+.Example
+
+Expand to local subgraph (and all its relationships) within 4 traversals:
+
+[source,cypher]
+----
+MATCH (user:User) WHERE user.id = 460
+CALL apoc.path.subgraphAll(user, {maxLevel:4}) YIELD nodes, relationships
+RETURN nodes, relationships;
+----
+
+== Expand a spanning tree
+
+----
+apoc.path.spanningTree(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true}) yield path
+----
+
+Expand a spanning tree reachable from start node following relationships to max-level adhering to the label filters.
+The paths returned collectively form a spanning tree.
+
+Accepts the same `config` values as in `expandConfig()`, though `uniqueness` and `minLevel` are not configurable.
+
+.Example
+
+Expand a spanning tree of all contiguous :User nodes:
+
+[source,cypher]
+----
+MATCH (user:User) WHERE user.id = 460
+CALL apoc.path.spanningTree(user, {labelFilter:'+User'}) YIELD path
+RETURN path;
 ----

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -869,6 +869,15 @@ The apoc.path.expand procedure makes it possible to do variable length path trav
 | call apoc.path.expand(startNode <id>\|Node, relationshipFilter, labelFilter, minDepth, maxDepth ) yield path as <identifier> | expand from given nodes(s) taking the provided restrictions into account
 |===
 
+Variations allow more configurable expansions, and expansions for more specific use cases:
+
+[cols="1m,5"]
+|===
+| call apoc.path.expandConfig(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, uniqueness:'RELATIONSHIP_PATH'}) yield path | expand from given nodes(s) taking the provided restrictions into account
+| call apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true}) yield node | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns all nodes in the subgraph
+| call apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true}) yield nodes, relationships | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns the collection of subgraph nodes, and the collection of all relationships within the subgraph
+| call apoc.path.spanningTree(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true}) yield path | expand a spanning tree from given nodes(s) taking the provided restrictions into account; the paths returned collectively form a spanning tree
+|===
 
 === Relationship Filter
 
@@ -893,6 +902,30 @@ Syntax: `[+-/]LABEL1|LABEL2|...`
 | -Foe | Foe | exclude label (blacklist)
 | /Friend | Friend | stop traversal after reaching a friend (but include him)
 |===
+
+=== Uniqueness
+
+Uniqueness of nodes and relationships guides the expansion and the returned results.
+Uniqueness is only configurable using `expandConfig()`.
+
+`subgraphNodes()`, `subgraphAll()`, and `spanningTree()` all use 'NODE_GLOBAL' uniqueness.
+
+[opts=header,cols="m,a"]
+|===
+| value | description
+| RELATIONSHIP_PATH | For each returned node there's a (relationship wise) unique path from the start node to it. This is Cypher's default expansion mode.
+| NODE_GLOBAL | A node cannot be traversed more than once. This is what the legacy traversal framework does.
+| NODE_LEVEL | Entities on the same level are guaranteed to be unique.
+| NODE_PATH | For each returned node there's a unique path from the start node to it.
+| NODE_RECENT | This is like NODE_GLOBAL, but only guarantees uniqueness among the most recent visited nodes, with a configurable count. Traversing a huge graph is quite memory intensive in that it keeps track of all the nodes it has visited.
+For huge graphs a traverser can hog all the memory in the JVM, causing OutOfMemoryError. Together with this Uniqueness you can supply a count, which is the number of most recent visited nodes. This can cause a node to be visited more than once, but scales infinitely.
+| RELATIONSHIP_GLOBAL | A relationship cannot be traversed more than once, whereas nodes can.
+| RELATIONSHIP_LEVEL | Entities on the same level are guaranteed to be unique.
+| RELATIONSHIP_RECENT | Same as for NODE_RECENT, but for relationships.
+| NONE | No restriction (the user will have to manage it)
+|===
+
+
 
 == Parallel Node Search 
 

--- a/src/main/java/apoc/algo/Cover.java
+++ b/src/main/java/apoc/algo/Cover.java
@@ -1,33 +1,21 @@
 package apoc.algo;
 
-import org.neo4j.procedure.Description;
-import apoc.get.Get;
-import apoc.path.PathExplorer;
-import apoc.path.RelationshipTypeAndDirections;
-import apoc.result.PathResult;
 import apoc.result.RelationshipResult;
-import apoc.result.WeightedPathResult;
 import apoc.util.Util;
-import org.neo4j.graphalgo.CommonEvaluators;
-import org.neo4j.graphalgo.GraphAlgoFactory;
-import org.neo4j.graphalgo.PathFinder;
-import org.neo4j.graphalgo.WeightedPath;
-import org.neo4j.graphdb.*;
-import org.neo4j.graphdb.traversal.BranchState;
-import org.neo4j.helpers.collection.Pair;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
-import static org.neo4j.graphdb.traversal.Evaluators.atDepth;
 
 public class Cover {
 
@@ -45,5 +33,14 @@ public class Cover {
                                 .spliterator(),false)
                                 .filter(r -> nodeSet.contains(r.getEndNode()))
                                 .map(RelationshipResult::new)));
+    }
+
+    // non-parallelized utility method for use by other procedures
+    public static Stream<Relationship> coverNodes(Collection<Node> nodes) {
+        return nodes.stream()
+                .flatMap(n ->
+                        StreamSupport.stream(n.getRelationships(Direction.OUTGOING)
+                                .spliterator(),false)
+                                .filter(r -> nodes.contains(r.getEndNode())));
     }
 }

--- a/src/main/java/apoc/path/PathExplorer.java
+++ b/src/main/java/apoc/path/PathExplorer.java
@@ -1,9 +1,13 @@
 package apoc.path;
 
+import apoc.algo.Cover;
+import apoc.result.GraphResult;
+import apoc.result.NodeResult;
 import org.neo4j.procedure.Description;
 import apoc.result.PathResult;
 import apoc.util.Util;
 import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.traversal.Evaluation;
 import org.neo4j.graphdb.traversal.*;
 import org.neo4j.helpers.collection.Pair;
 import org.neo4j.logging.Log;
@@ -12,6 +16,7 @@ import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.neo4j.graphdb.traversal.Evaluation.*;
@@ -35,23 +40,47 @@ public class PathExplorer {
 			                   , @Name("minLevel") long minLevel
 			                   , @Name("maxLevel") long maxLevel ) throws Exception {
 		List<Node> nodes = startToNodes(start);
-		return explorePathPrivate(nodes, pathFilter, labelFilter, minLevel, maxLevel, BFS, UNIQUENESS);
+		return explorePathPrivate(nodes, pathFilter, labelFilter, minLevel, maxLevel, BFS, UNIQUENESS).map( PathResult::new );
 	}
 
 	//
 	@Procedure("apoc.path.expandConfig")
 	@Description("apoc.path.expandConfig(startNode <id>|Node|list, {minLevel,maxLevel,uniqueness,relationshipFilter,labelFilter,uniqueness:'RELATIONSHIP_PATH',bfs:true}) yield path expand from start node following the given relationships from min to max-level adhering to the label filters")
 	public Stream<PathResult> expandConfig(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
-		List<Node> nodes = startToNodes(start);
+		return expandConfigPrivate(start, config).map( PathResult::new );
+	}
 
-		String uniqueness = (String) config.getOrDefault("uniqueness", UNIQUENESS.name());
-		String relationshipFilter = (String) config.getOrDefault("relationshipFilter", null);
-		String labelFilter = (String) config.getOrDefault("labelFilter", null);
-		long minLevel = Util.toLong(config.getOrDefault("minLevel", "-1"));
-		long maxLevel = Util.toLong(config.getOrDefault("maxLevel", "-1"));
-		boolean bfs = Util.toBoolean(config.getOrDefault("bfs",true));
+	@Procedure("apoc.path.subgraphNodes")
+	@Description("apoc.path.subgraphNodes(startNode <id>|Node|list, {maxLevel,relationshipFilter,labelFilter,bfs:true}) yield node expand the subgraph nodes reachable from start node following relationships to max-level adhering to the label filters")
+	public Stream<NodeResult> subgraphNodes(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
+		Map<String, Object> configMap = new HashMap<>(config);
+		configMap.remove("minLevel");
+		configMap.put("uniqueness", "NODE_GLOBAL");
 
-		return explorePathPrivate(nodes, relationshipFilter, labelFilter, minLevel, maxLevel, bfs, getUniqueness(uniqueness));
+		return expandConfigPrivate(start, configMap).map( path -> new NodeResult(path.endNode()) );
+	}
+
+	@Procedure("apoc.path.subgraphAll")
+	@Description("apoc.path.subgraphAll(startNode <id>|Node|list, {maxLevel,relationshipFilter,labelFilter,bfs:true}) yield nodes, relationships expand the subgraph reachable from start node following relationships to max-level adhering to the label filters, and also return all relationships within the subgraph")
+	public Stream<GraphResult> subgraphAll(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
+		Map<String, Object> configMap = new HashMap<>(config);
+		configMap.remove("minLevel");
+		configMap.put("uniqueness", "NODE_GLOBAL");
+
+		List<Node> subgraphNodes = expandConfigPrivate(start, configMap).map( Path::endNode ).collect(Collectors.toList());
+		List<Relationship> subgraphRels = Cover.coverNodes(subgraphNodes).collect(Collectors.toList());
+
+		return Stream.of(new GraphResult(subgraphNodes, subgraphRels));
+	}
+
+	@Procedure("apoc.path.spanningTree")
+	@Description("apoc.path.spanningTree(startNode <id>|Node|list, {maxLevel,relationshipFilter,labelFilter,bfs:true}) yield path expand a spanning tree reachable from start node following relationships to max-level adhering to the label filters")
+	public Stream<PathResult> spanningTree(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
+		Map<String, Object> configMap = new HashMap<>(config);
+		configMap.remove("minLevel");
+		configMap.put("uniqueness", "NODE_GLOBAL");
+
+		return expandConfigPrivate(start, configMap).map( PathResult::new );
 	}
 
 	private Uniqueness getUniqueness(String uniqueness) {
@@ -91,7 +120,20 @@ public class PathExplorer {
 		throw new Exception("Unsupported data type for start parameter a Node or an Identifier (long) of a Node must be given!");
 	}
 
-	private Stream<PathResult> explorePathPrivate(Iterable<Node> startNodes
+	private Stream<Path> expandConfigPrivate(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
+		List<Node> nodes = startToNodes(start);
+
+		String uniqueness = (String) config.getOrDefault("uniqueness", UNIQUENESS.name());
+		String relationshipFilter = (String) config.getOrDefault("relationshipFilter", null);
+		String labelFilter = (String) config.getOrDefault("labelFilter", null);
+		long minLevel = Util.toLong(config.getOrDefault("minLevel", "-1"));
+		long maxLevel = Util.toLong(config.getOrDefault("maxLevel", "-1"));
+		boolean bfs = Util.toBoolean(config.getOrDefault("bfs",true));
+
+		return explorePathPrivate(nodes, relationshipFilter, labelFilter, minLevel, maxLevel, bfs, getUniqueness(uniqueness));
+	}
+
+	private Stream<Path> explorePathPrivate(Iterable<Node> startNodes
 			, String pathFilter
 			, String labelFilter
 			, long minLevel
@@ -101,7 +143,7 @@ public class PathExplorer {
 		// +:Label or :Label include labels
 
 		Traverser traverser = traverse(db.traversalDescription(), startNodes, pathFilter, labelFilter, minLevel, maxLevel, uniqueness,bfs);
-		return traverser.stream().map( PathResult::new );
+		return traverser.stream();
 	}
 
 	public static Traverser traverse(TraversalDescription traversalDescription, Iterable<Node> startNodes, String pathFilter, String labelFilter, long minLevel, long maxLevel, Uniqueness uniqueness, boolean bfs) {

--- a/src/test/java/apoc/path/SubgraphTest.java
+++ b/src/test/java/apoc/path/SubgraphTest.java
@@ -1,0 +1,171 @@
+package apoc.path;
+
+import apoc.algo.Cover;
+import apoc.result.NodeResult;
+import apoc.result.RelationshipResult;
+import apoc.util.TestUtil;
+import apoc.util.Util;
+import java.util.List;
+import java.util.Map;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+public class SubgraphTest {
+
+	private static GraphDatabaseService db;
+	
+	private static Long fullGraphCount;
+
+	public SubgraphTest() throws Exception {
+	}
+
+	@BeforeClass
+	public static void setUp() throws Exception {
+		db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+		TestUtil.registerProcedure(db, PathExplorer.class);
+		TestUtil.registerProcedure(db, Cover.class);
+		String movies = Util.readResourceFile("movies.cypher");
+		String bigbrother = "MATCH (per:Person) MERGE (bb:BigBrother {name : 'Big Brother' })  MERGE (bb)-[:FOLLOWS]->(per)";
+		try (Transaction tx = db.beginTx()) {
+			db.execute(movies);
+			db.execute(bigbrother);
+			tx.success();
+		}
+		
+		String getCounts = 
+			"match (n) \n" +
+			"return count(n) as graphCount";
+		try (Transaction tx = db.beginTx()) {
+			Result result = db.execute(getCounts);
+			
+			Map<String, Object> row = result.next();
+			fullGraphCount = (Long) row.get("graphCount");
+		}
+	}
+
+	@AfterClass
+	public static void tearDown() {
+		db.shutdown();
+	}
+
+	@Test
+	public void testFullSubgraphShouldContainAllNodes() throws Throwable {
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphNodes(m,{}) yield node return count(distinct node) as cnt";
+		TestUtil.testCall(db, query, (row) -> assertEquals(fullGraphCount, row.get("cnt")));
+	}
+	
+	@Test
+	public void testSugbraphWithMaxDepthShouldContainExpectedNodes() throws Throwable {
+		String controlQuery = "MATCH (m:Movie {title: 'The Matrix'})-[*0..3]-(subgraphNode) return collect(distinct subgraphNode) as subgraph";
+		List<NodeResult> subgraph;
+		try (Transaction tx = db.beginTx()) {
+			Result result = db.execute(controlQuery);
+			subgraph = (List<NodeResult>) result.next().get("subgraph");
+		}
+		
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphNodes(m,{maxLevel:3}) yield node return COLLECT(node) as subgraphNodes";
+		TestUtil.testCall(db, query, (row) -> {
+			List<NodeResult> subgraphNodes = (List<NodeResult>) row.get("subgraphNodes");
+			assertEquals(subgraph.size(), subgraphNodes.size());
+			assertTrue(subgraph.containsAll(subgraphNodes));
+		});
+	}
+	
+	@Test
+	public void testSugbraphWithLabelFilterShouldContainExpectedNodes() throws Throwable {
+		String controlQuery = "MATCH path = (:Person {name: 'Keanu Reeves'})-[*0..3]-(subgraphNode) where all(node in nodes(path) where node:Person) return collect(distinct subgraphNode) as subgraph";
+		List<NodeResult> subgraph;
+		try (Transaction tx = db.beginTx()) {
+			Result result = db.execute(controlQuery);
+			subgraph = (List<NodeResult>) result.next().get("subgraph");
+		}
+		
+		String query = "MATCH (k:Person {name: 'Keanu Reeves'}) CALL apoc.path.subgraphNodes(k,{maxLevel:3, labelFilter:'+Person'}) yield node return COLLECT(node) as subgraphNodes";
+		TestUtil.testCall(db, query, (row) -> {
+			List<NodeResult> subgraphNodes = (List<NodeResult>) row.get("subgraphNodes");
+			assertEquals(subgraph.size(), subgraphNodes.size());
+			assertTrue(subgraph.containsAll(subgraphNodes));
+		});
+	}
+	
+	@Test
+	public void testSugbraphWithRelationshipFilterShouldContainExpectedNodes() throws Throwable {
+		String controlQuery = "MATCH path = (:Person {name: 'Keanu Reeves'})-[:ACTED_IN*0..3]-(subgraphNode) return collect(distinct subgraphNode) as subgraph";
+		List<NodeResult> subgraph;
+		try (Transaction tx = db.beginTx()) {
+			Result result = db.execute(controlQuery);
+			subgraph = (List<NodeResult>) result.next().get("subgraph");
+		}
+		
+		String query = "MATCH (k:Person {name: 'Keanu Reeves'}) CALL apoc.path.subgraphNodes(k,{maxLevel:3, relationshipFilter:'ACTED_IN'}) yield node return COLLECT(node) as subgraphNodes";
+		TestUtil.testCall(db, query, (row) -> {
+			List<NodeResult> subgraphNodes = (List<NodeResult>) row.get("subgraphNodes");
+			assertEquals(subgraph.size(), subgraphNodes.size());
+			assertTrue(subgraph.containsAll(subgraphNodes));
+		});
+	}
+
+	@Test
+	public void testSugbraphAllShouldContainExpectedNodesAndRels() throws Throwable {
+		String controlQuery =
+				"MATCH path = (:Person {name: 'Keanu Reeves'})-[*0..3]-(subgraphNode) " +
+				"with collect(distinct subgraphNode) as subgraph " +
+				"call apoc.algo.cover([node in subgraph | id(node)]) yield rel " +
+				"return subgraph, collect(rel) as relationships";
+		final List<NodeResult> subgraph;
+		final List<RelationshipResult> relationships;
+		try (Transaction tx = db.beginTx()) {
+			Result result = db.execute(controlQuery);
+			Map<String, Object> row = result.next();
+			subgraph = (List<NodeResult>) row.get("subgraph");
+			relationships = (List<RelationshipResult>) row.get("relationships");
+		}
+
+		String query =
+				"MATCH (k:Person {name: 'Keanu Reeves'}) " +
+				"CALL apoc.path.subgraphAll(k,{maxLevel:3}) yield nodes, relationships " +
+				"return nodes as subgraphNodes, relationships as subgraphRelationships";
+		TestUtil.testCall(db, query, (row) -> {
+			List<NodeResult> subgraphNodes = (List<NodeResult>) row.get("subgraphNodes");
+			List<RelationshipResult> subgraphRelationships = (List<RelationshipResult>) row.get("subgraphRelationships");
+			assertEquals(subgraph.size(), subgraphNodes.size());
+			assertTrue(subgraph.containsAll(subgraphNodes));
+			assertEquals(relationships.size(), subgraphRelationships.size());
+			assertTrue(relationships.containsAll(subgraphRelationships));
+		});
+	}
+
+	@Test
+	public void testSpanningTreeShouldHaveOnlyOnePathToEachNode() throws Throwable {
+		String controlQuery = "MATCH (m:Movie {title: 'The Matrix'})-[*0..4]-(subgraphNode) return collect(distinct subgraphNode) as subgraph";
+		List<NodeResult> subgraph;
+		try (Transaction tx = db.beginTx()) {
+			Result result = db.execute(controlQuery);
+			subgraph = (List<NodeResult>) result.next().get("subgraph");
+		}
+
+		String query =
+				"MATCH (m:Movie {title: 'The Matrix'}) " +
+						"CALL apoc.path.spanningTree(m,{maxLevel:4}) yield path " +
+						"with collect(path) as paths " +
+						"with paths, size(paths) as pathCount " +
+						"unwind paths as path " +
+						"with pathCount, collect(distinct last(nodes(path))) as subgraphNodes " +
+						"return pathCount, subgraphNodes";
+		TestUtil.testCall(db, query, (row) -> {
+			List<NodeResult> subgraphNodes = (List<NodeResult>) row.get("subgraphNodes");
+			long pathCount = (Long) row.get("pathCount");
+			assertEquals(subgraph.size(), subgraphNodes.size());
+			assertTrue(subgraph.containsAll(subgraphNodes));
+			// assert every node has a single path to that node - no cycles
+			assertEquals(pathCount, subgraphNodes.size());
+		});
+	}
+}


### PR DESCRIPTION
Also added a static Cover.cover() method for internal usage, and updated path expander documentation.

This replaces PR #279, switching to base on APOC 3.1 branch.

This fulfills feature requests #273 #274 and #275.