### PR TITLE
Add apoc.cypher.runFirstColumn function

### DIFF
--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -521,6 +521,7 @@ CALL apoc.generate.simple([2,2,2,2], null, null)
 [cols="1m,5"]
 |===
 | CALL apoc.cypher.run(fragment, params) yield value | executes reading fragment with the given parameters
+| apoc.cypher.runFirstColumn(statement, params, [expectMultiplevalues]) | function that executes statement with given parameters returning first column only, if expectMultipleValues is true will collect results into a list
 | CALL apoc.cypher.runFile(file or url) yield row, result | runs each statement in the file, all semicolon separated - currently no schema operations
 | CALL apoc.cypher.runFiles([files or urls]) yield row, result | runs each statement in the files, all semicolon separated
 | CALL apoc.cypher.runSchemaFile(file or url) - allows only schema operations, runs each schema statement in the file, all semicolon separated

--- a/src/main/java/apoc/cypher/CypherFunctions.java
+++ b/src/main/java/apoc/cypher/CypherFunctions.java
@@ -21,17 +21,14 @@ public class CypherFunctions {
 
     @UserFunction
     @Description("apoc.cypher.runFirstColumn(statement, params, expectMultipleValues) - executes statement with given parameters, returns first column only, if expectMultipleValues is true will collect results into an array")
-    public Object runFirstColumn(@Name("cypher") String statement, @Name("params") Map<String, Object> params, @Name(value = "expectMultipleValues",defaultValue = "true") Boolean expectMultipleValues) {
+    public Object runFirstColumn(@Name("cypher") String statement, @Name("params") Map<String, Object> params, @Name(value = "expectMultipleValues",defaultValue = "true") boolean expectMultipleValues) {
         if (params == null) params = Collections.emptyMap();
-        Result result = db.execute(withParamMapping(statement, params.keySet()), params);
+        try (Result result = db.execute(withParamMapping(statement, params.keySet()), params)) {
 
         String firstColumn = result.columns().get(0);
-
-        if (expectMultipleValues) {
-            return result.columnAs(firstColumn).stream().toArray();
-        } else {
-            return result.columnAs(firstColumn).next();
+        try (ResourceIterator<Object> iter = result.columnAs(firstColumn)) { 
+           return expectMultipleValues ? iter.stream().toArray() : iter.next();
         }
+      }
     }
-
 }

--- a/src/main/java/apoc/cypher/CypherFunctions.java
+++ b/src/main/java/apoc/cypher/CypherFunctions.java
@@ -1,0 +1,37 @@
+package apoc.cypher;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Result;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.UserFunction;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static apoc.cypher.Cypher.withParamMapping;
+
+/**
+ * Created by lyonwj on 9/29/17.
+ */
+public class CypherFunctions {
+    @Context
+    public GraphDatabaseService db;
+
+    @UserFunction
+    @Description("apoc.cypher.runFirstColumn(statement, params, expectMultipleValues) - executes statement with given parameters, returns first column only, if expectMultipleValues is true will collect results into an array")
+    public Object runFirstColumn(@Name("cypher") String statement, @Name("params") Map<String, Object> params, @Name(value = "expectMultipleValues",defaultValue = "true") Boolean expectMultipleValues) {
+        if (params == null) params = Collections.emptyMap();
+        Result result = db.execute(withParamMapping(statement, params.keySet()), params);
+
+        String firstColumn = result.columns().get(0);
+
+        if (expectMultipleValues) {
+            return result.columnAs(firstColumn).stream().toArray();
+        } else {
+            return result.columnAs(firstColumn).next();
+        }
+    }
+
+}

--- a/src/test/java/apoc/cypher/CypherTest.java
+++ b/src/test/java/apoc/cypher/CypherTest.java
@@ -14,17 +14,13 @@ import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
 import static apoc.util.Util.withMapping;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 
 /**
  * @author mh
@@ -46,6 +42,7 @@ public class CypherTest {
                 .newGraphDatabase();
         TestUtil.registerProcedure(db, Cypher.class);
         TestUtil.registerProcedure(db, Utils.class);
+        TestUtil.registerProcedure(db, CypherFunctions.class);
     }
 
     @AfterClass
@@ -79,6 +76,19 @@ public class CypherTest {
     public void testRunVariable() throws Exception {
         testCall(db, "CALL apoc.cypher.run('RETURN a + 7 as b',{a:3})",
                 r -> assertEquals(10L, ((Map) r.get("value")).get("b")));
+    }
+
+    @Test
+    public void testRunFirstColumn() throws Exception {
+        testCall(db, "RETURN apoc.cypher.runFirstColumn('RETURN a + 7 AS b', {a: 3}, false) AS s",
+                r -> assertEquals(10L, (r.get("s"))));
+    }
+
+    @Test
+    public void testRunFirstColumnMultipleValues() throws Exception {
+        Object[] expected = new Object[]{1L, 2L, 3L};
+        testCall(db, "RETURN apoc.cypher.runFirstColumn('UNWIND [1, 2, 3] AS e RETURN e', {}, true) AS arr",
+                r -> assertArrayEquals(expected, (Object[])(r.get("arr"))));
     }
 
     @Test


### PR DESCRIPTION
Executes a Cypher statement and returns first column only,
optionally collected into an array. Used by neo4j-graphql-js