### PR TITLE
use parameters so that queries are easier to read fixes #345

### DIFF
--- a/docs/elasticsearch.adoc
+++ b/docs/elasticsearch.adoc
@@ -23,6 +23,43 @@ call apoc.es.stats("localhost")
 
 image::http://i.imgur.com/qHAj9ma.png[width=500]
 
+=== Pagination
+
+To use the pagination feature of Elasticsearch you have to follow these steps:
+
+1. Call *apoc.es.query* to get the first chunk of data and obtain also the scroll_id (in order to enable the pagination).
+2. Do your merge/create etc. operations with the first N hits
+3. Use the *range(start,end,step)* function to repeat a second call to get all the other chunks until the end. For example, if you have 1000 documents and you want to retrieve 10 documents for each request, you cand do *range(11,1000,10)*. You start from 11 because the first 10 documents are already processed. If you don't know the exact upper bound (the total size of your documents) you can set a number that is bigger than the real total size.
+4. The second call to repeat is *apoc.es.get*. Remember to set the *scroll_id* as a parameter.
+5. Then process the result of each chunk of data as the first one.
+
+Here an example:
+
+[source,cypher]
+----
+// It's important to create an index to improve performance
+CREATE INDEX ON :Document(id)
+// First query: get first chunk of data + the scroll_id for pagination
+CALL apoc.es.query('localhost','test-index','test-type','name:Neo4j&size=1&scroll=5m',null) yield value with value._scroll_id as scrollId, value.hits.hits as hits
+// Do something with hits
+UNWIND hits as hit
+// Here we simply create a document and a relation to a company
+MERGE (doc:Document {id: hit._id, description: hit._source.description, name: hit._source.name})
+MERGE (company:Company {name: hit._source.company})
+MERGE (doc)-[:IS_FROM]->(company)
+// Then call for the other docs and use the scrollId value from previous query
+// Use a range to count our chunk of data (i.e. i want to get chunks from 2 to 10)
+WITH range(2,10,1) as list, scrollId
+UNWIND list as count
+CALL apoc.es.get("localhost","_search","scroll",null,{scroll:"5m",scroll_id:scrollId},null) yield value with value._scoll_id as scrollId, value.hits.hits as nextHits
+// Again, do something with hits
+UNWIND nextHits as hit
+MERGE (doc:Document {id: hit._id, description: hit._source.description, name: hit._source.name})
+MERGE (company:Company {name: hit._source.company})
+MERGE (doc)-[:IS_FROM]->(company) return scrollId, doc, company
+----
+
+This example was tested on a Mac Book Pro with 16GB of RAM. Loading 20000 documents from ES to Neo4j (100 documents for each request) took 1 minute.
 
 == General Structure and Parameters
 

--- a/src/test/java/apoc/es/ElasticSearchTest.java
+++ b/src/test/java/apoc/es/ElasticSearchTest.java
@@ -33,6 +33,16 @@ public class ElasticSearchTest {
     private final static String HOST = "localhost";
 
     protected static GraphDatabaseService db;
+
+    private static Map<String, Object> defaultParams = new HashMap<>();
+
+    static {
+        defaultParams.put("index", ES_INDEX);
+        defaultParams.put("type", ES_TYPE);
+        defaultParams.put("id", ES_ID);
+        defaultParams.put("host", HOST);
+    }
+
     // We need a reference to the class implementing the procedures
     private final ElasticSearch es = new ElasticSearch();
     private Configuration JSON_PATH_CONFIG = Configuration.builder().options(Option.DEFAULT_PATH_LEAF_TO_NULL, Option.SUPPRESS_EXCEPTIONS).build();
@@ -53,25 +63,37 @@ public class ElasticSearchTest {
         db.shutdown();
     }
 
+    /**
+     * Default params (host, index, type, id) + payload
+     *
+     * @param payload
+     * @return
+     */
+    private static Map<String, Object> createDefaultProcedureParametersWithPayloadAndId(String payload, String id) {
+        Map<String, Object> params = new HashMap<>(defaultParams);
+        params.put("payload", payload);
+        params.put("id", id);
+
+        return params;
+    }
+
     private static void insertDocuments() {
         TestUtil.ignoreException(() -> {
-            String payload = "{procedurePackage:'es',procedureName:'get',procedureDescription:'performa a GET operation to ElasticSearch'}";
-            String id = UUID.randomUUID().toString();
+            Map<String, Object> params = createDefaultProcedureParametersWithPayloadAndId("{\"procedurePackage\":\"es\",\"procedureName\":\"get\",\"procedureDescription\":\"perform a GET operation to ElasticSearch\"}", UUID.randomUUID().toString());
 
-            TestUtil.testCall(db, "CALL apoc.es.post('" + HOST + "','" + ES_INDEX + "','" + ES_TYPE + "','" + id + "',null," + payload + ") yield value", r -> assertNotNull(r.get("value")));
+            TestUtil.testCall(db, "CALL apoc.es.post({host},{index},{type},{id},null,{payload}) yield value", params, r -> assertNotNull(r.get("value")));
         }, ConnectException.class);
 
         TestUtil.ignoreException(() -> {
-            String payload = "{procedurePackage:'es',procedureName:'post',procedureDescription:'performa a POST operation to ElasticSearch'}";
-            String id = UUID.randomUUID().toString();
+            Map<String, Object> params = createDefaultProcedureParametersWithPayloadAndId("{\"procedurePackage\":\"es\",\"procedureName\":\"post\",\"procedureDescription\":\"perform a POST operation to ElasticSearch\"}", UUID.randomUUID().toString());
 
-            TestUtil.testCall(db, "CALL apoc.es.post('" + HOST + "','" + ES_INDEX + "','" + ES_TYPE + "','" + id + "',null," + payload + ") yield value", r -> assertNotNull(r.get("value")));
+            TestUtil.testCall(db, "CALL apoc.es.post({host},{index},{type},{id},null,{payload}) yield value", params, r -> assertNotNull(r.get("value")));
         }, ConnectException.class);
 
         TestUtil.ignoreException(() -> {
-            String payload = "{name:'Neo4j',company:'Neo Technology',description:'Awesome stuff with a graph database'}";
+            Map<String, Object> params = createDefaultProcedureParametersWithPayloadAndId("{\"name\":\"Neo4j\",\"company\":\"Neo Technology\",\"description\":\"Awesome stuff with a graph database\"}", ES_ID);
 
-            TestUtil.testCall(db, "CALL apoc.es.post('" + HOST + "','" + ES_INDEX + "','" + ES_TYPE + "','" + ES_ID + "',null," + payload + ") yield value", r -> assertNotNull(r.get("value")));
+            TestUtil.testCall(db, "CALL apoc.es.post({host},{index},{type},{id},null,{payload}) yield value", params, r -> assertNotNull(r.get("value")));
         }, ConnectException.class);
     }
 
@@ -106,7 +128,7 @@ public class ElasticSearchTest {
     @Test
     public void testGetWithQueryNull() throws Exception {
         TestUtil.ignoreException(() -> {
-            TestUtil.testCall(db, "CALL apoc.es.get('" + HOST + "','" + ES_INDEX + "','" + ES_TYPE + "','" + ES_ID + "',null,null) yield value", r -> {
+            TestUtil.testCall(db, "CALL apoc.es.get({host},{index},{type},{id},null,null) yield value", defaultParams, r -> {
                 Object name = extractValueFromResponse(r, "$._source.name");
                 assertEquals("Neo4j", name);
             });
@@ -122,7 +144,7 @@ public class ElasticSearchTest {
     @Test
     public void testGetWithQueryAsMapMultipleParams() throws Exception {
         TestUtil.ignoreException(() -> {
-            TestUtil.testCall(db, "CALL apoc.es.get('" + HOST + "','" + ES_INDEX + "','" + ES_TYPE + "','" + ES_ID + "',{_source_include:'name',_source_exclude:'description'},null) yield value", r -> {
+            TestUtil.testCall(db, "CALL apoc.es.get({host},{index},{type},{id},{_source_include:'name',_source_exclude:'description'},null) yield value", defaultParams, r -> {
                 Object name = extractValueFromResponse(r, "$._source.name");
                 assertEquals("Neo4j", name);
             });
@@ -138,7 +160,7 @@ public class ElasticSearchTest {
     @Test
     public void testGetWithQueryAsMapSingleParam() throws Exception {
         TestUtil.ignoreException(() -> {
-            TestUtil.testCall(db, "CALL apoc.es.get('" + HOST + "','" + ES_INDEX + "','" + ES_TYPE + "','" + ES_ID + "',{_source_include:'name'},null) yield value", r -> {
+            TestUtil.testCall(db, "CALL apoc.es.get({host},{index},{type},{id},{_source_include:'name'},null) yield value", defaultParams, r -> {
                 Object name = extractValueFromResponse(r, "$._source.name");
                 assertEquals("Neo4j", name);
             });
@@ -154,7 +176,7 @@ public class ElasticSearchTest {
     @Test
     public void testGetWithQueryAsStringMultipleParams() throws Exception {
         TestUtil.ignoreException(() -> {
-            TestUtil.testCall(db, "CALL apoc.es.get('" + HOST + "','" + ES_INDEX + "','" + ES_TYPE + "','" + ES_ID + "','_source_include=name&_source_exclude=description',null) yield value", r -> {
+            TestUtil.testCall(db, "CALL apoc.es.get({host},{index},{type},{id},'_source_include=name&_source_exclude=description',null) yield value", defaultParams, r -> {
                 Object name = extractValueFromResponse(r, "$._source.name");
                 assertEquals("Neo4j", name);
             });
@@ -170,7 +192,7 @@ public class ElasticSearchTest {
     @Test
     public void testGetWithQueryAsStringSingleParam() throws Exception {
         TestUtil.ignoreException(() -> {
-            TestUtil.testCall(db, "CALL apoc.es.get('" + HOST + "','" + ES_INDEX + "','" + ES_TYPE + "','" + ES_ID + "','_source_include=name',null) yield value", r -> {
+            TestUtil.testCall(db, "CALL apoc.es.get({host},{index},{type},{id},'_source_include=name',null) yield value", defaultParams, r -> {
                 Object name = extractValueFromResponse(r, "$._source.name");
                 assertEquals("Neo4j", name);
             });
@@ -184,7 +206,7 @@ public class ElasticSearchTest {
     @Test
     public void testSearchWithQueryAsAString() throws Exception {
         TestUtil.ignoreException(() -> {
-            TestUtil.testCall(db, "CALL apoc.es.query('" + HOST + "','" + ES_INDEX + "','" + ES_TYPE + "','name:Neo4j',null) yield value", r -> {
+            TestUtil.testCall(db, "CALL apoc.es.query({host},{index},{type},'name:Neo4j',null) yield value", defaultParams, r -> {
                 Object name = extractValueFromResponse(r, "$.hits.hits[0]._source.name");
                 assertEquals("Neo4j", name);
             });
@@ -198,16 +220,15 @@ public class ElasticSearchTest {
     @Test
     public void testPostAddNewDocument() {
         TestUtil.ignoreException(() -> {
-            String payload = "{event:'Graph Connect 2017'}";
-            String id = UUID.randomUUID().toString();
+            Map<String, Object> params = createDefaultProcedureParametersWithPayloadAndId("{\"event\":\"Graph Connect 2017\"}", UUID.randomUUID().toString());
 
-            TestUtil.testCall(db, "CALL apoc.es.post('" + HOST + "','" + ES_INDEX + "','" + ES_TYPE + "','" + id + "',null," + payload + ") yield value", r -> {
+            TestUtil.testCall(db, "CALL apoc.es.post({host},{index},{type},{id},null,{payload}) yield value", params, r -> {
                 Object response = extractValueFromResponse(r, "$._shards.successful");
                 assertEquals(1, response);
             });
 
             // We try to get the document back
-            TestUtil.testCall(db, "CALL apoc.es.get('" + HOST + "','" + ES_INDEX + "','" + ES_TYPE + "','" + id + "',null,null) yield value", r -> {
+            TestUtil.testCall(db, "CALL apoc.es.get({host},{index},{type},{id},null,null) yield value", params, r -> {
                 Object event = extractValueFromResponse(r, "$._source.event");
                 assertEquals("Graph Connect 2017", event);
             });
@@ -224,22 +245,23 @@ public class ElasticSearchTest {
     @Test
     public void testPostUpdateDocument() {
         TestUtil.ignoreException(() -> {
-            String payload = "{tags:['awesome']}";
             String id = UUID.randomUUID().toString();
+            Map<String, Object> params = createDefaultProcedureParametersWithPayloadAndId("{\"tags\":[\"awesome\"]}", id);
 
-            TestUtil.testCall(db, "CALL apoc.es.put('" + HOST + "','" + ES_INDEX + "','" + ES_TYPE + "','" + id + "',null," + payload + ") yield value", r -> {
+            TestUtil.testCall(db, "CALL apoc.es.put({host},{index},{type},{id},null,{payload}) yield value", params, r -> {
                 Object created = extractValueFromResponse(r, "$.created");
                 assertEquals(true, created);
             });
 
-            payload = "{doc:{tags:['beautiful']}}";
-            TestUtil.testCall(db, "CALL apoc.es.post('" + HOST + "','" + ES_INDEX + "','" + ES_TYPE + "','" + id + "/_update',null," + payload + ") yield value", r -> {
+            params = createDefaultProcedureParametersWithPayloadAndId("{\"doc\":{\"tags\":[\"beautiful\"]}}", id + "/_update");
+            TestUtil.testCall(db, "CALL apoc.es.post({host},{index},{type},{id},null,{payload}) yield value", params, r -> {
                 Object updated = extractValueFromResponse(r, "$.result");
                 assertEquals("updated", updated);
             });
 
             // We try to get the document back
-            TestUtil.testCall(db, "CALL apoc.es.get('" + HOST + "','" + ES_INDEX + "','" + ES_TYPE + "','" + id + "',null,null) yield value", r -> {
+            params = createDefaultProcedureParametersWithPayloadAndId("", id);
+            TestUtil.testCall(db, "CALL apoc.es.get({host},{index},{type},{id},null,null) yield value", params, r -> {
                 Object tag = extractValueFromResponse(r, "$._source.tags[0]");
                 assertEquals("beautiful", tag);
             });
@@ -253,16 +275,15 @@ public class ElasticSearchTest {
     @Test
     public void testPutNewDocument() {
         TestUtil.ignoreException(() -> {
-            String payload = "{tags:['awesome']}";
-            String id = UUID.randomUUID().toString();
+            Map<String, Object> params = createDefaultProcedureParametersWithPayloadAndId("{\"tags\":[\"awesome\"]}", UUID.randomUUID().toString());
 
-            TestUtil.testCall(db, "CALL apoc.es.put('" + HOST + "','" + ES_INDEX + "','" + ES_TYPE + "','" + id + "',null," + payload + ") yield value", r -> {
+            TestUtil.testCall(db, "CALL apoc.es.put({host},{index},{type},{id},null,{payload}) yield value", params, r -> {
                 Object created = extractValueFromResponse(r, "$.created");
                 assertEquals(true, created);
             });
 
             // We try to get the document back
-            TestUtil.testCall(db, "CALL apoc.es.get('" + HOST + "','" + ES_INDEX + "','" + ES_TYPE + "','" + id + "',null,null) yield value", r -> {
+            TestUtil.testCall(db, "CALL apoc.es.get({host},{index},{type},{id},null,null) yield value", params, r -> {
                 Object tag = extractValueFromResponse(r, "$._source.tags[0]");
                 assertEquals("awesome", tag);
             });

--- a/src/test/java/apoc/es/ElasticSearchTest.java
+++ b/src/test/java/apoc/es/ElasticSearchTest.java
@@ -2,6 +2,7 @@ package apoc.es;
 
 import apoc.periodic.Periodic;
 import apoc.util.TestUtil;
+import apoc.util.Util;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
@@ -34,14 +35,7 @@ public class ElasticSearchTest {
 
     protected static GraphDatabaseService db;
 
-    private static Map<String, Object> defaultParams = new HashMap<>();
-
-    static {
-        defaultParams.put("index", ES_INDEX);
-        defaultParams.put("type", ES_TYPE);
-        defaultParams.put("id", ES_ID);
-        defaultParams.put("host", HOST);
-    }
+    private static Map<String, Object> defaultParams = Util.map("index", ES_INDEX, "type", ES_TYPE, "id", ES_ID, "host", HOST);
 
     // We need a reference to the class implementing the procedures
     private final ElasticSearch es = new ElasticSearch();
@@ -70,11 +64,7 @@ public class ElasticSearchTest {
      * @return
      */
     private static Map<String, Object> createDefaultProcedureParametersWithPayloadAndId(String payload, String id) {
-        Map<String, Object> params = new HashMap<>(defaultParams);
-        params.put("payload", payload);
-        params.put("id", id);
-
-        return params;
+        return Util.merge(defaultParams, Util.map("payload", payload, "id", id));
     }
 
     private static void insertDocuments() {


### PR DESCRIPTION
use parameters so that queries are easier to read fixes #345