### PR TITLE
Added brand new apoc.sequence and hashing utils from 3.1.

### DIFF
--- a/src/main/java/apoc/sequence/Sequence.java
+++ b/src/main/java/apoc/sequence/Sequence.java
@@ -1,0 +1,151 @@
+package apoc.sequence;
+
+import apoc.result.NodeResult;
+import apoc.result.ObjectResult;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.procedure.*;
+
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+/**
+ * Created by Valentino Maiorca on 6/29/17.
+ */
+public class Sequence {
+
+    /**
+     * Label for all sequence-node.
+     */
+    public static final Label SEQUENCE_LABEL = Label.label("Apoc_Sequence");
+
+    public static final String PROVIDER_PROPERTY = "provider";
+
+    public static final String NAME_PROPERTY = "name";
+
+    // Simple provider. Increments by 1 the value.
+    public static final SequenceProvider<Long> LONG_SP = new SequenceProvider<Long>() {
+
+        @Override
+        public Long start() {
+            return 0L;
+        }
+
+        @Override
+        public Long next(Long current) {
+            return current + 1;
+        }
+
+        @Override
+        public LinkedList<Long> next(Long current, long length) {
+            return LongStream.range(current + 1, current + length + 1).boxed()
+                    .collect(Collectors.toCollection(LinkedList::new));
+        }
+
+        @Override
+        public String getName() {
+            return "LongCounter";
+        }
+
+    };
+
+    // Map <providerName, sequenceProvider> holding instances of provider for fast access.
+
+    private static final Map<String, SequenceProvider> SEQUENCE_PROVIDER_MAP = new ConcurrentHashMap<>();
+
+    static {
+        SEQUENCE_PROVIDER_MAP.put(LONG_SP.getName(), LONG_SP);
+    }
+
+    /**
+     * Registers a new provider. It will be available for sequence creation.
+     *
+     * @param provider
+     * @return True if the provider wasn't already registered, false otherwise.
+     */
+    public static boolean registerProvider(SequenceProvider provider) {
+        return SEQUENCE_PROVIDER_MAP.put(provider.getName(), provider) == null;
+    }
+
+    @Context
+    public GraphDatabaseService db;
+
+    @UserFunction(value = "apoc.sequence.get")
+    @Description("apoc.sequence.get('sequenceName') - returns the node representing that sequence, null if not existing.")
+    public Node get(@Name("sequenceName") String sequenceName) {
+        return db.findNode(SEQUENCE_LABEL, NAME_PROPERTY, sequenceName);
+    }
+
+
+    // TODO: 29/06/17 Can't be completely thread safe. Can't acquire a lock on a node if the node doesn't exist.
+    @Procedure(mode = Mode.WRITE)
+    @Description("apoc.sequence.create('sequenceName', 'providerName') - create sequence with given provider")
+    public Stream<NodeResult> create(@Name("sequenceName") String sequenceName,
+                                     @Name(value = "providerName", defaultValue = "LongCounter") String providerName) {
+        // MultipleFoundException if more than one.
+        Node sequenceNode = db.findNode(SEQUENCE_LABEL, NAME_PROPERTY, sequenceName);
+        if (sequenceNode != null)
+            throw new RuntimeException(String.format("There's already a sequence with name <%s> !", sequenceName));
+
+        SequenceProvider provider = SEQUENCE_PROVIDER_MAP.get(providerName);
+        if (provider == null)
+            throw new RuntimeException("No provider registered with name: " + providerName);
+
+        Node node = db.createNode(SEQUENCE_LABEL);
+        node.setProperty(NAME_PROPERTY, sequenceName);
+        node.setProperty(PROVIDER_PROPERTY, providerName);
+        node.setProperty(provider.propertyName(), provider.start());
+
+        return Stream.of(new NodeResult(node));
+    }
+
+    @Procedure(mode = Mode.WRITE)
+    @Description("apoc.sequence.next('sequenceName') - get&increment sequence value using related provider and length as increments number")
+    @SuppressWarnings("unchecked")
+    public Stream<ObjectResult> next(@Name("sequenceName") String sequenceName, @Name(value = "length", defaultValue = "1") long length) {
+        LinkedList<Object> result = new LinkedList<>();
+
+        try (Transaction tx = db.beginTx()) {
+            Node sequenceNode = db.findNode(SEQUENCE_LABEL, NAME_PROPERTY, sequenceName);
+
+            if (sequenceNode == null)
+                throw new RuntimeException(String.format("You must create %s (with apoc.sequence.create) before using it!",
+                        sequenceName));
+
+            String providerName = (String) sequenceNode.getProperty(PROVIDER_PROPERTY);
+            SequenceProvider provider = SEQUENCE_PROVIDER_MAP.get(providerName);
+
+            if (provider == null)
+                throw new RuntimeException(String.format("No provider associated with <%s>", sequenceName));
+
+            tx.acquireWriteLock(sequenceNode);
+
+            Object current = sequenceNode.getProperty(provider.propertyName());
+
+            if (length < 1)
+                throw new RuntimeException("Length can't be lower than 1!");
+            if (length > 1) {
+                result = provider.next(current, length - 1);
+                // next method doesn't include the left bound, so we add it later.
+                result.addFirst(current);
+
+                current = result.getLast();
+            } else
+                result.add(current);
+
+
+            sequenceNode.setProperty(provider.propertyName(), provider.next(current));
+
+            tx.success();
+        }
+
+        return result.stream().map(ObjectResult::new);
+    }
+
+}

--- a/src/main/java/apoc/sequence/SequenceProvider.java
+++ b/src/main/java/apoc/sequence/SequenceProvider.java
@@ -1,0 +1,48 @@
+package apoc.sequence;
+
+import java.util.LinkedList;
+
+/**
+ * Created by Valentino Maiorca on 6/29/17.
+ */
+public interface SequenceProvider<V> {
+
+    String SEQUENCE_LABEL_PROPERTY = "next_value";
+
+    default String propertyName() {
+        return SEQUENCE_LABEL_PROPERTY;
+    }
+
+    /**
+     * Returns the start value for this sequence.
+     */
+    V start();
+
+    /**
+     * Returns the value next to the one provided.
+     *
+     * @param current
+     * @return
+     */
+    V next(V current);
+
+    /**
+     * @return The name for the sequence.
+     */
+    String getName();
+
+    /**
+     * Returns a list of values next to the one provided (not included).
+     * @param current The start value to compute from.
+     * @param length The list size.
+     * @return The next values list.
+     */
+    default LinkedList<V> next(V current, long length) {
+        LinkedList<V> result = new LinkedList<>();
+
+        for (int i = 0; i < length; i++)
+            result.add(current = next(current));
+
+        return result;
+    }
+}

--- a/src/main/java/apoc/util/Utils.java
+++ b/src/main/java/apoc/util/Utils.java
@@ -27,6 +27,27 @@ public class Utils {
     }
 
     @UserFunction
+    @Description("apoc.util.sha256([values]) | computes the sha256 of the concatenation of all string values of the list")
+    public String sha256(@Name("values") List<Object> values) {
+        String value = values.stream().map(v -> v == null ? "" : v.toString()).collect(Collectors.joining());
+        return DigestUtils.sha256Hex(value);
+    }
+
+    @UserFunction
+    @Description("apoc.util.sha384([values]) | computes the sha384 of the concatenation of all string values of the list")
+    public String sha384(@Name("values") List<Object> values) {
+        String value = values.stream().map(v -> v == null ? "" : v.toString()).collect(Collectors.joining());
+        return DigestUtils.sha384Hex(value);
+    }
+
+    @UserFunction
+    @Description("apoc.util.sha512([values]) | computes the sha512 of the concatenation of all string values of the list")
+    public String sha512(@Name("values") List<Object> values) {
+        String value = values.stream().map(v -> v == null ? "" : v.toString()).collect(Collectors.joining());
+        return DigestUtils.sha512Hex(value);
+    }
+
+    @UserFunction
     @Description("apoc.util.md5([values]) | computes the md5 of the concatenation of all string values of the list")
     public String md5(@Name("values") List<Object> values) {
         String value = values.stream().map(v -> v == null ? "" : v.toString()).collect(Collectors.joining());

--- a/src/test/java/apoc/sequence/SequenceTest.java
+++ b/src/test/java/apoc/sequence/SequenceTest.java
@@ -1,0 +1,197 @@
+package apoc.sequence;
+
+import apoc.util.MapUtil;
+import apoc.util.TestUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by Valentino Maiorca on 6/29/17.
+ */
+public class SequenceTest {
+
+    private static GraphDatabaseService db;
+
+    private static String CREATE_SEQUENCE_QUERY = "CALL apoc.sequence.create($sequence) YIELD node as n return n";
+
+    private static String NEXT_VALUE_QUERY = "CALL apoc.sequence.next($sequence) YIELD value as n return n";
+
+    private static String NEXT_VALUES_QUERY = "CALL apoc.sequence.next($sequence, $length) YIELD value as n return n";
+
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        TestUtil.registerProcedure(db, Sequence.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
+    }
+
+    @Test
+    public void testDefaultSequence() throws Throwable {
+        final String NEW_SEQUENCE = "TEST1_SEQUENCE";
+
+        // Test creation
+        TestUtil.testCall(db, CREATE_SEQUENCE_QUERY, MapUtil.map("sequence", NEW_SEQUENCE), (row) -> {
+        });
+        TestUtil.testCall(db, String.format("MATCH (n:%s {%s: $sequence}) RETURN count(*) AS result",
+                Sequence.SEQUENCE_LABEL.name(),
+                Sequence.NAME_PROPERTY),
+                MapUtil.map("sequence", NEW_SEQUENCE),
+                (row) -> assertEquals(1L, row.get("result")));
+
+        //Test increment
+        for (long tries = 0; tries < 100; tries++) {
+            long finalTries = tries;
+            TestUtil.testCall(db, NEXT_VALUE_QUERY, MapUtil.map("sequence", NEW_SEQUENCE),
+                    (row) -> assertEquals(finalTries, row.get("n")));
+        }
+    }
+
+    @Test
+    public void testSequenceMultithread() throws Throwable {
+        Map<String, Object> params = MapUtil.map("sequence", "TEST2_SEQUENCE");
+
+        TestUtil.testCall(db, CREATE_SEQUENCE_QUERY, params, (row) -> {
+        });
+
+        long threadsNumber = 1000;
+        ExecutorService executorService = Executors.newFixedThreadPool(50);
+
+        for (int threadNumber = 0; threadNumber < threadsNumber; threadNumber++)
+            executorService.submit(() -> TestUtil.testCall(db, NEXT_VALUE_QUERY, params, row -> {
+            }));
+
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.HOURS);
+
+        TestUtil.testCall(db, NEXT_VALUE_QUERY, params, row -> assertEquals(threadsNumber, row.get("n")));
+    }
+
+    @Test
+    public void testMultipleSequencesMultithread() throws Throwable {
+        long threadsNumber = 1000;
+        String[] names = new String[5];
+        for (int i = 0; i < 5; i++)
+            names[i] = "Seq_" + i;
+
+        for (String name : names)
+            TestUtil.testCall(db, CREATE_SEQUENCE_QUERY, MapUtil.map("sequence", name), (row) -> {
+            });
+
+        ExecutorService executorService = Executors.newFixedThreadPool(50);
+        for (int i = 0; i < threadsNumber; i++)
+            for (String name : names)
+                executorService.submit(() ->
+                        TestUtil.testCall(db, NEXT_VALUE_QUERY, MapUtil.map("sequence", name), row -> {
+                        }));
+
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.HOURS);
+
+        for (String name : names)
+            TestUtil.testCall(db, NEXT_VALUE_QUERY, MapUtil.map("sequence", name),
+                    (row) -> assertEquals(threadsNumber, row.get("n")));
+    }
+
+    @Test
+    public void testMultipleSequencesMultithread2() throws Throwable {
+        int sequenceNumber = 100;
+        String[] names = new String[sequenceNumber];
+        for (int i = 0; i < sequenceNumber; i++)
+            names[i] = "Seq2_" + i;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(50);
+        for (String name : names) {
+            TestUtil.testCall(db, CREATE_SEQUENCE_QUERY, MapUtil.map("sequence", name), row -> {
+            });
+            for (int i = 0; i < 6; i++)
+                executorService.submit(() ->
+                        TestUtil.testCall(db, NEXT_VALUE_QUERY, MapUtil.map("sequence", name), row -> {
+                        }));
+        }
+
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.HOURS);
+
+        for (String name : names)
+            TestUtil.testCall(db, NEXT_VALUE_QUERY, MapUtil.map("sequence", name),
+                    (row) -> assertEquals(6L, row.get("n")));
+    }
+
+    @Test
+    public void testGetSequence() throws Throwable {
+        Map<String, Object> params = MapUtil.map("sequence", "TestSequenceRoot");
+        TestUtil.testCall(db, String.format("MATCH (n:%s {%s: $sequence}) RETURN count(*) AS result",
+                Sequence.SEQUENCE_LABEL.name(),
+                Sequence.NAME_PROPERTY),
+                params,
+                (row) -> assertEquals(0L, row.get("result")));
+
+        TestUtil.testCall(db, CREATE_SEQUENCE_QUERY, params, row -> {
+        });
+
+        TestUtil.testCall(db, String.format("MATCH (n:%s {%s: $sequence}) RETURN count(*) AS result",
+                Sequence.SEQUENCE_LABEL.name(),
+                Sequence.NAME_PROPERTY),
+                params,
+                (row) -> assertEquals(1L, row.get("result")));
+    }
+
+    @Test
+    public void testRegisterAndUseNewProvider() throws Throwable {
+        SequenceProvider<String> provider = new SequenceProvider<String>() {
+            @Override
+            public String start() {
+                return "a";
+            }
+
+            @Override
+            public String next(String previous) {
+                return previous + "a";
+            }
+
+            @Override
+            public String getName() {
+                return "StupidStringProvider";
+            }
+        };
+        Sequence.registerProvider(provider);
+
+        Map<String, Object> params = MapUtil.map("sequence", "StupidStringSequence");
+
+        TestUtil.testCall(db, "CALL apoc.sequence.create($sequence, 'StupidStringProvider') YIELD node as n return n",
+                params, row -> {
+                });
+        TestUtil.testCall(db, NEXT_VALUE_QUERY, params, (row) -> assertEquals("a", row.get("n")));
+        TestUtil.testCall(db, NEXT_VALUE_QUERY, params, (row) -> assertEquals("aa", row.get("n")));
+        TestUtil.testCall(db, NEXT_VALUE_QUERY, params, (row) -> assertEquals("aaa", row.get("n")));
+    }
+
+    @Test
+    public void testNextWithLength() throws Throwable {
+        Map<String, Object> params = new HashMap<>();
+        params.put("sequence", "TestLength");
+        TestUtil.testCall(db, CREATE_SEQUENCE_QUERY, params, (row) -> {
+        });
+
+        params.put("length", 100);
+
+        TestUtil.testCallCount(db, NEXT_VALUES_QUERY, params, 100);
+    }
+
+}


### PR DESCRIPTION
A sequence has a thread safe _increment_ (not creation).
The problem mentioned here https://github.com/neo4j/neo4j/issues/9599 only appears in test environment. We're not able to reproduce it on different environments (Java embedded and bolt) with the same test code.