### PR TITLE
Fixes #681 - Compound index dropping using apoc.schema.assert fails

### DIFF
--- a/src/main/java/apoc/result/AssertSchemaResult.java
+++ b/src/main/java/apoc/result/AssertSchemaResult.java
@@ -1,13 +1,29 @@
 package apoc.result;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class AssertSchemaResult {
     public final String label;
     public final String key;
+    public final List<String> keys;
     public boolean unique = false;
     public String action = "KEPT";
 
-    public AssertSchemaResult(String label, String key) {
+    public AssertSchemaResult(String label, List<String> keys) {
         this.label = label;
+        if(keys.size() > 1) {
+            this.keys = keys;
+            this.key = null;
+        } else {
+            this.key = keys.get(0);
+            this.keys = null;
+        }
+    }
+
+    public AssertSchemaResult(String label, String key){
+        this.label = label;
+        this.keys = null;
         this.key = key;
     }
 

--- a/src/main/java/apoc/result/AssertSchemaResult.java
+++ b/src/main/java/apoc/result/AssertSchemaResult.java
@@ -1,5 +1,6 @@
 package apoc.result;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -12,18 +13,18 @@ public class AssertSchemaResult {
 
     public AssertSchemaResult(String label, List<String> keys) {
         this.label = label;
-        if(keys.size() > 1) {
+        if (keys.size() == 1) {
+            this.key = keys.get(0);
+            this.keys = keys;
+        } else {
             this.keys = keys;
             this.key = null;
-        } else {
-            this.key = keys.get(0);
-            this.keys = null;
         }
     }
 
     public AssertSchemaResult(String label, String key){
         this.label = label;
-        this.keys = null;
+        this.keys = Arrays.asList(key);
         this.key = key;
     }
 

--- a/src/main/java/apoc/schema/Schemas.java
+++ b/src/main/java/apoc/schema/Schemas.java
@@ -107,17 +107,22 @@ public class Schemas {
         for (IndexDefinition definition : schema.getIndexes()) {
             if (definition.isConstraintIndex()) continue;
             String label = definition.getLabel().name();
-            String key = Iterables.single(definition.getPropertyKeys());
-            AssertSchemaResult info = new AssertSchemaResult(label, key);
 
-            if (!indexes.containsKey(label) || !indexes.get(label).remove(key)) {
-                if (dropExisting) {
-                    definition.drop();
-                    info.dropped();
+            Boolean alreadyDropped = false;
+            for (String key : definition.getPropertyKeys()) {
+
+                AssertSchemaResult info = new AssertSchemaResult(label, key);
+
+                if (!indexes.containsKey(label) || !indexes.get(label).remove(key)) {
+                    if (dropExisting && !alreadyDropped) {
+                        definition.drop();
+                        alreadyDropped = true;
+                    }
+                    if(alreadyDropped)
+                        info.dropped();
                 }
+                result.add(info);
             }
-
-            result.add(info);
         }
 
         for (Map.Entry<String, List<String>> index : indexes.entrySet()) {

--- a/src/test/java/apoc/schema/SchemasTest.java
+++ b/src/test/java/apoc/schema/SchemasTest.java
@@ -233,6 +233,7 @@ public class SchemasTest {
             Map<String, Object> r = result.next();
             assertEquals("Foo", r.get("label"));
             assertEquals("bar", r.get("key"));
+            assertEquals(expectedKeys("bar"), r.get("keys"));
             assertEquals(true, r.get("unique"));
             assertEquals("KEPT", r.get("action"));
 

--- a/src/test/java/apoc/schema/SchemasTest.java
+++ b/src/test/java/apoc/schema/SchemasTest.java
@@ -12,7 +12,6 @@ import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.ConstraintType;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.util.List;
 import java.util.Map;
@@ -20,8 +19,8 @@ import java.util.concurrent.TimeUnit;
 
 import static apoc.util.TestUtil.*;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.*;
-import static java.util.Collections.singleton;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author mh
@@ -208,7 +207,7 @@ public class SchemasTest {
     @Test
     public void testKeepIndex() throws Exception {
         db.execute("CREATE INDEX ON :Foo(bar)").close();
-        testResult(db, "CALL apoc.schema.assert({Foo:['bar', 'foo']},null)", (result) -> {
+        testResult(db, "CALL apoc.schema.assert({Foo:['bar', 'foo']},null,false)", (result) -> { 
             Map<String, Object> r = result.next();
             assertEquals("Foo", r.get("label"));
             assertEquals("bar", r.get("key"));
@@ -361,7 +360,7 @@ public class SchemasTest {
             testResult(db, "CALL apoc.schema.nodes()", (result) -> {
                 Map<String, Object> r = result.next();
 
-                assertEquals("Bar", r.get("label"));
+                assertEquals("bar", r.get("label"));
                 assertEquals("NODE_PROPERTY_EXISTENCE", r.get("type"));
                 assertEquals("foobar", ((List<String>) r.get("properties")).get(0));
 
@@ -392,16 +391,10 @@ public class SchemasTest {
     @Test
     public void testDropCompoundIndexWhenUsingDropExisting() throws Exception {
         db.execute("CREATE INDEX ON :Foo(bar,baa)").close();
-        testResult(db, "CALL apoc.schema.assert(null,null)", (result) -> {
+        testResult(db, "CALL apoc.schema.assert(null,null,true)", (result) -> {
             Map<String, Object> r = result.next();
             assertEquals("Foo", r.get("label"));
-            assertEquals("bar", r.get("key"));
-            assertEquals(false, r.get("unique"));
-            assertEquals("DROPPED", r.get("action"));
-
-            r = result.next();
-            assertEquals("Foo", r.get("label"));
-            assertEquals("baa", r.get("key"));
+            assertEquals(expectedKeys("bar", "baa"), r.get("keys"));
             assertEquals(false, r.get("unique"));
             assertEquals("DROPPED", r.get("action"));
         });
@@ -409,5 +402,121 @@ public class SchemasTest {
             List<IndexDefinition> indexes = Iterables.asList(db.schema().getIndexes());
             assertEquals(0, indexes.size());
         }
+    }
+
+    /*
+        This is only for 3.2+
+    */
+    @Test
+    public void testDropCompoundIndexAndRecreateWithDropExisting() throws Exception {
+        db.execute("CREATE INDEX ON :Foo(bar,baa)").close();
+        testResult(db, "CALL apoc.schema.assert({Foo:[['bar','baa']]},null,true)", (result) -> {
+            Map<String, Object> r = result.next();
+            assertEquals("Foo", r.get("label"));
+            assertEquals(expectedKeys("bar", "baa"), r.get("keys"));
+            assertEquals(false, r.get("unique"));
+            assertEquals("DROPPED", r.get("action"));
+        });
+        try (Transaction tx = db.beginTx()) {
+            List<IndexDefinition> indexes = Iterables.asList(db.schema().getIndexes());
+            assertEquals(1, indexes.size());
+        }
+    }
+
+    /*
+        This is only for 3.2+
+    */
+    @Test
+    public void testDoesntDropCompoundIndexWhenSupplyingSameCompoundIndex() throws Exception {
+        db.execute("CREATE INDEX ON :Foo(bar,baa)").close();
+        testResult(db, "CALL apoc.schema.assert({Foo:[['bar','baa']]},null,false)", (result) -> {
+            Map<String, Object> r = result.next();
+            assertEquals("Foo", r.get("label"));
+            assertEquals(expectedKeys("bar", "baa"), r.get("keys"));
+            assertEquals(false, r.get("unique"));
+            assertEquals("KEPT", r.get("action"));
+        });
+        try (Transaction tx = db.beginTx()) {
+            List<IndexDefinition> indexes = Iterables.asList(db.schema().getIndexes());
+            assertEquals(1, indexes.size());
+        }
+    }
+    /*
+        This is only for 3.2+
+    */
+    @Test
+    public void testKeepCompoundIndex() throws Exception {
+        db.execute("CREATE INDEX ON :Foo(bar,baa)").close();
+        testResult(db, "CALL apoc.schema.assert({Foo:[['bar','baa'], ['foo','faa']]},null,false)", (result) -> {
+            Map<String, Object> r = result.next();
+            assertEquals("Foo", r.get("label"));
+            assertEquals(expectedKeys("bar", "baa"), r.get("keys"));
+            assertEquals(false, r.get("unique"));
+            assertEquals("KEPT", r.get("action"));
+
+            r = result.next();
+            assertEquals("Foo", r.get("label"));
+            assertEquals(expectedKeys("foo", "faa"), r.get("keys"));
+            assertEquals(false, r.get("unique"));
+            assertEquals("CREATED", r.get("action"));
+        });
+        try (Transaction tx = db.beginTx()) {
+            List<IndexDefinition> indexes = Iterables.asList(db.schema().getIndexes());
+            assertEquals(2, indexes.size());
+        }
+    }
+
+    /*
+        This is only for 3.2+
+    */
+    @Test
+    public void testDropIndexAndCreateCompoundIndexWhenUsingDropExisting() throws Exception {
+        db.execute("CREATE INDEX ON :Foo(bar)").close();
+        testResult(db, "CALL apoc.schema.assert({Bar:[['foo','bar']]},null)", (result) -> {
+            Map<String, Object> r = result.next();
+            assertEquals("Foo", r.get("label"));
+            assertEquals("bar", r.get("key"));
+            assertEquals(false, r.get("unique"));
+            assertEquals("DROPPED", r.get("action"));
+
+            r = result.next();
+            assertEquals("Bar", r.get("label"));
+            assertEquals(expectedKeys("foo", "bar"), r.get("keys"));
+            assertEquals(false, r.get("unique"));
+            assertEquals("CREATED", r.get("action"));
+        });
+        try (Transaction tx = db.beginTx()) {
+            List<IndexDefinition> indexes = Iterables.asList(db.schema().getIndexes());
+            assertEquals(1, indexes.size());
+        }
+    }
+
+    /*
+        This is only for 3.2+
+    */
+    @Test
+    public void testDropCompoundIndexAndCreateCompoundIndexWhenUsingDropExisting() throws Exception {
+        db.execute("CREATE INDEX ON :Foo(bar,baa)").close();
+        testResult(db, "CALL apoc.schema.assert({Foo:[['bar','baa']]},null)", (result) -> {
+            Map<String, Object> r = result.next();
+            assertEquals("Foo", r.get("label"));
+            assertEquals(expectedKeys("bar","baa"), r.get("keys"));
+            assertEquals(false, r.get("unique"));
+            assertEquals("DROPPED", r.get("action"));
+
+            r = result.next();
+            assertEquals("Foo", r.get("label"));
+            assertEquals(expectedKeys("bar", "baa"), r.get("keys"));
+            assertEquals(false, r.get("unique"));
+            assertEquals("CREATED", r.get("action"));
+        });
+        try (Transaction tx = db.beginTx()) {
+            List<IndexDefinition> indexes = Iterables.asList(db.schema().getIndexes());
+            assertEquals(1, indexes.size());
+        }
+    }
+
+    private List<String> expectedKeys(String... keys){
+        return asList(keys);
     }
 }


### PR DESCRIPTION
So as not to change the output, I create multiple `AssertSchemaResult` instances per key in a compound index. This should get into 3.2 and 3.3 branches.