### PR TITLE
add jmh for performance testing and improvements for background index population

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,9 +10,10 @@ buildscript {
 plugins {
     id 'java'
     id 'idea'
-    id 'com.github.johnrengelman.shadow' version '1.2.3'
+    id 'com.github.johnrengelman.shadow' version '1.2.4'
     id "org.asciidoctor.convert" version "1.5.3"
     id "com.bmuschko.nexus" version "2.3.1"
+    id "me.champeau.gradle.jmh" version "0.3.1"
 }
 asciidoctorj {
     version = '1.5.5'
@@ -86,6 +87,8 @@ dependencies {
     compile group: 'com.github.javafaker', name: 'javafaker', version:'0.10'
 
     compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
+    jmh group: 'org.neo4j', name: 'neo4j-lucene-index', version:neo4jVersion
+    jmh group: 'org.neo4j', name: 'neo4j-kernel', version:neo4jVersion, classifier: "tests"
 }
 
 test {
@@ -106,16 +109,17 @@ javadoc {
 }
 
 shadowJar {
-  dependencies {
-    include(dependency('commons-codec:commons-codec'))
-    include(dependency('com.jayway.jsonpath:json-path'))
-    include(dependency('net.minidev:asm'))
-    include(dependency('net.minidev:json-smart'))
-    include(dependency('org.slf4j:slf4j-api'))
-    include(dependency('net.minidev:accessors-smart'))
-    include(dependency('com.github.javafaker:javafaker'))
-  }
+    dependencies {
+        include(dependency('commons-codec:commons-codec'))
+        include(dependency('com.jayway.jsonpath:json-path'))
+        include(dependency('net.minidev:asm'))
+        include(dependency('net.minidev:json-smart'))
+        include(dependency('org.slf4j:slf4j-api'))
+        include(dependency('net.minidev:accessors-smart'))
+        include(dependency('com.github.javafaker:javafaker'))
+    }
 }
+
 
 /**************
 * ASCIIDOCTOR *
@@ -212,4 +216,47 @@ if (System.env.TRAVIS == 'true') {
 task copyRuntimeLibs(type: Copy) {
     into "lib"
     from configurations.testRuntime 
+}
+
+jmh {
+//    include = ['some regular expression'] // include pattern (regular expression) for benchmarks to be executed
+//    exclude = ['some regular expression'] // exclude pattern (regular expression) for benchmarks to be executed
+    iterations = 5 // Number of measurement iterations to do.
+    benchmarkMode = ['ss']
+//    benchmarkMode = ['thrpt','ss'] // Benchmark mode. Available modes are: [Throughput/thrpt, AverageTime/avgt, SampleTime/sample, SingleShotTime/ss, All/all]
+//    batchSize = 1 // Batch size: number of benchmark method calls per operation. (some benchmark modes can ignore this setting)
+    fork = 1 // How many times to forks a single benchmark. Use 0 to disable forking altogether
+//    failOnError = false // Should JMH fail immediately if any benchmark had experienced the unrecoverable error?
+//    forceGC = false // Should JMH force GC between iterations?
+//    jvm = 'myjvm' // Custom JVM to use when forking.
+//    jvmArgs = ['Custom JVM args to use when forking.']
+//    jvmArgsAppend = ['Custom JVM args to use when forking (append these)']
+//    jvmArgsPrepend =[ 'Custom JVM args to use when forking (prepend these)']
+//    humanOutputFile = project.file("${project.buildDir}/reports/jmh/human.txt") // human-readable output file
+//    resultsFile = project.file("${project.buildDir}/reports/jmh/results.txt") // results file
+//    operationsPerInvocation = 10 // Operations per invocation.
+//    benchmarkParameters =  [:] // Benchmark parameters.
+//    profilers = [] // Use profilers to collect additional data. Supported profilers: [cl, comp, gc, stack, perf, perfnorm, perfasm, xperf, xperfasm, hs_cl, hs_comp, hs_gc, hs_rt, hs_thr]
+//    timeOnIteration = '1s' // Time to spend at each measurement iteration.
+//    resultFormat = 'CSV' // Result format type (one of CSV, JSON, NONE, SCSV, TEXT)
+//    synchronizeIterations = false // Synchronize iterations?
+//    threads = 4 // Number of worker threads to run with.
+//    threadGroups = [2,3,4] //Override thread group distribution for asymmetric benchmarks.
+//    timeout = '1s' // Timeout for benchmark iteration.
+//    timeUnit = 'ms' // Output time unit. Available time units are: [m, s, ms, us, ns].
+//    verbosity = 'NORMAL' // Verbosity mode. Available modes are: [SILENT, NORMAL, EXTRA]
+//    warmup = '1s' // Time to spend at each warmup iteration.
+//    warmupBatchSize = 2 // Warmup batch size: number of benchmark method calls per operation.
+    warmupForks = 1 // How many warmup forks to make for a single benchmark. 0 to disable warmup forks.
+    warmupIterations = 1 // Number of warmup iterations to do.
+//    warmupMode = 'INDI' // Warmup mode for warming up selected benchmarks. Warmup modes are: [INDI, BULK, BULK_INDI].
+//    warmupBenchmarks = ['.*Warmup'] // Warmup benchmarks to include in the run in addition to already selected. JMH will not measure these benchmarks, but only use them for the warmup.
+//    zip64 = true // Use ZIP64 format for bigger archives
+//    jmhVersion = '1.15' // Specifies JMH version
+//    includeTests = true // Allows to include test sources into generate JMH jar, i.e. use it when benchmarks depend on the test classes.
+//    duplicateClassesStrategy = 'fail' // Strategy to apply when encountring duplicate classes during creation of the fat jar (i.e. while executing jmhJar task)
+}
+
+jmhJar {
+    mergeServiceFiles()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -251,7 +251,7 @@ jmh {
     warmupIterations = 1 // Number of warmup iterations to do.
 //    warmupMode = 'INDI' // Warmup mode for warming up selected benchmarks. Warmup modes are: [INDI, BULK, BULK_INDI].
 //    warmupBenchmarks = ['.*Warmup'] // Warmup benchmarks to include in the run in addition to already selected. JMH will not measure these benchmarks, but only use them for the warmup.
-//    zip64 = true // Use ZIP64 format for bigger archives
+    zip64 = true // Use ZIP64 format for bigger archives
 //    jmhVersion = '1.15' // Specifies JMH version
 //    includeTests = true // Allows to include test sources into generate JMH jar, i.e. use it when benchmarks depend on the test classes.
 //    duplicateClassesStrategy = 'fail' // Strategy to apply when encountring duplicate classes during creation of the fat jar (i.e. while executing jmhJar task)

--- a/docs/fulltext.adoc
+++ b/docs/fulltext.adoc
@@ -194,17 +194,22 @@ Alternatively, you can decide to perform index updates asynchronously in a separ
 apoc.autoIndex.async=true
 -----
 
-With setting enabled, index updates are fed to a buffer queue that is consumed asynchronously using transaction batches. 
+With this setting enabled, index updates are fed to a buffer queue that is consumed asynchronously using transaction batches.
 The batching can be further configured using
 
 [source,properties]
 -----
-apoc.autoIndex.async_rollover_opscount=10000
+apoc.autoIndex.queue_capacity=100000
+apoc.autoIndex.async_rollover_opscount=50000
 apoc.autoIndex.async_rollover_millis=5000
+apoc.autoIndex.tx_handler_stopwatch=false
 -----
 
 The values above are the default setting. 
-In this example the index updates are consumed in transactions of maximum 10000 operations or 5000 milliseconds - whichever triggers first will cause the index update transaction to be committed and rolled over.
+In this example the index updates are consumed in transactions of maximum 50000 operations or 5000 milliseconds - whichever triggers first will cause the index update transaction to be committed and rolled over.
+
+If `apoc.autoIndex.tx_handler_stopwatch` is enabled, the time spent in `beforeCommit` and `afterCommit` is traced to `debug.log`.
+Use this setting only for diagnosis.
 
 === A Worked Example on Fulltext Index Tracking
 

--- a/docs/jmh.adoc
+++ b/docs/jmh.adoc
@@ -1,0 +1,11 @@
+= usage of JMH in apoc
+
+The APOC library uses http://openjdk.java.net/projects/code-tools/jmh/[JMH] for micro benchmarking. You'll find the
+source code for the benchmarks in
+src/jmh/main. We use the https://github.com/melix/jmh-gradle-plugin[Gradle JMH plugin] to configure JMH and run the
+benchmarks.
+
+NOTE: JMH is *not* run during a regular build.
+
+To run JMH benchmarks, type `./gradlew jmh`
+

--- a/src/jmh/java/apoc/AsyncIndexingGraphDatabaseState.java
+++ b/src/jmh/java/apoc/AsyncIndexingGraphDatabaseState.java
@@ -1,0 +1,16 @@
+package apoc;
+
+import org.neo4j.helpers.collection.MapUtil;
+
+import java.util.Map;
+
+public class AsyncIndexingGraphDatabaseState extends SyncIndexingGraphDatabaseState {
+
+    @Override
+    public Map<String, String> getGraphDatabaseConfig() {
+        return MapUtil.genericMap("apoc.autoIndex.enabled", "true",
+                "apoc.autoIndex.async", "true",
+                "apoc.autoIndex.configUpdateInterval", "-1");
+    }
+
+}

--- a/src/jmh/java/apoc/GraphDatabaseState.java
+++ b/src/jmh/java/apoc/GraphDatabaseState.java
@@ -21,12 +21,11 @@ public class GraphDatabaseState {
     }
 
     @Setup(Level.Invocation)
-    public final void setup() throws KernelException {
+    public final void setup() {
         graphDatabaseService = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
                 .setConfig(getGraphDatabaseConfig())
                 .newGraphDatabase();
         setupGraphDatabase(graphDatabaseService);
-//            System.out.println("new graphdb");
     }
 
     @TearDown(Level.Invocation)

--- a/src/jmh/java/apoc/GraphDatabaseState.java
+++ b/src/jmh/java/apoc/GraphDatabaseState.java
@@ -1,0 +1,51 @@
+package apoc;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.Collections;
+import java.util.Map;
+
+@State(Scope.Benchmark)
+public class GraphDatabaseState {
+
+
+    private GraphDatabaseService graphDatabaseService;
+
+    public GraphDatabaseService getGraphDatabaseService() {
+        return graphDatabaseService;
+    }
+
+    @Setup(Level.Invocation)
+    public final void setup() throws KernelException {
+        graphDatabaseService = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
+                .setConfig(getGraphDatabaseConfig())
+                .newGraphDatabase();
+        setupGraphDatabase(graphDatabaseService);
+//            System.out.println("new graphdb");
+    }
+
+    @TearDown(Level.Invocation)
+    public final void tearDown() {
+
+        try (Transaction tx = graphDatabaseService.beginTx()) {
+            long numberOfNodes = Iterables.count(graphDatabaseService.getAllNodes());
+            System.out.println(" we have " + numberOfNodes + " nodes");
+            tx.success();
+        }
+        graphDatabaseService.shutdown();
+//            System.out.println("db stopped.");
+    }
+
+    public Map<String, String> getGraphDatabaseConfig() {
+        return Collections.EMPTY_MAP;
+    }
+
+    void setupGraphDatabase(GraphDatabaseService graphDatabaseService) {
+    }
+}
+

--- a/src/jmh/java/apoc/IndexTrackingGraphDatabaseState.java
+++ b/src/jmh/java/apoc/IndexTrackingGraphDatabaseState.java
@@ -1,16 +1,16 @@
 package apoc;
 
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.helpers.collection.MapUtil;
 
-import java.util.Collections;
 import java.util.Map;
 
 public class IndexTrackingGraphDatabaseState extends GraphDatabaseState {
 
     @Override
     public Map<String, String> getGraphDatabaseConfig() {
-//        return Collections.singletonMap("apoc.autoIndex.enabled", "true");
-        return Collections.EMPTY_MAP;
+        return MapUtil.genericMap("apoc.autoIndex.enabled", "true",
+            "apoc.autoIndex.configUpdateInterval", "-1");
     }
 
     @Override

--- a/src/jmh/java/apoc/IndexTrackingGraphDatabaseState.java
+++ b/src/jmh/java/apoc/IndexTrackingGraphDatabaseState.java
@@ -1,0 +1,24 @@
+package apoc;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class IndexTrackingGraphDatabaseState extends GraphDatabaseState {
+
+    @Override
+    public Map<String, String> getGraphDatabaseConfig() {
+//        return Collections.singletonMap("apoc.autoIndex.enabled", "true");
+        return Collections.EMPTY_MAP;
+    }
+
+    @Override
+    void setupGraphDatabase(GraphDatabaseService graphDatabaseService) {
+//            TestUtil.registerProcedure(getGraphDatabaseService(), FreeTextSearch.class);
+//            graphDatabaseService.execute("call apoc.index.addAllNodesExtended('person_index',{Person:['name']},{autoUpdate:true})");
+//        System.out.println("creating index");
+
+        super.setupGraphDatabase(graphDatabaseService);
+    }
+}

--- a/src/jmh/java/apoc/IndexTrackingGraphDatabaseState.java
+++ b/src/jmh/java/apoc/IndexTrackingGraphDatabaseState.java
@@ -1,7 +1,11 @@
 package apoc;
 
+import apoc.index.FreeTextSearch;
+import apoc.util.TestUtil;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.kernel.api.exceptions.KernelException;
 
 import java.util.Map;
 
@@ -10,15 +14,16 @@ public class IndexTrackingGraphDatabaseState extends GraphDatabaseState {
     @Override
     public Map<String, String> getGraphDatabaseConfig() {
         return MapUtil.genericMap("apoc.autoIndex.enabled", "true",
-            "apoc.autoIndex.configUpdateInterval", "-1");
+                "apoc.autoIndex.configUpdateInterval", "-1");
     }
 
     @Override
     void setupGraphDatabase(GraphDatabaseService graphDatabaseService) {
-//            TestUtil.registerProcedure(getGraphDatabaseService(), FreeTextSearch.class);
-//            graphDatabaseService.execute("call apoc.index.addAllNodesExtended('person_index',{Person:['name']},{autoUpdate:true})");
-//        System.out.println("creating index");
-
-        super.setupGraphDatabase(graphDatabaseService);
+        try {
+            TestUtil.registerProcedure(getGraphDatabaseService(), FreeTextSearch.class);
+            //graphDatabaseService.execute("CALL apoc.index.addAllNodesExtended('person_index',{Person:['name']},{autoUpdate:true})");
+        } catch (KernelException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/jmh/java/apoc/IndexUpdateBenchmarks.java
+++ b/src/jmh/java/apoc/IndexUpdateBenchmarks.java
@@ -1,0 +1,40 @@
+package apoc;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.openjdk.jmh.annotations.Benchmark;
+
+public class IndexUpdateBenchmarks {
+
+    @Benchmark
+    public void add10kNonIndexedNodes(GraphDatabaseState state) {
+        final GraphDatabaseService db = state.getGraphDatabaseService();
+        final Label label = Label.label("Person");
+        try (Transaction tx = db.beginTx()) {
+            for (int i=0; i<10000; i++) {
+                Node n = db.createNode(label);
+                n.setProperty("name", "myname_i");
+            }
+            tx.success();
+        }
+
+    }
+
+    @Benchmark
+    public void add10kIndexedNodes(IndexTrackingGraphDatabaseState state) {
+//    public void add10kIndexedNodes(GraphDatabaseState state) throws KernelException {
+//        TestUtil.registerProcedure(state.getGraphDatabaseService(), FreeTextSearch.class);
+        final GraphDatabaseService db = state.getGraphDatabaseService();
+        final Label label = Label.label("Person");
+        try (Transaction tx = db.beginTx()) {
+            for (int i=0; i<10000; i++) {
+                Node n = db.createNode(label);
+                n.setProperty("name", "myname_i");
+            }
+            tx.success();
+        }
+
+    }
+}

--- a/src/jmh/java/apoc/IndexUpdateBenchmarks.java
+++ b/src/jmh/java/apoc/IndexUpdateBenchmarks.java
@@ -10,31 +10,35 @@ public class IndexUpdateBenchmarks {
 
     @Benchmark
     public void add10kNonIndexedNodes(GraphDatabaseState state) {
-        final GraphDatabaseService db = state.getGraphDatabaseService();
-        final Label label = Label.label("Person");
-        try (Transaction tx = db.beginTx()) {
-            for (int i=0; i<10000; i++) {
-                Node n = db.createNode(label);
-                n.setProperty("name", "myname_i");
-            }
-            tx.success();
-        }
-
+        populateDb( state, 10000 );
     }
 
     @Benchmark
-    public void add10kIndexedNodes(IndexTrackingGraphDatabaseState state) {
-//    public void add10kIndexedNodes(GraphDatabaseState state) throws KernelException {
-//        TestUtil.registerProcedure(state.getGraphDatabaseService(), FreeTextSearch.class);
+    public void add10kNodesWithBackgroundUpdatesEnabled(IndexTrackingGraphDatabaseState state) {
+        populateDb( state, 10000 );
+    }
+
+    @Benchmark
+    public void add10kIndexedSyncNodes(SyncIndexingGraphDatabaseState state) {
+        populateDb( state, 10000 );
+    }
+
+    @Benchmark
+    public void add10kIndexedAsyncNodes(AsyncIndexingGraphDatabaseState state) {
+        populateDb( state, 10000 );
+    }
+
+    private void populateDb( GraphDatabaseState state, int numberOfNodes )
+    {
         final GraphDatabaseService db = state.getGraphDatabaseService();
         final Label label = Label.label("Person");
         try (Transaction tx = db.beginTx()) {
-            for (int i=0; i<10000; i++) {
+            for (int i=0; i<numberOfNodes; i++) {
                 Node n = db.createNode(label);
                 n.setProperty("name", "myname_i");
             }
             tx.success();
         }
-
     }
+
 }

--- a/src/jmh/java/apoc/SyncIndexingGraphDatabaseState.java
+++ b/src/jmh/java/apoc/SyncIndexingGraphDatabaseState.java
@@ -1,0 +1,12 @@
+package apoc;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+
+public class SyncIndexingGraphDatabaseState extends IndexTrackingGraphDatabaseState {
+
+    @Override
+    void setupGraphDatabase(GraphDatabaseService graphDatabaseService) {
+        super.setupGraphDatabase(graphDatabaseService);
+        graphDatabaseService.execute("CALL apoc.index.addAllNodesExtended('person_index',{Person:['name']},{autoUpdate:true})");
+    }
+}


### PR DESCRIPTION
I've added JMH library to run micro benchmarks. Note that JMH is not enabled by default, you need to run `./gradlew jmh` for this.

Additionally this PR adds more config options for index population. 

Related to #329.

This PR should be cherry-picked to 3.2 branch as well.