### PR TITLE
adding apoc.merge.node/relationship

### DIFF
--- a/src/main/java/apoc/merge/Merge.java
+++ b/src/main/java/apoc/merge/Merge.java
@@ -1,0 +1,59 @@
+package apoc.merge;
+
+import apoc.result.*;
+import org.neo4j.graphdb.*;
+import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.procedure.*;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class Merge {
+
+    @Context
+    public GraphDatabaseService db;
+
+    @Procedure(mode = Mode.WRITE)
+    @Description("apoc.merge.node(['Label'], {key:value, ...}, {key:value,...}) - merge node with dynamic labels")
+    public Stream<NodeResult> node(@Name("label") List<String> labelNames, @Name("identProps") Map<String, Object> identProps, @Name("props") Map<String, Object> props) {
+        String labels = String.join(":", labelNames);
+
+        Map<String, Object> params = buildParams(identProps, props);
+        String identPropsString = buildIdentPropsString(identProps);
+
+        final String cypher = "MERGE (n:" + labels + "{" + identPropsString + "}) ON CREATE SET n += $props RETURN n";
+        Node node = Iterators.single(db.execute(cypher, params ).columnAs("n"));
+        return Stream.of(new NodeResult(node));
+    }
+
+    @Procedure(mode = Mode.WRITE)
+    @Description("apoc.merge.relationship(startNode, relType,  {key:value, ...}, {key:value, ...}, endNode) - merge relationship with dynamic type")
+    public Stream<RelationshipResult> relationship(@Name("startNode") Node startNode, @Name("relationshipType") String relType,
+                                                   @Name("identProps") Map<String, Object> identProps, @Name("props") Map<String, Object> props, @Name("endNode") Node endNode) {
+        Map<String, Object> params = buildParams(identProps, props);
+        String identPropsString = buildIdentPropsString(identProps);
+
+        params.put("startNode", startNode);
+        params.put("endNode", endNode);
+
+        final String cypher = "WITH $startNode as startNode, $endNode as endNode MERGE (startNode)-[r:"+ relType +"{"+identPropsString+"}]->(endNode) ON CREATE SET r+= $props RETURN r";
+        Relationship rel = Iterators.single(db.execute(cypher, params ).columnAs("r"));
+        return Stream.of(new RelationshipResult(rel));
+    }
+
+    private String buildIdentPropsString(Map<String, Object> identProps) {
+        if (identProps==null) {
+            return "";
+        } else {
+            return identProps.keySet().stream().map(s -> "`"+s+"`:$`" + s+"`").collect(Collectors.joining(","));
+        }
+    }
+
+    private Map<String, Object> buildParams(Map<String, Object> identProps, Map<String, Object> props) {
+        Map<String, Object> map = identProps == null ? new HashMap<>() : new HashMap<>(identProps);
+        map.put("props", props == null ? Collections.EMPTY_MAP : props);
+        return map;
+    }
+
+}

--- a/src/main/java/apoc/util/Util.java
+++ b/src/main/java/apoc/util/Util.java
@@ -381,8 +381,8 @@ public class Util {
     }
 
     public static Map<String, Object> merge(Map<String, Object> first, Map<String, Object> second) {
-        if (second == null || second.isEmpty()) return first;
-        if (first == null || first.isEmpty()) return second;
+        if (second == null || second.isEmpty()) return first == null ? Collections.EMPTY_MAP : first;
+        if (first == null || first.isEmpty()) return second == null ? Collections.EMPTY_MAP : second;
         Map<String,Object> combined = new HashMap<>(first);
         combined.putAll(second);
         return combined;

--- a/src/test/java/apoc/merge/MergeTest.java
+++ b/src/test/java/apoc/merge/MergeTest.java
@@ -1,0 +1,90 @@
+package apoc.merge;
+
+import apoc.util.TestUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testResult;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MergeTest {
+
+    private GraphDatabaseService db;
+    public static final Label PERSON = Label.label("Person");
+
+    @Before
+    public void setUp() throws Exception {
+        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        TestUtil.registerProcedure(db, Merge.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
+    }
+
+    @Test
+    public void testMergeNode() throws Exception {
+        testCall(db, "CALL apoc.merge.node(['Person','Bastard'],{ssid:'123'}, {name:'John'}) YIELD node RETURN node",
+                (row) -> {
+                    Node node = (Node) row.get("node");
+                    assertEquals(true, node.hasLabel(Label.label("Person")));
+                    assertEquals(true, node.hasLabel(Label.label("Bastard")));
+                    assertEquals("John", node.getProperty("name"));
+                    assertEquals("123", node.getProperty("ssid"));
+                });
+    }
+
+    @Test
+    public void testMergeNodeWithPreExisting() throws Exception {
+        db.execute("CREATE (p:Person{ssid:'123', name:'Jim'})");
+        testCall(db, "CALL apoc.merge.node(['Person'],{ssid:'123'}, {name:'John'}) YIELD node RETURN node",
+                (row) -> {
+                    Node node = (Node) row.get("node");
+                    assertEquals(true, node.hasLabel(Label.label("Person")));
+                    assertEquals("Jim", node.getProperty("name"));
+                    assertEquals("123", node.getProperty("ssid"));
+                });
+
+        testResult(db, "match (p:Person) return count(*) as c", result ->
+                assertEquals(1, (long)(Iterators.single(result.columnAs("c"))))
+        );
+    }
+
+    @Test
+    public void testMergeRelationships() throws Exception {
+        db.execute("create (:Person{name:'Foo'}), (:Person{name:'Bar'})");
+
+        testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship(s, 'KNOWS', {rid:123}, {since:'Thu'}, e) YIELD rel RETURN rel",
+                (row) -> {
+                    Relationship rel = (Relationship) row.get("rel");
+                    assertEquals("KNOWS", rel.getType().name());
+                    assertEquals(123l, rel.getProperty("rid"));
+                    assertEquals("Thu", rel.getProperty("since"));
+                });
+
+        testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship(s, 'KNOWS', {rid:123}, {since:'Fri'}, e) YIELD rel RETURN rel",
+                (row) -> {
+                    Relationship rel = (Relationship) row.get("rel");
+                    assertEquals("KNOWS", rel.getType().name());
+                    assertEquals(123l, rel.getProperty("rid"));
+                    assertEquals("Thu", rel.getProperty("since"));
+                });
+        testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship(s, 'OTHER', null, null, e) YIELD rel RETURN rel",
+                (row) -> {
+                    Relationship rel = (Relationship) row.get("rel");
+                    assertEquals("OTHER", rel.getType().name());
+                    assertTrue(rel.getAllProperties().isEmpty());
+                });
+    }
+
+}

--- a/src/test/java/apoc/util/UtilTest.java
+++ b/src/test/java/apoc/util/UtilTest.java
@@ -75,4 +75,9 @@ public class UtilTest {
         String url = "http://%slocalhost:7474/path?query#ref";
         assertEquals(format(url,""), Util.cleanUrl(format(url, "user:pass@")));
     }
+
+    @Test
+    public void mergeNullMaps() {
+        assertNotNull(Util.merge(null, null));
+    }
 }


### PR DESCRIPTION
We already have `apoc.create.node|relationship` to deal with dynamic relationship types or labels. These two new procedures do the very same for `merge`. In the implementation I'm assembling a Cypher `merge` statement.

This PR should be cherry-picked to 3.2 branch as well.