### PR TITLE
Add missing apoc.coll.combinations() to 3.3

### DIFF
--- a/src/main/java/apoc/coll/Coll.java
+++ b/src/main/java/apoc/coll/Coll.java
@@ -738,4 +738,34 @@ public class Coll {
         return result;
     }
 
+    @UserFunction
+    @Description("apoc.coll.combinations(coll, minSelect, maxSelect:minSelect) - Returns collection of all combinations of list elements of selection size between minSelect and maxSelect (default:minSelect), inclusive")
+    public List<List<Object>> combinations(@Name("coll") List<Object> coll, @Name(value="minSelect") long minSelectIn, @Name(value="maxSelect",defaultValue = "-1") long maxSelectIn) {
+        int minSelect = (int) minSelectIn;
+        int maxSelect = (int) maxSelectIn;
+        maxSelect = maxSelect == -1 ? minSelect : maxSelect;
+
+        if (coll == null || coll.isEmpty() || minSelect < 1 || minSelect > coll.size() || minSelect > maxSelect || maxSelect > coll.size()) {
+            return Collections.emptyList();
+        }
+
+        List<List<Object>> combinations = new ArrayList<>();
+
+        for (int i = minSelect; i <= maxSelect; i++) {
+            Iterator<int[]> itr = new Combinations(coll.size(), i).iterator();
+
+            while (itr.hasNext()) {
+                List<Object> entry = new ArrayList<>(i);
+                int[] indexes = itr.next();
+                if (indexes.length > 0) {
+                    for (int index : indexes) {
+                        entry.add(coll.get(index));
+                    }
+                    combinations.add(entry);
+                }
+            }
+        }
+
+        return combinations;
+    }
 }

--- a/src/test/java/apoc/coll/CollTest.java
+++ b/src/test/java/apoc/coll/CollTest.java
@@ -603,4 +603,91 @@ public class CollTest {
         testCall(db, "RETURN apoc.coll.flatten([[1,2],[3,4],[4],[5,6,7]]) as value",
                 (row) -> assertEquals(asList(1L,2L,3L,4L,4L,5L,6L,7L), row.get("value")));
     }
+
+    @Test
+    public void testCombinationsWith0() throws Exception {
+        testCall(db, "RETURN apoc.coll.combinations([1,2,3,4,5], 0) as value",
+                (row) -> assertEquals(Collections.emptyList(), row.get("value")));
+    }
+
+    @Test
+    public void testCombinationsWithNegative() throws Exception {
+        testCall(db, "RETURN apoc.coll.combinations([1,2,3,4,5], -1) as value",
+                (row) -> assertEquals(Collections.emptyList(), row.get("value")));
+    }
+
+    @Test
+    public void testCombinationsWithEmptyCollection() throws Exception {
+        testCall(db, "RETURN apoc.coll.combinations([], 0) as value",
+                (row) -> assertEquals(Collections.emptyList(), row.get("value")));
+    }
+
+    @Test
+    public void testCombinationsWithNullCollection() throws Exception {
+        testCall(db, "RETURN apoc.coll.combinations(null, 0) as value",
+                (row) -> assertEquals(Collections.emptyList(), row.get("value")));
+    }
+
+    @Test
+    public void testCombinationsWithTooLargeSelect() throws Exception {
+        testCall(db, "RETURN apoc.coll.combinations([1,2,3,4,5], 6) as value",
+                (row) -> assertEquals(Collections.emptyList(), row.get("value")));
+    }
+
+    @Test
+    public void testCombinationsWithListSizeSelect() throws Exception {
+        testCall(db, "RETURN apoc.coll.combinations([1,2,3,4,5], 5) as value",
+                (row) -> {
+                    List<List<Object>> result = new ArrayList<>();
+                    result.add(asList(1l,2l,3l,4l,5l));
+                    assertEquals(result, row.get("value"));
+                });
+    }
+
+    @Test
+    public void testCombinationsWithSingleSelect() throws Exception {
+        testCall(db, "RETURN apoc.coll.combinations([1,2,3,4,5], 3) as value",
+                (row) -> {
+                    List<List<Object>> result = new ArrayList<>();
+                    result.add(asList(1l,2l,3l));
+                    result.add(asList(1l,2l,4l));
+                    result.add(asList(1l,3l,4l));
+                    result.add(asList(2l,3l,4l));
+                    result.add(asList(1l,2l,5l));
+                    result.add(asList(1l,3l,5l));
+                    result.add(asList(2l,3l,5l));
+                    result.add(asList(1l,4l,5l));
+                    result.add(asList(2l,4l,5l));
+                    result.add(asList(3l,4l,5l));
+                    assertEquals(result, row.get("value"));
+                });
+    }
+
+    @Test
+    public void testCombinationsWithMinSelectGreaterThanMax() throws Exception {
+        testCall(db, "RETURN apoc.coll.combinations([1,2,3,4], 3, 2) as value",
+                (row) -> {
+                    assertEquals(Collections.emptyList(), row.get("value"));
+                });
+    }
+
+    @Test
+    public void testCombinationsWithMinAndMaxSelect() throws Exception {
+        testCall(db, "RETURN apoc.coll.combinations([1,2,3,4], 2, 3) as value",
+                (row) -> {
+                    List<List<Object>> result = new ArrayList<>();
+                    result.add(asList(1l,2l));
+                    result.add(asList(1l,3l));
+                    result.add(asList(2l,3l));
+                    result.add(asList(1l,4l));
+                    result.add(asList(2l,4l));
+                    result.add(asList(3l,4l));
+                    result.add(asList(1l,2l,3l));
+                    result.add(asList(1l,2l,4l));
+                    result.add(asList(1l,3l,4l));
+                    result.add(asList(2l,3l,4l));
+
+                    assertEquals(result, row.get("value"));
+                });
+    }
 }


### PR DESCRIPTION
apoc.coll.combinations was missing in the code of version 3.3 while being in the docs.
Code was added in version 3.2 but only partially merged into 3.3

This code is based on the original from contributor InverseFalcon