### PR TITLE
Close all statements using try-with-resources

### DIFF
--- a/src/main/java/apoc/meta/Meta.java
+++ b/src/main/java/apoc/meta/Meta.java
@@ -12,7 +12,7 @@ import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.helpers.collection.Pair;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ReadOperations;
-import org.neo4j.kernel.impl.api.KernelStatement;
+import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.procedure.*;
 
@@ -226,7 +226,7 @@ public class Meta {
 
     private MetaStats collectStats() {
         Map<String, Long> relStatsCount = new LinkedHashMap<>();
-        try (KernelStatement stmt = (KernelStatement) kernelTx.acquireStatement()) {
+        try (Statement stmt = kernelTx.acquireStatement()) {
             ReadOperations ops = stmt.readOperations();
 
             int labelCount = ops.labelCount();
@@ -261,7 +261,7 @@ public class Meta {
     }
 
     private void collectStats(Collection<String> labelNames, Collection<String> relTypeNames, StatsCallback cb) {
-        try (KernelStatement stmt = (KernelStatement) kernelTx.acquireStatement()) {
+        try (Statement stmt = kernelTx.acquireStatement()) {
             ReadOperations ops = stmt.readOperations();
 
             Map<String, Integer> labels = labelsInUse(ops, labelNames);
@@ -623,7 +623,7 @@ public class Meta {
     }
 
     private Stream<GraphResult> metaGraph(Collection<String> labelNames, Collection<String> relTypeNames, boolean removeMissing) {
-        try (KernelStatement stmt = (KernelStatement) kernelTx.acquireStatement()) {
+        try (Statement stmt = kernelTx.acquireStatement()) {
             ReadOperations ops = stmt.readOperations();
 
             Map<String, Integer> labels = labelsInUse(ops, labelNames);


### PR DESCRIPTION
Neo4j has become more strict about making sure that statements are closed by procedures using them. If this does not happen, chaining multiple procedure calls can fail. Please forward merge this into 3.3, and possibly have a look at 3.1 as well.