### PR TITLE
Prevent path expander termination filter from filtering below minLevel

### DIFF
--- a/src/test/java/apoc/path/ExpandPathTest.java
+++ b/src/test/java/apoc/path/ExpandPathTest.java
@@ -247,4 +247,26 @@ public class ExpandPathTest {
 					assertEquals("Clint Eastwood", path.endNode().getProperty("name"));
 				});
 	}
+
+	@Test
+	public void testTerminationFilterDoesNotPruneBelowMinLevel() {
+		db.execute("MATCH (c:Person) WHERE c.name in ['Clint Eastwood', 'Gene Hackman'] SET c:Western");
+
+		TestUtil.testResult(db,
+				"MATCH (k:Person {name:'Keanu Reeves'}) " +
+						"CALL apoc.path.expandConfig(k, {relationshipFilter:'ACTED_IN|PRODUCED|DIRECTED', labelFilter:'/Western', uniqueness: 'NODE_GLOBAL', minLevel:3}) yield path " +
+						"return path",
+				result -> {
+					List<Map<String, Object>> maps = Iterators.asList(result);
+					assertEquals(1, maps.size());
+					Path path = (Path) maps.get(0).get("path");
+					assertEquals("Clint Eastwood", path.endNode().getProperty("name"));
+				});
+	}
+
+	@Test
+	public void testFilterStartNodeFalseDoesNotFilterStartNodeWhenBelowMinLevel() throws Throwable {
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.expandConfig(m,{labelFilter:'+Person', minLevel:1, maxLevel:2, filterStartNode:false}) yield path return count(*) as c";
+		TestUtil.testCall(db, query, (row) -> assertEquals(8L,row.get("c")));
+	}
 }

--- a/src/test/java/apoc/path/ExpandPathTest.java
+++ b/src/test/java/apoc/path/ExpandPathTest.java
@@ -157,7 +157,7 @@ public class ExpandPathTest {
 	}
 
 	@Test
-	public void testBlacklistBeforeTerminationList() {
+	public void testBlacklistBeforeTerminationFilter() {
 		db.execute("MATCH (c:Person) WHERE c.name in ['Clint Eastwood', 'Gene Hackman'] SET c:Western");
 
 		TestUtil.testResult(db,
@@ -171,7 +171,7 @@ public class ExpandPathTest {
 	}
 
 	@Test
-	public void testBlacklistBeforeEndNodeList() {
+	public void testBlacklistBeforeEndNodeFilter() {
 		db.execute("MATCH (c:Person) WHERE c.name in ['Clint Eastwood', 'Gene Hackman'] SET c:Western");
 
 		TestUtil.testResult(db,
@@ -185,7 +185,7 @@ public class ExpandPathTest {
 	}
 
 	@Test
-	public void testTerminationListBeforeWhitelist() {
+	public void testTerminationFilterBeforeWhitelist() {
 		db.execute("MATCH (c:Person) WHERE c.name in ['Clint Eastwood', 'Gene Hackman', 'Christian Bale'] SET c:Western");
 
 		TestUtil.testResult(db,
@@ -201,7 +201,7 @@ public class ExpandPathTest {
 	}
 
 	@Test
-	public void testTerminationListBeforeEndNodeList() {
+	public void testTerminationFilterBeforeEndNodeFilter() {
 		db.execute("MATCH (c:Person) WHERE c.name in ['Clint Eastwood', 'Gene Hackman'] SET c:Western");
 
 		TestUtil.testResult(db,
@@ -217,7 +217,7 @@ public class ExpandPathTest {
 	}
 
 	@Test
-	public void testEndNodeListBeforeWhitelist() {
+	public void testEndNodeFilterBeforeWhitelist() {
 		db.execute("MATCH (c:Person) WHERE c.name in ['Clint Eastwood', 'Gene Hackman'] SET c:Western");
 
 		TestUtil.testResult(db,


### PR DESCRIPTION
This fixes bug #364.