### PR TITLE
Add apoc.coll.reverse() 

### DIFF
--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -695,6 +695,7 @@ Sometimes type information gets lost, these functions help you to coerce an "Any
 | apoc.coll.toSet([list]) | returns a unique list backed by a set
 | apoc.coll.sort(coll) | sort on Collections
 | apoc.coll.sortNodes([nodes], 'name') | sort nodes by property
+| apoc.coll.reverse(coll) | returns the reversed list
 | apoc.coll.contains(coll, value) | optimized contains operation (using a HashSet) (returns single row or not)
 | apoc.coll.containsAll(coll, values) | optimized contains-all operation (using a HashSet) (returns single row or not)
 | apoc.coll.containsSorted(coll, value) | optimized contains on a sorted list operation (Collections.binarySearch) (returns single row or not)

--- a/src/main/java/apoc/coll/Coll.java
+++ b/src/main/java/apoc/coll/Coll.java
@@ -262,6 +262,12 @@ public class Coll {
     @UserFunction
     @Description("apoc.coll.shuffle(coll) - returns the shuffled list")
     public List<Object> shuffle(@Name("coll") List<Object> coll) {
+        if (coll == null || coll.isEmpty()) {
+            return Collections.emptyList();
+        } else if (coll.size() == 1) {
+            return coll;
+        }
+
         List<Object> shuffledList = new ArrayList<>(coll);
         Collections.shuffle(shuffledList);
         return shuffledList;
@@ -272,6 +278,8 @@ public class Coll {
     public Object randomItem(@Name("coll") List<Object> coll) {
         if (coll == null || coll.isEmpty()) {
             return null;
+        } else if (coll.size() == 1) {
+            return coll.get(0);
         }
 
         return coll.get(ThreadLocalRandom.current().nextInt(coll.size()));
@@ -304,6 +312,10 @@ public class Coll {
     @UserFunction
     @Description("apoc.coll.containsDuplicates(coll) - returns true if a collection contains duplicate elements")
     public boolean containsDuplicates(@Name("coll") List<Object> coll) {
+        if (coll == null || coll.size() <= 1) {
+            return false;
+        }
+
         Set<Object> set = new HashSet<>(coll);
         return set.size() < coll.size();
     }
@@ -311,6 +323,10 @@ public class Coll {
     @UserFunction
     @Description("apoc.coll.duplicates(coll) - returns a list of duplicate items in the collection")
     public List<Object> duplicates(@Name("coll") List<Object> coll) {
+        if (coll == null || coll.size() <= 1) {
+            return Collections.emptyList();
+        }
+
         Set<Object> set = new HashSet<>(coll.size());
         Set<Object> duplicates = new LinkedHashSet<>();
 
@@ -326,6 +342,10 @@ public class Coll {
     @UserFunction
     @Description("apoc.coll.duplicatesWithCount(coll) - returns a list of duplicate items in the collection and their count, keyed by `item` and `count` (e.g., `[{item: xyz, count:2}, {item:zyx, count:5}]`)")
     public List<Map<String, Object>> duplicatesWithCount(@Name("coll") List<Object> coll) {
+        if (coll == null || coll.size() <= 1) {
+            return Collections.emptyList();
+        }
+
         // mimicking a counted bag
         Map<Object, IntCounter> duplicates = new LinkedHashMap<>(coll.size());
         List<Map<String, Object>> resultList = new ArrayList<>();
@@ -355,6 +375,10 @@ public class Coll {
     @UserFunction
     @Description("apoc.coll.occurrences(coll, item) - returns the count of the given item in the collection")
     public long occurrences(@Name("coll") List<Object> coll, @Name("item") Object item) {
+        if (coll == null || coll.isEmpty()) {
+            return 0;
+        }
+
         long occurrences = 0;
 
         for (Object obj : coll) {
@@ -364,5 +388,20 @@ public class Coll {
         }
 
         return occurrences;
+    }
+
+    @UserFunction
+    @Description("apoc.coll.reverse(coll) - returns reversed list")
+    public List<Object> reverse(@Name("coll") List<Object> coll) {
+        if (coll == null || coll.isEmpty()) {
+            return Collections.emptyList();
+        } else if (coll.size() == 1) {
+            return coll;
+        }
+
+        List<Object> reversed = new ArrayList<Object>(coll);
+        Collections.reverse(reversed);
+
+        return reversed;
     }
 }

--- a/src/test/java/apoc/coll/CollTest.java
+++ b/src/test/java/apoc/coll/CollTest.java
@@ -210,6 +210,15 @@ public class CollTest {
     }
 
     @Test
+    public void testShuffleOnNullAndEmptyList() throws Exception {
+        testCall(db, "RETURN apoc.coll.shuffle([]) as value",
+                (row) -> assertEquals(Collections.EMPTY_LIST, row.get("value")));
+
+        testCall(db, "RETURN apoc.coll.shuffle(null) as value",
+                (row) -> assertEquals(Collections.EMPTY_LIST, row.get("value")));
+    }
+
+    @Test
     public void testShuffle() throws Exception {
         // with 10k elements, very remote chance of randomly getting same order
         int elements = 10_000;
@@ -342,6 +351,11 @@ public class CollTest {
                     assertTrue(original.containsAll(result));
                 });
     }
+    @Test
+    public void testContainsDuplicatesOnNullAndEmptyList() throws Exception {
+        testCall(db,"RETURN apoc.coll.containsDuplicates([]) AS value", r -> assertEquals(false, r.get("value")));
+        testCall(db,"RETURN apoc.coll.containsDuplicates(null) AS value", r -> assertEquals(false, r.get("value")));
+    }
 
     @Test
     public void testContainsDuplicates() throws Exception {
@@ -349,12 +363,30 @@ public class CollTest {
         testCall(db,"RETURN apoc.coll.containsDuplicates([1,2,1,5,4]) AS value", r -> assertEquals(true, r.get("value")));
     }
 
-    @Test public void testDuplicates() throws Exception {
+    @Test
+    public void testDuplicatesOnNullAndEmptyList() throws Exception {
+        testCall(db, "RETURN apoc.coll.duplicates([]) as value",
+                (row) -> assertEquals(Collections.EMPTY_LIST, row.get("value")));
+        testCall(db, "RETURN apoc.coll.duplicates(null) as value",
+                (row) -> assertEquals(Collections.EMPTY_LIST, row.get("value")));
+    }
+
+    @Test
+    public void testDuplicates() throws Exception {
         testCall(db, "RETURN apoc.coll.duplicates([1,2,1,3,2,5,2,3,1,2]) as value",
                 (row) -> assertEquals(asList(1L,2L,3L), row.get("value")));
     }
 
-    @Test public void testDuplicatesWithCount() throws Exception {
+    @Test
+    public void testDuplicatesWithCountOnNullAndEmptyList() throws Exception {
+        testCall(db, "RETURN apoc.coll.duplicatesWithCount([]) as value",
+                (row) -> assertEquals(Collections.EMPTY_LIST, row.get("value")));
+        testCall(db, "RETURN apoc.coll.duplicatesWithCount(null) as value",
+                (row) -> assertEquals(Collections.EMPTY_LIST, row.get("value")));
+    }
+
+    @Test
+    public void testDuplicatesWithCount() throws Exception {
         testCall(db, "RETURN apoc.coll.duplicatesWithCount([1,2,1,3,2,5,2,3,1,2]) as value",
                 (row) -> {
                     Map<Long, Long> expectedMap = new HashMap<>(3);
@@ -379,7 +411,16 @@ public class CollTest {
                 });
     }
 
-    @Test public void testOccurrences() throws Exception {
+    @Test
+    public void testOccurrencesOnNullAndEmptyList() throws Exception {
+        testCall(db, "RETURN apoc.coll.occurrences([], 5) as value",
+                (row) -> assertEquals(0l, row.get("value")));
+        testCall(db, "RETURN apoc.coll.occurrences(null, 5) as value",
+                (row) -> assertEquals(0l, row.get("value")));
+    }
+
+    @Test
+    public void testOccurrences() throws Exception {
         testCall(db, "RETURN apoc.coll.occurrences([1,2,1,3,2,5,2,3,1,2], 1) as value",
                 (row) -> assertEquals(3l, row.get("value")));
         testCall(db, "RETURN apoc.coll.occurrences([1,2,1,3,2,5,2,3,1,2], 2) as value",
@@ -390,7 +431,19 @@ public class CollTest {
                 (row) -> assertEquals(1l, row.get("value")));
         testCall(db, "RETURN apoc.coll.occurrences([1,2,1,3,2,5,2,3,1,2], -5) as value",
                 (row) -> assertEquals(0l, row.get("value")));
-        testCall(db, "RETURN apoc.coll.occurrences([], 5) as value",
-                (row) -> assertEquals(0l, row.get("value")));
+    }
+
+    @Test
+    public void testReverseOnNullAndEmptyList() throws Exception {
+        testCall(db, "RETURN apoc.coll.reverse([]) as value",
+                (row) -> assertEquals(Collections.EMPTY_LIST, row.get("value")));
+        testCall(db, "RETURN apoc.coll.reverse(null) as value",
+                (row) -> assertEquals(Collections.EMPTY_LIST, row.get("value")));
+    }
+
+    @Test
+    public void testReverse() throws Exception {
+        testCall(db, "RETURN apoc.coll.reverse([1,2,1,3,2,5,2,3,1,2]) as value",
+                (row) -> assertEquals(asList(2l,1l,3l,2l,5l,2l,3l,1l,2l,1l), row.get("value")));
     }
 }


### PR DESCRIPTION
Also tightened null and empty list handling on newer collection functions.

This fulfills feature request #322 