### PR TITLE
Email and URL extraction functions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ compileJava {
 
 dependencies {
     compile group: 'commons-codec', name: 'commons-codec', version:'1.9'
+    compile group: 'com.sun.mail', name: 'javax.mail', version: '1.6.0'
     compile 'com.jayway.jsonpath:json-path:2.2.0'
     compile 'org.hdrhistogram:HdrHistogram:2.1.9'
     compile 'org.neo4j.driver:neo4j-java-driver:1.4.4'

--- a/src/main/java/apoc/data/Extract.java
+++ b/src/main/java/apoc/data/Extract.java
@@ -6,6 +6,11 @@ import org.neo4j.procedure.UserFunction;
 
 import java.util.regex.Pattern;
 
+/**
+ * Extracts domains from URLs and email addresses
+ * @deprecated use ExtractEmail or ExtractURI
+ */
+@Deprecated
 public class Extract {
 
     public static final Pattern DOMAIN = Pattern.compile("([\\w-]+\\.[\\w-]+)+(\\w+)");

--- a/src/main/java/apoc/data/email/ExtractEmail.java
+++ b/src/main/java/apoc/data/email/ExtractEmail.java
@@ -1,0 +1,53 @@
+package apoc.data.email;
+
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.UserFunction;
+
+import javax.mail.internet.AddressException;
+
+// Validates RFC822 syntax
+import javax.mail.internet.InternetAddress;
+
+public class ExtractEmail {
+    protected InternetAddress addressOrNull(String value) {
+        if (value == null || value.indexOf('@') == -1) {
+            return null;
+        }
+        try {
+            return new InternetAddress(value);
+        } catch(AddressException adr) {
+            return null;
+        }
+    }
+
+    @UserFunction
+    @Description("apoc.data.email.personal('email_address') YIELD personal - extract the personal name from an email address like 'David <david.allen@neo4j.com>'")
+    public String personal(final @Name("email_address") String value) {
+        InternetAddress addr = addressOrNull(value);
+        return addr != null ? addr.getPersonal() : null;
+    }
+
+    @UserFunction
+    @Description("apoc.data.email.domain('email_address') YIELD domain - extract the domain name from an email address. If nothing was found, yield null.")
+    public String domain(final @Name("email_address") String value) {
+        InternetAddress addr = addressOrNull(value);
+
+        if (addr == null) return null;
+
+        // This naive parsing is only safe because of going through previous
+        // validation.
+        String rawAddr = addr.getAddress();
+        return rawAddr.substring(rawAddr.indexOf('@') + 1);
+    }
+
+    @UserFunction
+    @Description("apoc.data.email.user('email_address') YIELD user - extract the user from an email address")
+    public String user(final @Name("email_address") String value) {
+        InternetAddress addr = addressOrNull(value);
+        if (addr == null) return null;
+
+        String rawAddr = addr.getAddress();
+        return rawAddr.substring(0, rawAddr.indexOf('@'));
+    }
+}

--- a/src/main/java/apoc/data/url/ExtractURL.java
+++ b/src/main/java/apoc/data/url/ExtractURL.java
@@ -1,0 +1,92 @@
+package apoc.data.url;
+
+import java.net.URL;
+import java.net.MalformedURLException;
+
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.UserFunction;
+
+/**
+ * This class is pretty simple.  It just constructs a java.net.URL instance
+ * from the user's input to do validation/parsing, and delegates the actual
+ * functionality to that class.  As such, the behavior of these functions
+ * matches that class, which is nice.
+ */
+public class ExtractURL {
+    /**
+     * In the context of a user function, we want to ignore parse errors.
+     */
+    protected static URL uriOrNull(String value) {
+        if (value == null) return null;
+        try {
+            URL u = new URL(value);
+            return u;
+        } catch(MalformedURLException exc) {
+            return null;
+        }
+    }
+
+    @UserFunction
+    @Description("apoc.data.url.protocol('url') YIELD protocol - extract protocol from a URL")
+    public String protocol(final @Name("url") String value) {
+        URL u = uriOrNull(value);
+        return u != null ? u.getProtocol() : null;
+    }
+
+    @UserFunction
+    @Description("apoc.data.url.port('url') YIELD port - extract a port from a URL; returns -1 if none specified")
+    public Long port(final @Name("url") String value) {
+        URL u = uriOrNull(value);
+
+        // -1 is the default behavior because thats what java.net.URL does when a port
+        // isn't specified.  E.g. the port for http://google.com/ in this context is -1,
+        // *not* 80, it's not doing any special protocol inference magic.
+        // The port for null is similarly -1.
+        return u != null ? new Long(u.getPort()) : -1L;
+    }
+
+    @UserFunction
+    @Description("apoc.data.url.query('url') YIELD query - extract a query from a URL")
+    public String query(final @Name("url") String value) {
+        URL u = uriOrNull(value);
+
+        return u != null ? u.getQuery() : null;
+    }
+
+    @UserFunction
+    @Description("apoc.data.url.path('url') YIELD path - extract a path from a URL")
+    public String path(final @Name("url") String value) {
+        URL u = uriOrNull(value);
+        return u != null ? u.getPath() : null;
+    }
+
+    @UserFunction
+    @Description("apoc.data.url.file('url') YIELD file - extract a file from a URL")
+    public String file(final @Name("url") String value) {
+        URL u = uriOrNull(value);
+        return u != null ? u.getFile() : null;
+    }
+
+    @UserFunction
+    @Description("apoc.data.url.anchor('url') YIELD anchor - extract a file from a URL")
+    public String anchor(final @Name("url") String value) {
+        URL u = uriOrNull(value);
+        return u != null ? u.getRef() : null;
+    }
+
+    @UserFunction
+    @Description("apoc.data.url.userInfo('url') YIELD anchor - extract user information from a URL")
+    public String userInfo(final @Name("url") String value) {
+        URL u = uriOrNull(value);
+        return u != null ? u.getUserInfo() : null;
+    }
+
+    @UserFunction
+    @Description("apoc.data.url.host('url') YIELD domain - extract the host name from a uri. If nothing was found, yield null.")
+    public String host(final @Name("url") String value) {
+        URL u = uriOrNull(value);
+        return u != null ? u.getHost() : null;
+    }
+
+}

--- a/src/test/java/apoc/data/email/ExtractEmailTest.java
+++ b/src/test/java/apoc/data/email/ExtractEmailTest.java
@@ -1,0 +1,89 @@
+package apoc.data.email;
+
+import apoc.util.TestUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static apoc.util.TestUtil.testCall;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+
+public class ExtractEmailTest {
+    private GraphDatabaseService db;
+
+    @Before
+    public void setUp() throws Exception {
+        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        TestUtil.registerProcedure(db, ExtractEmail.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
+    }
+
+    @Test
+    public void testPersonalPresent() {
+        testCall(db, "RETURN apoc.data.email.personal('David <david.allen@neo4j.com>') AS value",
+            row -> assertEquals("David", row.get("value")));
+    }
+
+    @Test
+    public void testPersonalMissing() {
+        testCall(db, "RETURN apoc.data.email.personal('<david.allen@neo4j.com>') AS value",
+            row -> assertEquals(null, row.get("value")));
+    }
+
+    @Test
+    public void testUser() {
+        testCall(db, "RETURN apoc.data.email.user('Unusual <example-throwaway@gmail.com>') AS value",
+        row -> assertEquals("example-throwaway", row.get("value")));    
+    }
+
+    @Test
+    public void testMissingUser() {
+        testCall(db, "RETURN apoc.data.email.user('mail.com') AS value",
+        row -> assertEquals(null, row.get("value")));    
+    }
+
+    @Test
+    public void testQuotedEmail() {
+        testCall(db, "RETURN apoc.data.email.domain('<foo@bar.baz>') AS value",
+                row -> Assert.assertThat(row.get("value"), equalTo("bar.baz")));
+    }
+
+    @Test
+    public void testEmail() {
+        testCall(db, "RETURN apoc.data.email.domain('foo@bar.baz') AS value",
+                row -> Assert.assertThat(row.get("value"), equalTo("bar.baz")));
+    }
+
+    @Test
+    public void testLocalEmail() {
+        // Internet standards strongly discourage this possibility, but it's out there.
+        testCall(db, "RETURN apoc.data.email.domain('root@localhost') AS value",
+        row -> Assert.assertThat(row.get("value"), equalTo("localhost")));
+    }
+
+    @Test
+    public void testNull() {
+        testCall(db, "RETURN apoc.data.email.domain(null) AS value",
+                row -> assertEquals(null, row.get("value")));
+    }
+
+    @Test
+    public void testBadString() {
+        testCall(db, "RETURN apoc.data.email.domain('asdsgawe4ge') AS value",
+                row -> assertEquals(null, row.get("value")));
+    }
+
+    @Test
+    public void testEmailWithDotsBeforeAt() {
+        testCall(db, "RETURN apoc.data.email.domain('foo.foo@bar.baz') AS value",
+                row -> Assert.assertThat(row.get("value"), equalTo("bar.baz")));
+    }
+}

--- a/src/test/java/apoc/data/url/ExtractURLTest.java
+++ b/src/test/java/apoc/data/url/ExtractURLTest.java
@@ -1,0 +1,141 @@
+package apoc.data.url;
+
+import apoc.util.TestUtil;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import java.util.HashMap;
+
+import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.testCall;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertEquals;
+
+public class ExtractURLTest {
+    private GraphDatabaseService db;
+    private HashMap<String,Object[]> testCases;
+    String [] methods = new String [] { 
+        "protocol", 
+        "userInfo", 
+        "host", 
+        "port", 
+        "path", 
+        "file", 
+        // "query", 
+        // "anchor" 
+    };
+    
+
+    @Before
+    public void setUp() throws Exception {
+        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        TestUtil.registerProcedure(db, ExtractURL.class);
+
+        // Test cases map URLs to an array of strings representing what their correct answers should
+        // be for components:
+        // protocol, user, host, port, path, file, query, anchor.
+        // Ordering must match "methods" above.
+        testCases = new HashMap<String,Object[]>();
+
+        testCases.put("http://simple.com/", new Object [] {
+            "http", null, "simple.com", -1L, "/", "/", null, null
+        });
+
+        // Something kinda complicated...
+        testCases.put("https://user:secret@localhost:666/path/to/file.html?x=1#b", new Object [] {
+            "https", "user:secret", "localhost", 666L, "/path/to/file.html", "/path/to/file.html?x=1", "x=1", "b"
+        });
+
+        // This is a malformed URL
+        testCases.put("google.com", new Object [] {
+            null, null, null, -1L, null, null, null, null
+        });
+
+        // Real-world semi complex URL.  So meta! :)
+        testCases.put("https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/31cf4b60236ef5e08f7b231ed03f3d8ace511fd2#diff-a084b794bc0759e7a6b77810e01874f2",
+            new Object [] {
+                "https", null, "github.com", -1L,
+                "/neo4j-contrib/neo4j-apoc-procedures/commit/31cf4b60236ef5e08f7b231ed03f3d8ace511fd2",
+                "/neo4j-contrib/neo4j-apoc-procedures/commit/31cf4b60236ef5e08f7b231ed03f3d8ace511fd2",
+                "diff-a084b794bc0759e7a6b77810e01874f2"
+            });
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
+    }
+
+    @Test
+    public void testByCase() {
+        for(String url : testCases.keySet()) {
+            Object [] answers = testCases.get(url);
+
+            for(int x=0; x<methods.length; x++) {
+                String method = methods[x];
+                final int answerIdx = x;
+                testCall(db, "RETURN apoc.data.url."+method+"('" + url + "') AS value",
+                row -> assertEquals(answers[answerIdx], row.get("value")));
+            }   
+        }
+
+        // Test all null cases.
+        for (int x=0; x<methods.length; x++) {
+            String method = methods[x];
+            final int answerIdx = x;
+            testCall(db, "RETURN apoc.data.url."+method+"(null) AS value",
+                row -> {
+                   if (method == "port") {
+                       assertEquals(-1L, row.get("value"));
+                       return;
+                   } 
+                   assertEquals(null, row.get("value"));
+                   return;
+                });
+        }
+    }
+
+    /* Previous test cases matching the deprecated Extract class' requirements are below */
+
+    @Test
+    public void testNull() {
+        testCall(db, "RETURN apoc.data.url.host(null) AS value",
+                row -> assertEquals(null, row.get("value")));
+    }
+
+    @Test
+    public void testBadString() {
+        testCall(db, "RETURN apoc.data.url.host('asdsgawe4ge') AS value",
+                row -> assertEquals(null, row.get("value")));
+    }
+
+    @Test
+    public void testEmptyString() {
+        testCall(db, "RETURN apoc.data.url.host('') AS value",
+                row -> assertEquals(null, row.get("value")));
+    }
+
+    @Test
+    public void testUrl() {
+        testCall(db, "RETURN apoc.data.url.host('http://www.example.com/lots-of-stuff') AS value",
+                row -> assertEquals("www.example.com", row.get("value")));
+    }
+
+    @Test
+    public void testQueryParameter() {
+        testCall(db, "RETURN apoc.data.url.host({param}) AS value",
+                map("param", "http://www.foo.bar/baz"),
+                row -> assertEquals("www.foo.bar", row.get("value")));
+    }
+
+    @Test
+    public void testShorthandURL() {
+        testCall(db, "RETURN apoc.data.url.host({param}) AS value",
+            map("param", "partial.com/foobar"),
+            row -> assertEquals(null, row.get("value")));
+    }
+}


### PR DESCRIPTION
This PR is intended to address https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/664

Additionally it adds new functions mapping to standard Java API provided functions which are easy and useful to expose.

All of the original test cases that were used as part of the original Extract class have been preserved and new test cases have been added to cover the new functions added.