### PR TITLE
Added function apoc.convert.toListOf(value, type) (ref. #152)

### DIFF
--- a/src/main/java/apoc/convert/Convert.java
+++ b/src/main/java/apoc/convert/Convert.java
@@ -91,48 +91,69 @@ public class Convert {
         return list == null ? null : new SetBackedList(new LinkedHashSet<>(list));
     }
     
-    @SuppressWarnings("rawtypes")
 	@UserFunction
-    @Description("apoc.convert.toListOf(value, type) | tries it's best to convert "
-    		+ "the value to a list of supported type, supported types are: "
-    		+ "int, long, double, String, boolean, node, relationship")
-    public List toListOf(@Name("list") Object list, @Name("type") String type) {
-        List objectList = convertToList(list);
+    @Description("apoc.convert.toIntList(value) | tries it's best to convert "
+    		+ "the value to a list of integers")
+    public List<Integer> toIntList(@Name("list") Object list) {
+        List<Object> objectList = convertToList(list);
         if (objectList == null) {
         	return null;
         }
-        return convertToListOf(objectList, type);
+        return objectList.stream()
+        		.map(e -> e != null ? Integer.parseInt(e.toString()) : null)
+        		.collect(Collectors.toList());
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    private List convertToListOf(List list, String type) {
-		Stream stream = list.stream();
-		switch (type.toLowerCase()) {
-		case "int":
-			stream = (Stream) stream.map(e -> Integer.parseInt(e.toString()));
-			break;
-		case "long":
-			stream = (Stream) stream.map(e -> Long.parseLong(e.toString()));
-			break;
-		case "double":
-			stream = (Stream) stream.map(e -> Double.parseDouble(e.toString()));
-			break;
-		case "string":
-			stream = (Stream) stream.map(this::toString);
-			break;
-		case "boolean":
-			stream = (Stream) stream.map(this::toBoolean);
-			break;
-		case "node":
-			stream = (Stream) stream.map(this::toNode);
-			break;
-		case "relationship":
-			stream = (Stream) stream.map(this::toRelationship);
-			break;
-		default:
-			throw new UnsupportedTypeException("Supported types are: int, long, double, String, boolean, node, relationship");
+	@UserFunction
+	@Description("apoc.convert.toStringList(value) | tries it's best to convert "
+			+ "the value to a list of strings")
+	public List<String> toStringList(@Name("list") Object list) {
+		List<Object> objectList = convertToList(list);
+		if (objectList == null) {
+			return null;
 		}
-		return (List) stream.collect(Collectors.toList());
+		return objectList.stream()
+				.map(this::toString)
+				.collect(Collectors.toList());
 	}
 
+	@UserFunction
+	@Description("apoc.convert.toBooleanList(value) | tries it's best to convert "
+			+ "the value to a list of booleans")
+	public List<Boolean> toBooleanList(@Name("list") Object list) {
+		List<Object> objectList = convertToList(list);
+		if (objectList == null) {
+			return null;
+		}
+		return objectList.stream()
+				.map(this::toBoolean)
+				.collect(Collectors.toList());
+	}
+
+	@UserFunction
+	@Description("apoc.convert.toNodeList(value) | tries it's best to convert "
+			+ "the value to a list of nodes")
+	public List<Node> toNodeList(@Name("list") Object list) {
+		List<Object> objectList = convertToList(list);
+		if (objectList == null) {
+			return null;
+		}
+		return objectList.stream()
+				.map(this::toNode)
+				.collect(Collectors.toList());
+	}
+
+	@UserFunction
+	@Description("apoc.convert.toRelationshipList(value) | tries it's best to convert "
+			+ "the value to a list of relationships")
+	public List<Relationship> toRelationshipList(@Name("list") Object list) {
+		List<Object> objectList = convertToList(list);
+		if (objectList == null) {
+			return null;
+		}
+		return objectList.stream()
+				.map(this::toRelationship)
+				.collect(Collectors.toList());
+	}
+	
 }

--- a/src/main/java/apoc/convert/UnsupportedTypeException.java
+++ b/src/main/java/apoc/convert/UnsupportedTypeException.java
@@ -1,7 +1,0 @@
-package apoc.convert;
-
-public class UnsupportedTypeException extends RuntimeException {
-	public UnsupportedTypeException(String message) {
-		super(message);
-	}
-}

--- a/src/main/java/apoc/convert/UnsupportedTypeException.java
+++ b/src/main/java/apoc/convert/UnsupportedTypeException.java
@@ -1,9 +1,0 @@
-package apoc.convert;
-
-public class UnsupportedTypeException extends RuntimeException {
-
-	public UnsupportedTypeException(String message) {
-		super(message);
-	}
-
-}

--- a/src/main/java/apoc/convert/UnsupportedTypeException.java
+++ b/src/main/java/apoc/convert/UnsupportedTypeException.java
@@ -1,0 +1,7 @@
+package apoc.convert;
+
+public class UnsupportedTypeException extends RuntimeException {
+	public UnsupportedTypeException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/apoc/convert/UnsupportedTypeException.java
+++ b/src/main/java/apoc/convert/UnsupportedTypeException.java
@@ -1,0 +1,9 @@
+package apoc.convert;
+
+public class UnsupportedTypeException extends RuntimeException {
+
+	public UnsupportedTypeException(String message) {
+		super(message);
+	}
+
+}

--- a/src/main/java/apoc/meta/Meta.java
+++ b/src/main/java/apoc/meta/Meta.java
@@ -38,8 +38,11 @@ public class Meta {
         INTEGER,FLOAT,STRING,BOOLEAN,RELATIONSHIP,NODE,PATH,NULL,UNKNOWN,MAP,LIST;
 
         public static Types of(Object value) {
-            if (value==null) return NULL;
-            Class type = value.getClass();
+            return of(value == null ? null : value.getClass());
+        }
+
+        public static Types of(Class<?> type) {
+            if (type==null) return NULL;
             if (type.isArray()) {
                 type = type.getComponentType();
             }
@@ -48,7 +51,7 @@ public class Meta {
                         Float.class.isAssignableFrom(type) || float.class.isAssignableFrom(type) ? FLOAT : INTEGER;
             }
             if (type == Boolean.class || type == boolean.class) return BOOLEAN;
-            if (value instanceof String) return STRING;
+            if (String.class.isAssignableFrom(type)) return STRING;
             if (Map.class.isAssignableFrom(type)) return MAP;
             if (Node.class.isAssignableFrom(type)) return NODE;
             if (Relationship.class.isAssignableFrom(type)) return RELATIONSHIP;

--- a/src/main/java/apoc/util/Util.java
+++ b/src/main/java/apoc/util/Util.java
@@ -201,7 +201,11 @@ public class Util {
     public static Double toDouble(Object value) {
         if (value == null) return null;
         if (value instanceof Number) return ((Number) value).doubleValue();
-        return Double.parseDouble(value.toString());
+        try {
+        	return Double.parseDouble(value.toString());
+        } catch (NumberFormatException e) {
+        	return null;
+        }
     }
 
     public static Map<String, Object> subMap(Map<String, ?> params, String prefix) {
@@ -216,9 +220,14 @@ public class Util {
         return config;
     }
 
-    public static long toLong(Object value) {
+    public static Long toLong(Object value) {
+    	if (value == null) return null;
         if (value instanceof Number) return ((Number)value).longValue();
-        return Long.parseLong(value.toString());
+        try {
+        	return Long.parseLong(value.toString());
+        } catch (NumberFormatException e) {
+        	return null;
+        }
     }
 
     public static URLConnection openUrlConnection(String url, Map<String, Object> headers) throws IOException {
@@ -236,8 +245,8 @@ public class Util {
             headers.forEach((k,v) -> con.setRequestProperty(k, v == null ? "" : v.toString()));
         }
         con.setDoInput(true);
-        con.setConnectTimeout((int)toLong(ApocConfiguration.get("http.timeout.connect",10_000)));
-        con.setReadTimeout((int)toLong(ApocConfiguration.get("http.timeout.read",60_000)));
+        con.setConnectTimeout(toLong(ApocConfiguration.get("http.timeout.connect",10_000)).intValue());
+        con.setReadTimeout(toLong(ApocConfiguration.get("http.timeout.read",60_000)).intValue());
         return con;
     }
 

--- a/src/test/java/apoc/convert/ConvertTest.java
+++ b/src/test/java/apoc/convert/ConvertTest.java
@@ -109,7 +109,7 @@ public class ConvertTest {
     @Test
     public void testToIntList() throws Exception {
          testCall(db, "return apoc.convert.toIntList([null, 1, '1']) as value",
-        		 r -> assertEquals(Arrays.asList(null, 1, 1), r.get("value")));
+        		 r -> assertEquals(Arrays.asList(null, 1L, 1L), r.get("value")));
     }
 
     @Test

--- a/src/test/java/apoc/convert/ConvertTest.java
+++ b/src/test/java/apoc/convert/ConvertTest.java
@@ -101,37 +101,43 @@ public class ConvertTest {
     }
 
     @Test
-    public void toListOf() throws Exception {
-         testCall(db, "return apoc.convert.toListOf({a}, 'string') as value", map("a", null),
-        		 r -> assertEquals(null, r.get("value")));
-         testCall(db, "return apoc.convert.toListOf({a}, 'string') as value", map("a", new Object[]{"a"}),
-        		 r -> assertEquals(singletonList("a"), r.get("value")));
-         testCall(db, "return apoc.convert.toListOf({a}, 'int') as value", map("a", new Object[]{"1"}),
-        		 r -> assertEquals(singletonList(1), r.get("value")));
-         testCall(db, "return apoc.convert.toListOf({a}, 'double') as value", map("a", new Object[]{"1.0"}),
-        		 r -> assertEquals(singletonList(1.0d), r.get("value")));
-         testCall(db, "CREATE (n) WITH [n] as x RETURN apoc.convert.toListOf(x, 'node') as nodes",
-                 r -> {
-                	 assertEquals(true, r.get("nodes") instanceof List);
-                	 List<Node> nodes = (List<Node>) r.get("nodes");
-                	 assertEquals(true, nodes.get(0) instanceof Node);
-                 });
-         testCall(db, "CREATE (n)-[r:KNOWS]->(m) WITH [r] as x RETURN apoc.convert.toListOf(x, 'relationship') AS rels",
-                 r -> {
-                	 assertEquals(true, r.get("rels") instanceof List);
-                	 List<Relationship> rels = (List<Relationship>) r.get("rels");
-                	 assertEquals(true, rels.get(0) instanceof Relationship);
-                 });
-         testCall(db, "return apoc.convert.toListOf({a}, 'boolean') as value",
-        		 map("a", new Object[]{"true", 1, "yes"}),
-        		 r -> assertEquals(Arrays.asList(true, true, true), r.get("value")));
-         testCall(db, "return apoc.convert.toListOf({a}, 'boolean') as value",
-        		 map("a", new Object[]{"false", 0, "no", "", null}),
-        		 r -> assertEquals(Arrays.asList(false, false, false, false, false), r.get("value")));
+    public void testToStringList() throws Exception {
+         testCall(db, "return apoc.convert.toStringList([null, 'a', 1, true, [1]]) as value",
+        		 r -> assertEquals(Arrays.asList(null, "a", "1", "true", "[1]"), r.get("value")));
     }
-    
-    @Test(expected = UnsupportedTypeException.class)
-    public void toListOfShouldThrowException() throws Exception {
-    	new Convert().toListOf(new Object[]{"1"}, "integer");
+
+    @Test
+    public void testToIntList() throws Exception {
+         testCall(db, "return apoc.convert.toIntList([null, 1, '1']) as value",
+        		 r -> assertEquals(Arrays.asList(null, 1, 1), r.get("value")));
     }
+
+    @Test
+    public void testToBooleanList() throws Exception {
+    	testCall(db, "return apoc.convert.toBooleanList(['false', 0, 'no', '', null]) as value",
+    			r -> assertEquals(Arrays.asList(false, false, false, false, false), r.get("value")));
+		testCall(db, "return apoc.convert.toBooleanList(['true', 1, 'yes']) as value",
+				r -> assertEquals(Arrays.asList(true, true, true), r.get("value")));
+    }
+
+    @Test
+    public void testToNodeList() throws Exception {
+        testCall(db, "CREATE (n) WITH [n] as x RETURN apoc.convert.toNodeList(x) as nodes",
+                r -> {
+					assertEquals(true, r.get("nodes") instanceof List);
+					List<Node> nodes = (List<Node>) r.get("nodes");
+					assertEquals(true, nodes.get(0) instanceof Node);
+                });
+    }
+
+    @Test
+    public void testToRelationshipList() throws Exception {
+        testCall(db, "CREATE (n)-[r:KNOWS]->(m) WITH [r] as x  RETURN apoc.convert.toRelationshipList(x) as rels",
+                r -> {
+					assertEquals(true, r.get("rels") instanceof List);
+					List<Relationship> rels = (List<Relationship>) r.get("rels");
+					assertEquals(true, rels.get(0) instanceof Relationship);
+                });
+    }
+
 }

--- a/src/test/java/apoc/cypher/CypherTest.java
+++ b/src/test/java/apoc/cypher/CypherTest.java
@@ -1,6 +1,7 @@
 package apoc.cypher;
 
 import apoc.util.TestUtil;
+import apoc.util.Util;
 import apoc.util.Utils;
 import org.junit.*;
 import org.junit.rules.ExpectedException;
@@ -21,7 +22,6 @@ import java.util.Map;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
-import static apoc.util.Util.toLong;
 import static apoc.util.Util.withMapping;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -116,6 +116,9 @@ public class CypherTest {
                 });
     }
 
+    private long toLong(Object value) {
+    	return Util.toLong(value);
+    }
 
     @Test
     public void testRunMany() throws Exception {


### PR DESCRIPTION
Hi!
I created the method `apoc.convert.toListOf(value, type)` that converts a collection to the required type, following some examples (taken from the test):
```java
testCall(db, "return apoc.convert.toListOf({a}, 'int') as value", map("a", new Object[]{"1"}),
        		 r -> assertEquals(singletonList(1), r.get("value")));
testCall(db, "CREATE (n) WITH [n] as x RETURN apoc.convert.toListOf(x, 'node') as nodes",
                 r -> {
                	 assertEquals(true, r.get("nodes") instanceof List);
                	 List<Node> nodes = (List<Node>) r.get("nodes");
                	 assertEquals(true, nodes.get(0) instanceof Node);
                 })
testCall(db, "CREATE (n)-[r:KNOWS]->(m) WITH [r] as x RETURN apoc.convert.toListOf(x, 'relationship') AS rels",
                 r -> {
                	 assertEquals(true, r.get("rels") instanceof List);
                	 List<Relationship> rels = (List<Relationship>) r.get("rels");
                	 assertEquals(true, rels.get(0) instanceof Relationship);
                 });
testCall(db, "return apoc.convert.toListOf({a}, 'boolean') as value",
        		 map("a", new Object[]{"false", 0, "no", "", null}),
        		 r -> assertEquals(Arrays.asList(false, false, false, false, false), r.get("value")));
```
Hope it helps.
Andrea
