### PR TITLE
Fixes #334 - make sure that manual index operations are read-only

### DIFF
--- a/src/main/java/apoc/index/IndexUpdateTransactionEventHandler.java
+++ b/src/main/java/apoc/index/IndexUpdateTransactionEventHandler.java
@@ -10,6 +10,7 @@ import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.graphdb.event.TransactionEventHandler;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.IndexManager;
+import org.neo4j.kernel.KernelApi;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.logging.Log;
@@ -171,8 +172,10 @@ public class IndexUpdateTransactionEventHandler extends TransactionEventHandler.
 
             final IndexManager indexManager = graphDatabaseService.index();
             for (String indexName : indexManager.nodeIndexNames()) {
+
                 final Index<Node> index = indexManager.forNodes(indexName);
-                Map<String, String> indexConfig = indexManager.getConfiguration(index);
+
+                Map<String, String> indexConfig = KernelApi.getIndexConfiguration(indexName, graphDatabaseService);
 
                 if (Util.toBoolean(indexConfig.get("autoUpdate"))) {
                     String labels = indexConfig.getOrDefault("labels", "");

--- a/src/main/java/org/neo4j/kernel/KernelApi.java
+++ b/src/main/java/org/neo4j/kernel/KernelApi.java
@@ -1,0 +1,72 @@
+package org.neo4j.kernel;
+
+import apoc.result.WeightedNodeResult;
+import apoc.result.WeightedRelationshipResult;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.kernel.api.LegacyIndexHits;
+import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.exceptions.legacyindex.LegacyIndexNotFoundKernelException;
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author AgileLARUS
+ *
+ * @since 21-04-2017
+ */
+public class KernelApi {
+
+    public static LegacyIndexHits nodeQueryIndex(String indexName, Object query, GraphDatabaseService db) throws Exception {
+        return getReadOperation(db).nodeLegacyIndexQuery(indexName, query);
+    }
+    
+    public static LegacyIndexHits relationshipQueryIndex(String indexName, Object query, GraphDatabaseService db, Long startNode, Long endNode) throws Exception {
+        long startingNode = (startNode == null) ? -1 : startNode;
+        long endingNode = (endNode == null) ? -1 : endNode;
+        return getReadOperation(db).relationshipLegacyIndexQuery(indexName, query, startingNode, endingNode);
+    }
+
+    public static Node getEndNode(GraphDatabaseService db, long id) {
+        Relationship rel = db.getRelationshipById(id);
+        return rel.getEndNode();
+    }
+
+    public static Map<String, String> getIndexConfiguration(String indexName, GraphDatabaseService db) {
+        Map<String, String> stringStringMap = null;
+        try {
+            stringStringMap = getReadOperation(db).nodeLegacyIndexGetConfiguration(indexName);
+        } catch (LegacyIndexNotFoundKernelException e) {
+            throw new RuntimeException();
+        }
+        return stringStringMap;
+    }
+
+    public static List<WeightedNodeResult> toWeightedNodeResultFromLegacyIndex(LegacyIndexHits hits, GraphDatabaseService db){
+        List<WeightedNodeResult> result = new ArrayList<>(hits.size());
+        while(hits.hasNext()){
+            result.add(new WeightedNodeResult(db.getNodeById(hits.next()), hits.currentScore()));
+        }
+        return result;
+    }
+
+    public static List<WeightedRelationshipResult> toWeightedRelationshipResultFromLegacyIndex(LegacyIndexHits hits, GraphDatabaseService db){
+        List<WeightedRelationshipResult> result = new ArrayList<>(hits.size());
+        while(hits.hasNext()){
+            result.add(new WeightedRelationshipResult(db.getRelationshipById(hits.next()), hits.currentScore()));
+        }
+        return result;
+    }
+
+    private static ReadOperations getReadOperation(GraphDatabaseService db){
+        return  ((GraphDatabaseAPI)db)
+                .getDependencyResolver()
+                .resolveDependency(ThreadToStatementContextBridge.class).get()
+                .readOperations();
+    }
+}

--- a/src/test/java/apoc/util/UtilTest.java
+++ b/src/test/java/apoc/util/UtilTest.java
@@ -1,6 +1,13 @@
 package apoc.util;
 
+import apoc.index.FreeTextSearch;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.index.Index;
+import org.neo4j.graphdb.index.IndexHits;
+import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -16,6 +23,27 @@ import static org.junit.Assert.*;
  * @since 19.05.16
  */
 public class UtilTest {
+
+    private static GraphDatabaseService db;
+
+    private static Node node;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        TestUtil.registerProcedure(db, Utils.class);
+        TestUtil.registerProcedure(db, FreeTextSearch.class);
+        try (Transaction tx = db.beginTx()) {
+            node = db.createNode(Label.label("User"));
+            node.setProperty("name", "foo");
+            tx.success();
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
+    }
 
     @Test
     public void testSubMap() throws Exception {
@@ -41,6 +69,7 @@ public class UtilTest {
         assertEquals(10,Util.partitionSubList(list,11).count());
         assertEquals(10,Util.partitionSubList(list,20).count());
     }
+    
     @Test
     public void cleanPassword() throws Exception {
         String url = "http://%slocalhost:7474/path?query#ref";


### PR DESCRIPTION
`apoc.index.forRelationships` and `apoc.index.forNodes` are gets or create so we cannot transform it into read only operations. We can split it into two different procedure, get and create or leave it like this.

Using the method `relationshipLegacyIndexQuery` of `ReadOperation` :
`relationshipLegacyIndexQuery(indexName, query, startingNode, endingNode)`
if we pass `null` on the `endNode` parameter (that we transform in **-1** to ignore the parameter), we have an unexpected behavior. For example if we test `apoc.index.out` (see `testOut)` we have the same result as the incoming (`apoc.index.in`).
We have this problem only if we pass **-1** as parameter, for every other number it works.  If we pass **-1**  on startingNode it works. It seems a bug