### PR TITLE
Added 'filterStartNode' config parameter to expandConfig()

### DIFF
--- a/docs/expand.adoc
+++ b/docs/expand.adoc
@@ -86,24 +86,22 @@ Takes an additional config to provide configuration options:
  labelFilter: '[+-]LABEL1|LABEL2|...',
  uniqueness: RELATIONSHIP_PATH|NONE|NODE_GLOBAL|NODE_LEVEL|NODE_PATH|NODE_RECENT|RELATIONSHIP_GLOBAL|RELATIONSHIP_LEVEL|RELATIONSHIP_RECENT,
  bfs: true|false,
- startNodeExempt: true|false}
+ filterStartNode: true|false}
 ----
 
 .Start Node and label filters
-The config parameter `startNodeExempt` defines whether or not the labelFilter applies to the start node of the expansion.
+The config parameter `filterStartNode` defines whether or not the labelFilter applies to the start node of the expansion.
 
-Use `startNodeExempt = true` when you want your label filter to only apply to all other nodes in the path, ignoring the start node.
+Use `filterStartNode = false` when you want your label filter to only apply to all other nodes in the path, ignoring the start node.
 
-`startNodeExempt` defaults for all path expander procedures:
+`filterStartNode` defaults for all path expander procedures:
 
 [opts=header,cols="a,a"]
 |===
 | version |  default
-| >= APOC 3.2.x.x | startNodeExempt = true
-| < APOC 3.2.x.x | startNodeExempt = false
+| >= APOC 3.2.x.x | filterStartNode = false
+| < APOC 3.2.x.x | filterStartNode = true
 |===
-
-To adhere to existing behavior, startNodeExempt will default to `false` for versions below 3.2.x.x.
 
 .Uniqueness
 
@@ -150,7 +148,7 @@ RETURN count(*);
 == Expand to nodes in a subgraph
 
 ----
-apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true,startNodeExempt:false}) yield node
+apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true,filterStartNode:true}) yield node
 ----
 
 Expand to subgraph nodes reachable from the start node following relationships to max-level adhering to the label filters.
@@ -180,7 +178,7 @@ RETURN node;
 == Expand to a subgraph and return all nodes and relationships within the subgraph
 
 ----
-apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true,startNodeExempt:false}) yield nodes, relationships
+apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true,filterStartNode:true}) yield nodes, relationships
 ----
 
 Expand to subgraph nodes reachable from the start node following relationships to max-level adhering to the label filters.
@@ -202,7 +200,7 @@ RETURN nodes, relationships;
 == Expand a spanning tree
 
 ----
-apoc.path.spanningTree(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true,startNodeExempt:false}) yield path
+apoc.path.spanningTree(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true,filterStartNode:true}) yield path
 ----
 
 Expand a spanning tree reachable from start node following relationships to max-level adhering to the label filters.

--- a/docs/expand.adoc
+++ b/docs/expand.adoc
@@ -37,6 +37,8 @@ Syntax: `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`
 
 Syntax: `[+-/]LABEL1|LABEL2|...`
 
+With APOC 3.2.x.x, label filters will no longer apply to starting nodes of the expansion by default.
+
 [opts=header,cols="m,m,a"]
 |===
 | input | label | result
@@ -83,9 +85,25 @@ Takes an additional config to provide configuration options:
  relationshipFilter: '[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...',
  labelFilter: '[+-]LABEL1|LABEL2|...',
  uniqueness: RELATIONSHIP_PATH|NONE|NODE_GLOBAL|NODE_LEVEL|NODE_PATH|NODE_RECENT|RELATIONSHIP_GLOBAL|RELATIONSHIP_LEVEL|RELATIONSHIP_RECENT,
- bfs: true|false}
+ bfs: true|false,
+ startNodeExempt: true|false}
 ----
 
+.Start Node and label filters
+The config parameter `startNodeExempt` defines whether or not the labelFilter applies to the start node of the expansion.
+
+Use `startNodeExempt = true` when you want your label filter to only apply to all other nodes in the path, ignoring the start node.
+
+`startNodeExempt` defaults for all path expander procedures:
+
+[opts=header,cols="a,a"]
+|===
+| version |  default
+| >= APOC 3.2.x.x | startNodeExempt = true
+| < APOC 3.2.x.x | startNodeExempt = false
+|===
+
+To adhere to existing behavior, startNodeExempt will default to `false` for versions below 3.2.x.x.
 
 .Uniqueness
 
@@ -132,7 +150,7 @@ RETURN count(*);
 == Expand to nodes in a subgraph
 
 ----
-apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true}) yield node
+apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true,startNodeExempt:false}) yield node
 ----
 
 Expand to subgraph nodes reachable from the start node following relationships to max-level adhering to the label filters.
@@ -162,7 +180,7 @@ RETURN node;
 == Expand to a subgraph and return all nodes and relationships within the subgraph
 
 ----
-apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true}) yield nodes, relationships
+apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true,startNodeExempt:false}) yield nodes, relationships
 ----
 
 Expand to subgraph nodes reachable from the start node following relationships to max-level adhering to the label filters.
@@ -184,7 +202,7 @@ RETURN nodes, relationships;
 == Expand a spanning tree
 
 ----
-apoc.path.spanningTree(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true}) yield path
+apoc.path.spanningTree(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true,startNodeExempt:false}) yield path
 ----
 
 Expand a spanning tree reachable from start node following relationships to max-level adhering to the label filters.

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -877,10 +877,10 @@ Variations allow more configurable expansions, and expansions for more specific 
 
 [cols="1m,5"]
 |===
-| call apoc.path.expandConfig(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, uniqueness:'RELATIONSHIP_PATH', startNodeExempt:false}) yield path | expand from given nodes(s) taking the provided restrictions into account
-| call apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, startNodeExempt:false}) yield node | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns all nodes in the subgraph
-| call apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, startNodeExempt:false}) yield nodes, relationships | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns the collection of subgraph nodes, and the collection of all relationships within the subgraph
-| call apoc.path.spanningTree(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, startNodeExempt:false}) yield path | expand a spanning tree from given nodes(s) taking the provided restrictions into account; the paths returned collectively form a spanning tree
+| call apoc.path.expandConfig(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, uniqueness:'RELATIONSHIP_PATH', filterStartNode:true}) yield path | expand from given nodes(s) taking the provided restrictions into account
+| call apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true}) yield node | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns all nodes in the subgraph
+| call apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true}) yield nodes, relationships | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns the collection of subgraph nodes, and the collection of all relationships within the subgraph
+| call apoc.path.spanningTree(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true}) yield path | expand a spanning tree from given nodes(s) taking the provided restrictions into account; the paths returned collectively form a spanning tree
 |===
 
 === Relationship Filter

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -877,10 +877,10 @@ Variations allow more configurable expansions, and expansions for more specific 
 
 [cols="1m,5"]
 |===
-| call apoc.path.expandConfig(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, uniqueness:'RELATIONSHIP_PATH'}) yield path | expand from given nodes(s) taking the provided restrictions into account
-| call apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true}) yield node | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns all nodes in the subgraph
-| call apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true}) yield nodes, relationships | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns the collection of subgraph nodes, and the collection of all relationships within the subgraph
-| call apoc.path.spanningTree(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true}) yield path | expand a spanning tree from given nodes(s) taking the provided restrictions into account; the paths returned collectively form a spanning tree
+| call apoc.path.expandConfig(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, uniqueness:'RELATIONSHIP_PATH', startNodeExempt:false}) yield path | expand from given nodes(s) taking the provided restrictions into account
+| call apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, startNodeExempt:false}) yield node | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns all nodes in the subgraph
+| call apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, startNodeExempt:false}) yield nodes, relationships | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns the collection of subgraph nodes, and the collection of all relationships within the subgraph
+| call apoc.path.spanningTree(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, startNodeExempt:false}) yield path | expand a spanning tree from given nodes(s) taking the provided restrictions into account; the paths returned collectively form a spanning tree
 |===
 
 === Relationship Filter
@@ -898,6 +898,8 @@ Syntax: `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`
 === Label Filter
 
 Syntax: `[+-/]LABEL1|LABEL2|...`
+
+With APOC 3.2.x.x, label filters will no longer apply to starting nodes of the expansion by default.
 
 [opts=header,cols="m,m,a"]
 |===

--- a/src/main/java/apoc/path/PathExplorer.java
+++ b/src/main/java/apoc/path/PathExplorer.java
@@ -45,13 +45,13 @@ public class PathExplorer {
 
 	//
 	@Procedure("apoc.path.expandConfig")
-	@Description("apoc.path.expandConfig(startNode <id>|Node|list, {minLevel,maxLevel,uniqueness,relationshipFilter,labelFilter,uniqueness:'RELATIONSHIP_PATH',bfs:true, startNodeExempt:false}) yield path expand from start node following the given relationships from min to max-level adhering to the label filters")
+	@Description("apoc.path.expandConfig(startNode <id>|Node|list, {minLevel,maxLevel,uniqueness,relationshipFilter,labelFilter,uniqueness:'RELATIONSHIP_PATH',bfs:true, filterStartNode:false}) yield path expand from start node following the given relationships from min to max-level adhering to the label filters")
 	public Stream<PathResult> expandConfig(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
 		return expandConfigPrivate(start, config).map( PathResult::new );
 	}
 
 	@Procedure("apoc.path.subgraphNodes")
-	@Description("apoc.path.subgraphNodes(startNode <id>|Node|list, {maxLevel,relationshipFilter,labelFilter,bfs:true, startNodeExempt:false}) yield node expand the subgraph nodes reachable from start node following relationships to max-level adhering to the label filters")
+	@Description("apoc.path.subgraphNodes(startNode <id>|Node|list, {maxLevel,relationshipFilter,labelFilter,bfs:true, filterStartNode:false}) yield node expand the subgraph nodes reachable from start node following relationships to max-level adhering to the label filters")
 	public Stream<NodeResult> subgraphNodes(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
 		Map<String, Object> configMap = new HashMap<>(config);
 		configMap.remove("minLevel");
@@ -61,7 +61,7 @@ public class PathExplorer {
 	}
 
 	@Procedure("apoc.path.subgraphAll")
-	@Description("apoc.path.subgraphAll(startNode <id>|Node|list, {maxLevel,relationshipFilter,labelFilter,bfs:true, startNodeExempt:false}) yield nodes, relationships expand the subgraph reachable from start node following relationships to max-level adhering to the label filters, and also return all relationships within the subgraph")
+	@Description("apoc.path.subgraphAll(startNode <id>|Node|list, {maxLevel,relationshipFilter,labelFilter,bfs:true, filterStartNode:false}) yield nodes, relationships expand the subgraph reachable from start node following relationships to max-level adhering to the label filters, and also return all relationships within the subgraph")
 	public Stream<GraphResult> subgraphAll(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
 		Map<String, Object> configMap = new HashMap<>(config);
 		configMap.remove("minLevel");
@@ -74,7 +74,7 @@ public class PathExplorer {
 	}
 
 	@Procedure("apoc.path.spanningTree")
-	@Description("apoc.path.spanningTree(startNode <id>|Node|list, {maxLevel,relationshipFilter,labelFilter,bfs:true, startNodeExempt:false}) yield path expand a spanning tree reachable from start node following relationships to max-level adhering to the label filters")
+	@Description("apoc.path.spanningTree(startNode <id>|Node|list, {maxLevel,relationshipFilter,labelFilter,bfs:true, filterStartNode:false}) yield path expand a spanning tree reachable from start node following relationships to max-level adhering to the label filters")
 	public Stream<PathResult> spanningTree(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
 		Map<String, Object> configMap = new HashMap<>(config);
 		configMap.remove("minLevel");
@@ -129,25 +129,25 @@ public class PathExplorer {
 		long minLevel = Util.toLong(config.getOrDefault("minLevel", "-1"));
 		long maxLevel = Util.toLong(config.getOrDefault("maxLevel", "-1"));
 		boolean bfs = Util.toBoolean(config.getOrDefault("bfs",true));
-		boolean startNodeExempt = Util.toBoolean(config.getOrDefault("startNodeExempt", false));
+		boolean filterStartNode = Util.toBoolean(config.getOrDefault("filterStartNode", true));
 
-		return explorePathPrivate(nodes, relationshipFilter, labelFilter, minLevel, maxLevel, bfs, getUniqueness(uniqueness), startNodeExempt);
+		return explorePathPrivate(nodes, relationshipFilter, labelFilter, minLevel, maxLevel, bfs, getUniqueness(uniqueness), filterStartNode);
 	}
 
 	private Stream<Path> explorePathPrivate(Iterable<Node> startNodes
 			, String pathFilter
 			, String labelFilter
 			, long minLevel
-			, long maxLevel, boolean bfs, Uniqueness uniqueness, boolean startNodeExempt) {
+			, long maxLevel, boolean bfs, Uniqueness uniqueness, boolean filterStartNode) {
 		// LabelFilter
 		// -|Label|:Label|:Label excluded label list
 		// +:Label or :Label include labels
 
-		Traverser traverser = traverse(db.traversalDescription(), startNodes, pathFilter, labelFilter, minLevel, maxLevel, uniqueness,bfs,startNodeExempt);
+		Traverser traverser = traverse(db.traversalDescription(), startNodes, pathFilter, labelFilter, minLevel, maxLevel, uniqueness,bfs,filterStartNode);
 		return traverser.stream();
 	}
 
-	public static Traverser traverse(TraversalDescription traversalDescription, Iterable<Node> startNodes, String pathFilter, String labelFilter, long minLevel, long maxLevel, Uniqueness uniqueness, boolean bfs, boolean startNodeExempt) {
+	public static Traverser traverse(TraversalDescription traversalDescription, Iterable<Node> startNodes, String pathFilter, String labelFilter, long minLevel, long maxLevel, Uniqueness uniqueness, boolean bfs, boolean filterStartNode) {
 		TraversalDescription td = traversalDescription;
 		// based on the pathFilter definition now the possible relationships and directions must be shown
 
@@ -167,7 +167,7 @@ public class PathExplorer {
 		if (maxLevel != -1) td = td.evaluator(Evaluators.toDepth((int) maxLevel));
 
 		if (labelFilter != null && !labelFilter.trim().isEmpty()) {
-			td = td.evaluator(new LabelEvaluator(labelFilter, startNodeExempt));
+			td = td.evaluator(new LabelEvaluator(labelFilter, filterStartNode));
 		}
 
 		td = td.uniqueness(uniqueness); // this is how Cypher works !! Uniqueness.RELATIONSHIP_PATH
@@ -178,12 +178,12 @@ public class PathExplorer {
 	public static class LabelEvaluator implements Evaluator {
 		private char operator;
 		private Set<String> labels = new HashSet<String>();
-		boolean startNodeExempt;
+		boolean filterStartNode;
 
-		public LabelEvaluator(String labelFilter, boolean startNodeExempt) {
+		public LabelEvaluator(String labelFilter, boolean filterStartNode) {
 			// parse the filter
 			if (labelFilter ==  null || labelFilter.isEmpty()) labelFilter = "-"; // exclude nothing
-            this.startNodeExempt = startNodeExempt;
+            this.filterStartNode = filterStartNode;
 			operator = labelFilter.charAt(0);
 			String work = labelFilter.substring(1); // remove the + or -
 			// split on |
@@ -196,7 +196,7 @@ public class PathExplorer {
 
 		@Override
 		public Evaluation evaluate(Path path) {
-			if (path.length() == 0 && startNodeExempt) {
+			if (path.length() == 0 && !filterStartNode) {
 				if (operator == '/') {
 					return EXCLUDE_AND_CONTINUE;
 				} else {

--- a/src/main/java/apoc/path/PathExplorer.java
+++ b/src/main/java/apoc/path/PathExplorer.java
@@ -40,18 +40,18 @@ public class PathExplorer {
 			                   , @Name("minLevel") long minLevel
 			                   , @Name("maxLevel") long maxLevel ) throws Exception {
 		List<Node> nodes = startToNodes(start);
-		return explorePathPrivate(nodes, pathFilter, labelFilter, minLevel, maxLevel, BFS, UNIQUENESS).map( PathResult::new );
+		return explorePathPrivate(nodes, pathFilter, labelFilter, minLevel, maxLevel, BFS, UNIQUENESS, false).map( PathResult::new );
 	}
 
 	//
 	@Procedure("apoc.path.expandConfig")
-	@Description("apoc.path.expandConfig(startNode <id>|Node|list, {minLevel,maxLevel,uniqueness,relationshipFilter,labelFilter,uniqueness:'RELATIONSHIP_PATH',bfs:true}) yield path expand from start node following the given relationships from min to max-level adhering to the label filters")
+	@Description("apoc.path.expandConfig(startNode <id>|Node|list, {minLevel,maxLevel,uniqueness,relationshipFilter,labelFilter,uniqueness:'RELATIONSHIP_PATH',bfs:true, startNodeExempt:false}) yield path expand from start node following the given relationships from min to max-level adhering to the label filters")
 	public Stream<PathResult> expandConfig(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
 		return expandConfigPrivate(start, config).map( PathResult::new );
 	}
 
 	@Procedure("apoc.path.subgraphNodes")
-	@Description("apoc.path.subgraphNodes(startNode <id>|Node|list, {maxLevel,relationshipFilter,labelFilter,bfs:true}) yield node expand the subgraph nodes reachable from start node following relationships to max-level adhering to the label filters")
+	@Description("apoc.path.subgraphNodes(startNode <id>|Node|list, {maxLevel,relationshipFilter,labelFilter,bfs:true, startNodeExempt:false}) yield node expand the subgraph nodes reachable from start node following relationships to max-level adhering to the label filters")
 	public Stream<NodeResult> subgraphNodes(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
 		Map<String, Object> configMap = new HashMap<>(config);
 		configMap.remove("minLevel");
@@ -61,7 +61,7 @@ public class PathExplorer {
 	}
 
 	@Procedure("apoc.path.subgraphAll")
-	@Description("apoc.path.subgraphAll(startNode <id>|Node|list, {maxLevel,relationshipFilter,labelFilter,bfs:true}) yield nodes, relationships expand the subgraph reachable from start node following relationships to max-level adhering to the label filters, and also return all relationships within the subgraph")
+	@Description("apoc.path.subgraphAll(startNode <id>|Node|list, {maxLevel,relationshipFilter,labelFilter,bfs:true, startNodeExempt:false}) yield nodes, relationships expand the subgraph reachable from start node following relationships to max-level adhering to the label filters, and also return all relationships within the subgraph")
 	public Stream<GraphResult> subgraphAll(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
 		Map<String, Object> configMap = new HashMap<>(config);
 		configMap.remove("minLevel");
@@ -74,7 +74,7 @@ public class PathExplorer {
 	}
 
 	@Procedure("apoc.path.spanningTree")
-	@Description("apoc.path.spanningTree(startNode <id>|Node|list, {maxLevel,relationshipFilter,labelFilter,bfs:true}) yield path expand a spanning tree reachable from start node following relationships to max-level adhering to the label filters")
+	@Description("apoc.path.spanningTree(startNode <id>|Node|list, {maxLevel,relationshipFilter,labelFilter,bfs:true, startNodeExempt:false}) yield path expand a spanning tree reachable from start node following relationships to max-level adhering to the label filters")
 	public Stream<PathResult> spanningTree(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
 		Map<String, Object> configMap = new HashMap<>(config);
 		configMap.remove("minLevel");
@@ -129,24 +129,25 @@ public class PathExplorer {
 		long minLevel = Util.toLong(config.getOrDefault("minLevel", "-1"));
 		long maxLevel = Util.toLong(config.getOrDefault("maxLevel", "-1"));
 		boolean bfs = Util.toBoolean(config.getOrDefault("bfs",true));
+		boolean startNodeExempt = Util.toBoolean(config.getOrDefault("startNodeExempt", false));
 
-		return explorePathPrivate(nodes, relationshipFilter, labelFilter, minLevel, maxLevel, bfs, getUniqueness(uniqueness));
+		return explorePathPrivate(nodes, relationshipFilter, labelFilter, minLevel, maxLevel, bfs, getUniqueness(uniqueness), startNodeExempt);
 	}
 
 	private Stream<Path> explorePathPrivate(Iterable<Node> startNodes
 			, String pathFilter
 			, String labelFilter
 			, long minLevel
-			, long maxLevel, boolean bfs, Uniqueness uniqueness) {
+			, long maxLevel, boolean bfs, Uniqueness uniqueness, boolean startNodeExempt) {
 		// LabelFilter
 		// -|Label|:Label|:Label excluded label list
 		// +:Label or :Label include labels
 
-		Traverser traverser = traverse(db.traversalDescription(), startNodes, pathFilter, labelFilter, minLevel, maxLevel, uniqueness,bfs);
+		Traverser traverser = traverse(db.traversalDescription(), startNodes, pathFilter, labelFilter, minLevel, maxLevel, uniqueness,bfs,startNodeExempt);
 		return traverser.stream();
 	}
 
-	public static Traverser traverse(TraversalDescription traversalDescription, Iterable<Node> startNodes, String pathFilter, String labelFilter, long minLevel, long maxLevel, Uniqueness uniqueness, boolean bfs) {
+	public static Traverser traverse(TraversalDescription traversalDescription, Iterable<Node> startNodes, String pathFilter, String labelFilter, long minLevel, long maxLevel, Uniqueness uniqueness, boolean bfs, boolean startNodeExempt) {
 		TraversalDescription td = traversalDescription;
 		// based on the pathFilter definition now the possible relationships and directions must be shown
 
@@ -166,7 +167,7 @@ public class PathExplorer {
 		if (maxLevel != -1) td = td.evaluator(Evaluators.toDepth((int) maxLevel));
 
 		if (labelFilter != null && !labelFilter.trim().isEmpty()) {
-			td = td.evaluator(new LabelEvaluator(labelFilter));
+			td = td.evaluator(new LabelEvaluator(labelFilter, startNodeExempt));
 		}
 
 		td = td.uniqueness(uniqueness); // this is how Cypher works !! Uniqueness.RELATIONSHIP_PATH
@@ -177,9 +178,12 @@ public class PathExplorer {
 	public static class LabelEvaluator implements Evaluator {
 		private char operator;
 		private Set<String> labels = new HashSet<String>();
-		public LabelEvaluator(String labelFilter) {
+		boolean startNodeExempt;
+
+		public LabelEvaluator(String labelFilter, boolean startNodeExempt) {
 			// parse the filter
 			if (labelFilter ==  null || labelFilter.isEmpty()) labelFilter = "-"; // exclude nothing
+            this.startNodeExempt = startNodeExempt;
 			operator = labelFilter.charAt(0);
 			String work = labelFilter.substring(1); // remove the + or -
 			// split on |
@@ -192,6 +196,14 @@ public class PathExplorer {
 
 		@Override
 		public Evaluation evaluate(Path path) {
+			if (path.length() == 0 && startNodeExempt) {
+				if (operator == '/') {
+					return EXCLUDE_AND_CONTINUE;
+				} else {
+					return INCLUDE_AND_CONTINUE;
+				}
+			}
+
 			Node check = path.endNode();
 			Evaluation result;
 			switch (operator) {

--- a/src/test/java/apoc/path/ExpandPathTest.java
+++ b/src/test/java/apoc/path/ExpandPathTest.java
@@ -75,8 +75,8 @@ public class ExpandPathTest {
 	}
 
 	@Test
-	public void testExplorePathWithStartNodeExemptIgnoresLabelFilter() throws Throwable {
-		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.expandConfig(m,{labelFilter:'+Person', maxLevel:2, startNodeExempt:true}) yield path return count(*) as c";
+	public void testExplorePathWithFilterStartNodeFalseIgnoresLabelFilter() throws Throwable {
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.expandConfig(m,{labelFilter:'+Person', maxLevel:2, filterStartNode:false}) yield path return count(*) as c";
 		TestUtil.testCall(db, query, (row) -> assertEquals(9L,row.get("c")));
 	}
 }

--- a/src/test/java/apoc/path/ExpandPathTest.java
+++ b/src/test/java/apoc/path/ExpandPathTest.java
@@ -73,4 +73,10 @@ public class ExpandPathTest {
 					assertEquals("Clint Eastwood", path.endNode().getProperty("name"));
 				});
 	}
+
+	@Test
+	public void testExplorePathWithStartNodeExemptIgnoresLabelFilter() throws Throwable {
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.expandConfig(m,{labelFilter:'+Person', maxLevel:2, startNodeExempt:true}) yield path return count(*) as c";
+		TestUtil.testCall(db, query, (row) -> assertEquals(9L,row.get("c")));
+	}
 }


### PR DESCRIPTION
(and all procedures using the config map). Default is false for versions < 3.2.x.x.