### PR TITLE
Util method for transaction termination checking (algo and warmup) fixes #211

### DIFF
--- a/src/main/java/apoc/algo/LabelPropagation.java
+++ b/src/main/java/apoc/algo/LabelPropagation.java
@@ -1,6 +1,7 @@
 package apoc.algo;
 
 import apoc.Pools;
+import apoc.util.Util;
 import org.neo4j.graphdb.*;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.Log;
@@ -25,7 +26,7 @@ public class LabelPropagation {
     @Context
     public Log log;
 
-    @Procedure(name = "apoc.algo.community",mode = Mode.WRITE)
+    @Procedure(name = "apoc.algo.community", mode = Mode.WRITE)
     @Description("CALL apoc.algo.community(times,labels,partitionKey,type,direction,weightKey,batchSize) - simple label propagation kernel")
     public void community(
             @Name("times") long times,
@@ -48,6 +49,11 @@ public class LabelPropagation {
             List<Node> batch = null;
             List<Future<Void>> futures = new ArrayList<>();
             try (Transaction tx = dbAPI.beginTx()) {
+                // Before doing anything we check the transaction status
+                if (Util.transactionIsTerminated(dbAPI)) {
+                    return;
+                }
+
                 for (Node node : dbAPI.getAllNodes()) {
                     boolean add = labels.size() == 0;
                     if (!add) {

--- a/src/main/java/apoc/util/Util.java
+++ b/src/main/java/apoc/util/Util.java
@@ -9,6 +9,8 @@ import org.neo4j.graphdb.*;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Pair;
 import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.Log;
 
@@ -502,5 +504,25 @@ public class Util {
             if (e.getStatusCode().equalsIgnoreCase("Neo.ClientError.Procedure.ProcedureNotFound")) return true;
             throw e;
         }
+    }
+
+    /**
+     * Given a context related to the procedure invocation this method checks if the transaction is terminated in some way
+     *
+     * @param db
+     * @return
+     *
+     */
+    public static boolean transactionIsTerminated(GraphDatabaseAPI db) {
+        final KernelTransaction ktx = db.getDependencyResolver()
+                .resolveDependency(ThreadToStatementContextBridge.class)
+                .getKernelTransactionBoundToThisThread(true);
+
+        Status reason = ktx.getReasonIfTerminated();
+        if (reason != null) {
+            return true;
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
In Utils class is now available a method to check if a transaction is terminated or not.
The following classes were fixed according to this new method:

- Warmup
- Pregel 
- LabelPropagation
- AlgoUtils
- BatchRunnable

All the methods that expect a return value are provided with a default one
We should check all the other packages in order to normalize the transaction checking with only one method