### PR TITLE
Added sequences to path expander procedures

### DIFF
--- a/docs/expand.adoc
+++ b/docs/expand.adoc
@@ -35,30 +35,43 @@ Syntax: `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`
 
 ==== Label Filter
 
-Syntax: `[+-/>]LABEL1|LABEL2|...`
+Syntax: `[+-/>]LABEL1|LABEL2|*|...`
+
+
+[opts=header,cols="m,a"]
+|===
+| input | result
+| -Foe | blacklist filter - No node in the path will have a label in the blacklist.
+| +Friend | whitelist filter - All nodes in the path must have a label in the whitelist (exempting termination and end nodes, if using those filters).
+If no whitelist operator is present, all labels are considered whitelisted.
+| /Friend | termination filter - Only return paths up to a node of the given labels, and stop further expansion beyond it.
+Termination nodes do not have to respect the whitelist. Termination filtering takes precedence over end node filtering.
+| >Friend | end node filter - Only return paths up to a node of the given labels, but continue expansion to match on end nodes beyond it.
+End nodes do not have to respect the whitelist to be returned, but expansion beyond them is only allowed if the node has a label in the whitelist.
+|===
+
+.Syntax Changes
 
 As of APOC 3.1.3.x multiple label filter operations are allowed.
 In prior versions, only one type of operation is allowed in the label filter (`+` or `-` or `/` or `>`, never more than one).
 
-With APOC 3.2.x.x, label filters will no longer apply to starting nodes of the expansion by default.
+With APOC 3.2.x.x, label filters will no longer apply to starting nodes of the expansion by default, but this can be toggled with the `filterStartNode` config parameter.
 
-With the APOC releases in February 2018, compound labels are supported (like `Person:Manager`), and only apply to nodes with all of those labels present (order agnositic).
+With the APOC releases in January 2018, some behavior has changed in the label filters:
 
-[opts=header,cols="m,m,a"]
+[opts=header,cols="m,a"]
 |===
-| input | label | result
-| -Foe | Foe | blacklist filter - No node in the path will have a label in the blacklist.
-| +Friend | Friend | whitelist filter - All nodes in the path must have a label in the whitelist (exempting termination and end nodes, if using those filters).
-
-If no whitelist operator is present, all labels are considered whitelisted.
-| /Friend | Friend | termination filter - Only return paths up to a node of the given labels, and stop further expansion beyond it.
-
-Termination nodes do not have to respect the whitelist. Termination filtering takes precedence over end node filtering.
-| >Friend | Friend | end node filter - Only return paths up to a node of the given labels, but continue expansion to match on end nodes beyond it.
-
-End nodes do not have to respect the whitelist to be returned, but expansion beyond them is only allowed if the node has a label in the whitelist.
+| filter | changed behavior
+| No filter | Now indicates the label is whitelisted, same as if it were prefixed with `+`.
+Previously, a label without a filter symbol reused the previously used symbol.
+| `>` (end node filter) | The label is additionally whitelisted, so expansion will always continue beyond an end node (unless prevented by the blacklist).
+Previously, expansion would only continue if allowed by the whitelist and not disallowed by the blacklist.
+This also applies at a depth below `minLevel`, allowing expansion to continue.
+| `/` (termination filter) | When at depth below `minLevel`, expansion is allowed to continue and no pruning will take place (unless prevented by the blacklist).
+Previously, expansion would only continue if allowed by the whitelist and not disallowed by the blacklist.
+| All filters | `*` is allowed as a standin for all labels.
+Additionally, compound labels are supported (like `Person:Manager`), and only apply to nodes with all of those labels present (order agnositic).
 |===
-
 
 .Examples
 
@@ -111,6 +124,7 @@ If you didn't want to stop expansion on reaching 'Gene Hackman', and wanted 'Cli
 As of APOC 3.1.3.x, multiple label filter operators are allowed at the same time.
 
 When processing the labelFilter string, once a filter operator is introduced, it remains the active filter until another filter supplants it.
+(Not applicable after February 2018 release, as no filter will now mean the label is whitelisted).
 
 In the following example, `:Person` and `:Movie` labels are whitelisted, `:SciFi` is blacklisted, with `:Western` acting as an end node label, and `:Romance` acting as a termination label.
 
@@ -126,9 +140,66 @@ The consequences are as follows:
 * If the termination filter `/` or end node filter `>` is used, then only paths up to nodes with those labels will be returned as results. These end nodes are exempt from the whitelist filter.
 * If a node is a termination node `/`, no further expansion beyond the node will occur.
 * If a node is an end node `>`, expansion beyond that node will only occur if the end node has a label in the whitelist. This is to prevent returning paths to nodes where a node on that path violates the whitelist.
+(this no longer applies in releases after February 2018)
 * The whitelist only applies to nodes up to but not including end nodes from the termination or end node filters. If no end node or termination node operators are present, then the whitelist applies to all nodes of the path.
 * If no whitelist operators are present in the labelFilter, this is treated as if all labels are whitelisted.
 * If `filterStartNode` is false (which will be default in APOC 3.2.x.x), then the start node is exempt from the label filter.
+
+
+=== Sequences
+
+Introduced in the February 2018 APOC releases, path expander procedures can expand on repeating sequences of labels, relationship types, or both.
+
+If only using label sequences, just use the `labelFilter`, but use commas to separate the filtering for each step in the repeating sequence.
+
+If only using relationship sequences, just use the `relationshipFilter`, but use commas to separate the filtering for each step of the repeating sequence.
+
+If using sequences of both relationships and labels, use the `sequence` parameter.
+
+[opts=header,cols="a, m,a,m,a"]
+|===
+| Usage | config param | description | syntax | explanation
+| label sequences only | labelFilter | Same syntax and filters, but uses commas (`,`) to separate the filters for each step in the sequence. |
+ labelFilter:'Post\|-Blocked,Reply,>Admin' | Start node must be a :Post node that isn't :Blocked, next node must be a :Reply, and the next must be an :Admin, then repeat if able. Only paths ending with the `:Admin` node in that position of the sequence will be returned.
+| relationship sequences only | relationshipFilter | Same syntax, but uses commas (`,`) to separate the filters for each relationship traversal in the sequence. |
+relationshipFilter:'NEXT>,<FROM,POSTED>\|REPLIED>' | Expansion will first expand `NEXT>` from the start node, then `<FROM`, then either `POSTED>` or `REPLIED>`, then repeat if able.
+| sequences of both labels and relationships | sequence | A string of comma-separated alternating label and relationship filters, for each step in a repeating sequence. The sequence should begin with a label filter, and end with a relationship filter. If present, `labelFilter`, and `relationshipFilter` are ignored, as this takes priority. |
+sequence:'Post\|-Blocked, NEXT>, Reply, <FROM, >Admin, POSTED>\|REPLIED>'  | Combines the behaviors above.
+|===
+
+
+==== Starting the sequence at one-off from the start node
+
+There are some uses cases where the sequence does not begin at the start node, but at one node distant.
+
+A new config parameter, `beginSequenceAtStart`, can toggle this behavior.
+
+Default value is `true`.
+
+If set to `false`, this changes the expected values for `labelFilter`, `relationshipFilter`, and `sequence` as noted below:
+
+
+[opts=header,cols="m,a,m,a"]
+|===
+| sequence | altered behavior | example | explanation
+| labelFilter | The start node is not considered part of the sequence. The sequence begins one node off from the start node. |
+beginSequenceAtStart:false, labelFilter:'Post\|-Blocked,Reply,>Admin' | The next node(s) out from the start node begins the sequence (and must be a :Post node that isn't :Blocked), and only paths ending with `Admin` nodes returned.
+| relationshipFilter | The first relationship filter in the sequence string will not be considered part of the repeating sequence, and will only be used for the first relationship from the start node to the node that will be the actual start of the sequence. |
+beginSequenceAtStart:false, relationshipFilter:'FIRST>,NEXT>,<FROM,POSTED>\|REPLIED>' | `FIRST>` will be traversed just from the start node to the node that will be the start of the repeating `NEXT>,<FROM,POSTED>\|REPLIED>` sequence.
+| sequence | Combines the above two behaviors. |
+beginSequenceAtStart:false, sequence:'FIRST>, Post\|-Blocked, NEXT>, Reply, <FROM, >Admin, POSTED>\|REPLIED>' | Combines the behaviors above.
+|===
+
+.Sequence tips
+
+Label filtering in sequences work together with the `endNodes`+`terminatorNodes`, though inclusion of a node must be unanimous.
+
+Remember that `filterStartNode` defaults to `false` for APOC 3.2.x.x and newer. If you want the start node filtered according to the first step in the sequence, you may need to set this explicitly to `true`.
+
+If you need to limit the number of times a sequence repeats, this can be done with the `maxLevel` config param (multiply the number of iterations with the size of the nodes in the sequence).
+
+As paths are important when expanding sequences, we recommend avoiding `apoc.path.subgraphNodes()`, `apoc.path.subgraphAll()`, and `apoc.path.spanningTree()` when using sequences,
+as the configurations that make these efficient at matching to distinct nodes may interfere with sequence pathfinding.
 
 
 == Expand with Config
@@ -143,8 +214,8 @@ Takes an additional map parameter, `config`, to provide configuration options:
 ----
 {minLevel: -1|number,
  maxLevel: -1|number,
- relationshipFilter: '[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...',
- labelFilter: '[+-/>]LABEL1|LABEL2|...',
+ relationshipFilter: '[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>], [<]RELATIONSHIP_TYPE3[>]|[<]RELATIONSHIP_TYPE4[>]',
+ labelFilter: '[+-/>]LABEL1|LABEL2|*,[+-/>]LABEL1|LABEL2|*,...',
  uniqueness: RELATIONSHIP_PATH|NONE|NODE_GLOBAL|NODE_LEVEL|NODE_PATH|NODE_RECENT|
              RELATIONSHIP_GLOBAL|RELATIONSHIP_LEVEL|RELATIONSHIP_RECENT,
  bfs: true|false,
@@ -153,12 +224,11 @@ Takes an additional map parameter, `config`, to provide configuration options:
  optional: true|false,
  endNodes: [nodes],
  terminatorNodes: [nodes],
- labelSequence: '[+-/>]LABEL1|LABEL2, [+-/>]LABEL3|LABEL4, ...',
  beginSequenceAtStart: true|false}
 ----
 
 .Start Node and label filters
-The config parameter `filterStartNode` defines whether or not the labelFilter (and labelSequence filter) applies to the start node of the expansion.
+The config parameter `filterStartNode` defines whether or not the labelFilter (and `sequence`) applies to the start node of the expansion.
 
 Use `filterStartNode: false` when you want your label filter to only apply to all other nodes in the path, ignoring the start node.
 
@@ -317,60 +387,3 @@ MATCH (user:User) WHERE user.id = 460
 CALL apoc.path.spanningTree(user, {labelFilter:'+User'}) YIELD path
 RETURN path;
 ----
-
-
-=== Sequences
-
-Introduced in the February 2018 APOC releases, path expander procedures can expand on repeating sequences of labels, relationship types, or both.
-
-[opts=header,cols="m,a,m,a"]
-|===
-| config param | description | syntax | explanation
-| labelSequence | A string of comma-separated label filters for each step in a repeating sequence. Uses similar syntax to the `labelFilter` (`+`,`-`,`>`,`/` for whitelist, blacklist, end node, and terminator node, respectively), but these filters only apply to a specific step in the sequence, not the entire sequence. Commas (`,`) separate the filters for each step in the sequence. |
- labelSequence:'Post\|-Blocked,Reply,>Admin' | Start node must be a :Post node that isn't :Blocked, next node must be a :Reply, and the next must be an :Admin. Only paths ending with the `:Admin` node in the sequence will be returned.
-| relationshipSequence | A string of comma-separated relationship filters for each step in a repeating sequence. If present, `relationshipFilter` is ignored, as this takes priority. |
-relationshipSequence:'NEXT>,<FROM,POSTED>\|REPLIED>' | Expansion will first expand `NEXT>` from the start node, then `<FROM`, then either `POSTED>` or `REPLIED>`, then repeat if able.
-| sequence | A string of comma-separated alternating label and relationship filters, for each step in a repeating sequence. The sequence should begin with a label filter, and end with a relationship filter. If present, `labelSequence`, `relationshipSequence`, and `relationshipFilter` are ignored, as this takes priority. |
-sequence:'Post\|-Blocked, NEXT>, Reply, <FROM, >Admin, POSTED>\|REPLIED>'  | Combines the behaviors above.
-| beginSequenceAtStart | Boolean value, default: true. Indicates that any of the above sequences begin at the start node provided to the expansion.
- If false, indicates that the sequence begins one node off from the start node, and this changes what is expected from the sequence parameters above. See table below for details. | beginSequenceAtStart:true | Indicates that the given start node should be used as the beginning of a sequence.
-|===
-
-
-==== Effects when `beginSequenceAtStart: false`
-
-[opts=header,cols="m,a,m,a"]
-|===
-| sequence | altered behavior | example | explanation
-| labelSequence | The start node is not considered part of the sequence. The sequence begins one node off from the start node. |
-beginSequenceAtStart:false, labelSequence:'Post\|-Blocked,Reply,>Admin' | The next node(s) out from the start node begins the sequence (and must be a :Post node that isn't :Blocked), and only paths ending with `Admin` nodes returned.
-| relationshipSequence | The first relationship filter in the sequence string will not be considered part of the repeating sequence, and will only be used for the first relationship from the start node to the node that will be the actual start of the sequence. |
-beginSequenceAtStart:false, relationshipSequence:'FIRST>,NEXT>,<FROM,POSTED>\|REPLIED>' | `FIRST>` will be traversed just from the start node to the node that will be the start of the repeating `NEXT>,<FROM,POSTED>\|REPLIED>` sequence.
-| sequence | The first relationship filter in the sequence string will not be considered part of the repeating sequence, and will only be used for the first relationship from the start node to the node that will be the actual start of the sequence. |
-beginSequenceAtStart:false, sequence:'FIRST>, Post\|-Blocked, NEXT>, Reply, <FROM, >Admin, POSTED>\|REPLIED>' | Combines the behaviors above.
-|===
-
-Label filtering in sequences work together with the `endNodes`+`terminatorNodes` and `labelFilter`, though inclusion of a node must be unanimous.
-
-Aside from the comma separators, there are a few differences in syntax between this and the `labelFilter`.
-
-1. In the `labelFilter`, a label without a symbol reused the previously used filter (and may error out if no previous filter symbol is present).
-In `labelSequence` and `sequence`, no filter symbol instead means the label is whitelisted. In effect, `+` is now optional when whitelisting a label.
-
-2. You can provide `*` in place of a label, which stands in for all labels.
-This can be used to specify that at a certain step in the sequence, it doesn't matter what the labels are, everything is whitelisted.
-(relationships can still use `''` for any relationship type/direction, or just the direction arrow).
-
-3. In the `labelFilter`, a label with the end node filter isn't automatically whitelisted. It is included in the results, but to expand beyond it the node must pass the whitelist filter.
-In `labelSequence` and `sequence`, a node with the end node filter is automatically considered whitelisted, and expansion will continue.
-
-4. Behavior is slightly different on matches when depth is below `minLevel`, though these nodes are never included in the results.
-In the `labelFilter`, when below `minLevel`, only nodes allowed by the whitelist and not disallowed by the blacklist would continue.
-In `labelSequence` and `sequence`, this additionally includes nodes with labels in the end node and termination node filters (though the termination node filter will not prune when below `minLevel`).
-
-Remember that `filterStartNode` defaults to false for APOC 3.2.x.x and newer. If you want the start node filtered according to the first step in the sequence, you may need to set this explicitly to false.
-
-If you need to limit the number of times a sequence repeats, this can be done with the `maxLevel` config param (multiply the number of iterations with the size of the nodes in the sequence).
-
-As paths are important when expanding sequences, we recommend avoiding `apoc.path.subgraphNodes()`, `apoc.path.subgraphAll()`, and `apoc.path.spanningTree()` when using sequences,
-as the configurations that make these efficient at matching to distinct nodes may interfere with sequence pathfinding.

--- a/docs/expand.adoc
+++ b/docs/expand.adoc
@@ -42,7 +42,7 @@ In prior versions, only one type of operation is allowed in the label filter (`+
 
 With APOC 3.2.x.x, label filters will no longer apply to starting nodes of the expansion by default.
 
-With the APOC releases in January 2018, compound labels are supported (like `Person:Manager`), and only apply to nodes with all of those labels present (order agnositic).
+With the APOC releases in February 2018, compound labels are supported (like `Person:Manager`), and only apply to nodes with all of those labels present (order agnositic).
 
 [opts=header,cols="m,m,a"]
 |===
@@ -151,14 +151,16 @@ Takes an additional map parameter, `config`, to provide configuration options:
  filterStartNode: true|false,
  limit: -1|number,
  optional: true|false,
- endNodes: [nodes]
- terminatorNodes: [nodes]}
+ endNodes: [nodes],
+ terminatorNodes: [nodes],
+ labelSequence: '[+-/>]LABEL1|LABEL2, [+-/>]LABEL3|LABEL4, ...',
+ beginLabelSequenceAtStart: true|false}
 ----
 
 .Start Node and label filters
-The config parameter `filterStartNode` defines whether or not the labelFilter applies to the start node of the expansion.
+The config parameter `filterStartNode` defines whether or not the labelFilter (and labelSequence filter) applies to the start node of the expansion.
 
-Use `filterStartNode = false` when you want your label filter to only apply to all other nodes in the path, ignoring the start node.
+Use `filterStartNode: false` when you want your label filter to only apply to all other nodes in the path, ignoring the start node.
 
 `filterStartNode` defaults for all path expander procedures:
 
@@ -212,7 +214,7 @@ For huge graphs a traverser can hog all the memory in the JVM, causing OutOfMemo
 
 .endNodes and terminatorNodes
 
-As of the January 2018 APOC releases, if the end nodes of the expansion are known ahead of time (such as when testing reachability), then these nodes can be passed in as `endNodes` or `terminatorNodes`.
+As of the February 2018 APOC releases, if the end nodes of the expansion are known ahead of time (such as when testing reachability), then these nodes can be passed in as `endNodes` or `terminatorNodes`.
 
 This restricts the returned paths (or nodes) to only these nodes (or nodes with the given ids, if an integer list is passed).
 
@@ -220,7 +222,42 @@ For `endNodes`, expansion continues past end nodes.
 
 For `terminatorNodes`, expansion down a path stops when a terminator node is reached.
 
-.Examples
+.Label Sequences
+
+Introduced in the February 2018 APOC releases, `labelSequence` allows the definition of label filters for each step in a looping sequence.
+
+This can be used, for example, to expand along a repeating sequence of the labels :A, :B, and :C.
+
+`labelSequence` uses similar syntax to the `labelFilter` (`+`,`-`,`>`,`/` for whitelist, blacklist, end node, and terminator node, respectively),
+but these filters only apply to a specific step in the sequence, not the entire sequence. Commas (`,`) separate the filters for each step in the sequence.
+
+As a more complex example, `labelSequence: 'A|D, B|-E, C:F'` means: the first node should be :A or :D, the second node should be :B (but never labeled :E), and the last in the sequence should be labeled both :C and :F. The sequence then repeats.
+We could add end node or termination filters to any step, which would change which paths are returned (or nodes, if using `subgraphNodes()`) even as we keep expanding along the repeating sequence (terminating of course when reaching a node with a terminator filter).
+
+Aside from the comma separators, there are a few differences in syntax between this and the `labelFilter`.
+
+1. In the `labelFilter`, a label without a symbol reused the previously used filter (and may error out if no previous filter symbol is present).
+In `labelSequence`, no filter symbol instead means the label is whitelisted. In effect, `+` is now optional when whitelisting a label.
+
+2. In the `labelFilter`, the termination and end node filters applied to labels. In `labelSequence`, it's more correct to say they apply to the step in the sequence as a whole, and any labels provided are considered whitelisted for that step.
+Because of this, it doesn't matter which label the end node or terminator node filter is applied to...as long as the filter is present in the sequence step, that node in the sequence will be treated as an end node or terminator node.
+So as a result, `>C|D` is equivalent to `C|>D` . The nodes at that step of the sequence (that are labeled :C or :D) will be treated as end nodes.
+We recommend the convention of using the end node or terminator filter at the start of the step in the sequence.
+
+3. You can provide `*` in place of a label, which stands in for all labels.
+This can be used to specify that at a certain step in the sequence, it doesn't matter what the labels are, everything is whitelisted.
+
+Remember that `filterStartNode` defaults to false for APOC 3.2.x.x and newer. If you want the start node filtered according to the first step in the sequence, you may need to set this explicitly to false.
+
+There may be some cases where the sequence you're expanding starts at the first step away from the start node, rather than at the start node itself, and the start node isn't involved in the sequence at all.
+For these cases, use `beginLabelSequenceAtStart:false`.
+
+If you need to limit the number of times a sequence repeats, this can be done with the `maxLevel` config param (multiply the number of iterations with the size of the sequence).
+
+`labelSequence`, `labelFilter`, and `endNodes` and `terminatorNodes` can be freely used together,
+for example if needing to expand a repeating sequence of labels to specific already-matched end-nodes, with a blacklist defined for the expansion.
+
+.General Examples
 
 You can turn this cypher query:
 

--- a/docs/expand.adoc
+++ b/docs/expand.adoc
@@ -355,17 +355,22 @@ Label filtering in sequences work together with the `endNodes`+`terminatorNodes`
 Aside from the comma separators, there are a few differences in syntax between this and the `labelFilter`.
 
 1. In the `labelFilter`, a label without a symbol reused the previously used filter (and may error out if no previous filter symbol is present).
-In `labelSequence`, no filter symbol instead means the label is whitelisted. In effect, `+` is now optional when whitelisting a label.
+In `labelSequence` and `sequence`, no filter symbol instead means the label is whitelisted. In effect, `+` is now optional when whitelisting a label.
 
-2. In the `labelFilter`, the termination and end node filters applied to labels. In `labelSequence`, it's more correct to say they apply to the step in the sequence as a whole, and any labels provided are considered whitelisted for that step.
-Because of this, it doesn't matter which label the end node or terminator node filter is applied to...as long as the filter is present in the sequence step, that node in the sequence will be treated as an end node or terminator node.
-So as a result, `>C|D` is equivalent to `C|>D` . The nodes at that step of the sequence (that are labeled :C or :D) will be treated as end nodes.
-We recommend the convention of using the end node or terminator filter at the start of the step in the sequence.
-
-3. You can provide `*` in place of a label, which stands in for all labels.
+2. You can provide `*` in place of a label, which stands in for all labels.
 This can be used to specify that at a certain step in the sequence, it doesn't matter what the labels are, everything is whitelisted.
 (relationships can still use `''` for any relationship type/direction, or just the direction arrow).
+
+3. In the `labelFilter`, a label with the end node filter isn't automatically whitelisted. It is included in the results, but to expand beyond it the node must pass the whitelist filter.
+In `labelSequence` and `sequence`, a node with the end node filter is automatically considered whitelisted, and expansion will continue.
+
+4. Behavior is slightly different on matches when depth is below `minLevel`, though these nodes are never included in the results.
+In the `labelFilter`, when below `minLevel`, only nodes allowed by the whitelist and not disallowed by the blacklist would continue.
+In `labelSequence` and `sequence`, this additionally includes nodes with labels in the end node and termination node filters (though the termination node filter will not prune when below `minLevel`).
 
 Remember that `filterStartNode` defaults to false for APOC 3.2.x.x and newer. If you want the start node filtered according to the first step in the sequence, you may need to set this explicitly to false.
 
 If you need to limit the number of times a sequence repeats, this can be done with the `maxLevel` config param (multiply the number of iterations with the size of the nodes in the sequence).
+
+As paths are important when expanding sequences, we recommend avoiding `apoc.path.subgraphNodes()`, `apoc.path.subgraphAll()`, and `apoc.path.spanningTree()` when using sequences,
+as the configurations that make these efficient at matching to distinct nodes may interfere with sequence pathfinding.

--- a/docs/expand.adoc
+++ b/docs/expand.adoc
@@ -154,7 +154,7 @@ Takes an additional map parameter, `config`, to provide configuration options:
  endNodes: [nodes],
  terminatorNodes: [nodes],
  labelSequence: '[+-/>]LABEL1|LABEL2, [+-/>]LABEL3|LABEL4, ...',
- beginLabelSequenceAtStart: true|false}
+ beginSequenceAtStart: true|false}
 ----
 
 .Start Node and label filters
@@ -221,41 +221,6 @@ This restricts the returned paths (or nodes) to only these nodes (or nodes with 
 For `endNodes`, expansion continues past end nodes.
 
 For `terminatorNodes`, expansion down a path stops when a terminator node is reached.
-
-.Label Sequences
-
-Introduced in the February 2018 APOC releases, `labelSequence` allows the definition of label filters for each step in a looping sequence.
-
-This can be used, for example, to expand along a repeating sequence of the labels :A, :B, and :C.
-
-`labelSequence` uses similar syntax to the `labelFilter` (`+`,`-`,`>`,`/` for whitelist, blacklist, end node, and terminator node, respectively),
-but these filters only apply to a specific step in the sequence, not the entire sequence. Commas (`,`) separate the filters for each step in the sequence.
-
-As a more complex example, `labelSequence: 'A|D, B|-E, C:F'` means: the first node should be :A or :D, the second node should be :B (but never labeled :E), and the last in the sequence should be labeled both :C and :F. The sequence then repeats.
-We could add end node or termination filters to any step, which would change which paths are returned (or nodes, if using `subgraphNodes()`) even as we keep expanding along the repeating sequence (terminating of course when reaching a node with a terminator filter).
-
-Aside from the comma separators, there are a few differences in syntax between this and the `labelFilter`.
-
-1. In the `labelFilter`, a label without a symbol reused the previously used filter (and may error out if no previous filter symbol is present).
-In `labelSequence`, no filter symbol instead means the label is whitelisted. In effect, `+` is now optional when whitelisting a label.
-
-2. In the `labelFilter`, the termination and end node filters applied to labels. In `labelSequence`, it's more correct to say they apply to the step in the sequence as a whole, and any labels provided are considered whitelisted for that step.
-Because of this, it doesn't matter which label the end node or terminator node filter is applied to...as long as the filter is present in the sequence step, that node in the sequence will be treated as an end node or terminator node.
-So as a result, `>C|D` is equivalent to `C|>D` . The nodes at that step of the sequence (that are labeled :C or :D) will be treated as end nodes.
-We recommend the convention of using the end node or terminator filter at the start of the step in the sequence.
-
-3. You can provide `*` in place of a label, which stands in for all labels.
-This can be used to specify that at a certain step in the sequence, it doesn't matter what the labels are, everything is whitelisted.
-
-Remember that `filterStartNode` defaults to false for APOC 3.2.x.x and newer. If you want the start node filtered according to the first step in the sequence, you may need to set this explicitly to false.
-
-There may be some cases where the sequence you're expanding starts at the first step away from the start node, rather than at the start node itself, and the start node isn't involved in the sequence at all.
-For these cases, use `beginLabelSequenceAtStart:false`.
-
-If you need to limit the number of times a sequence repeats, this can be done with the `maxLevel` config param (multiply the number of iterations with the size of the sequence).
-
-`labelSequence`, `labelFilter`, and `endNodes` and `terminatorNodes` can be freely used together,
-for example if needing to expand a repeating sequence of labels to specific already-matched end-nodes, with a blacklist defined for the expansion.
 
 .General Examples
 
@@ -352,3 +317,55 @@ MATCH (user:User) WHERE user.id = 460
 CALL apoc.path.spanningTree(user, {labelFilter:'+User'}) YIELD path
 RETURN path;
 ----
+
+
+=== Sequences
+
+Introduced in the February 2018 APOC releases, path expander procedures can expand on repeating sequences of labels, relationship types, or both.
+
+[opts=header,cols="m,a,m,a"]
+|===
+| config param | description | syntax | explanation
+| labelSequence | A string of comma-separated label filters for each step in a repeating sequence. Uses similar syntax to the `labelFilter` (`+`,`-`,`>`,`/` for whitelist, blacklist, end node, and terminator node, respectively), but these filters only apply to a specific step in the sequence, not the entire sequence. Commas (`,`) separate the filters for each step in the sequence. |
+ labelSequence:'Post\|-Blocked,Reply,>Admin' | Start node must be a :Post node that isn't :Blocked, next node must be a :Reply, and the next must be an :Admin. Only paths ending with the `:Admin` node in the sequence will be returned.
+| relationshipSequence | A string of comma-separated relationship filters for each step in a repeating sequence. If present, `relationshipFilter` is ignored, as this takes priority. |
+relationshipSequence:'NEXT>,<FROM,POSTED>\|REPLIED>' | Expansion will first expand `NEXT>` from the start node, then `<FROM`, then either `POSTED>` or `REPLIED>`, then repeat if able.
+| sequence | A string of comma-separated alternating label and relationship filters, for each step in a repeating sequence. The sequence should begin with a label filter, and end with a relationship filter. If present, `labelSequence`, `relationshipSequence`, and `relationshipFilter` are ignored, as this takes priority. |
+sequence:'Post\|-Blocked, NEXT>, Reply, <FROM, >Admin, POSTED>\|REPLIED>'  | Combines the behaviors above.
+| beginSequenceAtStart | Boolean value, default: true. Indicates that any of the above sequences begin at the start node provided to the expansion.
+ If false, indicates that the sequence begins one node off from the start node, and this changes what is expected from the sequence parameters above. See table below for details. | beginSequenceAtStart:true | Indicates that the given start node should be used as the beginning of a sequence.
+|===
+
+
+==== Effects when `beginSequenceAtStart: false`
+
+[opts=header,cols="m,a,m,a"]
+|===
+| sequence | altered behavior | example | explanation
+| labelSequence | The start node is not considered part of the sequence. The sequence begins one node off from the start node. |
+beginSequenceAtStart:false, labelSequence:'Post\|-Blocked,Reply,>Admin' | The next node(s) out from the start node begins the sequence (and must be a :Post node that isn't :Blocked), and only paths ending with `Admin` nodes returned.
+| relationshipSequence | The first relationship filter in the sequence string will not be considered part of the repeating sequence, and will only be used for the first relationship from the start node to the node that will be the actual start of the sequence. |
+beginSequenceAtStart:false, relationshipSequence:'FIRST>,NEXT>,<FROM,POSTED>\|REPLIED>' | `FIRST>` will be traversed just from the start node to the node that will be the start of the repeating `NEXT>,<FROM,POSTED>\|REPLIED>` sequence.
+| sequence | The first relationship filter in the sequence string will not be considered part of the repeating sequence, and will only be used for the first relationship from the start node to the node that will be the actual start of the sequence. |
+beginSequenceAtStart:false, sequence:'FIRST>, Post\|-Blocked, NEXT>, Reply, <FROM, >Admin, POSTED>\|REPLIED>' | Combines the behaviors above.
+|===
+
+Label filtering in sequences work together with the `endNodes`+`terminatorNodes` and `labelFilter`, though inclusion of a node must be unanimous.
+
+Aside from the comma separators, there are a few differences in syntax between this and the `labelFilter`.
+
+1. In the `labelFilter`, a label without a symbol reused the previously used filter (and may error out if no previous filter symbol is present).
+In `labelSequence`, no filter symbol instead means the label is whitelisted. In effect, `+` is now optional when whitelisting a label.
+
+2. In the `labelFilter`, the termination and end node filters applied to labels. In `labelSequence`, it's more correct to say they apply to the step in the sequence as a whole, and any labels provided are considered whitelisted for that step.
+Because of this, it doesn't matter which label the end node or terminator node filter is applied to...as long as the filter is present in the sequence step, that node in the sequence will be treated as an end node or terminator node.
+So as a result, `>C|D` is equivalent to `C|>D` . The nodes at that step of the sequence (that are labeled :C or :D) will be treated as end nodes.
+We recommend the convention of using the end node or terminator filter at the start of the step in the sequence.
+
+3. You can provide `*` in place of a label, which stands in for all labels.
+This can be used to specify that at a certain step in the sequence, it doesn't matter what the labels are, everything is whitelisted.
+(relationships can still use `''` for any relationship type/direction, or just the direction arrow).
+
+Remember that `filterStartNode` defaults to false for APOC 3.2.x.x and newer. If you want the start node filtered according to the first step in the sequence, you may need to set this explicitly to false.
+
+If you need to limit the number of times a sequence repeats, this can be done with the `maxLevel` config param (multiply the number of iterations with the size of the nodes in the sequence).

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -1123,21 +1123,25 @@ Label filtering in sequences work together with the `endNodes`+`terminatorNodes`
 Aside from the comma separators, there are a few differences in syntax between this and the `labelFilter`.
 
 1. In the `labelFilter`, a label without a symbol reused the previously used filter (and may error out if no previous filter symbol is present).
-In `labelSequence`, no filter symbol instead means the label is whitelisted. In effect, `+` is now optional when whitelisting a label.
+In `labelSequence` and `sequence`, no filter symbol instead means the label is whitelisted. In effect, `+` is now optional when whitelisting a label.
 
-2. In the `labelFilter`, the termination and end node filters applied to labels. In `labelSequence`, it's more correct to say they apply to the step in the sequence as a whole, and any labels provided are considered whitelisted for that step.
-Because of this, it doesn't matter which label the end node or terminator node filter is applied to...as long as the filter is present in the sequence step, that node in the sequence will be treated as an end node or terminator node.
-So as a result, `>C|D` is equivalent to `C|>D` . The nodes at that step of the sequence (that are labeled :C or :D) will be treated as end nodes.
-We recommend the convention of using the end node or terminator filter at the start of the step in the sequence.
-
-3. You can provide `*` in place of a label, which stands in for all labels.
+2. You can provide `*` in place of a label, which stands in for all labels.
 This can be used to specify that at a certain step in the sequence, it doesn't matter what the labels are, everything is whitelisted.
 (relationships can still use `''` for any relationship type/direction, or just the direction arrow).
+
+3. In the `labelFilter`, a label with the end node filter isn't automatically whitelisted. It is included in the results, but to expand beyond it the node must pass the whitelist filter.
+In `labelSequence` and `sequence`, a node with the end node filter is automatically considered whitelisted, and expansion will continue.
+
+4. Behavior is slightly different on matches when depth is below `minLevel`, though these nodes are never included in the results.
+In the `labelFilter`, when below `minLevel`, only nodes allowed by the whitelist and not disallowed by the blacklist would continue.
+In `labelSequence` and `sequence`, this additionally includes nodes with labels in the end node and termination node filters (though the termination node filter will not prune when below `minLevel`).
 
 Remember that `filterStartNode` defaults to false for APOC 3.2.x.x and newer. If you want the start node filtered according to the first step in the sequence, you may need to set this explicitly to false.
 
 If you need to limit the number of times a sequence repeats, this can be done with the `maxLevel` config param (multiply the number of iterations with the size of the nodes in the sequence).
 
+As paths are important when expanding sequences, we recommend avoiding `apoc.path.subgraphNodes()`, `apoc.path.subgraphAll()`, and `apoc.path.spanningTree()` when using sequences,
+as the configurations that make these efficient at matching to distinct nodes may interfere with sequence pathfinding.
 
 == Parallel Node Search
 

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -1005,10 +1005,10 @@ Variations allow more configurable expansions, and expansions for more specific 
 
 [cols="1m,5"]
 |===
-| call apoc.path.expandConfig(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, uniqueness:'RELATIONSHIP_PATH', filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, labelSequence, beginLabelSequenceAtStart:true}) yield path | expand from given nodes(s) taking the provided restrictions into account
-| call apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, labelSequence, beginLabelSequenceAtStart:true}) yield node | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns all nodes in the subgraph
-| call apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, endNodes, terminatorNodes, labelSequence, beginLabelSequenceAtStart:true}) yield nodes, relationships | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns the collection of subgraph nodes, and the collection of all relationships within the subgraph
-| call apoc.path.spanningTree(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, labelSequence, beginLabelSequenceAtStart:true}) yield path | expand a spanning tree from given nodes(s) taking the provided restrictions into account; the paths returned collectively form a spanning tree
+| call apoc.path.expandConfig(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, uniqueness:'RELATIONSHIP_PATH', filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, labelSequence, beginSequenceAtStart:true}) yield path | expand from given nodes(s) taking the provided restrictions into account
+| call apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, labelSequence, beginSequenceAtStart:true}) yield node | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns all nodes in the subgraph
+| call apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, endNodes, terminatorNodes, labelSequence, beginSequenceAtStart:true}) yield nodes, relationships | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns the collection of subgraph nodes, and the collection of all relationships within the subgraph
+| call apoc.path.spanningTree(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, labelSequence, beginSequenceAtStart:true}) yield path | expand a spanning tree from given nodes(s) taking the provided restrictions into account; the paths returned collectively form a spanning tree
 |===
 
 === Relationship Filter
@@ -1077,25 +1077,48 @@ For huge graphs a traverser can hog all the memory in the JVM, causing OutOfMemo
 As of the January 2018 APOC releases, you can optionally use `endNodes` and `terminatorNodes` params in the config param map when the end nodes of the expansion are known.
 
 When `endNodes` are present, only these end nodes must be at the end of the expanded paths.
-Expansion continues beyond found end nodes.
+Expansion continues beyond end nodes.
 This behavior is similar to the end node filter `>` in the label filters.
 
-Nodes given as `terminatorNodes` behave just like `endNodes` (they must be at the end of expanded paths), but stops treversal beyond the found nodes.
+Nodes given as `terminatorNodes` behave just like `endNodes` (they must be at the end of expanded paths), but stops traversal beyond the terminator nodes.
 This behavior is similar to the termination filter `/` in the label filters.
 
-`endNodes` and/or `terminatorNodes` can freely be used along with the labelFilter.
+`endNodes` and/or `terminatorNodes` do not conflict with each other (an end node will be returned even if not present in the terminator nodes, and vice versa),
+and they can freely be used along with the labelFilter, but a node can only be included by unanimous agreement from endNodes+terminatoNodes and the labelFilter.
 
-=== Label Sequences
+=== Sequences
 
-Introduced in the February 2018 APOC releases, `labelSequence` allows the definition of label filters for each step in a looping sequence.
+Introduced in the February 2018 APOC releases, path expander procedures can expand on repeating sequences of labels, relationship types, or both.
 
-This can be used, for example, to expand along a repeating sequence of the labels :A, :B, and :C.
 
-`labelSequence` uses similar syntax to the `labelFilter` (`+`,`-`,`>`,`/` for whitelist, blacklist, end node, and terminator node, respectively),
-but these filters only apply to a specific step in the sequence, not the entire sequence. Commas (`,`) separate the filters for each step in the sequence.
+[opts=header,cols="m,a,m,a"]
+|===
+| config param | description | syntax | explanation
+| labelSequence | A string of comma-separated label filters for each step in a repeating sequence. Uses similar syntax to the `labelFilter` (`+`,`-`,`>`,`/` for whitelist, blacklist, end node, and terminator node, respectively), but these filters only apply to a specific step in the sequence, not the entire sequence. Commas (`,`) separate the filters for each step in the sequence. |
+ labelSequence:'Post\|-Blocked,Reply,>Admin' | Start node must be a :Post node that isn't :Blocked, next node must be a :Reply, and the next must be an :Admin. Only paths ending with the `:Admin` node in the sequence will be returned.
+| relationshipSequence | A string of comma-separated relationship filters for each step in a repeating sequence. If present, `relationshipFilter` is ignored, as this takes priority. |
+relationshipSequence:'NEXT>,<FROM,POSTED>\|REPLIED>' | Expansion will first expand `NEXT>` from the start node, then `<FROM`, then either `POSTED>` or `REPLIED>`, then repeat if able.
+| sequence | A string of comma-separated alternating label and relationship filters, for each step in a repeating sequence. The sequence should begin with a label filter, and end with a relationship filter. If present, `labelSequence`, `relationshipSequence`, and `relationshipFilter` are ignored, as this takes priority. |
+sequence:'Post\|-Blocked, NEXT>, Reply, <FROM, >Admin, POSTED>\|REPLIED>'  | Combines the behaviors above.
+| beginSequenceAtStart | Boolean value, default: true. Indicates that any of the above sequences begin at the start node provided to the expansion.
+ If false, indicates that the sequence begins one node off from the start node, and this changes what is expected from the sequence parameters above. See table below for details. | beginSequenceAtStart:true | Indicates that the given start node should be used as the beginning of a sequence.
+|===
 
-As a more complex example, `labelSequence: 'A|D, B|-E, C:F'` means: the first node should be :A or :D, the second node should be :B (but never labeled :E), and the last in the sequence should be labeled both :C and :F. The sequence then repeats.
-We could add end node or termination filters to any step, which would change which paths are returned (or nodes, if using `subgraphNodes()`) even as we keep expanding along the repeating sequence (terminating of course when reaching a node with a terminator filter).
+
+==== Effects when `beginSequenceAtStart: false`
+
+[opts=header,cols="m,a,m,a"]
+|===
+| sequence | altered behavior | example | explanation
+| labelSequence | The start node is not considered part of the sequence. The sequence begins one node off from the start node. |
+beginSequenceAtStart:false, labelSequence:'Post\|-Blocked,Reply,>Admin' | The next node(s) out from the start node begins the sequence (and must be a :Post node that isn't :Blocked), and only paths ending with `Admin` nodes returned.
+| relationshipSequence | The first relationship filter in the sequence string will not be considered part of the repeating sequence, and will only be used for the first relationship from the start node to the node that will be the actual start of the sequence. |
+beginSequenceAtStart:false, relationshipSequence:'FIRST>,NEXT>,<FROM,POSTED>\|REPLIED>' | `FIRST>` will be traversed just from the start node to the node that will be the start of the repeating `NEXT>,<FROM,POSTED>\|REPLIED>` sequence.
+| sequence | The first relationship filter in the sequence string will not be considered part of the repeating sequence, and will only be used for the first relationship from the start node to the node that will be the actual start of the sequence. |
+beginSequenceAtStart:false, sequence:'FIRST>, Post\|-Blocked, NEXT>, Reply, <FROM, >Admin, POSTED>\|REPLIED>' | Combines the behaviors above.
+|===
+
+Label filtering in sequences work together with the `endNodes`+`terminatorNodes` and `labelFilter`, though inclusion of a node must be unanimous.
 
 Aside from the comma separators, there are a few differences in syntax between this and the `labelFilter`.
 
@@ -1109,16 +1132,11 @@ We recommend the convention of using the end node or terminator filter at the st
 
 3. You can provide `*` in place of a label, which stands in for all labels.
 This can be used to specify that at a certain step in the sequence, it doesn't matter what the labels are, everything is whitelisted.
+(relationships can still use `''` for any relationship type/direction, or just the direction arrow).
 
 Remember that `filterStartNode` defaults to false for APOC 3.2.x.x and newer. If you want the start node filtered according to the first step in the sequence, you may need to set this explicitly to false.
 
-There may be some cases where the sequence you're expanding starts at the first step away from the start node, rather than at the start node itself, and the start node isn't involved in the sequence at all.
-For these cases, use `beginLabelSequenceAtStart:false`.
-
-If you need to limit the number of times a sequence repeats, this can be done with the `maxLevel` config param (multiply the number of iterations with the size of the sequence).
-
-`labelSequence`, `labelFilter`, and `endNodes` and `terminatorNodes` can be freely used together,
-for example if needing to expand a repeating sequence of labels to specific already-matched end-nodes, with a blacklist defined for the expansion.
+If you need to limit the number of times a sequence repeats, this can be done with the `maxLevel` config param (multiply the number of iterations with the size of the nodes in the sequence).
 
 
 == Parallel Node Search

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -1005,10 +1005,10 @@ Variations allow more configurable expansions, and expansions for more specific 
 
 [cols="1m,5"]
 |===
-| call apoc.path.expandConfig(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, uniqueness:'RELATIONSHIP_PATH', filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, labelSequence, beginSequenceAtStart:true}) yield path | expand from given nodes(s) taking the provided restrictions into account
-| call apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, labelSequence, beginSequenceAtStart:true}) yield node | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns all nodes in the subgraph
-| call apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, endNodes, terminatorNodes, labelSequence, beginSequenceAtStart:true}) yield nodes, relationships | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns the collection of subgraph nodes, and the collection of all relationships within the subgraph
-| call apoc.path.spanningTree(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, labelSequence, beginSequenceAtStart:true}) yield path | expand a spanning tree from given nodes(s) taking the provided restrictions into account; the paths returned collectively form a spanning tree
+| call apoc.path.expandConfig(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, uniqueness:'RELATIONSHIP_PATH', filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, sequence, beginSequenceAtStart:true}) yield path | expand from given nodes(s) taking the provided restrictions into account
+| call apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, sequence, beginSequenceAtStart:true}) yield node | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns all nodes in the subgraph
+| call apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, endNodes, terminatorNodes, sequence, beginSequenceAtStart:true}) yield nodes, relationships | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns the collection of subgraph nodes, and the collection of all relationships within the subgraph
+| call apoc.path.spanningTree(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, sequence, beginSequenceAtStart:true}) yield path | expand a spanning tree from given nodes(s) taking the provided restrictions into account; the paths returned collectively form a spanning tree
 |===
 
 === Relationship Filter
@@ -1025,29 +1025,100 @@ Syntax: `[<]RELATIONSHIP_TYPE1[>]|[<]RELATIONSHIP_TYPE2[>]|...`
 
 === Label Filter
 
-Syntax: `[+-/>]LABEL1|LABEL2|...`
+Syntax: `[+-/>]LABEL1|LABEL2|*|...`
+
+
+[opts=header,cols="m,a"]
+|===
+| input | result
+| -Foe | blacklist filter - No node in the path will have a label in the blacklist.
+| +Friend | whitelist filter - All nodes in the path must have a label in the whitelist (exempting termination and end nodes, if using those filters).
+If no whitelist operator is present, all labels are considered whitelisted.
+| /Friend | termination filter - Only return paths up to a node of the given labels, and stop further expansion beyond it.
+Termination nodes do not have to respect the whitelist. Termination filtering takes precedence over end node filtering.
+| >Friend | end node filter - Only return paths up to a node of the given labels, but continue expansion to match on end nodes beyond it.
+End nodes do not have to respect the whitelist to be returned, but expansion beyond them is only allowed if the node has a label in the whitelist.
+|===
+
+.Syntax Changes
 
 As of APOC 3.1.3.x multiple label filter operations are allowed.
 In prior versions, only one type of operation is allowed in the label filter (`+` or `-` or `/` or `>`, never more than one).
 
-With APOC 3.2.x.x, label filters will no longer apply to starting nodes of the expansion by default.
+With APOC 3.2.x.x, label filters will no longer apply to starting nodes of the expansion by default, but this can be toggled with the `filterStartNode` config parameter.
 
-With the APOC releases in January 2018, compound labels are supported (like `Person:Manager`), and only apply to nodes with all of those labels present (order agnositic).
+With the APOC releases in January 2018, some behavior has changed in the label filters:
 
-[opts=header,cols="m,m,a"]
+[opts=header,cols="m,a"]
 |===
-| input | label | result
-| -Foe | Foe | blacklist filter - No node in the path will have a label in the blacklist.
-| +Friend | Friend | whitelist filter - All nodes in the path must have a label in the whitelist (exempting termination and end nodes, if using those filters).
-
-If no whitelist operator is present, all labels are considered whitelisted.
-| /Friend | Friend | termination filter - Only return paths up to a node of the given labels, and stop further expansion beyond it.
-
-Termination nodes do not have to respect the whitelist. Termination filtering takes precedence over end node filtering.
-| >Friend | Friend | end node filter - Only return paths up to a node of the given labels, but continue expansion to match on end nodes beyond it.
-
-End nodes do not have to respect the whitelist to be returned, but expansion beyond them is only allowed if the node has a label in the whitelist.
+| filter | changed behavior
+| No filter | Now indicates the label is whitelisted, same as if it were prefixed with `+`.
+Previously, a label without a filter symbol reused the previously used symbol.
+| `>` (end node filter) | The label is additionally whitelisted, so expansion will always continue beyond an end node (unless prevented by the blacklist).
+Previously, expansion would only continue if allowed by the whitelist and not disallowed by the blacklist.
+This also applies at a depth below `minLevel`, allowing expansion to continue.
+| `/` (termination filter) | When at depth below `minLevel`, expansion is allowed to continue and no pruning will take place (unless prevented by the blacklist).
+Previously, expansion would only continue if allowed by the whitelist and not disallowed by the blacklist.
+| All filters | `*` is allowed as a standin for all labels.
+Additionally, compound labels are supported (like `Person:Manager`), and only apply to nodes with all of those labels present (order agnositic).
 |===
+
+
+=== Sequences
+
+Introduced in the February 2018 APOC releases, path expander procedures can expand on repeating sequences of labels, relationship types, or both.
+
+If only using label sequences, just use the `labelFilter`, but use commas to separate the filtering for each step in the repeating sequence.
+
+If only using relationship sequences, just use the `relationshipFilter`, but use commas to separate the filtering for each step of the repeating sequence.
+
+If using sequences of both relationships and labels, use the `sequence` parameter.
+
+[opts=header,cols="a, m,a,m,a"]
+|===
+| Usage | config param | description | syntax | explanation
+| label sequences only | labelFilter | Same syntax and filters, but uses commas (`,`) to separate the filters for each step in the sequence. |
+ labelFilter:'Post\|-Blocked,Reply,>Admin' | Start node must be a :Post node that isn't :Blocked, next node must be a :Reply, and the next must be an :Admin, then repeat if able. Only paths ending with the `:Admin` node in that position of the sequence will be returned.
+| relationship sequences only | relationshipFilter | Same syntax, but uses commas (`,`) to separate the filters for each relationship traversal in the sequence. |
+relationshipFilter:'NEXT>,<FROM,POSTED>\|REPLIED>' | Expansion will first expand `NEXT>` from the start node, then `<FROM`, then either `POSTED>` or `REPLIED>`, then repeat if able.
+| sequences of both labels and relationships | sequence | A string of comma-separated alternating label and relationship filters, for each step in a repeating sequence. The sequence should begin with a label filter, and end with a relationship filter. If present, `labelFilter`, and `relationshipFilter` are ignored, as this takes priority. |
+sequence:'Post\|-Blocked, NEXT>, Reply, <FROM, >Admin, POSTED>\|REPLIED>'  | Combines the behaviors above.
+|===
+
+
+==== Starting the sequence at one-off from the start node
+
+There are some uses cases where the sequence does not begin at the start node, but at one node distant.
+
+A new config parameter, `beginSequenceAtStart`, can toggle this behavior.
+
+Default value is `true`.
+
+If set to `false`, this changes the expected values for `labelFilter`, `relationshipFilter`, and `sequence` as noted below:
+
+
+[opts=header,cols="m,a,m,a"]
+|===
+| sequence | altered behavior | example | explanation
+| labelFilter | The start node is not considered part of the sequence. The sequence begins one node off from the start node. |
+beginSequenceAtStart:false, labelFilter:'Post\|-Blocked,Reply,>Admin' | The next node(s) out from the start node begins the sequence (and must be a :Post node that isn't :Blocked), and only paths ending with `Admin` nodes returned.
+| relationshipFilter | The first relationship filter in the sequence string will not be considered part of the repeating sequence, and will only be used for the first relationship from the start node to the node that will be the actual start of the sequence. |
+beginSequenceAtStart:false, relationshipFilter:'FIRST>,NEXT>,<FROM,POSTED>\|REPLIED>' | `FIRST>` will be traversed just from the start node to the node that will be the start of the repeating `NEXT>,<FROM,POSTED>\|REPLIED>` sequence.
+| sequence | Combines the above two behaviors. |
+beginSequenceAtStart:false, sequence:'FIRST>, Post\|-Blocked, NEXT>, Reply, <FROM, >Admin, POSTED>\|REPLIED>' | Combines the behaviors above.
+|===
+
+.Sequence tips
+
+Label filtering in sequences work together with the `endNodes`+`terminatorNodes`, though inclusion of a node must be unanimous.
+
+Remember that `filterStartNode` defaults to `false` for APOC 3.2.x.x and newer. If you want the start node filtered according to the first step in the sequence, you may need to set this explicitly to `true`.
+
+If you need to limit the number of times a sequence repeats, this can be done with the `maxLevel` config param (multiply the number of iterations with the size of the nodes in the sequence).
+
+As paths are important when expanding sequences, we recommend avoiding `apoc.path.subgraphNodes()`, `apoc.path.subgraphAll()`, and `apoc.path.spanningTree()` when using sequences,
+as the configurations that make these efficient at matching to distinct nodes may interfere with sequence pathfinding.
+
 
 === Uniqueness
 
@@ -1085,63 +1156,6 @@ This behavior is similar to the termination filter `/` in the label filters.
 
 `endNodes` and/or `terminatorNodes` do not conflict with each other (an end node will be returned even if not present in the terminator nodes, and vice versa),
 and they can freely be used along with the labelFilter, but a node can only be included by unanimous agreement from endNodes+terminatoNodes and the labelFilter.
-
-=== Sequences
-
-Introduced in the February 2018 APOC releases, path expander procedures can expand on repeating sequences of labels, relationship types, or both.
-
-
-[opts=header,cols="m,a,m,a"]
-|===
-| config param | description | syntax | explanation
-| labelSequence | A string of comma-separated label filters for each step in a repeating sequence. Uses similar syntax to the `labelFilter` (`+`,`-`,`>`,`/` for whitelist, blacklist, end node, and terminator node, respectively), but these filters only apply to a specific step in the sequence, not the entire sequence. Commas (`,`) separate the filters for each step in the sequence. |
- labelSequence:'Post\|-Blocked,Reply,>Admin' | Start node must be a :Post node that isn't :Blocked, next node must be a :Reply, and the next must be an :Admin. Only paths ending with the `:Admin` node in the sequence will be returned.
-| relationshipSequence | A string of comma-separated relationship filters for each step in a repeating sequence. If present, `relationshipFilter` is ignored, as this takes priority. |
-relationshipSequence:'NEXT>,<FROM,POSTED>\|REPLIED>' | Expansion will first expand `NEXT>` from the start node, then `<FROM`, then either `POSTED>` or `REPLIED>`, then repeat if able.
-| sequence | A string of comma-separated alternating label and relationship filters, for each step in a repeating sequence. The sequence should begin with a label filter, and end with a relationship filter. If present, `labelSequence`, `relationshipSequence`, and `relationshipFilter` are ignored, as this takes priority. |
-sequence:'Post\|-Blocked, NEXT>, Reply, <FROM, >Admin, POSTED>\|REPLIED>'  | Combines the behaviors above.
-| beginSequenceAtStart | Boolean value, default: true. Indicates that any of the above sequences begin at the start node provided to the expansion.
- If false, indicates that the sequence begins one node off from the start node, and this changes what is expected from the sequence parameters above. See table below for details. | beginSequenceAtStart:true | Indicates that the given start node should be used as the beginning of a sequence.
-|===
-
-
-==== Effects when `beginSequenceAtStart: false`
-
-[opts=header,cols="m,a,m,a"]
-|===
-| sequence | altered behavior | example | explanation
-| labelSequence | The start node is not considered part of the sequence. The sequence begins one node off from the start node. |
-beginSequenceAtStart:false, labelSequence:'Post\|-Blocked,Reply,>Admin' | The next node(s) out from the start node begins the sequence (and must be a :Post node that isn't :Blocked), and only paths ending with `Admin` nodes returned.
-| relationshipSequence | The first relationship filter in the sequence string will not be considered part of the repeating sequence, and will only be used for the first relationship from the start node to the node that will be the actual start of the sequence. |
-beginSequenceAtStart:false, relationshipSequence:'FIRST>,NEXT>,<FROM,POSTED>\|REPLIED>' | `FIRST>` will be traversed just from the start node to the node that will be the start of the repeating `NEXT>,<FROM,POSTED>\|REPLIED>` sequence.
-| sequence | The first relationship filter in the sequence string will not be considered part of the repeating sequence, and will only be used for the first relationship from the start node to the node that will be the actual start of the sequence. |
-beginSequenceAtStart:false, sequence:'FIRST>, Post\|-Blocked, NEXT>, Reply, <FROM, >Admin, POSTED>\|REPLIED>' | Combines the behaviors above.
-|===
-
-Label filtering in sequences work together with the `endNodes`+`terminatorNodes` and `labelFilter`, though inclusion of a node must be unanimous.
-
-Aside from the comma separators, there are a few differences in syntax between this and the `labelFilter`.
-
-1. In the `labelFilter`, a label without a symbol reused the previously used filter (and may error out if no previous filter symbol is present).
-In `labelSequence` and `sequence`, no filter symbol instead means the label is whitelisted. In effect, `+` is now optional when whitelisting a label.
-
-2. You can provide `*` in place of a label, which stands in for all labels.
-This can be used to specify that at a certain step in the sequence, it doesn't matter what the labels are, everything is whitelisted.
-(relationships can still use `''` for any relationship type/direction, or just the direction arrow).
-
-3. In the `labelFilter`, a label with the end node filter isn't automatically whitelisted. It is included in the results, but to expand beyond it the node must pass the whitelist filter.
-In `labelSequence` and `sequence`, a node with the end node filter is automatically considered whitelisted, and expansion will continue.
-
-4. Behavior is slightly different on matches when depth is below `minLevel`, though these nodes are never included in the results.
-In the `labelFilter`, when below `minLevel`, only nodes allowed by the whitelist and not disallowed by the blacklist would continue.
-In `labelSequence` and `sequence`, this additionally includes nodes with labels in the end node and termination node filters (though the termination node filter will not prune when below `minLevel`).
-
-Remember that `filterStartNode` defaults to false for APOC 3.2.x.x and newer. If you want the start node filtered according to the first step in the sequence, you may need to set this explicitly to false.
-
-If you need to limit the number of times a sequence repeats, this can be done with the `maxLevel` config param (multiply the number of iterations with the size of the nodes in the sequence).
-
-As paths are important when expanding sequences, we recommend avoiding `apoc.path.subgraphNodes()`, `apoc.path.subgraphAll()`, and `apoc.path.spanningTree()` when using sequences,
-as the configurations that make these efficient at matching to distinct nodes may interfere with sequence pathfinding.
 
 == Parallel Node Search
 

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -1005,10 +1005,10 @@ Variations allow more configurable expansions, and expansions for more specific 
 
 [cols="1m,5"]
 |===
-| call apoc.path.expandConfig(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, uniqueness:'RELATIONSHIP_PATH', filterStartNode:true, limit, optional:false, endNodes, terminatorNodes}) yield path | expand from given nodes(s) taking the provided restrictions into account
-| call apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, optional:false, endNodes, terminatorNodes}) yield node | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns all nodes in the subgraph
-| call apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, endNodes, terminatorNodes}) yield nodes, relationships | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns the collection of subgraph nodes, and the collection of all relationships within the subgraph
-| call apoc.path.spanningTree(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, optional:false, endNodes, terminatorNodes}) yield path | expand a spanning tree from given nodes(s) taking the provided restrictions into account; the paths returned collectively form a spanning tree
+| call apoc.path.expandConfig(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, uniqueness:'RELATIONSHIP_PATH', filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, labelSequence, beginLabelSequenceAtStart:true}) yield path | expand from given nodes(s) taking the provided restrictions into account
+| call apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, labelSequence, beginLabelSequenceAtStart:true}) yield node | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns all nodes in the subgraph
+| call apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, endNodes, terminatorNodes, labelSequence, beginLabelSequenceAtStart:true}) yield nodes, relationships | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns the collection of subgraph nodes, and the collection of all relationships within the subgraph
+| call apoc.path.spanningTree(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, labelSequence, beginLabelSequenceAtStart:true}) yield path | expand a spanning tree from given nodes(s) taking the provided restrictions into account; the paths returned collectively form a spanning tree
 |===
 
 === Relationship Filter
@@ -1084,6 +1084,42 @@ Nodes given as `terminatorNodes` behave just like `endNodes` (they must be at th
 This behavior is similar to the termination filter `/` in the label filters.
 
 `endNodes` and/or `terminatorNodes` can freely be used along with the labelFilter.
+
+=== Label Sequences
+
+Introduced in the February 2018 APOC releases, `labelSequence` allows the definition of label filters for each step in a looping sequence.
+
+This can be used, for example, to expand along a repeating sequence of the labels :A, :B, and :C.
+
+`labelSequence` uses similar syntax to the `labelFilter` (`+`,`-`,`>`,`/` for whitelist, blacklist, end node, and terminator node, respectively),
+but these filters only apply to a specific step in the sequence, not the entire sequence. Commas (`,`) separate the filters for each step in the sequence.
+
+As a more complex example, `labelSequence: 'A|D, B|-E, C:F'` means: the first node should be :A or :D, the second node should be :B (but never labeled :E), and the last in the sequence should be labeled both :C and :F. The sequence then repeats.
+We could add end node or termination filters to any step, which would change which paths are returned (or nodes, if using `subgraphNodes()`) even as we keep expanding along the repeating sequence (terminating of course when reaching a node with a terminator filter).
+
+Aside from the comma separators, there are a few differences in syntax between this and the `labelFilter`.
+
+1. In the `labelFilter`, a label without a symbol reused the previously used filter (and may error out if no previous filter symbol is present).
+In `labelSequence`, no filter symbol instead means the label is whitelisted. In effect, `+` is now optional when whitelisting a label.
+
+2. In the `labelFilter`, the termination and end node filters applied to labels. In `labelSequence`, it's more correct to say they apply to the step in the sequence as a whole, and any labels provided are considered whitelisted for that step.
+Because of this, it doesn't matter which label the end node or terminator node filter is applied to...as long as the filter is present in the sequence step, that node in the sequence will be treated as an end node or terminator node.
+So as a result, `>C|D` is equivalent to `C|>D` . The nodes at that step of the sequence (that are labeled :C or :D) will be treated as end nodes.
+We recommend the convention of using the end node or terminator filter at the start of the step in the sequence.
+
+3. You can provide `*` in place of a label, which stands in for all labels.
+This can be used to specify that at a certain step in the sequence, it doesn't matter what the labels are, everything is whitelisted.
+
+Remember that `filterStartNode` defaults to false for APOC 3.2.x.x and newer. If you want the start node filtered according to the first step in the sequence, you may need to set this explicitly to false.
+
+There may be some cases where the sequence you're expanding starts at the first step away from the start node, rather than at the start node itself, and the start node isn't involved in the sequence at all.
+For these cases, use `beginLabelSequenceAtStart:false`.
+
+If you need to limit the number of times a sequence repeats, this can be done with the `maxLevel` config param (multiply the number of iterations with the size of the sequence).
+
+`labelSequence`, `labelFilter`, and `endNodes` and `terminatorNodes` can be freely used together,
+for example if needing to expand a repeating sequence of labels to specific already-matched end-nodes, with a blacklist defined for the expansion.
+
 
 == Parallel Node Search
 

--- a/src/main/java/apoc/path/LabelMatcher.java
+++ b/src/main/java/apoc/path/LabelMatcher.java
@@ -14,6 +14,8 @@ import java.util.*;
  * If the LabelMatcher only had `Person:Manager` and `Person:Boss`, then only nodes with both :Person and :Manager, or :Person and :Boss, would match.
  * Some nodes that would not match would be: :Person, :Boss, :Manager, :Boss:Manager, but :Boss:Person:HeadHoncho would match fine.
  * Also accepts a special `*` label, indicating that the matcher will always return a positive match.
+ * LabelMatchers hold no context about what a match means, and do not handle labels prefixed with filter symbols (+, -, /, >).
+ * Please strip these symbols from the start of each label before adding to the matcher.
  */
 public class LabelMatcher {
     private List<String> labels = new ArrayList<>();
@@ -28,6 +30,11 @@ public class LabelMatcher {
         @Override
         public LabelMatcher addLabel(String label) {
             return this; // no-op
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return false;
         }
     };
 
@@ -77,6 +84,10 @@ public class LabelMatcher {
         }
 
         return false;
+    }
+
+    public boolean isEmpty() {
+        return labels.isEmpty() && (compoundLabels == null || compoundLabels.isEmpty());
     }
 }
 

--- a/src/main/java/apoc/path/LabelMatcherGroup.java
+++ b/src/main/java/apoc/path/LabelMatcherGroup.java
@@ -1,0 +1,85 @@
+package apoc.path;
+
+import org.neo4j.graphdb.Node;
+
+/**
+ * A matcher for evaluating whether or not a node has at least one of the whitelisted labels (and does not have any blacklisted label).
+ * Unlike a LabelMatcher, LabelMatcherGroups interpret context for labels according to filter symbols provided.
+ * Labels can be added that are prefixed with filter symbols (+, -, /, >) (for whitelist, blacklist, terminator, and end node respectively).
+ * Lack of a symbol is interpreted as whitelisted. Labels provided with the endnode and terminator filter symbols are also considered whitelisted.
+ * The group as a whole carries the status of terminator node or end node...if any label added has the appropriate filter symbol, the appropriate flag is toggled on for the entire group,
+ * which will be reflected in `isEndNode()` and `isTerminatorNode()`.
+ * Because of this, the endnode and terminator filter symbols can be prefixed in combination with a whitelist or blacklist symbol.
+ * For example, '>-EXCLUDED' means that there is a blacklist on any node with the label 'EXCLUDED', but if not caught by the blacklist the
+ * node is marked as an endnode.
+ * If no labels are set as whitelisted, then all labels are considered whitelisted (if not otherwise disallowed by the blacklist).
+ */
+public class LabelMatcherGroup {
+    private boolean isEndNode;
+    private boolean isTerminatorNode;
+    private LabelMatcher whitelistMatcher = new LabelMatcher();
+    private LabelMatcher blacklistMatcher = new LabelMatcher();
+
+    public LabelMatcherGroup addLabels(String fullFilterString) {
+        if (fullFilterString !=  null && !fullFilterString.isEmpty()) {
+            String[] elements = fullFilterString.split("\\|");
+
+            for (String filterString : elements) {
+                addLabel(filterString);
+            }
+        }
+
+        return this;
+    }
+
+    public LabelMatcherGroup addLabel(String filterString) {
+        if (filterString !=  null && !filterString.isEmpty()) {
+
+            char operator = filterString.charAt(0);
+            if (operator == '>') {
+                isEndNode = true;
+                filterString = filterString.substring(1);
+            } else if (operator == '/') {
+                isTerminatorNode = true;
+                filterString = filterString.substring(1);
+            }
+
+            LabelMatcher matcher;
+
+            if (filterString.charAt(0) == '-') {
+                matcher = blacklistMatcher;
+                filterString = filterString.substring(1);
+            } else if (filterString.charAt(0) == '+') {
+                matcher = whitelistMatcher;
+                filterString = filterString.substring(1);
+            } else {
+                matcher = whitelistMatcher;
+            }
+
+            matcher.addLabel(filterString);
+        }
+
+        return this;
+    }
+
+    public boolean matchesLabels(Node node) {
+        if (blacklistMatcher.matchesLabels(node)) {
+            return false;
+        }
+
+        // empty whitelist is equivalent to everything whitelisted (unless caught by blacklist above)
+        if (whitelistMatcher.isEmpty() || whitelistMatcher.matchesLabels(node)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public boolean isEndNode() {
+        return isEndNode;
+    }
+
+    public boolean isTerminatorNode() {
+        return isTerminatorNode;
+    }
+}

--- a/src/main/java/apoc/path/PathExplorer.java
+++ b/src/main/java/apoc/path/PathExplorer.java
@@ -58,6 +58,10 @@ public class PathExplorer {
 		Map<String, Object> configMap = new HashMap<>(config);
 		configMap.put("uniqueness", "NODE_GLOBAL");
 
+		if (config.containsKey("minLevel")) {
+			throw new IllegalArgumentException("minLevel not supported in subgraphNodes");
+		}
+
 		return expandConfigPrivate(start, configMap).map( path -> path == null ? new NodeResult(null) : new NodeResult(path.endNode()) );
 	}
 
@@ -67,6 +71,10 @@ public class PathExplorer {
 		Map<String, Object> configMap = new HashMap<>(config);
 		configMap.remove("optional"); // not needed, will return empty collections anyway if no results
 		configMap.put("uniqueness", "NODE_GLOBAL");
+
+		if (config.containsKey("minLevel")) {
+			throw new IllegalArgumentException("minLevel not supported in subgraphAll");
+		}
 
 		List<Node> subgraphNodes = expandConfigPrivate(start, configMap).map( Path::endNode ).collect(Collectors.toList());
 		List<Relationship> subgraphRels = Cover.coverNodes(subgraphNodes).collect(Collectors.toList());
@@ -79,6 +87,10 @@ public class PathExplorer {
 	public Stream<PathResult> spanningTree(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
 		Map<String, Object> configMap = new HashMap<>(config);
 		configMap.put("uniqueness", "NODE_GLOBAL");
+
+		if (config.containsKey("minLevel")) {
+			throw new IllegalArgumentException("minLevel not supported in spanningTree");
+		}
 
 		if (configMap.containsKey("sequence") || configMap.containsKey("labelSequence") || configMap.containsKey("relationshipSequence")) {
 			throw new IllegalArgumentException("sequences not supported by spanningTree");

--- a/src/main/java/apoc/path/RelationshipSequenceExpander.java
+++ b/src/main/java/apoc/path/RelationshipSequenceExpander.java
@@ -1,0 +1,107 @@
+package apoc.path;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.impl.StandardExpander;
+import org.neo4j.graphdb.traversal.BranchState;
+import org.neo4j.helpers.collection.NestingIterator;
+import org.neo4j.helpers.collection.Pair;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * An expander for repeating sequences of relationships. The sequence provided should be a string consisting of
+ * relationship type/direction patterns (exactly the same as the `relationshipFilter`), separated by commas.
+ * Each comma-separated pattern represents the relationships that will be expanded with each step of expansion, which
+ * repeats indefinitely (unless otherwise stopped by `maxLevel`, `limit`, or terminator filtering from the other expander config options).
+ * The exception is if `beginSequenceAtStart` is false. This indicates that the sequence should not begin from the start node,
+ * but from one node distant. In this case, we may still need a restriction on the relationship used to reach the start node
+ * of the sequence, so when `beginSequenceAtStart` is false, then the first relationship step in the sequence given will not
+ * actually be used as part of the sequence, but will only be used once to reach the starting node of the sequence.
+ * The remaining relationship steps will be used as the repeating relationship sequence.
+ */
+public class RelationshipSequenceExpander implements PathExpander {
+    private final List<List<Pair<RelationshipType, Direction>>> relSequences = new ArrayList<>();
+    private List<Pair<RelationshipType, Direction>> initialRels = null;
+
+
+    public RelationshipSequenceExpander(String relSequenceString, boolean beginSequenceAtStart) {
+        int index = 0;
+
+        for (String sequenceStep : relSequenceString.split(",")) {
+            sequenceStep = sequenceStep.trim();
+            Iterable<Pair<RelationshipType, Direction>> relDirIterable = RelationshipTypeAndDirections.parse(sequenceStep);
+
+            List<Pair<RelationshipType, Direction>> stepRels = new ArrayList<>();
+            for (Pair<RelationshipType, Direction> pair : relDirIterable) {
+                stepRels.add(pair);
+            }
+
+            if (!beginSequenceAtStart && index == 0) {
+                initialRels = stepRels;
+            } else {
+                relSequences.add(stepRels);
+            }
+
+            index++;
+        }
+    }
+
+    public RelationshipSequenceExpander(List<String> relSequenceList, boolean beginSequenceAtStart) {
+        int index = 0;
+
+        for (String sequenceStep : relSequenceList) {
+            sequenceStep = sequenceStep.trim();
+            Iterable<Pair<RelationshipType, Direction>> relDirIterable = RelationshipTypeAndDirections.parse(sequenceStep);
+
+            List<Pair<RelationshipType, Direction>> stepRels = new ArrayList<>();
+            for (Pair<RelationshipType, Direction> pair : relDirIterable) {
+                stepRels.add(pair);
+            }
+
+            if (!beginSequenceAtStart && index == 0) {
+                initialRels = stepRels;
+            } else {
+                relSequences.add(stepRels);
+            }
+
+            index++;
+        }
+    }
+
+    @Override
+    public Iterable<Relationship> expand( Path path, BranchState state ) {
+        final Node node = path.endNode();
+        int depth = path.length();
+        List<Pair<RelationshipType, Direction>> stepRels;
+
+        if (depth == 0 && initialRels != null) {
+            stepRels = initialRels;
+        } else {
+            stepRels = relSequences.get((initialRels == null ? depth : depth - 1) % relSequences.size());
+        }
+
+        return IteratorUtils.toList(
+         new NestingIterator<Relationship, Pair<RelationshipType, Direction>>(
+                stepRels.iterator() )
+        {
+            @Override
+            protected Iterator<Relationship> createNestedIterator(
+                    Pair<RelationshipType, Direction> entry )
+            {
+                RelationshipType type = entry.first();
+                Direction dir = entry.other();
+                return ( ( dir == Direction.BOTH ) ? node.getRelationships( type ) :
+                        node.getRelationships( type, dir ) ).iterator();
+            }
+        });
+    }
+
+    @Override
+    public PathExpander reverse() {
+        throw new RuntimeException("Not implemented");
+    }
+}

--- a/src/test/java/apoc/path/ExpandPathTest.java
+++ b/src/test/java/apoc/path/ExpandPathTest.java
@@ -361,6 +361,25 @@ public class ExpandPathTest {
 	}
 
 	@Test
+	public void testEndNodesAndTerminatorNodesReturnExpectedResults() {
+		db.execute("MATCH (c:Person) WHERE c.name in ['Clint Eastwood', 'Gene Hackman'] SET c:Western WITH c WHERE c.name = 'Clint Eastwood' SET c:Blacklist");
+
+		TestUtil.testResult(db,
+				"MATCH (k:Person {name:'Keanu Reeves'}), (gene:Person {name:'Gene Hackman'}), (clint:Person {name:'Clint Eastwood'}) " +
+						"CALL apoc.path.subgraphNodes(k, {relationshipFilter:'ACTED_IN|PRODUCED|DIRECTED', endNodes:[gene], terminatorNodes:[clint]}) yield node " +
+						"return node",
+				result -> {
+
+					List<Map<String, Object>> maps = Iterators.asList(result);
+					assertEquals(2, maps.size());
+					Node node = (Node) maps.get(0).get("node");
+					assertEquals("Gene Hackman", node.getProperty("name"));;
+					node = (Node) maps.get(1).get("node");
+					assertEquals("Clint Eastwood", node.getProperty("name"));
+				});
+	}
+
+	@Test
 	public void testEndNodesWithTerminationFilterPrunesExpansion() {
 		db.execute("MATCH (c:Person) WHERE c.name in ['Clint Eastwood', 'Gene Hackman'] SET c:Western");
 

--- a/src/test/java/apoc/path/ExpandPathTest.java
+++ b/src/test/java/apoc/path/ExpandPathTest.java
@@ -49,13 +49,13 @@ public class ExpandPathTest {
 
 	@Test
 	public void testExplorePathRelationshipsTest() throws Throwable {
-		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.expand(m,'<ACTED_IN|PRODUCED>|FOLLOWS','-',0,2) yield path return count(*) as c";
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.expand(m,'<ACTED_IN|PRODUCED>|FOLLOWS','',0,2) yield path return count(*) as c";
 		TestUtil.testCall(db, query, (row) -> assertEquals(11L,row.get("c")));
 	}
 
 	@Test
 	public void testExplorePathLabelWhiteListTest() throws Throwable {
-		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.expand(m,'ACTED_IN|PRODUCED|FOLLOWS','+Person|Movie',0,3) yield path return count(*) as c";
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.expand(m,'ACTED_IN|PRODUCED|FOLLOWS','+Person|+Movie',0,3) yield path return count(*) as c";
 		TestUtil.testCall(db, query, (row) -> assertEquals(107L,row.get("c"))); // 59 with Uniqueness.RELATIONSHIP_GLOBAL
 	}
 
@@ -220,7 +220,7 @@ public class ExpandPathTest {
 	}
 
 	@Test
-	public void testEndNodeFilterBeforeWhitelist() {
+	public void testEndNodeFilterAsWhitelist() {
 		db.execute("MATCH (c:Person) WHERE c.name in ['Clint Eastwood', 'Gene Hackman'] SET c:Western");
 
 		TestUtil.testResult(db,
@@ -229,9 +229,11 @@ public class ExpandPathTest {
 						"return path",
 				result -> {
 					List<Map<String, Object>> maps = Iterators.asList(result);
-					assertEquals(1, maps.size());
+					assertEquals(2, maps.size());
 					Path path = (Path) maps.get(0).get("path");
 					assertEquals("Gene Hackman", path.endNode().getProperty("name"));
+					path = (Path) maps.get(1).get("path");
+					assertEquals("Clint Eastwood", path.endNode().getProperty("name"));
 				});
 	}
 

--- a/src/test/java/apoc/path/LabelSequenceTest.java
+++ b/src/test/java/apoc/path/LabelSequenceTest.java
@@ -109,4 +109,34 @@ public class LabelSequenceTest {
             assertTrue(names.containsAll(Arrays.asList("a", "ac")));
         });
     }
+
+    @Test
+    public void testSequenceWithTerminatorNodeAsStartNodeWithoutFilteringStartNode() throws Throwable {
+        String query = "MATCH (a:A {name: 'a'}) CALL apoc.path.subgraphNodes(a,{labelSequence:'/A, B', filterStartNode:false}) yield node return collect(distinct node.name) as nodes";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> names = (List<String>) row.get("nodes");
+            assertEquals(1L, names.size());
+            assertTrue(names.containsAll(Arrays.asList("ac")));
+        });
+    }
+
+    @Test
+    public void testSequenceWithTerminatorNodeAndEndNode() throws Throwable {
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'>A|C|/A:C, B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> names = (List<String>) row.get("nodes");
+            assertEquals(2L, names.size());
+            assertTrue(names.containsAll(Arrays.asList("a", "ac")));
+        });
+    }
+
+    @Test
+    public void testSequenceWithTerminatorNodeWhenUsingMinLevel() throws Throwable {
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.expandConfig(s,{labelSequence:'/A, B', beginSequenceAtStart:false, minLevel:3}) yield path return collect(distinct last(nodes(path)).name) as nodes";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> names = (List<String>) row.get("nodes");
+            assertEquals(1L, names.size());
+            assertTrue(names.containsAll(Arrays.asList("ac")));
+        });
+    }
 }

--- a/src/test/java/apoc/path/LabelSequenceTest.java
+++ b/src/test/java/apoc/path/LabelSequenceTest.java
@@ -43,7 +43,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testBasicSequence() throws Throwable {
-        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'A,B', beginLabelSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'A,B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(6L,names.size());
@@ -53,7 +53,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testNoMatchWhenImproperlyStartingSequenceAtStart() throws Throwable {
-        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'A,B', beginLabelSequenceAtStart:true, filterStartNode:true}) yield node return collect(distinct node.name) as nodes";
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'A,B', beginSequenceAtStart:true, filterStartNode:true}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(0L,names.size());
@@ -62,7 +62,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testMatchWhenProperlyStartingSequenceAtStart() throws Throwable {
-        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'Start,A,B', beginLabelSequenceAtStart:true, filterStartNode:true}) yield node return collect(distinct node.name) as nodes";
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'Start,A,B', beginSequenceAtStart:true, filterStartNode:true}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(3L,names.size());
@@ -72,7 +72,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testSequenceWithBlacklist() throws Throwable {
-        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'A|-C,B', beginLabelSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'A|-C,B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(3L, names.size());
@@ -82,7 +82,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testSequenceWithTerminatorNode() throws Throwable {
-        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'/A|C,B', beginLabelSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'/A|C,B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(1L, names.size());
@@ -92,7 +92,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testSequenceWithEndNode() throws Throwable {
-        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'>A|C,B', beginLabelSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'>A|C,B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(3L, names.size());
@@ -102,7 +102,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testSequenceWithEndNodeAndLimit() throws Throwable {
-        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'>A|C,B', beginLabelSequenceAtStart:false, limit:2}) yield node return collect(distinct node.name) as nodes";
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'>A|C,B', beginSequenceAtStart:false, limit:2}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(2L, names.size());

--- a/src/test/java/apoc/path/LabelSequenceTest.java
+++ b/src/test/java/apoc/path/LabelSequenceTest.java
@@ -1,0 +1,112 @@
+package apoc.path;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import apoc.util.Util;
+import org.junit.*;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import apoc.util.TestUtil;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class LabelSequenceTest {
+    private static GraphDatabaseService db;
+
+    public LabelSequenceTest() throws Exception {
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        TestUtil.registerProcedure(db, PathExplorer.class);
+        String sequence = "create (s:Start{name:'start'})-[:REL]->(:A{name:'a'})-[:REL]->(:B{name:'b'})-[:REL]->(:A:C{name:'ac'})-[:REL]->(:B:A{name:'ba'})-[:REL]->(:D:A{name:'da'})";
+        try (Transaction tx = db.beginTx()) {
+            db.execute(sequence);
+            tx.success();
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
+    }
+
+
+
+    @Test
+    public void testBasicSequence() throws Throwable {
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'A,B', beginLabelSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> names = (List<String>) row.get("nodes");
+            assertEquals(6L,names.size());
+            assertTrue(names.containsAll(Arrays.asList("start", "a", "b", "ac", "ba", "da")));
+        });
+    }
+
+    @Test
+    public void testNoMatchWhenImproperlyStartingSequenceAtStart() throws Throwable {
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'A,B', beginLabelSequenceAtStart:true, filterStartNode:true}) yield node return collect(distinct node.name) as nodes";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> names = (List<String>) row.get("nodes");
+            assertEquals(0L,names.size());
+        });
+    }
+
+    @Test
+    public void testMatchWhenProperlyStartingSequenceAtStart() throws Throwable {
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'Start,A,B', beginLabelSequenceAtStart:true, filterStartNode:true}) yield node return collect(distinct node.name) as nodes";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> names = (List<String>) row.get("nodes");
+            assertEquals(3L,names.size());
+            assertTrue(names.containsAll(Arrays.asList("start", "a", "b")));
+        });
+    }
+
+    @Test
+    public void testSequenceWithBlacklist() throws Throwable {
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'A|-C,B', beginLabelSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> names = (List<String>) row.get("nodes");
+            assertEquals(3L, names.size());
+            assertTrue(names.containsAll(Arrays.asList("start", "a", "b")));
+        });
+    }
+
+    @Test
+    public void testSequenceWithTerminatorNode() throws Throwable {
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'/A|C,B', beginLabelSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> names = (List<String>) row.get("nodes");
+            assertEquals(1L, names.size());
+            assertTrue(names.containsAll(Arrays.asList("a")));
+        });
+    }
+
+    @Test
+    public void testSequenceWithEndNode() throws Throwable {
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'>A|C,B', beginLabelSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> names = (List<String>) row.get("nodes");
+            assertEquals(3L, names.size());
+            assertTrue(names.containsAll(Arrays.asList("a", "ac", "da")));
+        });
+    }
+
+    @Test
+    public void testSequenceWithEndNodeAndLimit() throws Throwable {
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'>A|C,B', beginLabelSequenceAtStart:false, limit:2}) yield node return collect(distinct node.name) as nodes";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> names = (List<String>) row.get("nodes");
+            assertEquals(2L, names.size());
+            assertTrue(names.containsAll(Arrays.asList("a", "ac")));
+        });
+    }
+}

--- a/src/test/java/apoc/path/LabelSequenceTest.java
+++ b/src/test/java/apoc/path/LabelSequenceTest.java
@@ -43,7 +43,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testBasicSequence() throws Throwable {
-        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'A,B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelFilter:'A,B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(6L,names.size());
@@ -53,7 +53,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testNoMatchWhenImproperlyStartingSequenceAtStart() throws Throwable {
-        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'A,B', beginSequenceAtStart:true, filterStartNode:true}) yield node return collect(distinct node.name) as nodes";
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelFilter:'A,B', beginSequenceAtStart:true, filterStartNode:true}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(0L,names.size());
@@ -62,7 +62,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testMatchWhenProperlyStartingSequenceAtStart() throws Throwable {
-        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'Start,A,B', beginSequenceAtStart:true, filterStartNode:true}) yield node return collect(distinct node.name) as nodes";
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelFilter:'Start,A,B', beginSequenceAtStart:true, filterStartNode:true}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(3L,names.size());
@@ -72,7 +72,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testSequenceWithBlacklist() throws Throwable {
-        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'A|-C,B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelFilter:'A|-C,B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(3L, names.size());
@@ -82,7 +82,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testSequenceWithTerminatorNode() throws Throwable {
-        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'/A|C,B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelFilter:'/A|C,B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(1L, names.size());
@@ -92,7 +92,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testSequenceWithEndNode() throws Throwable {
-        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'>A|C,B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelFilter:'>A|C,B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(3L, names.size());
@@ -102,7 +102,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testSequenceWithEndNodeAndLimit() throws Throwable {
-        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'>A|C,B', beginSequenceAtStart:false, limit:2}) yield node return collect(distinct node.name) as nodes";
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelFilter:'>A|C,B', beginSequenceAtStart:false, limit:2}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(2L, names.size());
@@ -112,7 +112,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testSequenceWithTerminatorNodeAsStartNodeWithoutFilteringStartNode() throws Throwable {
-        String query = "MATCH (a:A {name: 'a'}) CALL apoc.path.subgraphNodes(a,{labelSequence:'/A, B', filterStartNode:false}) yield node return collect(distinct node.name) as nodes";
+        String query = "MATCH (a:A {name: 'a'}) CALL apoc.path.subgraphNodes(a,{labelFilter:'/A, B', filterStartNode:false}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(1L, names.size());
@@ -122,7 +122,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testSequenceWithTerminatorNodeAndEndNode() throws Throwable {
-        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelSequence:'>A|C|/A:C, B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.subgraphNodes(s,{labelFilter:'>A|C|/A:C, B', beginSequenceAtStart:false}) yield node return collect(distinct node.name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(2L, names.size());
@@ -132,7 +132,7 @@ public class LabelSequenceTest {
 
     @Test
     public void testSequenceWithTerminatorNodeWhenUsingMinLevel() throws Throwable {
-        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.expandConfig(s,{labelSequence:'/A, B', beginSequenceAtStart:false, minLevel:3}) yield path return collect(distinct last(nodes(path)).name) as nodes";
+        String query = "MATCH (s:Start {name: 'start'}) CALL apoc.path.expandConfig(s,{labelFilter:'/A, B', beginSequenceAtStart:false, minLevel:3}) yield path return collect(distinct last(nodes(path)).name) as nodes";
         TestUtil.testCall(db, query, (row) -> {
             List<String> names = (List<String>) row.get("nodes");
             assertEquals(1L, names.size());

--- a/src/test/java/apoc/path/RelSequenceTest.java
+++ b/src/test/java/apoc/path/RelSequenceTest.java
@@ -43,7 +43,7 @@ public class RelSequenceTest {
 
     @Test
     public void testBasicRelSequence() throws Throwable {
-        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipSequence:'ACTED_IN>,<DIRECTED', labelSequence:'>Person,Movie'}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
+        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipFilter:'ACTED_IN>,<DIRECTED', labelFilter:'>Person,Movie'}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
         TestUtil.testCall(db, query, (row) -> {
             List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
             List<String> names = (List<String>) row.get("names");
@@ -54,7 +54,7 @@ public class RelSequenceTest {
 
     @Test
     public void testRelSequenceWithMinLevel() throws Throwable {
-        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipSequence:'ACTED_IN>,<DIRECTED', labelSequence:'>Person,Movie', minLevel:3}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
+        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipFilter:'ACTED_IN>,<DIRECTED', labelFilter:'>Person,Movie', minLevel:3}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
         TestUtil.testCall(db, query, (row) -> {
             List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
             List<String> names = (List<String>) row.get("names");
@@ -65,7 +65,7 @@ public class RelSequenceTest {
 
     @Test
     public void testRelSequenceWithMaxLevel() throws Throwable {
-        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipSequence:'ACTED_IN>,<DIRECTED', labelSequence:'>Person,Movie', maxLevel:2}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
+        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipFilter:'ACTED_IN>,<DIRECTED', labelFilter:'>Person,Movie', maxLevel:2}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
         TestUtil.testCall(db, query, (row) -> {
             List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Tom Hanks"));
             List<String> names = (List<String>) row.get("names");
@@ -76,18 +76,7 @@ public class RelSequenceTest {
 
     @Test
     public void testRelSequenceWhenNotBeginningAtStart() throws Throwable {
-        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipSequence:'ACTED_IN>,<DIRECTED,ACTED_IN>', labelSequence:'Movie,>Person', beginSequenceAtStart:false}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
-        TestUtil.testCall(db, query, (row) -> {
-            List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
-            List<String> names = (List<String>) row.get("names");
-            assertEquals(12l, names.size());
-            assertTrue(names.containsAll(expectedNames));
-        });
-    }
-
-    @Test
-    public void testExpandWithRelSequenceIgnoresRelFilter() throws Throwable {
-        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipSequence:'ACTED_IN>,<DIRECTED', relationshipFilter:'NONEXIST', labelSequence:'>Person,Movie'}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
+        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipFilter:'ACTED_IN>,<DIRECTED,ACTED_IN>', labelFilter:'Movie,>Person', beginSequenceAtStart:false}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
         TestUtil.testCall(db, query, (row) -> {
             List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
             List<String> names = (List<String>) row.get("names");

--- a/src/test/java/apoc/path/RelSequenceTest.java
+++ b/src/test/java/apoc/path/RelSequenceTest.java
@@ -1,0 +1,98 @@
+package apoc.path;
+
+import apoc.util.TestUtil;
+import apoc.util.Util;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class RelSequenceTest {
+    private static GraphDatabaseService db;
+
+    public RelSequenceTest() throws Exception {
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        TestUtil.registerProcedure(db, PathExplorer.class);
+        String movies = Util.readResourceFile("movies.cypher");
+        String additionalLink = "match (p:Person{name:'Nora Ephron'}), (m:Movie{title:'When Harry Met Sally'}) create (p)-[:ACTED_IN]->(m)";
+        try (Transaction tx = db.beginTx()) {
+            db.execute(movies);
+            db.execute(additionalLink);
+            tx.success();
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
+    }
+
+    @Test
+    public void testBasicRelSequence() throws Throwable {
+        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipSequence:'ACTED_IN>,<DIRECTED', labelSequence:'>Person,Movie'}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
+            List<String> names = (List<String>) row.get("names");
+            assertEquals(12l, names.size());
+            assertTrue(names.containsAll(expectedNames));
+        });
+    }
+
+    @Test
+    public void testRelSequenceWithMinLevel() throws Throwable {
+        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipSequence:'ACTED_IN>,<DIRECTED', labelSequence:'>Person,Movie', minLevel:3}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
+            List<String> names = (List<String>) row.get("names");
+            assertEquals(11l, names.size());
+            assertTrue(names.containsAll(expectedNames));
+        });
+    }
+
+    @Test
+    public void testRelSequenceWithMaxLevel() throws Throwable {
+        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipSequence:'ACTED_IN>,<DIRECTED', labelSequence:'>Person,Movie', maxLevel:2}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Tom Hanks"));
+            List<String> names = (List<String>) row.get("names");
+            assertEquals(11l, names.size());
+            assertTrue(names.containsAll(expectedNames));
+        });
+    }
+
+    @Test
+    public void testRelSequenceWhenNotBeginningAtStart() throws Throwable {
+        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipSequence:'ACTED_IN>,<DIRECTED,ACTED_IN>', labelSequence:'Movie,>Person', beginSequenceAtStart:false}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
+            List<String> names = (List<String>) row.get("names");
+            assertEquals(12l, names.size());
+            assertTrue(names.containsAll(expectedNames));
+        });
+    }
+
+    @Test
+    public void testExpandWithRelSequenceIgnoresRelFilter() throws Throwable {
+        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{relationshipSequence:'ACTED_IN>,<DIRECTED', relationshipFilter:'NONEXIST', labelSequence:'>Person,Movie'}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
+            List<String> names = (List<String>) row.get("names");
+            assertEquals(12l, names.size());
+            assertTrue(names.containsAll(expectedNames));
+        });
+    }
+}

--- a/src/test/java/apoc/path/SequenceTest.java
+++ b/src/test/java/apoc/path/SequenceTest.java
@@ -1,0 +1,109 @@
+package apoc.path;
+
+import apoc.util.TestUtil;
+import apoc.util.Util;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+
+public class SequenceTest {
+    private static GraphDatabaseService db;
+
+    public SequenceTest() throws Exception {
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        TestUtil.registerProcedure(db, PathExplorer.class);
+        String movies = Util.readResourceFile("movies.cypher");
+        String additionalLink = "match (p:Person{name:'Nora Ephron'}), (m:Movie{title:'When Harry Met Sally'}) create (p)-[:ACTED_IN]->(m)";
+        try (Transaction tx = db.beginTx()) {
+            db.execute(movies);
+            db.execute(additionalLink);
+            tx.success();
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
+    }
+
+    @Test
+    public void testBasicSequence() throws Throwable {
+        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{sequence:'>Person, ACTED_IN>, Movie, <DIRECTED'}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
+            List<String> names = (List<String>) row.get("names");
+            assertEquals(12l, names.size());
+            assertTrue(names.containsAll(expectedNames));
+        });
+    }
+
+    @Test
+    public void testSequenceWithMinLevel() throws Throwable {
+        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{sequence:'>Person, ACTED_IN>, Movie, <DIRECTED', minLevel:3}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
+            List<String> names = (List<String>) row.get("names");
+            assertEquals(11l, names.size());
+            assertTrue(names.containsAll(expectedNames));
+        });
+    }
+
+    @Test
+    public void testSequenceWithMaxLevel() throws Throwable {
+        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{sequence:'>Person, ACTED_IN>, Movie, <DIRECTED', maxLevel:2}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Tom Hanks"));
+            List<String> names = (List<String>) row.get("names");
+            assertEquals(11l, names.size());
+            assertTrue(names.containsAll(expectedNames));
+        });
+    }
+
+    @Test
+    public void testSequenceWhenNotBeginningAtStart() throws Throwable {
+        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{sequence:'ACTED_IN>, Movie, <DIRECTED, >Person, ACTED_IN>', beginSequenceAtStart:false}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
+            List<String> names = (List<String>) row.get("names");
+            assertEquals(12l, names.size());
+            assertTrue(names.containsAll(expectedNames));
+        });
+    }
+
+    @Test
+    public void testExpandWithSequenceIgnoresRelFilter() throws Throwable {
+        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{sequence:'>Person, ACTED_IN>, Movie, <DIRECTED', relationshipFilter:'NONEXIST'}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
+            List<String> names = (List<String>) row.get("names");
+            assertEquals(12l, names.size());
+            assertTrue(names.containsAll(expectedNames));
+        });
+    }
+
+    @Test
+    public void testExpandWithSequenceIgnoresLabelSequence() throws Throwable {
+        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{sequence:'>Person, ACTED_IN>, Movie, <DIRECTED', labelSequence:'-Person,-Movie'}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
+        TestUtil.testCall(db, query, (row) -> {
+            List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
+            List<String> names = (List<String>) row.get("names");
+            assertEquals(12l, names.size());
+            assertTrue(names.containsAll(expectedNames));
+        });
+    }
+}

--- a/src/test/java/apoc/path/SequenceTest.java
+++ b/src/test/java/apoc/path/SequenceTest.java
@@ -97,8 +97,8 @@ public class SequenceTest {
     }
 
     @Test
-    public void testExpandWithSequenceIgnoresLabelSequence() throws Throwable {
-        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{sequence:'>Person, ACTED_IN>, Movie, <DIRECTED', labelSequence:'-Person,-Movie'}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
+    public void testExpandWithSequenceIgnoresLabelFilter() throws Throwable {
+        String query = "MATCH (t:Person {name: 'Tom Hanks'}) CALL apoc.path.expandConfig(t,{sequence:'>Person, ACTED_IN>, Movie, <DIRECTED', labelFilter:'-Person,-Movie'}) yield path with distinct last(nodes(path)) as node return collect(node.name) as names";
         TestUtil.testCall(db, query, (row) -> {
             List<String> expectedNames = new ArrayList<>(Arrays.asList("Robert Zemeckis", "Mike Nichols", "Ron Howard", "Frank Darabont", "Tom Tykwer", "Andy Wachowski", "Lana Wachowski", "Tom Hanks", "John Patrick Stanley", "Nora Ephron", "Penny Marshall", "Rob Reiner"));
             List<String> names = (List<String>) row.get("names");


### PR DESCRIPTION
Added `labelSequence` to path expander config parameters, allowing label filters to define a repeating sequence of nodes to expand.

Further commits also include `relationshipSequence`, and `sequence` (when both are needed)
Addresses #691.