### PR TITLE
Add apoc.coll.frequencies

### DIFF
--- a/src/main/java/apoc/coll/Coll.java
+++ b/src/main/java/apoc/coll/Coll.java
@@ -381,6 +381,37 @@ public class Coll {
     }
 
     @UserFunction
+    @Description("apoc.coll.frequencies(coll) - returns a list of frequencies of the items in the collection, keyed by `item` and `count` (e.g., `[{item: xyz, count:2}, {item:zyx, count:5}]`)")
+    public List<Map<String, Object>> frequencies(@Name("coll") List<Object> coll) {
+        if (coll == null || coll.size() == 0) {
+            return Collections.emptyList();
+        }
+
+        // mimicking a counted bag
+        Map<Object, IntCounter> counts = new LinkedHashMap<>(coll.size());
+        List<Map<String, Object>> resultList = new ArrayList<>();
+
+        for (Object obj : coll) {
+            IntCounter counter = counts.get(obj);
+            if (counter == null) {
+                counter = new IntCounter();
+                counts.put(obj, counter);
+            }
+            counter.increment();
+        }
+
+        counts.forEach((o, intCounter) -> {
+            int count = intCounter.value();
+            Map<String, Object> entry = new LinkedHashMap<>(2);
+            entry.put("item", o);
+            entry.put("count", Long.valueOf(count));
+            resultList.add(entry);
+        });
+
+        return resultList;
+    }
+
+    @UserFunction
     @Description("apoc.coll.occurrences(coll, item) - returns the count of the given item in the collection")
     public long occurrences(@Name("coll") List<Object> coll, @Name("item") Object item) {
         if (coll == null || coll.isEmpty()) {

--- a/src/test/java/apoc/coll/CollTest.java
+++ b/src/test/java/apoc/coll/CollTest.java
@@ -462,6 +462,41 @@ public class CollTest {
     }
 
     @Test
+    public void testFrequenciesOnNullAndEmptyList() throws Exception {
+        testCall(db, "RETURN apoc.coll.frequencies([]) as value",
+                (row) -> assertEquals(Collections.EMPTY_LIST, row.get("value")));
+        testCall(db, "RETURN apoc.coll.frequencies(null) as value",
+                (row) -> assertEquals(Collections.EMPTY_LIST, row.get("value")));
+    }
+
+    @Test
+    public void testFrequencies() throws Exception {
+        testCall(db, "RETURN apoc.coll.frequencies([1,2,1,3,2,5,2,3,1,2]) as value",
+                (row) -> {
+                    Map<Long, Long> expectedMap = new HashMap<>(4);
+                    expectedMap.put(1l, 3l);
+                    expectedMap.put(2l, 4l);
+                    expectedMap.put(3l, 2l);
+                    expectedMap.put(5l, 1l);
+
+                    List<Map<String, Object>> result = (List<Map<String, Object>>) row.get("value");
+                    assertEquals(4, result.size());
+
+                    Set<Long> keys = new HashSet<>(4);
+
+                    for (Map<String, Object> map : result) {
+                        Object item = map.get("item");
+                        Long count = (Long) map.get("count");
+                        keys.add((Long) item);
+                        assertTrue(expectedMap.containsKey(item));
+                        assertEquals(expectedMap.get(item), count);
+                    }
+
+                    assertEquals(expectedMap.keySet(), keys);
+                });
+    }
+
+    @Test
     public void testOccurrencesOnNullAndEmptyList() throws Exception {
         testCall(db, "RETURN apoc.coll.occurrences([], 5) as value",
                 (row) -> assertEquals(0l, row.get("value")));


### PR DESCRIPTION
This address #643 by adding `apoc.coll.frequencies` which returns a list of maps with keys `item` and `count`. It returns all elements counts including counts 1.

This makes it easy to pass into `sortMaps` to get the top/bottom `n` items based on count.
