### PR TITLE
Configurable pool size for Pools.SCHEDULED

### DIFF
--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -58,6 +58,7 @@ All boolean options default to **false**, i.e. they are disabled, unless mention
 | apoc.es.<key>.uri=es-url-with-credentials | store es-urls under a key to be used by elasticsearch procedures
 | apoc.mongodb.<key>.uri=mongodb-url-with-credentials | store mongodb-urls under a key to be used by mongodb procedures
 | apoc.couchbase.<key>.uri=couchbase-url-with-credentials | store couchbase-urls under a key to be used by couchbase procedures
+| apoc.jobs.scheduled.num_threads=number-of-threads | Many periodic procedures rely on a scheduled executor that has a pool of threads with a default fixed size. You can configure the pool size using this configuration property
 |===
 
 

--- a/docs/periodic.adoc
+++ b/docs/periodic.adoc
@@ -13,6 +13,9 @@ Also sometimes you want to schedule execution of Cypher statements to run regula
 
 The `apoc.periodic.*` procedures provide such capabilities.
 
+Many periodic procedures rely on a scheduled executor that has a pool of threads with a default fixed size. You can configure the pool size using the following configuration property:
+
+`apoc.jobs.scheduled.num_threads=10`
 
 == apoc.periodic.iterate
 

--- a/src/main/java/apoc/Pools.java
+++ b/src/main/java/apoc/Pools.java
@@ -53,7 +53,6 @@ public class Pools {
     }
 
     private static ScheduledExecutorService createScheduledPool(int numOfThreads) {
-        System.out.println("Pools.createScheduledPool ---> " + numOfThreads);
         return Executors.newScheduledThreadPool(Math.max(1, numOfThreads));
     }
 

--- a/src/main/java/apoc/Pools.java
+++ b/src/main/java/apoc/Pools.java
@@ -10,9 +10,11 @@ import java.util.concurrent.locks.LockSupport;
 import java.util.function.Consumer;
 
 public class Pools {
+    private final static String DEFAULT_NUM_OF_THREADS = new Integer(Runtime.getRuntime().availableProcessors() / 4).toString();
+
     public final static ExecutorService SINGLE = createSinglePool();
     public final static ExecutorService DEFAULT = createDefaultPool();
-    public final static ScheduledExecutorService SCHEDULED = createScheduledPool();
+    public final static ScheduledExecutorService SCHEDULED = createScheduledPool(Integer.parseInt(ApocConfiguration.get("jobs.scheduled.num_threads", DEFAULT_NUM_OF_THREADS)));
     public static JobScheduler NEO4J_SCHEDULER = null;
 
     private Pools() {
@@ -50,8 +52,9 @@ public class Pools {
         return Executors.newSingleThreadExecutor();
     }
 
-    private static ScheduledExecutorService createScheduledPool() {
-        return Executors.newScheduledThreadPool(Math.max(1, Runtime.getRuntime().availableProcessors() / 4));
+    private static ScheduledExecutorService createScheduledPool(int numOfThreads) {
+        System.out.println("Pools.createScheduledPool ---> " + numOfThreads);
+        return Executors.newScheduledThreadPool(Math.max(1, numOfThreads));
     }
 
     public static <T> Future<Void> processBatch(List<T> batch, GraphDatabaseService db, Consumer<T> action) {


### PR DESCRIPTION
Now it's possible to set up the number of threads for the SCHEDULED pool.
The configuration property is `apoc.jobs.scheduled.num_threads`