### PR TITLE
fixes #391 - Update documentation for procedures that have converted to functions

### DIFF
--- a/docs/datetime.adoc
+++ b/docs/datetime.adoc
@@ -6,11 +6,8 @@ endif::env-guide[]
 
 == Conversion between formatted dates and timestamps
 
-* `apoc.date.parseDefault('2015-03-25 03:15:59','s')` get Unix time equivalent of given date (in seconds)
-* `apoc.date.parse('2015/03/25 03-15-59','s','yyyy/MM/dd HH/mm/ss')` same as previous, but accepts custom datetime format
-* `apoc.date.formatDefault(12345,'s')` get string representation of date corresponding to given Unix time (in seconds) in UTC time zone
-* `apoc.date.format(12345,'s', 'yyyy/MM/dd HH/mm/ss')` the same as previous, but accepts custom datetime format
-* `apoc.date.formatTimeZone(12345,'s', 'yyyy/MM/dd HH/mm/ss', 'ABC')` the same as previous, but accepts custom time zone
+* `apoc.date.parse('2015/03/25 03-15-59',['s'],['yyyy/MM/dd HH/mm/ss'])` same as previous, but accepts custom datetime format
+* `apoc.date.format(12345,['s'], ['yyyy/MM/dd HH/mm/ss'])` the same as previous, but accepts custom datetime format
 
 * possible unit values: `ms,s,m,h,d` and their long forms.
 * possible time zone values: Either an abbreviation such as `PST`, a full name such as `America/Los_Angeles`, or a custom ID such as `GMT-8:00`. Full names are recommended.
@@ -33,12 +30,7 @@ Splits date (optionally, using given custom format) into fields returning a map 
 
 [source,cypher]
 ----
-CALL apoc.date.fields('2015-03-25 03:15:59')
-----
-
-[source,cypher]
-----
-CALL apoc.date.fieldsFormatted('2015-01-02 03:04:05 EET', 'yyyy-MM-dd HH:mm:ss zzz')
+RETURN apoc.date.fields('2015-03-25 03:15:59')
 ----
 
 
@@ -60,48 +52,34 @@ Following fields are supported:
 
 [source,cypher]
 ----
-CALL apoc.date.fieldsDefault('2015-03-25 03:15:59')
-----
-
-----
-    {
-      'Months': 1,
-      'Days': 2,
-      'Hours': 3,
-      'Minutes': 4,
-      'Seconds': 5,
-      'Years': 2015
-    }
-----
-
-[source,cypher]
-----
-CALL apoc.date.fields('2015-01-02 03:04:05 EET', 'yyyy-MM-dd HH:mm:ss zzz')
+RETURN apoc.date.fields('2015-01-02 03:04:05 EET', 'yyyy-MM-dd HH:mm:ss zzz')
 ----
 
 ----
   {
-    'ZoneId': 'Europe/Bucharest',
-    'Months': 1,
-    'Days': 2,
-    'Hours': 3,
-    'Minutes': 4,
-    'Seconds': 5,
-    'Years': 2015
+    'weekdays': 5,
+    'years': 2015,
+    'seconds': 5,
+    'zoneid': 'EET',
+    'minutes': 4,
+    'hours': 3,
+    'months': 1,
+    'days': 2
   }
 ----
 
 [source,cypher]
 ----
-CALL apoc.date.fields('2015/01/02_EET', 'yyyy/MM/dd_z')
+RETURN apoc.date.fields('2015/01/02_EET', 'yyyy/MM/dd_z')
 ----
 
 ----
   {
-    'Years': 2015,
-    'ZoneId': 'Europe/Bucharest',
-    'Months': 1,
-    'Days': 2
+    'weekdays': 5,
+    'years': 2015,
+    'zoneid': 'EET',
+    'months': 1,
+    'days': 2
   }
 ----
 

--- a/docs/extract.adoc
+++ b/docs/extract.adoc
@@ -1,18 +1,16 @@
 = Extract Domain
 
-The procedure `apoc.data.domain` will take a url or email address and try to determine the domain name.
+The User Function `apoc.data.domain` will take a url or email address and try to determine the domain name.
 This can be useful to make easier correlations and equality tests between differently formatted email addresses, and between urls to the same domains but specifying different locations.
 
 [source,cypher]
 ----
 WITH 'foo@bar.com' AS email
-CALL apoc.data.domain(email) YIELD domain
-RETURN domain // will return 'bar.com'
+RETURN apoc.data.domain(email) // will return 'bar.com'
 ----
 
 [source,cypher]
 ----
 WITH 'http://www.example.com/all-the-things' AS url
-CALL apoc.data.domain(url) YIELD domain
-RETURN domain // will return 'www.example.com'
+RETURN apoc.data.domain(url) // will return 'www.example.com'
 ----

--- a/docs/functions.adoc
+++ b/docs/functions.adoc
@@ -12,7 +12,7 @@ For example:
 ----
 CREATE (v:Value {id:{id}, data:{data}})
 WITH v
-CALL apoc.date.formatDefault(timestamp(), "ms") YIELD value as created
+CALL apoc.date.format(timestamp(), "ms") YIELD value as created
 SET v.created = created
 ----
 

--- a/docs/number.adoc
+++ b/docs/number.adoc
@@ -2,28 +2,27 @@
 
 == Conversion between formatted decimals
 
-* `apoc.number.format(number) yield value` format a long or double using the default system pattern and language to produce a string
-* `apoc.number.format.pattern(number, pattern) yield value` format a long or double using a pattern and the default system language to produce a string
-* `apoc.number.format.lang(number, lang) yield value` format a long or double using the default system pattern pattern and a language to produce a string
-* `apoc.number.format.pattern.lang(number, pattern, lang) yield value` format a long or double using a pattern and a language to produce a string
+* `apoc.number.format(number)` format a long or double using the default system pattern and language to produce a string
+* `apoc.number.format(number, pattern)` format a long or double using a pattern and the default system language to produce a string
+* `apoc.number.format(number, lang)` format a long or double using the default system pattern pattern and a language to produce a string
+* `apoc.number.format(number, pattern, lang)` format a long or double using a pattern and a language to produce a string
 
-* `apoc.number.parseInt(text) yield value` parse a text using the default system pattern and language to produce a long
-* `apoc.number.parseInt.pattern(text, pattern) yield value` parse a text using a pattern and the default system language to produce a long
-* `apoc.number.parseInt.lang(text, lang) yield value` parse a text using the default system pattern and a language to produce a long
-* `apoc.number.parseInt.pattern.lang(text, pattern, lang) yield value` parse a text using a pattern and a language to produce a long
+* `apoc.number.parseInt(text)` parse a text using the default system pattern and language to produce a long
+* `apoc.number.parseInt(text, pattern)` parse a text using a pattern and the default system language to produce a long
+* `apoc.number.parseInt(text, '', lang)` parse a text using the default system pattern and a language to produce a long
+* `apoc.number.parseInt(text, pattern, lang)` parse a text using a pattern and a language to produce a long
 
-* `apoc.number.parseFloat(text) yield value` parse a text using the default system pattern and language to produce a double
-* `apoc.number.parseFloat.pattern(text, pattern) yield value` parse a text using a pattern and the default system language to produce a double
-* `apoc.number.parseFloat.lang(text, lang) yield value` parse a text using the default system pattern and a language to produce a double
-* `apoc.number.parseFloat.pattern.lang(text, pattern, lang) yield value` parse a text using a pattern and a language to produce a double
+* `apoc.number.parseFloat(text)` parse a text using the default system pattern and language to produce a double
+* `apoc.number.parseFloat(text, pattern)` parse a text using a pattern and the default system language to produce a double
+* `apoc.number.parseFloat(text,'',lang)` parse a text using the default system pattern and a language to produce a double
+* `apoc.number.parseFloat(text, pattern, lang)` parse a text using a pattern and a language to produce a double
 
 * The full list of supported values for `pattern` and `lang` params is described in https://docs.oracle.com/javase/9/docs/api/java/text/DecimalFormat.html[DecimalFormat JavaDoc]
 
 == Examples
 
 ....
-  call apoc.number.format(12345.67) yield value
-  return value
+  return apoc.number.format(12345.67) as value
 
   ╒═════════╕
   │value    │
@@ -33,8 +32,7 @@
 ....
 
 ....
-  call apoc.number.format.pattern.lang(12345, '#,##0.00;(#,##0.00)', 'it') yield value
-  return value
+  return apoc.number.format(12345, '#,##0.00;(#,##0.00)', 'it') as value
 
   ╒═════════╕
   │value    │
@@ -44,19 +42,17 @@
 ....
 
 ....
-  call apoc.number.format.pattern.lang(12345.67, '#,##0.00;(#,##0.00)', 'it') yield value
-  return value
-  
+  return apoc.number.format(12345.67, '#,##0.00;(#,##0.00)', 'it') as value
+
   ╒═════════╕
   │value    │
   ╞═════════╡
   │12.345,67│
-  └─────────┘  
+  └─────────┘
 ....
 
 ....
-  call apoc.number.parseInt.pattern.lang('12.345', '#,##0.00;(#,##0.00)', 'it') yield value
-  return value
+  return apoc.number.parseInt('12.345', '#,##0.00;(#,##0.00)', 'it') as value
 
   ╒═════╕
   │value│
@@ -66,9 +62,8 @@
 ....
 
 ....
-  call apoc.number.parseFloat.pattern.lang('12.345,67', '#,##0.00;(#,##0.00)', 'it') yield value
-  return value
-  
+  return apoc.number.parseFloat('12.345,67', '#,##0.00;(#,##0.00)', 'it') as value
+
   ╒════════╕
   │value   │
   ╞════════╡
@@ -77,19 +72,13 @@
 ....
 
 ....
-  call apoc.number.format('aaa') yield value
+  return apoc.number.format('aaa') as value
 
-  Failed to invoke procedure `apoc.number.format`: Caused by: java.lang.IllegalArgumentException: Number parameter must be long or double.
+  null beacuse 'aaa' isn't a number
 ....
 
 ....
-  call apoc.number.format.lang(12345, 'apoc')
+  RETURN apoc.number.parseInt('aaa')
   
-  Failed to invoke procedure `apoc.number.format.lang`: Caused by: java.lang.IllegalArgumentException: Unrecognized language value: 'apoc' isn't a valid ISO language
-....
-
-....
-  call apoc.number.parseInt('aaa')
-  
-  Failed to invoke procedure `apoc.number.parseAsLong`: Caused by: java.text.ParseException: Unparseable number: "aaa"
+  Return null because 'aaa' is unparsable.
 ....

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -1100,11 +1100,7 @@ Optionally set `apoc.ttl.schedule=5` as repeat frequency.
 |===
 | apoc.date.parse('2015/03/25 03:15:59',['ms'/'s'], ['yyyy/MM/dd HH:mm:ss']) | same as previous, but accepts custom datetime format
 | apoc.date.format(12345, ['ms'/'s'], ['yyyy/MM/dd HH:mm:ss']) | the same as previous, but accepts custom datetime format
-| apoc.date.formatTimeZone(12345,'s', 'yyyy/MM/dd HH/mm/ss', 'ABC') | the same as previous, but accepts custom time zone
 | apoc.date.systemTimezone() | return the system timezone display format string
-
-| apoc.date.parseDefault('2015-03-25 03:15:59','s') | DEPRECATED get Unix time equivalent of given date (in seconds)
-| apoc.date.formatDefault(12345,'s') | DEPRECATED get string representation of date corresponding to given Unix time (in seconds)
 |===
 
 * possible unit values: `ms,s,m,h,d` and their long forms `millis,milliseconds,seconds,minutes,hours,days`.
@@ -1127,7 +1123,6 @@ Optionally set `apoc.ttl.schedule=5` as repeat frequency.
 Splits date (optionally, using given custom format) into fields returning a map from field name to its value.
 
 * `apoc.date.fields('2015-03-25 03:15:59')`
-* `apoc.date.fieldsFormatted('2015-01-02 03:04:05 EET', 'yyyy-MM-dd HH:mm:ss zzz')`
 
 == Bitwise operations
 

--- a/docs/spatial.adoc
+++ b/docs/spatial.adoc
@@ -171,21 +171,18 @@ LIMIT 100
 
 == Combined Space and Time search
 
-Combining spatial and date-time procedures can allow for more complex queries:
+Combining spatial and date-time functions can allow for more complex queries:
 
 [source,cypher]
 ----
-CALL apoc.date.parse('2016-06-01 00:00:00','h') YIELD value AS due_date
-WITH due_date,
-point({latitude: 48.8582532, longitude: 2.294287}) AS eiffel
+WITH point({latitude: 48.8582532, longitude: 2.294287}) AS eiffel
 MATCH (e:Event)
 WHERE exists(e.address) AND exists(e.datetime)
 CALL apoc.spatial.geocodeOnce(e.address) YIELD location
-CALL apoc.date.parse(e.datetime,'h') YIELD value AS hours
 WITH e, location,
 distance(point(location), eiffel) AS distance,
-            (due_date - hours)/24.0 AS days_before_due
-WHERE distance < 5000 AND days_before_due < 14 AND hours < due_date
+            (apoc.date.parse('2016-06-01 00:00:00','h') - apoc.date.parse(e.datetime,'h'))/24.0 AS days_before_due
+WHERE distance < 5000 AND days_before_due < 14 AND apoc.date.parse(e.datetime,'h') < apoc.date.parse('2016-06-01 00:00:00','h')
 RETURN e.name AS event, e.datetime AS date,
 location.description AS description, distance
 ORDER BY distance


### PR DESCRIPTION
We don't found some procedures/functions, so we deleted them from documentation.

apoc.number.format.lang
apoc.number.format.pattern
apoc.number.format.pattern.lang
apoc.number.parseInt.pattern
apoc.number.parseInt.lang
apoc.number.parseInt.pattern.lang
apoc.number.parseFloat.pattern
apoc.number.parseFloat.lang
apoc.number.parseFloat.pattern.lang

apoc.date.formatDefault
apoc.date.parseDefault
apoc.date.formatTimeZone
apoc.date.fieldsFormatted
apoc.date.fieldsDefault