### PR TITLE
Allowed negative time parameter to apoc.date.format()

### DIFF
--- a/src/main/java/apoc/date/Date.java
+++ b/src/main/java/apoc/date/Date.java
@@ -150,9 +150,6 @@ public class Date {
 	}
 
 	public String parse(final @Name("millis") long millis, final @Name(value = "pattern", defaultValue = DEFAULT_FORMAT) String pattern, final @Name("timezone") String timezone) {
-		if (millis < 0) {
-			throw new IllegalArgumentException("The time argument should be >= 0, got: " + millis);
-		}
 		return getFormat(pattern, timezone).format(new java.util.Date(millis));
 	}
 

--- a/src/test/java/apoc/date/DateTest.java
+++ b/src/test/java/apoc/date/DateTest.java
@@ -166,8 +166,7 @@ public class DateTest {
 				row -> {});
 	}
 
-	@Test public void testFromUnixtimeWithNegativeInput() throws Exception {
-		expected.expect(instanceOf(QueryExecutionException.class));
+	@Test public void testFromUnixtimeWithNegativeInputDoesNotThrowException() throws Exception {
 		testCall(db, "RETURN apoc.date.format(-1,'s') AS value", row -> {});
 	}
 


### PR DESCRIPTION
Fulfills change request #392.

If there's a good reason for the restriction that I've overlooked, please reject the PR.