### PR TITLE
fixes #512

### DIFF
--- a/src/main/java/apoc/index/FreeTextSearch.java
+++ b/src/main/java/apoc/index/FreeTextSearch.java
@@ -91,15 +91,20 @@ public class FreeTextSearch {
      *
      * @param index The name of the index to search in.
      * @param query The query specifying what to search for.
+     * @param maxNumberOfresults maximum number of results to be retruned. Defaults to 100. If -1, returns all the results.
      * @return a stream of all matching nodes.
      */
     @Procedure(mode = Mode.READ)
-    @Description("apoc.index.search('name', 'query') YIELD node, weight - search for nodes in the free text index matching the given query")
-    public Stream<WeightedNodeResult> search(@Name("index") String index, @Name("query") String query) throws Exception {
+    @Description("apoc.index.search('name', 'query', [maxNumberOfResults]) YIELD node, weight - search for nodes in the free text index matching the given query")
+    public Stream<WeightedNodeResult> search(@Name("index") String index, @Name("query") String query,
+                                             @Name(value="numberOfResults", defaultValue = "100") long maxNumberOfresults) throws Exception {
         if (!db.index().existsForNodes(index)) {
             return Stream.empty();
         }
-        QueryContext queryParam = new QueryContext(parseFreeTextQuery(query)).sort(Sort.RELEVANCE).top(100);
+        QueryContext queryParam = new QueryContext(parseFreeTextQuery(query)).sort(Sort.RELEVANCE);
+        if (maxNumberOfresults!=-1) {
+            queryParam = queryParam.top((int)maxNumberOfresults);
+        }
         List<WeightedNodeResult> hits = KernelApi.toWeightedNodeResultFromLegacyIndex(KernelApi.nodeQueryIndex(index, queryParam, db), db);
 
         return hits.stream();

--- a/src/test/java/apoc/index/FreeTextSearchTest.java
+++ b/src/test/java/apoc/index/FreeTextSearchTest.java
@@ -199,6 +199,18 @@ public class FreeTextSearchTest {
 
         // then
         assertEquals(100, Iterators.count(result));
+
+        // when
+        result = db.execute("CALL apoc.index.search('numbers', 'The', 10)");
+
+        // then
+        assertEquals(10, Iterators.count(result));
+
+        // when
+        result = db.execute("CALL apoc.index.search('numbers', 'The', -1)");
+
+        // then
+        assertEquals(10000, Iterators.count(result));
     }
 
     @Test


### PR DESCRIPTION
adding an optional parameter to apoc.index.search to control max number of results. Defaults to 100 for backwards compatibility. -1 doesn't limit and returns all the results.