### PR TITLE
Compatible values flag for non-packable values

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ dependencies {
     compileOnly(group: 'org.neo4j', name: 'neo4j-enterprise', version:neo4jVersion)
     compileOnly(group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version:'1.9.7')
     testCompile(group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version:'1.9.7')
+    compile(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.0')
     compileOnly(group: 'org.ow2.asm', name: 'asm', version:'5.0.2')
     compile group: 'com.github.javafaker', name: 'javafaker', version:'0.10'
 
@@ -123,6 +124,9 @@ shadowJar {
         include(dependency('org.slf4j:slf4j-api'))
         include(dependency('net.minidev:accessors-smart'))
         include(dependency('com.github.javafaker:javafaker'))
+        include(dependency('com.fasterxml.jackson.core:jackson-databind'))
+        include(dependency('com.fasterxml.jackson.core:jackson-core'))
+        include(dependency('com.fasterxml.jackson.core:jackson-annotations'))
     }
 }
 

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -323,14 +323,16 @@ config contains any of: `{skip:1,limit:5,header:false,sep:'TAB',ignore:['tmp'],a
 
 [cols="3m,2"]
 |===
-| CALL apoc.mongodb.get(host-or-port,db-or-null,collection-or-null,query-or-null) yield value | perform a find operation on mongodb collection
+| CALL apoc.mongodb.get(host-or-port,db-or-null,collection-or-null,query-or-null,[compatibleValues=true|false]) yield value | perform a find operation on mongodb collection
 | CALL apoc.mongodb.count(host-or-port,db-or-null,collection-or-null,query-or-null) yield value | perform a find operation on mongodb collection
-| CALL apoc.mongodb.first(host-or-port,db-or-null,collection-or-null,query-or-null) yield value | perform a first operation on mongodb collection
-| CALL apoc.mongodb.find(host-or-port,db-or-null,collection-or-null,query-or-null,projection-or-null,sort-or-null) yield value | perform a find,project,sort operation on mongodb collection
+| CALL apoc.mongodb.first(host-or-port,db-or-null,collection-or-null,query-or-null,[compatibleValues=true|false]) yield value | perform a first operation on mongodb collection
+| CALL apoc.mongodb.find(host-or-port,db-or-null,collection-or-null,query-or-null,projection-or-null,sort-or-null,[compatibleValues=true|false]) yield value | perform a find,project,sort operation on mongodb collection
 | CALL apoc.mongodb.insert(host-or-port,db-or-null,collection-or-null,list-of-maps) | inserts the given documents into the mongodb collection
 | CALL apoc.mongodb.delete(host-or-port,db-or-null,collection-or-null,list-of-maps) | inserts the given documents into the mongodb collection
 | CALL apoc.mongodb.update(host-or-port,db-or-null,collection-or-null,list-of-maps) | inserts the given documents into the mongodb collection
 |===
+
+If your documents have date fields or any other type that can be automatically converted by Neo4j, you need to set *compatibleValues* to true. These values will be converted according to Jackson databind default mapping.
 
 Copy these jars into the plugins directory:
 
@@ -341,17 +343,25 @@ Copy these jars into the plugins directory:
 
 You should be able to get them from https://mongodb.github.io/mongo-java-driver/[here] and https://mvnrepository.com/artifact/org.mongodb/bson/3.4.2[here (BSON)] (via Download)
 
-Or you get them locally from your maven build of apoc.
+Or you get them locally from your gradle build of apoc.
 
 ----
-mvn dependency:copy-dependencies
-cp target/dependency/mongodb*.jar target/dependency/bson*.jar $NEO4J_HOME/plugins/
+gradle copyRuntimeLibs
+cp lib/mongodb*.jar lib/bson*.jar $NEO4J_HOME/plugins/
 ----
 
 [source,cypher]
 ----
 CALL apoc.mongodb.first('mongodb://localhost:27017','test','test',{name:'testDocument'})
 ----
+
+If you need automatic conversion of *unpackable* values then the cypher query will be:
+
+[source,cypher]
+----
+CALL apoc.mongodb.first('mongodb://localhost:27017','test','test',{name:'testDocument'},true)
+----
+
 // end::mongodb[]
 
 == Interacting with Couchbase

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -340,21 +340,14 @@ Copy these jars into the plugins directory:
 * mongo-java-driver-3.4.2.jar
 * mongodb-driver-3.4.2.jar
 * mongodb-driver-core-3.4.2.jar
-* jackson-annotations-2.9.0.jar
-* jackson-core-2.9.0.jar
-* jackson-databind-2.9.0.jar
 
-You should be able to get them from https://mongodb.github.io/mongo-java-driver/[here], https://mvnrepository.com/artifact/com.fasterxml.jackson.core[here (fasterxml-jackson)] and https://mvnrepository.com/artifact/org.mongodb/bson/3.4.2[here (BSON)] (via Download)
+You should be able to get them from https://mongodb.github.io/mongo-java-driver/[here], and https://mvnrepository.com/artifact/org.mongodb/bson/3.4.2[here (BSON)] (via Download)
 
 Or you get them locally from your gradle build of apoc.
 
 ----
 gradle copyRuntimeLibs
-<<<<<<< HEAD
 cp lib/mongodb*.jar lib/bson*.jar $NEO4J_HOME/plugins/
-=======
-cp lib/mongodb*.jar lib/bson*.jar lib/jackson-*-2.9.0.jar $NEO4J_HOME/plugins/
->>>>>>> dd3ce14d0ba6865eaef2c174f9ea23ea3a4569f5
 ----
 
 [source,cypher]

--- a/src/main/java/apoc/mongodb/MongoDB.java
+++ b/src/main/java/apoc/mongodb/MongoDB.java
@@ -1,10 +1,10 @@
 package apoc.mongodb;
 
-import apoc.util.MissingDependencyException;
-import org.neo4j.procedure.Description;
 import apoc.result.LongResult;
 import apoc.result.MapResult;
+import apoc.util.MissingDependencyException;
 import apoc.util.UrlResolver;
+import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
@@ -45,64 +45,64 @@ MERGE (c)-[:OFFERED_BY]->(u)
 public class MongoDB {
 
     @Procedure
-    @Description("apoc.mongodb.get(host-or-port,db-or-null,collection-or-null,query-or-null) yield value - perform a find operation on mongodb collection")
-    public Stream<MapResult> get(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String,Object> query) {
-        return getMongoColl(hostOrKey, db, collection).all(query).map(MapResult::new);
+    @Description("apoc.mongodb.get(host-or-port,db-or-null,collection-or-null,query-or-null,[compatibleValues=true|false]) yield value - perform a find operation on mongodb collection")
+    public Stream<MapResult> get(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String, Object> query, @Name(value = "compatibleValues", defaultValue = "false") boolean compatibleValues) {
+        return getMongoColl(hostOrKey, db, collection, compatibleValues).all(query).map(MapResult::new);
     }
 
     @Procedure
     @Description("apoc.mongodb.count(host-or-port,db-or-null,collection-or-null,query-or-null) yield value - perform a find operation on mongodb collection")
-    public Stream<LongResult> count(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String,Object> query) {
-        long count = getMongoColl(hostOrKey, db, collection).count(query);
+    public Stream<LongResult> count(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String, Object> query) {
+        long count = getMongoColl(hostOrKey, db, collection, false).count(query);
         return Stream.of(new LongResult(count));
     }
 
-    private Coll getColl(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection) {
+    private Coll getColl(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, boolean compatibleValues) {
         String url = getMongoDBUrl(hostOrKey);
-        return Coll.Factory.create(url, db, collection);
+        return Coll.Factory.create(url, db, collection, compatibleValues);
     }
 
     @Procedure
-    @Description("apoc.mongodb.first(host-or-port,db-or-null,collection-or-null,query-or-null) yield value - perform a first operation on mongodb collection")
-    public Stream<MapResult> first(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String,Object> query) {
-        Map<String, Object> result = getMongoColl(hostOrKey, db, collection).first(query);
+    @Description("apoc.mongodb.first(host-or-port,db-or-null,collection-or-null,query-or-null,[compatibleValues=true|false]) yield value - perform a first operation on mongodb collection")
+    public Stream<MapResult> first(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String, Object> query, @Name(value = "compatibleValues", defaultValue = "false") boolean compatibleValues) {
+        Map<String, Object> result = getMongoColl(hostOrKey, db, collection, compatibleValues).first(query);
         return Stream.of(new MapResult(result));
     }
 
     @Procedure
-    @Description("apoc.mongodb.find(host-or-port,db-or-null,collection-or-null,query-or-null,projection-or-null,sort-or-null) yield value - perform a find,project,sort operation on mongodb collection")
-    public Stream<MapResult> find(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String,Object> query,@Name("project") Map<String,Object> project,@Name("sort") Map<String,Object> sort) {
-        return getMongoColl(hostOrKey, db, collection).find(query,project,sort).map(MapResult::new);
+    @Description("apoc.mongodb.find(host-or-port,db-or-null,collection-or-null,query-or-null,projection-or-null,sort-or-null,[compatibleValues=true|false]) yield value - perform a find,project,sort operation on mongodb collection")
+    public Stream<MapResult> find(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String, Object> query, @Name("project") Map<String, Object> project, @Name("sort") Map<String, Object> sort, @Name(value = "compatibleValues", defaultValue = "false") boolean compatibleValues) {
+        return getMongoColl(hostOrKey, db, collection, compatibleValues).find(query, project, sort).map(MapResult::new);
     }
 
     @Procedure
     @Description("apoc.mongodb.insert(host-or-port,db-or-null,collection-or-null,list-of-maps) - inserts the given documents into the mongodb collection")
-    public void insert(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("documents") List<Map<String,Object>> documents) {
-        getMongoColl(hostOrKey, db, collection).insert(documents);
+    public void insert(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("documents") List<Map<String, Object>> documents) {
+        getMongoColl(hostOrKey, db, collection, false).insert(documents);
     }
 
     @Procedure
     @Description("apoc.mongodb.delete(host-or-port,db-or-null,collection-or-null,list-of-maps) - inserts the given documents into the mongodb collection")
-    public Stream<LongResult> delete(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String,Object> query) {
-        return Stream.of(new LongResult(getMongoColl(hostOrKey, db, collection).delete(query)));
+    public Stream<LongResult> delete(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String, Object> query) {
+        return Stream.of(new LongResult(getMongoColl(hostOrKey, db, collection, false).delete(query)));
     }
+
     @Procedure
     @Description("apoc.mongodb.update(host-or-port,db-or-null,collection-or-null,list-of-maps) - inserts the given documents into the mongodb collection")
-    public Stream<LongResult> update(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String,Object> query, @Name("update") Map<String,Object> update) {
-        return Stream.of(new LongResult(getMongoColl(hostOrKey, db, collection).update(query,update)));
+    public Stream<LongResult> update(@Name("host") String hostOrKey, @Name("db") String db, @Name("collection") String collection, @Name("query") Map<String, Object> query, @Name("update") Map<String, Object> update) {
+        return Stream.of(new LongResult(getMongoColl(hostOrKey, db, collection, false).update(query, update)));
     }
 
     private String getMongoDBUrl(String hostOrKey) {
         return new UrlResolver("mongodb", "localhost", 27017).getUrl("mongodb", hostOrKey);
     }
 
-    private Coll getMongoColl(String hostOrKey, String db, String collection){
+    private Coll getMongoColl(String hostOrKey, String db, String collection, boolean compatibleValues) {
         Coll coll = null;
         try {
-            coll = getColl(hostOrKey, db, collection);
-        }
-        catch (NoClassDefFoundError e) {
-            throw new MissingDependencyException("Cannot find the jar into the plugins folder. \n"+
+            coll = getColl(hostOrKey, db, collection, compatibleValues);
+        } catch (NoClassDefFoundError e) {
+            throw new MissingDependencyException("Cannot find the jar into the plugins folder. \n" +
                     "Please put these jar in the plugins folder :\n\n" +
                     "bson-x.y.z.jar\n" +
                     "\n" +
@@ -112,26 +112,34 @@ public class MongoDB {
                     "\n" +
                     "mongodb-driver-core-x.y.z.jar\n" +
                     "\n" +
-                    "See the documentation: https://neo4j-contrib.github.io/neo4j-apoc-procedures/#_interacting_with_mongodb");
+                    "jackson-annotations-x.y.z.jar\n\njackson-core-x.y.z.jar\n\njackson-databind-x.y.z.jar\n\nSee the documentation: https://neo4j-contrib.github.io/neo4j-apoc-procedures/#_interacting_with_mongodb");
         }
         return coll;
     }
 
     interface Coll extends Closeable {
-        Map<String,Object> first(Map<String,Object> params);
-        Stream<Map<String,Object>> all(Map<String,Object> query);
+        Map<String, Object> first(Map<String, Object> params);
+
+        Stream<Map<String, Object>> all(Map<String, Object> query);
+
         long count(Map<String, Object> query);
-        Stream<Map<String,Object>> find(Map<String,Object> query, Map<String,Object> project, Map<String,Object> sort);
-        void insert(List<Map<String,Object>> docs);
-        long update(Map<String,Object> query, Map<String,Object> update);
-        long delete(Map<String,Object> query);
+
+        Stream<Map<String, Object>> find(Map<String, Object> query, Map<String, Object> project, Map<String, Object> sort);
+
+        void insert(List<Map<String, Object>> docs);
+
+        long update(Map<String, Object> query, Map<String, Object> update);
+
+        long delete(Map<String, Object> query);
 
         class Factory {
-            public static Coll create(String url, String db, String coll) {
+            public static Coll create(String url, String db, String coll, boolean compatibleValues) {
                 try {
-                    return (Coll)Class.forName("apoc.mongodb.MongoDBColl").getConstructor(String.class,String.class,String.class).newInstance(url,db,coll);
+                    System.out.println(String.format("%s %s %s %s", url, db, coll, compatibleValues));
+                    return (Coll) Class.forName("apoc.mongodb.MongoDBColl").getConstructor(String.class, String.class, String.class, Boolean.class).newInstance(url, db, coll, compatibleValues);
                 } catch (InstantiationException | IllegalAccessException | NoSuchMethodException | InvocationTargetException | ClassNotFoundException e) {
-                    throw new RuntimeException("Could not create MongoDBClientWrapper instance",e);
+                    e.printStackTrace();
+                    throw new RuntimeException("Could not create MongoDBClientWrapper instance", e);
                 }
             }
         }

--- a/src/main/java/apoc/trigger/Trigger.java
+++ b/src/main/java/apoc/trigger/Trigger.java
@@ -218,7 +218,6 @@ public class Trigger {
             Map<String,String> exceptions = new LinkedHashMap<>();
             triggers.forEach((name, data) -> {
                 if( data.get("paused").equals(false)) {
-                    log.info("Inside if " + name + data);
                     try (Transaction tx = db.beginTx()) {
                         Map<String,Object> selector = (Map<String, Object>) data.get("selector");
                         if (when(selector, phase)) {


### PR DESCRIPTION
For all procedures that are related to document retrieval from MongoDB there is a new (boolean) parameter enabling/disabling automatic conversion in order to avoid exception for non-packable values