### PR TITLE
add apoc.text.split function that splits a string using a regexp (#502)

### DIFF
--- a/docs/text.adoc
+++ b/docs/text.adoc
@@ -2,6 +2,8 @@
 
 Basic utility procedures for string manipulation, comparison, filtering etc.
 
+The `replace`, `split` and `regexpGroups` functions work with regular expressions.
+
 The clean functionality can be useful for cleaning up slightly dirty text data with inconsistent formatting for non-exact comparisons.
 
 Cleaning will strip the string of all non-alphanumeric characters (including spaces) and convert it to lower case.
@@ -20,10 +22,10 @@ result> [["<link xxx1>yyy1</link>", "xxx1", "yyy1"], ["<link xxx2>yyy2</link>", 
 
 
 
-.will return ['Hello', 'World']
+.will split with the given regular expression return ['Hello', 'World']
 [source,cypher]
 ----
-CALL apoc.text.split('Hello World', ' ')
+CALL apoc.text.split('Hello   World', ' +')
 ----
 
 .will return 'Hello World'

--- a/docs/text.adoc
+++ b/docs/text.adoc
@@ -20,6 +20,12 @@ result> [["<link xxx1>yyy1</link>", "xxx1", "yyy1"], ["<link xxx2>yyy2</link>", 
 
 
 
+.will return ['Hello', 'World']
+[source,cypher]
+----
+CALL apoc.text.split('Hello World', ' ')
+----
+
 .will return 'Hello World'
 [source,cypher]
 ----

--- a/src/main/java/apoc/text/Strings.java
+++ b/src/main/java/apoc/text/Strings.java
@@ -16,6 +16,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
+import static java.util.Arrays.asList;
 
 /**
  * @author mh
@@ -35,6 +36,16 @@ public class Strings {
             return null;
         }
         return text.replaceAll(regex, replacement);
+    }
+
+    @UserFunction
+    @Description("apoc.text.split(text, regex, limit) - splits the given text around matches of the given regex.")
+    public List<String> split(final @Name("text") String text, final @Name("regex") String regex, final @Name(value = "limit", defaultValue = "0") Long limit) {
+        if (text == null || regex == null || limit == null) {
+            return null;
+        }
+        String[] resultArray = text.split(regex, limit.intValue());
+        return new ArrayList<>(asList(resultArray));
     }
 
     @UserFunction

--- a/src/test/java/apoc/text/StringsTest.java
+++ b/src/test/java/apoc/text/StringsTest.java
@@ -76,8 +76,8 @@ public class StringsTest {
 
     @Test
     public void testSplit() throws Exception {
-        String text = "1,2,3,4";
-        String regex = ",";
+        String text = "1,  2, 3,4";
+        String regex = ", *";
 
         testCall(db,
                 "RETURN apoc.text.split({text}, {regex}) AS value",
@@ -87,7 +87,7 @@ public class StringsTest {
         testCall(db,
                 "RETURN apoc.text.split({text}, {regex}, 2) AS value",
                 map("text", text, "regex", regex),
-                row -> assertEquals(Arrays.asList("1", "2,3,4"), row.get("value")));
+                row -> assertEquals(Arrays.asList("1", "2, 3,4"), row.get("value")));
     }
 
     @Test

--- a/src/test/java/apoc/text/StringsTest.java
+++ b/src/test/java/apoc/text/StringsTest.java
@@ -10,6 +10,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static apoc.util.MapUtil.map;
@@ -71,6 +72,48 @@ public class StringsTest {
                 "RETURN apoc.text.regreplace({text},{regex},{replacement}) AS value",
                 map("text",text,"regex",regex,"replacement",null),
                 row -> assertEquals(null, row.get("value")));
+    }
+
+    @Test
+    public void testSplit() throws Exception {
+        String text = "1,2,3,4";
+        String regex = ",";
+
+        testCall(db,
+                "RETURN apoc.text.split({text}, {regex}) AS value",
+                map("text", text, "regex", regex),
+                row -> assertEquals(Arrays.asList("1", "2", "3", "4"), row.get("value")));
+
+        testCall(db,
+                "RETURN apoc.text.split({text}, {regex}, 2) AS value",
+                map("text", text, "regex", regex),
+                row -> assertEquals(Arrays.asList("1", "2,3,4"), row.get("value")));
+    }
+
+    @Test
+    public void testSplitWithNull() throws Exception {
+        String text = "Hello World";
+        String regex = " ";
+
+        testCall(db,
+                "RETURN apoc.text.split({text}, {regex}) AS value",
+                map("text", null, "regex", regex),
+                row -> assertEquals(null, row.get("value")));
+
+        testCall(db,
+                "RETURN apoc.text.split({text}, {regex}) AS value",
+                map("text", text, "regex", null),
+                row -> assertEquals(null, row.get("value")));
+
+        testCall(db,
+                "RETURN apoc.text.split({text}, {regex}, null) AS value",
+                map("text", text, "regex", regex),
+                row -> assertEquals(null, row.get("value")));
+
+        testCall(db,
+                "RETURN apoc.text.split({text}, {regex}) AS value",
+                map("text", "", "regex", ""),
+                row -> assertEquals(Collections.singletonList(""), row.get("value")));
     }
 
     @Test


### PR DESCRIPTION
I've Implemented the apoc.text.split function from the https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/502 issue. Is the null handling as expected or should it return an empty list instead of null?