### PR TITLE
fixes #430 - Better error messages when missing drivers

### DIFF
--- a/src/main/java/apoc/couchbase/Couchbase.java
+++ b/src/main/java/apoc/couchbase/Couchbase.java
@@ -3,6 +3,7 @@ package apoc.couchbase;
 import java.util.List;
 import java.util.stream.Stream;
 
+import apoc.util.MissingDependencyException;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
@@ -96,9 +97,10 @@ public class Couchbase {
   @Procedure
   @Description("apoc.couchbase.get(nodes, bucket, documentId) yield id, expiry, cas, mutationToken, content - retrieves a couchbase json document by its unique ID.")
   public Stream<CouchbaseJsonDocument> get(@Name("nodes") List<String> nodes, @Name("bucket") String bucket,
-      @Name("documentId") String documentId) {
+      @Name("documentId") String documentId){
     Stream<CouchbaseJsonDocument> result = null;
-    try (CouchbaseConnection couchbaseConnection = CouchbaseManager.getConnection(nodes, bucket)) {
+
+    try (CouchbaseConnection couchbaseConnection = getCouchbaseConnection(nodes, bucket)) {
       JsonDocument jsonDocument = couchbaseConnection.get(documentId);
       if (jsonDocument != null) {
         result = Stream.of(new CouchbaseJsonDocument(jsonDocument));
@@ -127,9 +129,9 @@ public class Couchbase {
   @Procedure
   @Description("apoc.couchbase.exists(nodes, bucket, documentId) yield value - check whether a couchbase json document with the given ID does exist.")
   public Stream<BooleanResult> exists(@Name("nodes") List<String> nodes, @Name("bucket") String bucket,
-      @Name("documentId") String documentId) {
+      @Name("documentId") String documentId){
     Stream<BooleanResult> result = null;
-    try (CouchbaseConnection couchbaseConnection = CouchbaseManager.getConnection(nodes, bucket)) {
+    try (CouchbaseConnection couchbaseConnection = getCouchbaseConnection(nodes, bucket)) {
       result = Stream.of(new BooleanResult(couchbaseConnection.exists(documentId)));
     }
     return result;
@@ -157,9 +159,9 @@ public class Couchbase {
   @Procedure
   @Description("apoc.couchbase.insert(nodes, bucket, documentId, jsonDocument) yield id, expiry, cas, mutationToken, content - insert a couchbase json document with its unique ID.")
   public Stream<CouchbaseJsonDocument> insert(@Name("nodes") List<String> nodes, @Name("bucket") String bucket,
-      @Name("documentId") String documentId, @Name("json") String json) {
+      @Name("documentId") String documentId, @Name("json") String json){
     Stream<CouchbaseJsonDocument> result = null;
-    try (CouchbaseConnection couchbaseConnection = CouchbaseManager.getConnection(nodes, bucket)) {
+    try (CouchbaseConnection couchbaseConnection = getCouchbaseConnection(nodes, bucket)) {
       JsonDocument jsonDocument = couchbaseConnection.insert(documentId, json);
       if (jsonDocument != null) {
         result = Stream.of(new CouchbaseJsonDocument(jsonDocument));
@@ -191,9 +193,9 @@ public class Couchbase {
   @Procedure
   @Description("apoc.couchbase.upsert(nodes, bucket, documentId, jsonDocument) yield id, expiry, cas, mutationToken, content - insert or overwrite a couchbase json document with its unique ID.")
   public Stream<CouchbaseJsonDocument> upsert(@Name("nodes") List<String> nodes, @Name("bucket") String bucket,
-      @Name("documentId") String documentId, @Name("json") String json) {
+      @Name("documentId") String documentId, @Name("json") String json){
     Stream<CouchbaseJsonDocument> result = null;
-    try (CouchbaseConnection couchbaseConnection = CouchbaseManager.getConnection(nodes, bucket)) {
+    try (CouchbaseConnection couchbaseConnection = getCouchbaseConnection(nodes, bucket)) {
       JsonDocument jsonDocument = couchbaseConnection.upsert(documentId, json);
       if (jsonDocument != null) {
         result = Stream.of(new CouchbaseJsonDocument(jsonDocument));
@@ -224,9 +226,9 @@ public class Couchbase {
   @Procedure
   @Description("apoc.couchbase.append(nodes, bucket, documentId, jsonDocument) yield id, expiry, cas, mutationToken, content - append a couchbase json document to an existing one.")
   public Stream<CouchbaseJsonDocument> append(@Name("nodes") List<String> nodes, @Name("bucket") String bucket,
-      @Name("documentId") String documentId, @Name("json") String json) {
+      @Name("documentId") String documentId, @Name("json") String json){
     Stream<CouchbaseJsonDocument> result = null;
-    try (CouchbaseConnection couchbaseConnection = CouchbaseManager.getConnection(nodes, bucket)) {
+    try (CouchbaseConnection couchbaseConnection = getCouchbaseConnection(nodes, bucket)) {
       JsonDocument jsonDocument = couchbaseConnection.append(documentId, json);
       if (jsonDocument != null) {
         result = Stream.of(new CouchbaseJsonDocument(jsonDocument));
@@ -257,9 +259,9 @@ public class Couchbase {
   @Procedure
   @Description("apoc.couchbase.prepend(nodes, bucket, documentId, jsonDocument) yield id, expiry, cas, mutationToken, content - prepend a couchbase json document to an existing one.")
   public Stream<CouchbaseJsonDocument> prepend(@Name("nodes") List<String> nodes, @Name("bucket") String bucket,
-      @Name("documentId") String documentId, @Name("json") String json) {
+      @Name("documentId") String documentId, @Name("json") String json){
     Stream<CouchbaseJsonDocument> result = null;
-    try (CouchbaseConnection couchbaseConnection = CouchbaseManager.getConnection(nodes, bucket)) {
+    try (CouchbaseConnection couchbaseConnection = getCouchbaseConnection(nodes, bucket)) {
       JsonDocument jsonDocument = couchbaseConnection.prepend(documentId, json);
       if (jsonDocument != null) {
         result = Stream.of(new CouchbaseJsonDocument(jsonDocument));
@@ -288,9 +290,9 @@ public class Couchbase {
   @Procedure
   @Description("apoc.couchbase.remove(nodes, bucket, documentId) yield id, expiry, cas, mutationToken, content - remove the couchbase json document identified by its unique ID.")
   public Stream<CouchbaseJsonDocument> remove(@Name("nodes") List<String> nodes, @Name("bucket") String bucket,
-      @Name("documentId") String documentId) {
+      @Name("documentId") String documentId){
     Stream<CouchbaseJsonDocument> result = null;
-    try (CouchbaseConnection couchbaseConnection = CouchbaseManager.getConnection(nodes, bucket)) {
+    try (CouchbaseConnection couchbaseConnection = getCouchbaseConnection(nodes, bucket)) {
       JsonDocument jsonDocument = couchbaseConnection.remove(documentId);
       if (jsonDocument != null) {
         result = Stream.of(new CouchbaseJsonDocument(jsonDocument));
@@ -322,9 +324,9 @@ public class Couchbase {
   @Procedure
   @Description("apoc.couchbase.replace(nodes, bucket, documentId, jsonDocument) yield id, expiry, cas, mutationToken, content - replace the content of the couchbase json document identified by its unique ID.")
   public Stream<CouchbaseJsonDocument> replace(@Name("nodes") List<String> nodes, @Name("bucket") String bucket,
-      @Name("documentId") String documentId, @Name("json") String json) {
+      @Name("documentId") String documentId, @Name("json") String json){
     Stream<CouchbaseJsonDocument> result = null;
-    try (CouchbaseConnection couchbaseConnection = CouchbaseManager.getConnection(nodes, bucket)) {
+    try (CouchbaseConnection couchbaseConnection = getCouchbaseConnection(nodes, bucket)) {
       JsonDocument jsonDocument = couchbaseConnection.replace(documentId, json);
       if (jsonDocument != null) {
         result = Stream.of(new CouchbaseJsonDocument(jsonDocument));
@@ -354,9 +356,9 @@ public class Couchbase {
   @Procedure
   @Description("apoc.couchbase.query(nodes, bucket, statement) yield queryResult - executes a plain un-parameterized N1QL statement.")
   public Stream<CouchbaseQueryResult> query(@Name("nodes") List<String> nodes, @Name("bucket") String bucket,
-      @Name("statement") String statement) {
+      @Name("statement") String statement){
     Stream<CouchbaseQueryResult> result = null;
-    try (CouchbaseConnection couchbaseConnection = CouchbaseManager.getConnection(nodes, bucket)) {
+    try (CouchbaseConnection couchbaseConnection = getCouchbaseConnection(nodes, bucket)) {
       List<JsonObject> statementResult = couchbaseConnection.executeStatement(statement);
       if (statementResult != null) {
         result = Stream.of(CouchbaseUtils.convertToCouchbaseQueryResult(statementResult));
@@ -389,9 +391,9 @@ public class Couchbase {
   @Procedure
   @Description("apoc.couchbase.posParamsQuery(nodes, bucket, statement, params) yield queryResult - executes a N1QL statement with positional parameters.")
   public Stream<CouchbaseQueryResult> posParamsQuery(@Name("nodes") List<String> nodes, @Name("bucket") String bucket,
-      @Name("statement") String statement, @Name("params") List<Object> params) {
+      @Name("statement") String statement, @Name("params") List<Object> params){
     Stream<CouchbaseQueryResult> result = null;
-    try (CouchbaseConnection couchbaseConnection = CouchbaseManager.getConnection(nodes, bucket)) {
+    try (CouchbaseConnection couchbaseConnection = getCouchbaseConnection(nodes, bucket)) {
       List<JsonObject> statementResult = couchbaseConnection.executeParametrizedStatement(statement, params);
       if (statementResult != null) {
         result = Stream.of(CouchbaseUtils.convertToCouchbaseQueryResult(statementResult));
@@ -427,9 +429,9 @@ public class Couchbase {
   @Description("apoc.couchbase.namedParamsQuery(nodes, bucket, statement, paramNames, paramValues) yield queryResult - executes a N1QL statement with named parameters.")
   public Stream<CouchbaseQueryResult> namedParamsQuery(@Name("nodes") List<String> nodes, @Name("bucket") String bucket,
       @Name("statement") String statement, @Name("paramNames") List<String> paramNames,
-      @Name("paramValues") List<Object> paramValues) {
+      @Name("paramValues") List<Object> paramValues){
     Stream<CouchbaseQueryResult> result = null;
-    try (CouchbaseConnection couchbaseConnection = CouchbaseManager.getConnection(nodes, bucket)) {
+    try (CouchbaseConnection couchbaseConnection = getCouchbaseConnection(nodes, bucket)) {
       List<JsonObject> statementResult = couchbaseConnection.executeParametrizedStatement(statement, paramNames,
           paramValues);
       if (statementResult != null) {
@@ -437,5 +439,21 @@ public class Couchbase {
       }
     }
     return result;
+  }
+
+  private CouchbaseConnection getCouchbaseConnection(List<String> nodes, String bucket){
+    try (CouchbaseConnection couchbaseConnection = CouchbaseManager.getConnection(nodes, bucket)) {
+      return couchbaseConnection;
+    } catch (NoClassDefFoundError e){
+      throw new MissingDependencyException("Cannot find the jar into the plugins folder. \n"+
+              "Please put these jar in the plugins folder : \n\n" +
+              "java-client-x.y.z.jar\n" +
+              "\n" +
+              "core-io-x.y.z.jar\n" +
+              "\n" +
+              "rxjava-x.y.z.jar\n" +
+              "\n" +
+              "See the documentation: https://neo4j-contrib.github.io/neo4j-apoc-procedures/#_interacting_with_couchbase");
+    }
   }
 }

--- a/src/main/java/apoc/load/Jdbc.java
+++ b/src/main/java/apoc/load/Jdbc.java
@@ -72,7 +72,9 @@ public class Jdbc {
                     .onClose( () -> closeIt(log, stmt,connection));
         } catch (SQLException e) {
             log.error(String.format("Cannot execute SQL statement `%s`.%nError:%n%s", query, e.getMessage()),e);
-            throw new RuntimeException(String.format("Cannot execute SQL statement `%s`.%nError:%n%s", query, e.getMessage()), e);
+            String errorMessage = "Cannot execute SQL statement `%s`.%nError:%n%s";
+            if(e.getMessage().contains("No suitable driver")) errorMessage="Cannot execute SQL statement `%s`.%nError:%n%s%n%s";
+            throw new RuntimeException(String.format(errorMessage, query, e.getMessage(), "Please download and copy the JDBC driver into $NEO4J_HOME/plugins,more details at https://neo4j-contrib.github.io/neo4j-apoc-procedures/#_load_jdbc_resources"), e);
         }
     }
 

--- a/src/main/java/apoc/mongodb/MongoDB.java
+++ b/src/main/java/apoc/mongodb/MongoDB.java
@@ -1,5 +1,6 @@
 package apoc.mongodb;
 
+import apoc.util.MissingDependencyException;
 import org.neo4j.procedure.Description;
 import apoc.result.LongResult;
 import apoc.result.MapResult;
@@ -46,12 +47,13 @@ public class MongoDB {
     @Procedure
     @Description("apoc.mongodb.get(host-or-port,db-or-null,collection-or-null,query-or-null) yield value - perform a find operation on mongodb collection")
     public Stream<MapResult> get(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String,Object> query) {
-        return getColl(hostOrKey, db, collection).all(query).map(MapResult::new);
+        return getMongoColl(hostOrKey, db, collection).all(query).map(MapResult::new);
     }
+
     @Procedure
     @Description("apoc.mongodb.count(host-or-port,db-or-null,collection-or-null,query-or-null) yield value - perform a find operation on mongodb collection")
     public Stream<LongResult> count(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String,Object> query) {
-        long count = getColl(hostOrKey, db, collection).count(query);
+        long count = getMongoColl(hostOrKey, db, collection).count(query);
         return Stream.of(new LongResult(count));
     }
 
@@ -63,35 +65,56 @@ public class MongoDB {
     @Procedure
     @Description("apoc.mongodb.first(host-or-port,db-or-null,collection-or-null,query-or-null) yield value - perform a first operation on mongodb collection")
     public Stream<MapResult> first(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String,Object> query) {
-        Map<String, Object> result = getColl(hostOrKey, db, collection).first(query);
+        Map<String, Object> result = getMongoColl(hostOrKey, db, collection).first(query);
         return Stream.of(new MapResult(result));
     }
 
     @Procedure
     @Description("apoc.mongodb.find(host-or-port,db-or-null,collection-or-null,query-or-null,projection-or-null,sort-or-null) yield value - perform a find,project,sort operation on mongodb collection")
     public Stream<MapResult> find(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String,Object> query,@Name("project") Map<String,Object> project,@Name("sort") Map<String,Object> sort) {
-        return getColl(hostOrKey, db, collection).find(query,project,sort).map(MapResult::new);
+        return getMongoColl(hostOrKey, db, collection).find(query,project,sort).map(MapResult::new);
     }
 
     @Procedure
     @Description("apoc.mongodb.insert(host-or-port,db-or-null,collection-or-null,list-of-maps) - inserts the given documents into the mongodb collection")
     public void insert(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("documents") List<Map<String,Object>> documents) {
-        getColl(hostOrKey, db, collection).insert(documents);
+        getMongoColl(hostOrKey, db, collection).insert(documents);
     }
 
     @Procedure
     @Description("apoc.mongodb.delete(host-or-port,db-or-null,collection-or-null,list-of-maps) - inserts the given documents into the mongodb collection")
     public Stream<LongResult> delete(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String,Object> query) {
-        return Stream.of(new LongResult(getColl(hostOrKey, db, collection).delete(query)));
+        return Stream.of(new LongResult(getMongoColl(hostOrKey, db, collection).delete(query)));
     }
     @Procedure
     @Description("apoc.mongodb.update(host-or-port,db-or-null,collection-or-null,list-of-maps) - inserts the given documents into the mongodb collection")
     public Stream<LongResult> update(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String,Object> query, @Name("update") Map<String,Object> update) {
-        return Stream.of(new LongResult(getColl(hostOrKey, db, collection).update(query,update)));
+        return Stream.of(new LongResult(getMongoColl(hostOrKey, db, collection).update(query,update)));
     }
 
     private String getMongoDBUrl(String hostOrKey) {
         return new UrlResolver("mongodb", "localhost", 27017).getUrl("mongodb", hostOrKey);
+    }
+
+    private Coll getMongoColl(String hostOrKey, String db, String collection){
+        Coll coll = null;
+        try {
+            coll = getColl(hostOrKey, db, collection);
+        }
+        catch (NoClassDefFoundError e) {
+            throw new MissingDependencyException("Cannot find the jar into the plugins folder. \n"+
+                    "Please put these jar in the plugins folder :\n\n" +
+                    "bson-x.y.z.jar\n" +
+                    "\n" +
+                    "mongo-java-driver-x.y.z.jar\n" +
+                    "\n" +
+                    "mongodb-driver-x.y.z.jar\n" +
+                    "\n" +
+                    "mongodb-driver-core-x.y.z.jar\n" +
+                    "\n" +
+                    "See the documentation: https://neo4j-contrib.github.io/neo4j-apoc-procedures/#_interacting_with_mongodb");
+        }
+        return coll;
     }
 
     interface Coll extends Closeable {

--- a/src/main/java/apoc/util/MissingDependencyException.java
+++ b/src/main/java/apoc/util/MissingDependencyException.java
@@ -1,0 +1,10 @@
+package apoc.util;
+
+/**
+ * Created by larusba on 5/18/17.
+ */
+public class MissingDependencyException extends RuntimeException{
+    public MissingDependencyException(String message) {
+        super(message);
+    }
+}

--- a/src/test/java/apoc/couchbase/CouchbaseTest.java
+++ b/src/test/java/apoc/couchbase/CouchbaseTest.java
@@ -10,6 +10,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Stream;
 
+import apoc.util.MissingDependencyException;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -99,7 +100,7 @@ public class CouchbaseTest extends CouchbaseAbstractTest {
   }
 
   @Test
-  public void testInsertWithAlreadyExistingID() {
+  public void testInsertWithAlreadyExistingID(){
     expectedEx.expect(DocumentAlreadyExistsException.class);
     //@eclipse-formatter:off
     new Couchbase().insert(Arrays.asList("localhost"), "default", "artist:vincent_van_gogh", JsonObject.empty().toString());


### PR DESCRIPTION
@jexp for jdbc we have already an error who specifies that driver is missing.
If you want, we can create a map that specifies the drive to be inserted into the plugin folder (Oracle, Derby...). 

![missingdriverjdbcerror](https://cloud.githubusercontent.com/assets/14560890/26297353/c72c2880-3ed2-11e7-868d-038a34e1a965.PNG)
