### PR TITLE
Allow all labelFilter operations in path expander procedures

### DIFF
--- a/docs/expand.adoc
+++ b/docs/expand.adoc
@@ -37,17 +37,25 @@ Syntax: `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`
 
 Syntax: `[+-/>]LABEL1|LABEL2|...`
 
-Only one type of operation allowed in the label filter (`+` or `-` or `/` or `>`, never more than one).
+As of APOC 3.1.3.x multiple label filter operations are allowed.
+
+In prior versions, only one type of operation is allowed in the label filter (`+` or `-` or `/` or `>`, never more than one).
 
 With APOC 3.2.x.x, label filters will no longer apply to starting nodes of the expansion by default.
 
 [opts=header,cols="m,m,a"]
 |===
 | input | label | result
-| +Friend | Friend | whitelist filter - include label, all nodes in the path must have a label in the whitelist
-| -Foe | Foe | blacklist filter - exclude label, no node in the path will have a label in the blacklist
-| /Friend | Friend | termination filter - only return paths to :Friend nodes, and stop further traversal along a path after reaching a :Friend
-| >Friend | Friend | end node filter - only return paths to :Friend nodes, but continue traversal along a path after reaching a :Friend
+| -Foe | Foe | blacklist filter - No node in the path will have a label in the blacklist.
+| +Friend | Friend | whitelist filter - All nodes in the path must have a label in the whitelist (exempting termination and end nodes, if using those filters).
+
+If no whitelist operator is present, all labels are considered whitelisted.
+| /Friend | Friend | termination filter - Only return paths up to a node of the given labels, and stop further expansion beyond it.
+
+Termination nodes do not have to respect the whitelist. Termination filtering takes precedence over end node filtering.
+| >Friend | Friend | end node filter - Only return paths up to a node of the given labels, but continue expansion to match on end nodes beyond it.
+
+End nodes do not have to respect the whitelist to be returned, but expansion beyond them is only allowed if the node has a label in the whitelist.
 |===
 
 
@@ -96,6 +104,30 @@ The one returned path only matches up to 'Gene Hackman'.
 While there is a path from 'Keanu Reeves' to 'Clint Eastwood' through 'Gene Hackman', no further expansion is permitted through a node in the termination filter.
 
 If you didn't want to stop expansion on reaching 'Gene Hackman', and wanted 'Clint Eastwood' returned as well, use the end node filter  instead (`>`).
+
+.Label filter operator precedence and behavior
+
+As of APOC 3.1.3.x, multiple label filter operators are allowed at the same time.
+
+When processing the labelFilter string, once a filter operator is introduced, it remains the active filter until another filter supplants it.
+
+In the following example, `:Person` and `:Movie` labels are whitelisted, `:SciFi` is blacklisted, with `:Western` acting as an end node label, and `:Romance` acting as a termination label.
+
+`... labelFilter:'+Person|Movie|-SciFi|>Western|/Romance' ...`
+
+The precedence of operator evaluation isn't dependent upon their location in the labelFilter but is fixed:
+
+Blacklist filter `-`, termination filter `/`, end node filter `>`, whitelist filter `+`.
+
+The consequences are as follows:
+
+* No blacklisted label `-` will ever be present in the nodes of paths returned, no matter if the same label (or another label of a node with a blacklisted label) is included in another filter list.
+* If the termination filter `/` or end node filter `>` is used, then only paths up to nodes with those labels will be returned as results. These end nodes are exempt from the whitelist filter.
+* If a node is a termination node `/`, no further expansion beyond the node will occur.
+* If a node is an end node `>`, expansion beyond that node will only occur if the end node has a label in the whitelist. This is to prevent returning paths to nodes where a node on that path violates the whitelist.
+* The whitelist only applies to nodes up to but not including end nodes from the termination or end node filters. If no end node or termination node operators are present, then the whitelist applies to all nodes of the path.
+* If no whitelist operators are present in the labelFilter, this is treated as if all labels are whitelisted.
+* If `filterStartNode` is false (which will be default in APOC 3.2.x.x), then the start node is exempt from the label filter.
 
 
 == Expand with Config

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -908,17 +908,25 @@ Syntax: `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`
 
 Syntax: `[+-/>]LABEL1|LABEL2|...`
 
-Only one type of operation allowed in the label filter (`+` or `-` or `/` or `>`, never more than one).
+As of APOC 3.1.3.x multiple label filter operations are allowed.
+
+In prior versions, only one type of operation is allowed in the label filter (`+` or `-` or `/` or `>`, never more than one).
 
 With APOC 3.2.x.x, label filters will no longer apply to starting nodes of the expansion by default.
 
 [opts=header,cols="m,m,a"]
 |===
 | input | label | result
-| +Friend | Friend | whitelist filter - include label, all nodes in the path must have a label in the whitelist
-| -Foe | Foe | blacklist filter - exclude label, no node in the path will have a label in the blacklist
-| /Friend | Friend | termination filter - only return paths to :Friend nodes, and stop further traversal along a path after reaching a :Friend
-| >Friend | Friend | end node filter - only return paths to :Friend nodes, but continue traversal along a path after reaching a :Friend
+| -Foe | Foe | blacklist filter - No node in the path will have a label in the blacklist.
+| +Friend | Friend | whitelist filter - All nodes in the path must have a label in the whitelist (exempting termination and end nodes, if using those filters).
+
+If no whitelist operator is present, all labels are considered whitelisted.
+| /Friend | Friend | termination filter - Only return paths up to a node of the given labels, and stop further expansion beyond it.
+
+Termination nodes do not have to respect the whitelist. Termination filtering takes precedence over end node filtering.
+| >Friend | Friend | end node filter - Only return paths up to a node of the given labels, but continue expansion to match on end nodes beyond it.
+
+End nodes do not have to respect the whitelist to be returned, but expansion beyond them is only allowed if the node has a label in the whitelist.
 |===
 
 === Uniqueness

--- a/src/main/java/apoc/path/PathExplorer.java
+++ b/src/main/java/apoc/path/PathExplorer.java
@@ -208,8 +208,11 @@ public class PathExplorer {
 						case '>':
 							labelMap.putIfAbsent(operator, new HashSet<>());
 							labels = labelMap.get(operator);
-						case ':':
 							def = def.substring(1);
+					}
+
+					if (def.startsWith(":")) {
+						def = def.substring(1);
 					}
 
 					if (!def.isEmpty()) {


### PR DESCRIPTION
This implements proposed order 1 operator precedence from #317, including the adjustment on evaluation for the end node filter which first checks if the a label is in the whitelist before an INCLUDE_AND_CONTINUE, to avoid including paths to further end nodes which inadvertently include a node that violates the whitelist.

See included test cases for examples of operator precedence.

Please don't approve pull request yet, documentation is not yet included.

Documentation will come in a later commit, as I'd like to get some feedback and confirmation on the implementation first.