### PR TITLE
Sorted map properties

### DIFF
--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -683,6 +683,7 @@ Sometimes type information gets lost, these functions help you to coerce an "Any
 | apoc.map.clean(map,[keys],[values]) yield value | removes the keys and values (e.g. null-placeholders) contained in those lists, good for data cleaning from CSV/JSON
 | apoc.map.groupBy([maps/nodes/relationships],'key') yield value | creates a map of the list keyed by the given property, with single values
 | apoc.map.groupByMulti([maps/nodes/relationships],'key') yield value | creates a map of the list keyed by the given property, with list values
+| apoc.map.sortedProperties(map, ignoreCase:true) | returns a list of key/value list pairs, with pairs sorted by keys alphabetically, with optional case sensitivity
 |===
 
 

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -184,6 +184,7 @@ RETURN apoc.meta.isType(n.age,"INTEGER") as ageType
 |===
 | apoc.convert.toJson([1,2,3]) | converts value to json string
 | apoc.convert.toJson( {a:42,b:"foo",c:[1,2,3]}) | converts value to json map
+| apoc.convert.toSortedJsonMap(node\|map, ignoreCase:true ) | returns a JSON map with keys sorted alphabetically, with optional case sensitivity
 | apoc.convert.fromJsonList('[1,2,3]') | converts json list to Cypher list
 | apoc.convert.fromJsonMap( '{"a":42,"b":"foo","c":[1,2,3]}') | converts json map to Cypher map
 | apoc.convert.toTree([paths]) | creates a stream of nested documents representing the at least one root of these paths

--- a/src/main/java/apoc/convert/Json.java
+++ b/src/main/java/apoc/convert/Json.java
@@ -103,6 +103,34 @@ public class Json {
                 .map(MapResult::new);
     }
 
+    @UserFunction("apoc.convert.toSortedJsonMap")
+    @Description("apoc.convert.toSortedJsonMap(node|map, ignoreCase:true) - returns a JSON map with keys sorted alphabetically, with optional case sensitivity")
+    public String toSortedJsonMap(@Name("value") Object value, @Name(value="ignoreCase", defaultValue = "true") boolean ignoreCase) {
+        Map<String, Object> inputMap;
+        Map<String, Object> sortedMap;
+
+        if (value instanceof Node) {
+            inputMap = ((Node)value).getAllProperties();
+        } else if (value instanceof Map) {
+            inputMap = (Map<String, Object>) value;
+        } else {
+            throw new IllegalArgumentException("input value must be a Node or a map");
+        }
+
+        if (ignoreCase) {
+            sortedMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+            sortedMap.putAll(inputMap);
+        } else {
+            sortedMap = new TreeMap<>(inputMap);
+        }
+
+        try {
+            return JsonUtil.OBJECT_MAPPER.writeValueAsString(sortedMap);
+        } catch (IOException e) {
+            throw new RuntimeException("Can't convert " + value + " to json", e);
+        }
+    }
+
     private Map<String, Object> addRelProperties(Map<String, Object> mMap, String typeName, Relationship r) {
         Map<String, Object> rProps = r.getAllProperties();
         if (rProps.isEmpty()) return mMap;

--- a/src/main/java/apoc/map/Maps.java
+++ b/src/main/java/apoc/map/Maps.java
@@ -1,13 +1,13 @@
 package apoc.map;
 
+import apoc.result.MapResult;
 import apoc.util.Util;
 import org.neo4j.graphdb.*;
-import org.neo4j.procedure.Context;
-import org.neo4j.procedure.Description;
-import org.neo4j.procedure.Name;
-import org.neo4j.procedure.UserFunction;
+import org.neo4j.procedure.*;
 
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class Maps {
 
@@ -179,4 +179,22 @@ public class Maps {
         }
     }
 
+    @UserFunction
+    @Description("apoc.map.sortedProperties(map, ignoreCase:true) - returns a list of key/value list pairs, with pairs sorted by keys alphabetically, with optional case sensitivity")
+    public List<List<Object>> sortedProperties(@Name("map") Map<String, Object> map, @Name(value="ignoreCase", defaultValue = "true") boolean ignoreCase) {
+        List<List<Object>> sortedProperties = new ArrayList<>();
+        List<String> keys = new ArrayList<>(map.keySet());
+
+        if (ignoreCase) {
+            Collections.sort(keys, String.CASE_INSENSITIVE_ORDER);
+        } else {
+            Collections.sort(keys);
+        }
+
+        for (String key : keys) {
+            sortedProperties.add(Arrays.asList(key, map.get(key)));
+        }
+
+        return sortedProperties;
+    }
 }

--- a/src/test/java/apoc/convert/ConvertJsonTest.java
+++ b/src/test/java/apoc/convert/ConvertJsonTest.java
@@ -116,4 +116,13 @@ public class ConvertJsonTest {
                     assertEquals("CPU", cpu.get("name"));
                 });
     }
+    @Test public void testToJsonMapSortingProperties() throws Exception {
+        testCall(db, "WITH {b:8, d:3, a:2, E: 12, C:9} as map RETURN apoc.convert.toSortedJsonMap(map, false) as value",
+                (row) -> assertEquals("{\"C\":9,\"E\":12,\"a\":2,\"b\":8,\"d\":3}", row.get("value")) );
+    }
+
+    @Test public void testToJsonMapSortingPropertiesIgnoringCase() throws Exception {
+        testCall(db, "WITH {b:8, d:3, a:2, E: 12, C:9} as map RETURN apoc.convert.toSortedJsonMap(map) as value",
+                (row) -> assertEquals("{\"a\":2,\"b\":8,\"C\":9,\"d\":3,\"E\":12}", row.get("value")) );
+    }
 }

--- a/src/test/java/apoc/map/MapsTest.java
+++ b/src/test/java/apoc/map/MapsTest.java
@@ -9,6 +9,8 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import static apoc.util.MapUtil.map;
@@ -153,6 +155,32 @@ public class MapsTest {
                     "nested.anotherkey", "anotherValue",
                     "nested.nested.somekey", "someValue",
                     "nested.nested.somenumeric", 123), resultMap);
+        });
+    }
+
+    @Test
+    public void testSortedProperties() {
+        TestUtil.testCall(db, "WITH {b:8, d:3, a:2, E: 12, C:9} as map RETURN apoc.map.sortedProperties(map, false) AS sortedProperties", (r) -> {
+            List<List<String>> sortedProperties = (List<List<String>>)r.get("sortedProperties");
+            assertEquals(5, sortedProperties.size());
+            assertEquals(asList("C", 9l), sortedProperties.get(0));
+            assertEquals(asList("E", 12l), sortedProperties.get(1));
+            assertEquals(asList("a", 2l), sortedProperties.get(2));
+            assertEquals(asList("b", 8l), sortedProperties.get(3));
+            assertEquals(asList("d", 3l), sortedProperties.get(4));
+        });
+    }
+
+    @Test
+    public void testCaseInsensitiveSortedProperties() {
+        TestUtil.testCall(db, "WITH {b:8, d:3, a:2, E: 12, C:9} as map RETURN apoc.map.sortedProperties(map) AS sortedProperties", (r) -> {
+            List<List<String>> sortedProperties = (List<List<String>>)r.get("sortedProperties");
+            assertEquals(5, sortedProperties.size());
+            assertEquals(asList("a", 2l), sortedProperties.get(0));
+            assertEquals(asList("b", 8l), sortedProperties.get(1));
+            assertEquals(asList("C", 9l), sortedProperties.get(2));
+            assertEquals(asList("d", 3l), sortedProperties.get(3));
+            assertEquals(asList("E", 12l), sortedProperties.get(4));
         });
     }
 }


### PR DESCRIPTION
Added apoc.convert.toSortedJsonMap(), and apoc.map.sortedProperties(), which return map representations (with lists, in the case of apoc.map.sortedProperties()) with properties sorted alphabetically, with optional case sensitivity.