### PR TITLE
fixes #765 Missing Iterator Utils in apoc .jar file

### DIFF
--- a/src/main/java/apoc/path/RelationshipSequenceExpander.java
+++ b/src/main/java/apoc/path/RelationshipSequenceExpander.java
@@ -1,14 +1,12 @@
 package apoc.path;
 
-import org.apache.commons.collections.IteratorUtils;
 import org.neo4j.graphdb.*;
-import org.neo4j.graphdb.impl.StandardExpander;
 import org.neo4j.graphdb.traversal.BranchState;
+import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.helpers.collection.NestingIterator;
 import org.neo4j.helpers.collection.Pair;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
@@ -84,7 +82,7 @@ public class RelationshipSequenceExpander implements PathExpander {
             stepRels = relSequences.get((initialRels == null ? depth : depth - 1) % relSequences.size());
         }
 
-        return IteratorUtils.toList(
+        return Iterators.asList(
          new NestingIterator<Relationship, Pair<RelationshipType, Direction>>(
                 stepRels.iterator() )
         {

--- a/src/main/java/apoc/schema/Schemas.java
+++ b/src/main/java/apoc/schema/Schemas.java
@@ -3,7 +3,6 @@ package apoc.schema;
 import apoc.result.AssertSchemaResult;
 import apoc.result.ConstraintRelationshipInfo;
 import apoc.result.IndexConstraintNodeInfo;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -156,10 +155,6 @@ public class Schemas {
 
         db.execute(String.format("CREATE INDEX ON :`%s` (%s)", label, String.join(",", backTickedKeys)));
         return new AssertSchemaResult(label, keys).created();
-    }
-
-    private Boolean compareKeys(List<String> keys1, List<Object> keys2) {
-        return CollectionUtils.isEqualCollection(keys1, keys2);
     }
 
     private Map<String, List<Object>> copyMapOfObjects(Map<String, List<Object>> input) {


### PR DESCRIPTION
Fixes #765. Get rid of usage of commons-collections in apoc. Commons-collections is a transitive dependency in enterprise, but not in community. In order to prevent version glitches it's better to not depend on it at all.