### PR TITLE
Added possibility to remove nodes per labels

### DIFF
--- a/src/main/java/apoc/nodes/Nodes.java
+++ b/src/main/java/apoc/nodes/Nodes.java
@@ -17,6 +17,7 @@ import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.*;
+import org.neo4j.procedure.Description;
 import org.neo4j.storageengine.api.Token;
 
 import java.util.*;
@@ -24,6 +25,7 @@ import java.util.stream.Stream;
 
 import static apoc.path.RelationshipTypeAndDirections.parse;
 import static apoc.util.Util.map;
+import apoc.result.MapResult;
 
 public class Nodes {
 

--- a/src/main/java/apoc/nodes/Nodes.java
+++ b/src/main/java/apoc/nodes/Nodes.java
@@ -1,6 +1,9 @@
 package apoc.nodes;
 
-import apoc.result.*;
+import apoc.*;
+import apoc.result.LongResult;
+import apoc.result.NodeResult;
+import apoc.result.RelationshipResult;
 import apoc.util.Util;
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.graphdb.*;

--- a/src/main/java/apoc/nodes/Nodes.java
+++ b/src/main/java/apoc/nodes/Nodes.java
@@ -303,6 +303,16 @@ public class Nodes {
         }
     }
 
+    @Procedure(value = "apoc.remove.nodes.withlabel", mode = Mode.WRITE)
+    @Description("Will remove all the nodes having one of the given labels, via DETACH DELETE")
+    public void removeNodesWithLabels(@Name("labels") List<String> labels) {
+        for (String label : labels) {
+            if (label!=null && label.trim().length()>0)
+                db.execute("CALL apoc.periodic.commit('MATCH (n:`" + label + "`) DETACH DELETE n;',null)");
+        }
+    }
+
+
     private boolean isDense(ReadOperations ops, Node n) {
         try {
             return ops.nodeIsDense(n.getId());

--- a/src/main/java/apoc/nodes/Nodes.java
+++ b/src/main/java/apoc/nodes/Nodes.java
@@ -331,6 +331,7 @@ public class Nodes {
     }
 
 
+
     private boolean isDense(ReadOperations ops, Node n) {
         try {
             return ops.nodeIsDense(n.getId());

--- a/src/test/java/apoc/nodes/NodesTest.java
+++ b/src/test/java/apoc/nodes/NodesTest.java
@@ -1,6 +1,7 @@
 package apoc.nodes;
 
 import apoc.periodic.Periodic;
+import apoc.create.Create;
 import apoc.util.TestUtil;
 import org.junit.*;
 import org.neo4j.graphdb.GraphDatabaseService;

--- a/src/test/java/apoc/nodes/NodesTest.java
+++ b/src/test/java/apoc/nodes/NodesTest.java
@@ -323,8 +323,8 @@ public class NodesTest {
         String[] labels = {"A SPACE","HOPE ERA"};
         Map params = map("labels", labels,"limit", 50);
 
-        long baseNbr = 1_000  / labels.length ; // Chief M asked for a million nodes. Worked with 10.
-        int steps = 5;
+        long baseNbr = 1_000_000  / labels.length ; // Chief M asked for a million nodes. Worked with 10.
+        int steps = 500;
 
         for(String label: labels) {
             db.execute("CREATE CONSTRAINT ON (n:`"+ label+"`) ASSERT n.bid IS UNIQUE").close();

--- a/src/test/java/apoc/nodes/NodesTest.java
+++ b/src/test/java/apoc/nodes/NodesTest.java
@@ -1,5 +1,6 @@
 package apoc.nodes;
 
+import apoc.periodic.Periodic;
 import apoc.util.TestUtil;
 import org.junit.*;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -7,10 +8,7 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static apoc.util.Util.map;
 import static java.util.Arrays.asList;
@@ -28,6 +26,7 @@ public class NodesTest {
     public void setUp() throws Exception {
         db = TestUtil.apocGraphDatabaseBuilder().newGraphDatabase();
         TestUtil.registerProcedure(db,Nodes.class);
+        TestUtil.registerProcedure(db, Periodic.class);
     }
 
     @After
@@ -175,4 +174,57 @@ public class NodesTest {
         });
 
     }
+
+    @Test
+    public void testRemoveNodesWithLabels_NoParams() {
+        String[] labels = {};
+        Map params = new HashMap();
+        params.put("labels", labels);
+        TestUtil.testResult(db,
+                "CALL apoc.remove.nodes.withlabel",
+                params,
+                r -> {
+                });
+    }
+
+    @Test
+    public void testRemoveNodesWithLabels_OkParams() {
+        String[] labels = {"aa", "bb", "cc"};
+        Map params = new HashMap();
+        params.put("labels", labels);
+        TestUtil.testResult(db,
+                "CALL apoc.remove.nodes.withlabel",
+                params,
+                r -> {
+                });
+    }
+
+    @Test
+    public void testRemoveNodesWithLabels_AnEmptyParam() {
+        String[] labels = {"aa","bb","  ","cc"};
+        Map params = new HashMap();
+        params.put("labels", labels);
+        TestUtil.testResult(db,
+                "CALL apoc.remove.nodes.withlabel",
+                params,
+                r -> {
+                });
+    }
+
+    @Test
+    public void testRemoveNodesWithLabels_KoParamsMissing() {
+        boolean caught = false;
+        try {
+            TestUtil.testCall(db,
+                    "CALL apoc.remove.nodes.withlabel(['aa','',,'bb'])",
+                    null,
+                    r -> {
+                    });
+        } catch (Exception e) {
+            caught = true;
+        }
+        Assert.assertTrue(caught);
+    }
+
+
 }

--- a/src/test/java/apoc/nodes/NodesTest.java
+++ b/src/test/java/apoc/nodes/NodesTest.java
@@ -225,6 +225,4 @@ public class NodesTest {
         }
         Assert.assertTrue(caught);
     }
-
-
 }

--- a/src/test/java/apoc/nodes/NodesTest.java
+++ b/src/test/java/apoc/nodes/NodesTest.java
@@ -176,38 +176,37 @@ public class NodesTest {
     }
 
     @Test
-    public void testRemoveNodesWithLabels_NoParams() {
+    public void testRemoveNodesEmptyLabels() {
         String[] labels = {};
         Map params = new HashMap();
         params.put("labels", labels);
+        params.put("limit", 50);
         TestUtil.testResult(db,
-                "CALL apoc.remove.nodes.withlabel",
+                "CALL apoc.remove.nodes.withlabels",
                 params,
                 r -> {
+                    Map m = r.next();
+                    Map map = (Map) m.get("value");
+                    assertNotNull(map);
+                    assertEquals(0,map.size());
                 });
     }
 
-    @Test
-    public void testRemoveNodesWithLabels_OkParams() {
-        String[] labels = {"aa", "bb", "cc"};
-        Map params = new HashMap();
-        params.put("labels", labels);
-        TestUtil.testResult(db,
-                "CALL apoc.remove.nodes.withlabel",
-                params,
-                r -> {
-                });
-    }
 
     @Test
-    public void testRemoveNodesWithLabels_AnEmptyParam() {
+    public void testRemoveNodesWithLabels_AnEmptyLabel() {
         String[] labels = {"aa","bb","  ","cc"};
         Map params = new HashMap();
         params.put("labels", labels);
+        params.put("limit", 50);
         TestUtil.testResult(db,
-                "CALL apoc.remove.nodes.withlabel",
+                "CALL apoc.remove.nodes.withlabels",
                 params,
                 r -> {
+                    Map m = r.next();
+                    Map map = (Map) m.get("value");
+                    assertNotNull(map);
+                    assertEquals(3,map.size());
                 });
     }
 
@@ -224,5 +223,25 @@ public class NodesTest {
             caught = true;
         }
         Assert.assertTrue(caught);
+    }
+
+    @Test
+    public void testRemoveNodesWithLabels_OkParamsWithLimit() {
+        String[] labels = {"aa", "bb", "cc"};
+        Map params = new HashMap();
+        params.put("labels", labels);
+        params.put("limit", 50);
+        TestUtil.testResult(db,
+                "CALL apoc.remove.nodes.withlabels",
+                params,
+                r -> {
+                    Map m = r.next();
+                    Map map = (Map) m.get("value");
+                    assertNotNull(map);
+                    assertEquals(3,map.size());
+                    assertEquals(0, map.get("aa") );
+                    assertEquals(0, map.get("bb") );
+                    assertEquals(0, map.get("cc") );
+                });
     }
 }

--- a/src/test/java/apoc/nodes/NodesTest.java
+++ b/src/test/java/apoc/nodes/NodesTest.java
@@ -1,6 +1,5 @@
 package apoc.nodes;
 
-import apoc.periodic.Periodic;
 import apoc.create.Create;
 import apoc.util.TestUtil;
 import org.junit.*;
@@ -15,6 +14,7 @@ import static apoc.util.Util.map;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.*;
 import static org.neo4j.helpers.collection.Iterators.asSet;
+import apoc.periodic.Periodic;
 
 /**
  * @author mh
@@ -26,7 +26,7 @@ public class NodesTest {
     @Before
     public void setUp() throws Exception {
         db = TestUtil.apocGraphDatabaseBuilder().newGraphDatabase();
-        TestUtil.registerProcedure(db,Nodes.class);
+        TestUtil.registerProcedure(db,Nodes.class, Create.class);
         TestUtil.registerProcedure(db, Periodic.class);
     }
 


### PR DESCRIPTION
apoc.remove.nodes.withlabel("label1","label2",....) will remove the nodes that one at least one of those labels.

Under the hood, it does N times
CALL apoc.periodic.commit('MATCH (n:`label`) DETACH DELETE n;',null)