### PR TITLE
improving apoc.convert.toMap to support Node/Relationship

### DIFF
--- a/src/main/java/apoc/convert/Convert.java
+++ b/src/main/java/apoc/convert/Convert.java
@@ -1,5 +1,6 @@
 package apoc.convert;
 
+import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.procedure.Description;
 import apoc.coll.SetBackedList;
 import apoc.result.*;
@@ -25,8 +26,16 @@ public class Convert {
     @UserFunction
     @Description("apoc.convert.toMap(value) | tries it's best to convert the value to a map")
     public Map<String, Object> toMap(@Name("map") Object map) {
-        return map instanceof Map ? (Map<String, Object>) map :  null;
+
+        if (map instanceof PropertyContainer) {
+            return ((PropertyContainer)map).getAllProperties();
+        } else if (map instanceof Map) {
+            return (Map<String, Object>) map;
+        } else {
+            return null;
+        }
     }
+
     @UserFunction
     @Description("apoc.convert.toString(value) | tries it's best to convert the value to a string")
     public String toString(@Name("string") Object string) {

--- a/src/test/java/apoc/convert/ConvertTest.java
+++ b/src/test/java/apoc/convert/ConvertTest.java
@@ -9,6 +9,7 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.util.Collections;
+import java.util.Map;
 
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
@@ -39,6 +40,8 @@ public class ConvertTest {
     public void testToMap() throws Exception {
         testCall(db, "return apoc.convert.toMap({a}) as value", map("a", map("a", "b")), r -> assertEquals(map("a", "b"), r.get("value")));
         testCall(db, "return apoc.convert.toMap({a}) as value", map("a", null), r -> assertEquals(null, r.get("value")));
+        final Map<String, Object> props = map("name", "John", "age", 39);
+        testCall(db, "create (n) set n=$props return apoc.convert.toMap(n) as value", map("props", props), r -> assertEquals(props, r.get("value")));
     }
 
     @Test


### PR DESCRIPTION
When passing in a Node or Relationship, a map containing its properties is returned.