### PR TITLE
export now creates 3 different files fixes #270

### DIFF
--- a/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -82,7 +82,8 @@ public class ExportCypher {
         checkWriteAllowed();
         ProgressReporter reporter = new ProgressReporter(null, null, new ProgressInfo(fileName, source, "cypher"));
         MultiStatementCypherSubGraphExporter exporter = new MultiStatementCypherSubGraphExporter(graph);
-        exporter.export(fileName, c.getBatchSize(), reporter);
+        // Pass the full configuration to enable further enhancement
+        exporter.export(fileName, c, reporter);
         return reporter.stream();
     }
 }

--- a/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -1,6 +1,5 @@
 package apoc.export.cypher;
 
-import org.neo4j.procedure.Description;
 import apoc.export.util.ExportConfig;
 import apoc.export.util.NodesAndRelsSubGraph;
 import apoc.export.util.ProgressReporter;
@@ -15,18 +14,17 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Result;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
 import static apoc.export.util.FileUtils.checkWriteAllowed;
-import static apoc.export.util.FileUtils.getPrintWriter;
 
 /**
  * @author mh
@@ -58,9 +56,10 @@ public class ExportCypher {
         String source = String.format("data: nodes(%d), rels(%d)", nodes.size(), rels.size());
         return exportCypher(fileName, source, new NodesAndRelsSubGraph(db, nodes, rels), new ExportConfig(config));
     }
+
     @Procedure
     @Description("apoc.export.cypher.graph(graph,file,config) - exports given graph object incl. indexes as cypher statements to the provided file")
-    public Stream<ProgressInfo> graph(@Name("graph") Map<String,Object> graph, @Name("file") String fileName, @Name("config") Map<String, Object> config) throws IOException {
+    public Stream<ProgressInfo> graph(@Name("graph") Map<String, Object> graph, @Name("file") String fileName, @Name("config") Map<String, Object> config) throws IOException {
 
         Collection<Node> nodes = (Collection<Node>) graph.get("nodes");
         Collection<Relationship> rels = (Collection<Relationship>) graph.get("relationships");
@@ -82,9 +81,8 @@ public class ExportCypher {
     private Stream<ProgressInfo> exportCypher(@Name("file") String fileName, String source, SubGraph graph, ExportConfig c) throws IOException {
         checkWriteAllowed();
         ProgressReporter reporter = new ProgressReporter(null, null, new ProgressInfo(fileName, source, "cypher"));
-        PrintWriter printWriter = getPrintWriter(fileName, null);
         MultiStatementCypherSubGraphExporter exporter = new MultiStatementCypherSubGraphExporter(graph);
-        exporter.export(printWriter, c.getBatchSize(), reporter);
+        exporter.export(fileName, c.getBatchSize(), reporter);
         return reporter.stream();
     }
 }

--- a/src/main/java/apoc/export/util/ExportConfig.java
+++ b/src/main/java/apoc/export/util/ExportConfig.java
@@ -85,4 +85,8 @@ public class ExportConfig {
     public boolean storeNodeIds() {
         return toBoolean(config.getOrDefault("storeNodeIds",false));
     }
+
+    public boolean separateFiles(){
+        return toBoolean(config.getOrDefault("separateFiles", false));
+    }
 }

--- a/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -1,6 +1,5 @@
 package apoc.export.cypher;
 
-import apoc.export.Export;
 import apoc.graph.Graphs;
 import apoc.util.TestUtil;
 import org.junit.AfterClass;
@@ -16,7 +15,6 @@ import java.util.Scanner;
 
 import static apoc.util.MapUtil.map;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * @author mh
@@ -24,26 +22,11 @@ import static org.junit.Assert.assertTrue;
  */
 public class ExportCypherTest {
 
-    private static final String EXPECTED = String.format("begin%n" +
-            "CREATE (:`Foo`:`UNIQUE IMPORT LABEL` {`name`:\"foo\", `UNIQUE IMPORT ID`:0});%n" +
-            "CREATE (:`Bar` {`name`:\"bar\", `age`:42});%n" +
-            "CREATE (:`Bar`:`UNIQUE IMPORT LABEL` {`age`:12, `UNIQUE IMPORT ID`:2});%n" +
-            "commit%n" +
-            "begin%n" +
-            "CREATE INDEX ON :`Foo`(`name`);%n" +
-            "CREATE CONSTRAINT ON (node:`Bar`) ASSERT node.`name` IS UNIQUE;%n" +
-            "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT node.`UNIQUE IMPORT ID` IS UNIQUE;%n" +
-            "commit%n" +
-            "schema await%n" +
-            "begin%n" +
-            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`Bar`{`name`:\"bar\"}) CREATE (n1)-[:`KNOWS`]->(n2);%n" +
-            "commit%n" +
-            "begin%n" +
-            "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
-            "commit%n" +
-            "begin%n" +
-            "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT node.`UNIQUE IMPORT ID` IS UNIQUE;%n" +
-            "commit");
+    private static final String EXPECTED_NODES = String.format("begin%nCREATE (:`Foo`:`UNIQUE IMPORT LABEL` {`name`:\"foo\", `UNIQUE IMPORT ID`:0});%nCREATE (:`Bar` {`name`:\"bar\", `age`:42});%nCREATE (:`Bar`:`UNIQUE IMPORT LABEL` {`age`:12, `UNIQUE IMPORT ID`:2});%ncommit");
+
+    private static final String EXPECTED_RELATIONSHIPS = String.format("begin%nMATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`Bar`{`name`:\"bar\"}) CREATE (n1)-[:`KNOWS`]->(n2);%ncommit");
+
+    private static final String EXPECTED_SCHEMA = String.format("begin%nCREATE INDEX ON :`Foo`(`name`);%nCREATE CONSTRAINT ON (node:`Bar`) ASSERT node.`name` IS UNIQUE;%nCREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT node.`UNIQUE IMPORT ID` IS UNIQUE;%ncommit%nschema await%nbegin%nMATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%ncommit%nbegin%nDROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT node.`UNIQUE IMPORT ID` IS UNIQUE;%ncommit");
 
     private static GraphDatabaseService db;
     private static File directory = new File("target/import");
@@ -61,7 +44,7 @@ public class ExportCypherTest {
                 .newGraphDatabase();
         TestUtil.registerProcedure(db, ExportCypher.class, Graphs.class);
         db.execute("CREATE INDEX ON :Foo(name)").close();
-        db.execute("CREATE CONSTRAINT ON (b:Bar) ASSERT b.name is unique").close();
+        db.execute("CREATE CONSTRAINT ON (b:Bar) ASSERT b.name IS UNIQUE").close();
         db.execute("CREATE (f:Foo {name:'foo'})-[:KNOWS]->(b:Bar {name:'bar',age:42}),(c:Bar {age:12})").close();
     }
 
@@ -71,22 +54,60 @@ public class ExportCypherTest {
     }
 
     @Test
-    public void testExportAllCypher() throws Exception {
+    public void testExportAllCypherNodes() throws Exception {
         File output = new File(directory, "all.cypher");
         TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},null)", map("file", output.getAbsolutePath()),
                 (r) -> assertResults(output, r, "database"));
-        assertEquals(EXPECTED, new Scanner(output).useDelimiter("\\Z").next());
+        assertEquals(EXPECTED_NODES, new Scanner(new File(directory, "all.nodes.cypher")).useDelimiter("\\Z").next());
     }
 
     @Test
-    public void testExportGraphCypher() throws Exception {
+    public void testExportAllCypherRelationships() throws Exception {
+        File output = new File(directory, "all.cypher");
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},null)", map("file", output.getAbsolutePath()),
+                (r) -> assertResults(output, r, "database"));
+        assertEquals(EXPECTED_RELATIONSHIPS, new Scanner(new File(directory, "all.relationships.cypher")).useDelimiter("\\Z").next());
+    }
+
+    @Test
+    public void testExportAllCypherSchema() throws Exception {
+        File output = new File(directory, "all.cypher");
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},null)", map("file", output.getAbsolutePath()),
+                (r) -> assertResults(output, r, "database"));
+        assertEquals(EXPECTED_SCHEMA, new Scanner(new File(directory, "all.schema.cypher")).useDelimiter("\\Z").next());
+    }
+
+    @Test
+    public void testExportGraphCypherNodes() throws Exception {
         File output = new File(directory, "graph.cypher");
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
                         "CALL apoc.export.cypher.graph(graph, {file},null) " +
                         "YIELD nodes, relationships, properties, file, source,format, time " +
                         "RETURN *", map("file", output.getAbsolutePath()),
                 (r) -> assertResults(output, r, "graph"));
-        assertEquals(EXPECTED, new Scanner(output).useDelimiter("\\Z").next());
+        assertEquals(EXPECTED_NODES, new Scanner(new File(directory, "graph.nodes.cypher")).useDelimiter("\\Z").next());
+    }
+
+    @Test
+    public void testExportGraphCypherRelationships() throws Exception {
+        File output = new File(directory, "graph.cypher");
+        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.cypher.graph(graph, {file},null) " +
+                        "YIELD nodes, relationships, properties, file, source,format, time " +
+                        "RETURN *", map("file", output.getAbsolutePath()),
+                (r) -> assertResults(output, r, "graph"));
+        assertEquals(EXPECTED_RELATIONSHIPS, new Scanner(new File(directory, "graph.relationships.cypher")).useDelimiter("\\Z").next());
+    }
+
+    @Test
+    public void testExportGraphCypherSchema() throws Exception {
+        File output = new File(directory, "graph.cypher");
+        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.cypher.graph(graph, {file},null) " +
+                        "YIELD nodes, relationships, properties, file, source,format, time " +
+                        "RETURN *", map("file", output.getAbsolutePath()),
+                (r) -> assertResults(output, r, "graph"));
+        assertEquals(EXPECTED_SCHEMA, new Scanner(new File(directory, "graph.schema.cypher")).useDelimiter("\\Z").next());
     }
 
     private void assertResults(File output, Map<String, Object> r, final String source) {


### PR DESCRIPTION
Given a full path file name like /tmp/myexport.cypher this method will create:

1. /tmp/myexport.schema.cypher
2. /tmp/myexport.nodes.cypher
3. /tmp/myexport.relationships.cypher

We need to consider to normalize the export like the import. We can pass an URI that will be normalized to an export directory.