### PR TITLE
Support null labels, multiple labels in apoc.schema.properties.distinctCount

### DIFF
--- a/src/main/java/apoc/index/SchemaIndex.java
+++ b/src/main/java/apoc/index/SchemaIndex.java
@@ -203,7 +203,7 @@ public class SchemaIndex {
     @Procedure("apoc.schema.properties.distinctCount")
     @Description("apoc.schema.properties.distinctCount([label], [key]) YIELD label, key, value, count - quickly returns all distinct values and counts for a given key")
     public Stream<PropertyValueCount> distinctCount(@Name(value = "label", defaultValue = "") String labelName, @Name(value = "key", defaultValue = "") String keyName) throws SchemaRuleNotFoundException, IndexNotFoundKernelException, IOException {
-        Iterable<IndexDefinition> labels = (labelName.isEmpty()) ? db.schema().getIndexes(Label.label(labelName)) : db.schema().getIndexes(Label.label(labelName));
+        Iterable<IndexDefinition> labels = (labelName.isEmpty()) ? db.schema().getIndexes() : db.schema().getIndexes(Label.label(labelName));
         return StreamSupport.stream(labels.spliterator(), false).filter(i -> keyName.isEmpty() || isKeyIndexed(i, keyName)).flatMap(
                 index -> {
                     Iterable<String> keys = keyName.isEmpty() ? index.getPropertyKeys() : Collections.singletonList(keyName);

--- a/src/main/java/apoc/index/SchemaIndex.java
+++ b/src/main/java/apoc/index/SchemaIndex.java
@@ -188,7 +188,6 @@ public class SchemaIndex {
             TermsEnum termsEnum;
 
             Fields fields = MultiFields.getFields(sortedIndexReader.getIndexSearcher().getIndexReader());
-
             Terms terms = fields.terms("string");
             if (terms != null) {
                 termsEnum = terms.iterator();

--- a/src/main/java/apoc/index/SchemaIndex.java
+++ b/src/main/java/apoc/index/SchemaIndex.java
@@ -1,6 +1,5 @@
 package apoc.index;
 
-import com.hazelcast.util.IterableUtil;
 import org.neo4j.graphdb.*;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.kernel.api.Statement;
@@ -15,13 +14,11 @@ import org.apache.lucene.index.Terms;
 import org.apache.lucene.index.TermsEnum;
 import org.apache.lucene.search.Sort;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
-import org.neo4j.graphdb.*;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Label;
-import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -35,7 +32,6 @@ import org.neo4j.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.procedure.Context;
-import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.storageengine.api.schema.IndexReader;

--- a/src/main/java/apoc/index/SchemaIndex.java
+++ b/src/main/java/apoc/index/SchemaIndex.java
@@ -232,13 +232,6 @@ public class SchemaIndex {
             }
             return values;
         } catch (Exception e) {
-            if (tx.isOpen()) {
-                try {
-                    tx.close();
-                } catch (TransactionFailureException tfe) {
-                    throw new RuntimeException("Error collecting distinct terms due to transaction failure", e);
-                }
-            }
             throw new RuntimeException("Error collecting distinct terms of label: " + label + " and key: " + key, e);
         }
     }

--- a/src/test/java/apoc/index/SchemaIndexTest.java
+++ b/src/test/java/apoc/index/SchemaIndexTest.java
@@ -176,4 +176,31 @@ public class SchemaIndexTest {
                 });
     }
 
+    @Test
+    public void testDistinctPropertiesOnEmptyLabel() throws Exception {
+        String key = "bar";
+        testResult(db,"CALL apoc.schema.properties.distinctCount({label}, {key}) YIELD label,key,value,count RETURN * ORDER BY value",
+                map("label","","key",key),
+                (result) -> {
+                    assertTrue(result.hasNext());
+                    assertEquals(map("label","Foo","key",key,"value","four","count",2L),result.next());
+                    assertEquals(map("label","Foo","key",key,"value","three","count",1L),result.next());
+                    assertFalse(result.hasNext());
+                });
+    }
+
+    @Test
+    public void testDistinctPropertiesOnEmptyKey() throws Exception {
+        String label = "Foo";
+        testResult(db,"CALL apoc.schema.properties.distinctCount({label}, {key}) YIELD label,key,value,count RETURN * ORDER BY value",
+                map("label",label,"key",""),
+                (result) -> {
+                    assertTrue(result.hasNext());
+                    assertEquals(map("label",label,"key","baz","value","five","count",1L),result.next());
+                    assertEquals(map("label",label,"key","bar","value","four","count",2L),result.next());
+                    assertEquals(map("label",label,"key","bar","value","three","count",1L),result.next());
+                    assertFalse(result.hasNext());
+                });
+    }
+
 }


### PR DESCRIPTION
This PR should fix #639 and #640 

I removed the `finally` block that was closing the transaction to fix #639.

For #640, when `labelName.isEmpty()` all indexes are searched (rather than none). This exposed another bug, which is that we would count distinct terms on all indexes for the label, whether or not they contained the key under consideration. So there are two small changes to the logic in `@Procedure("apoc.schema.properties.distinctCount")`

I added test cases to check the behavior with:
1. Labels with more than one index
2. labelName.isEmpty()
3. keyName.isEmpty()
4. both (2) and (3)

In doing so I noticed that only `string` Lucene terms work with these distinct property APOC methods. I'm not sure how to fix that so I just created issue #641 and commented out the test lines that were failing.