### PR TITLE
Fixes #747: date.format(null) returns null, also add ISO8601 convenience format

### DIFF
--- a/src/main/java/apoc/date/Date.java
+++ b/src/main/java/apoc/date/Date.java
@@ -150,8 +150,14 @@ public class Date {
 
 	@UserFunction
 	@Description("apoc.date.format(12345,('ms|s|m|h|d'),('yyyy-MM-dd HH:mm:ss zzz'),('TZ')) get string representation of time value optionally using the specified unit (default ms) using specified format (default ISO) and specified time zone (default current TZ)")
-	public String format(final @Name("time") long time, @Name(value = "unit", defaultValue = "ms") String unit, @Name(value = "format",defaultValue = DEFAULT_FORMAT) String format, @Name(value = "timezone",defaultValue = "") String timezone) {
-		return parse(unit(unit).toMillis(time), format, timezone);
+	public String format(final @Name("time") Long time, @Name(value = "unit", defaultValue = "ms") String unit, @Name(value = "format",defaultValue = DEFAULT_FORMAT) String format, @Name(value = "timezone",defaultValue = "") String timezone) {
+		return time == null ? null : parse(unit(unit).toMillis(time), format, timezone);
+	}
+
+	@UserFunction
+	@Description("apoc.date.toISO8601(12345,('ms|s|m|h|d') return string representation of time in ISO8601 format")
+	public String toISO8601(final @Name("time") Long time, @Name(value = "unit", defaultValue = "ms") String unit) {
+		return time == null ? null : parse(unit(unit).toMillis(time), "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", null);
 	}
 
 	@UserFunction

--- a/src/test/java/apoc/date/DateTest.java
+++ b/src/test/java/apoc/date/DateTest.java
@@ -29,7 +29,6 @@ import static java.util.stream.Collectors.toList;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.*;
 
-
 public class DateTest {
 	@Rule public ExpectedException expected = ExpectedException.none();
 	private static GraphDatabaseService db;

--- a/src/test/java/apoc/date/DateTest.java
+++ b/src/test/java/apoc/date/DateTest.java
@@ -122,6 +122,18 @@ public class DateTest {
 				});
 	}
 
+	@Test public void testFromUnixtimeWithNullInputReturnsNull() throws Exception {
+		testCall(db,
+				"RETURN apoc.date.format(null,'s') AS value",
+				row -> assertEquals(null, row.get("value")));
+	}
+
+	@Test public void testToISO8601() throws Exception {
+		testCall(db,
+				"RETURN apoc.date.toISO8601(0) AS value",
+				row -> assertEquals("1970-01-01T00:00:00.000Z", row.get("value")));
+	}
+
 	@Test public void testFromUnixtimeWithCorrectFormat() throws Exception {
 		String pattern = "MM/dd/yyyy HH:mm:ss";
 		SimpleDateFormat customFormat = formatInUtcZone(pattern);


### PR DESCRIPTION
- date.format(null) returns null, instead of throw
- add ISO8601 convenience format function, ISO8601 is commonly used, eg in Neo4j OGM, API endpoints, etc. 