### PR TITLE
Add limit config parameter to expand path config

### DIFF
--- a/docs/expand.adoc
+++ b/docs/expand.adoc
@@ -37,14 +37,16 @@ Syntax: `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`
 
 Syntax: `[+-/]LABEL1|LABEL2|...`
 
+Only one type of operation allowed in the label filter (`+` or `-` or `/`, never more than one).
+
 With APOC 3.2.x.x, label filters will no longer apply to starting nodes of the expansion by default.
 
 [opts=header,cols="m,m,a"]
 |===
 | input | label | result
-| +Friend | Friend | include label (whitelist)
-| -Foe | Foe | exclude label (blacklist)
-| /Friend | Friend | stop traversal after reaching a friend (but include him)
+| +Friend | Friend | whitelist filter - include label, all nodes in the path must have a label in the whitelist
+| -Foe | Foe | blacklist filter - exclude label, no node in the path will have a label in the blacklist
+| /Friend | Friend | termination filter - only return paths to :Friend nodes, and stop further traversal along a path after reaching a :Friend
 |===
 
 
@@ -69,6 +71,29 @@ call apoc.path.expand(p,"ACTED_IN>|PRODUCED<|FOLLOWS<","+Movie|Person",1,2) yiel
 return p, pp
 ----
 
+.Termination label filter example
+
+We will first set a `:Western` label on some nodes.
+
+[source,cypher]
+----
+match (p:Person)
+where p.name in ['Clint Eastwood', 'Gene Hackman']
+set p:Western
+----
+
+Now expand from 'Keanu Reeves' to all `:Western` nodes.
+
+[source,cypher]
+----
+match (k:Person {name:'Keanu Reeves'})
+call apoc.path.expandConfig(k, {relationshipFilter:'ACTED_IN|PRODUCED|DIRECTED', labelFilter:'/Western', uniqueness: 'NODE_GLOBAL'}) yield path
+return path
+----
+
+The one returned path only matches up to 'Gene Hackman'.
+While there is a path from 'Keanu Reeves' to 'Clint Eastwood' through 'Gene Hackman', no further expansion is permitted through a node in the termination filter list.
+
 
 == Expand with Config
 
@@ -76,7 +101,7 @@ return p, pp
 apoc.path.expandConfig(startNode <id>Node/list, {config}) yield path expands from start nodes using the given configuration and yields the resulting paths
 ----
 
-Takes an additional config to provide configuration options:
+Takes an additional map parameter, `config`, to provide configuration options:
 
 .Config
 ----
@@ -84,9 +109,11 @@ Takes an additional config to provide configuration options:
  maxLevel: -1|number,
  relationshipFilter: '[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...',
  labelFilter: '[+-]LABEL1|LABEL2|...',
- uniqueness: RELATIONSHIP_PATH|NONE|NODE_GLOBAL|NODE_LEVEL|NODE_PATH|NODE_RECENT|RELATIONSHIP_GLOBAL|RELATIONSHIP_LEVEL|RELATIONSHIP_RECENT,
+ uniqueness: RELATIONSHIP_PATH|NONE|NODE_GLOBAL|NODE_LEVEL|NODE_PATH|NODE_RECENT|
+             RELATIONSHIP_GLOBAL|RELATIONSHIP_LEVEL|RELATIONSHIP_RECENT,
  bfs: true|false,
- filterStartNode: true|false}
+ filterStartNode: true|false,
+ limit: -1|number}
 ----
 
 .Start Node and label filters
@@ -102,6 +129,19 @@ Use `filterStartNode = false` when you want your label filter to only apply to a
 | >= APOC 3.2.x.x | filterStartNode = false
 | < APOC 3.2.x.x | filterStartNode = true
 |===
+
+.Limit
+
+Only when using the termination label filter `/`, you can use the `limit` config parameter to limit the number of paths returned.
+
+When using `bfs:true` (which is the default for all expand procedures), this has the effect of returning paths to the `n` nearest nodes with labels in the termination filter, where `n` is the limit given.
+
+Remember that when using the termination filter, further expansion is stopped when a termination node is reached, so other termination nodes beyond them may not be reachable or returned if there is no alternate path to them.
+
+The default limit value, `-1`, means no limit.
+
+If you want to make sure multiple paths should never match to the same node, use `expandConfig()` with 'NODE_GLOBAL' uniqueness, or any expand procedure which already uses this uniqueness
+(`subgraphNodes()`, `subgraphAll()`, and `spanningTree()`).
 
 .Uniqueness
 
@@ -148,7 +188,7 @@ RETURN count(*);
 == Expand to nodes in a subgraph
 
 ----
-apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true,filterStartNode:true}) yield node
+apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit:-1}) yield node
 ----
 
 Expand to subgraph nodes reachable from the start node following relationships to max-level adhering to the label filters.
@@ -178,7 +218,7 @@ RETURN node;
 == Expand to a subgraph and return all nodes and relationships within the subgraph
 
 ----
-apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true,filterStartNode:true}) yield nodes, relationships
+apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit:-1}) yield nodes, relationships
 ----
 
 Expand to subgraph nodes reachable from the start node following relationships to max-level adhering to the label filters.
@@ -200,7 +240,7 @@ RETURN nodes, relationships;
 == Expand a spanning tree
 
 ----
-apoc.path.spanningTree(startNode <id>Node/list, {maxLevel,relationshipFilter,labelFilter,bfs:true,filterStartNode:true}) yield path
+apoc.path.spanningTree(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit:-1}) yield path
 ----
 
 Expand a spanning tree reachable from start node following relationships to max-level adhering to the label filters.

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -877,10 +877,10 @@ Variations allow more configurable expansions, and expansions for more specific 
 
 [cols="1m,5"]
 |===
-| call apoc.path.expandConfig(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, uniqueness:'RELATIONSHIP_PATH', filterStartNode:true}) yield path | expand from given nodes(s) taking the provided restrictions into account
-| call apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true}) yield node | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns all nodes in the subgraph
-| call apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true}) yield nodes, relationships | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns the collection of subgraph nodes, and the collection of all relationships within the subgraph
-| call apoc.path.spanningTree(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true}) yield path | expand a spanning tree from given nodes(s) taking the provided restrictions into account; the paths returned collectively form a spanning tree
+| call apoc.path.expandConfig(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, uniqueness:'RELATIONSHIP_PATH', filterStartNode:true, limit}) yield path | expand from given nodes(s) taking the provided restrictions into account
+| call apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit}) yield node | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns all nodes in the subgraph
+| call apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit}) yield nodes, relationships | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns the collection of subgraph nodes, and the collection of all relationships within the subgraph
+| call apoc.path.spanningTree(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit}) yield path | expand a spanning tree from given nodes(s) taking the provided restrictions into account; the paths returned collectively form a spanning tree
 |===
 
 === Relationship Filter
@@ -899,14 +899,16 @@ Syntax: `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`
 
 Syntax: `[+-/]LABEL1|LABEL2|...`
 
+Only one type of operation allowed in the label filter (`+` or `-` or `/`, never more than one).
+
 With APOC 3.2.x.x, label filters will no longer apply to starting nodes of the expansion by default.
 
 [opts=header,cols="m,m,a"]
 |===
 | input | label | result
-| +Friend | Friend | include label (whitelist)
-| -Foe | Foe | exclude label (blacklist)
-| /Friend | Friend | stop traversal after reaching a friend (but include him)
+| +Friend | Friend | whitelist filter - include label, all nodes in the path must have a label in the whitelist
+| -Foe | Foe | blacklist filter - exclude label, no node in the path will have a label in the blacklist
+| /Friend | Friend | termination filter - only return paths to :Friend nodes, and stop further traversal along a path after reaching a :Friend
 |===
 
 === Uniqueness


### PR DESCRIPTION
Also cleaned up and clarified docuementation regarding label filters (only one operation allowed) and the termination filter behavior.

This fulfills feature request #324 