### PR TITLE
Fixed apoc.data.domain() when there are .'s before the @ symbol

### DIFF
--- a/src/main/java/apoc/data/Extract.java
+++ b/src/main/java/apoc/data/Extract.java
@@ -1,17 +1,10 @@
 package apoc.data;
 
-import org.neo4j.helpers.collection.ArrayIterator;
 import org.neo4j.procedure.Description;
-import apoc.result.StringResult;
 import org.neo4j.procedure.Name;
-import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.UserFunction;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Arrays;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 public class Extract {
 

--- a/src/main/java/apoc/data/Extract.java
+++ b/src/main/java/apoc/data/Extract.java
@@ -1,5 +1,6 @@
 package apoc.data;
 
+import org.neo4j.helpers.collection.ArrayIterator;
 import org.neo4j.procedure.Description;
 import apoc.result.StringResult;
 import org.neo4j.procedure.Name;
@@ -8,6 +9,7 @@ import org.neo4j.procedure.UserFunction;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
@@ -19,8 +21,16 @@ public class Extract {
     @Description("apoc.data.domain('url_or_email_address') YIELD domain - extract the domain name from a url or an email address. If nothing was found, yield null.")
     public String domain(final @Name("url_or_email_address") String value) {
         if (value != null) {
-            for (String part : value.split("[@/<>]")) {
-                if (DOMAIN.matcher(part).matches()) return part;
+            if (value.contains("@")) {
+                String[] tokens = value.split("[@/<>]");
+                for (int i = tokens.length - 1; i >= 0; i--) {
+                    String token = tokens[i];
+                    if (DOMAIN.matcher(token).matches()) return token;
+                }
+            } else {
+                for (String part : value.split("[@/<>]")) {
+                    if (DOMAIN.matcher(part).matches()) return part;
+                }
             }
         }
         return null;

--- a/src/test/java/apoc/data/ExtractTest.java
+++ b/src/test/java/apoc/data/ExtractTest.java
@@ -70,4 +70,10 @@ public class ExtractTest {
                 map("param", "www.foo.bar/baz"),
                 row -> assertEquals("www.foo.bar", row.get("value")));
     }
+
+    @Test
+    public void testEmailWithDotsBeforeAt() {
+        testCall(db, "RETURN apoc.data.domain('foo.foo@bar.baz') AS value",
+                row -> Assert.assertThat(row.get("value"), equalTo("bar.baz")));
+    }
 }


### PR DESCRIPTION
Fixes bug #250, but may alter behavior when run on URLs with an @ in the query string which shouldn't be picked up as the domain (if the domain part of an embedded email address, for example, is the last part of the query string, or immediately precedes a split delimiter)