### PR TITLE
Allow passing parameters to `apoc.cypher.runFile`

### DIFF
--- a/src/main/java/apoc/cypher/Cypher.java
+++ b/src/main/java/apoc/cypher/Cypher.java
@@ -64,19 +64,21 @@ public class Cypher {
     }
 
     @Procedure(mode = WRITE)
-    @Description("apoc.cypher.runFile(file or url,[{statistics:true,timeout:10}]) - runs each kernelTransaction in the file, all semicolon separated - currently no schema operations")
+    @Description("apoc.cypher.runFile(file or url,[{statistics:true,timeout:10,parameters:{}}]) - runs each kernelTransaction in the file, all semicolon separated - currently no schema operations")
     public Stream<RowResult> runFile(@Name("file") String fileName, @Name(value = "config",defaultValue = "{}") Map<String,Object> config) {
         return runFiles(singletonList(fileName),config);
     }
 
     @Procedure(mode = WRITE)
-    @Description("apoc.cypher.runFiles([files or urls],[{statistics:true,timeout:10}])) - runs each kernelTransaction in the files, all semicolon separated")
+    @Description("apoc.cypher.runFiles([files or urls],[{statistics:true,timeout:10,parameters:{}}])) - runs each kernelTransaction in the files, all semicolon separated")
     public Stream<RowResult> runFiles(@Name("file") List<String> fileNames, @Name(value = "config",defaultValue = "{}") Map<String,Object> config) {
         boolean addStatistics = Util.toBoolean(config.getOrDefault("statistics",true));
         int timeout = Util.toInteger(config.getOrDefault("timeout",10));
         List<RowResult> result = new ArrayList<>();
+        @SuppressWarnings( "unchecked" )
+        Map<String,Object> parameters = (Map<String,Object>)config.getOrDefault("parameters",Collections.emptyMap());
         for (String f : fileNames) {
-            List<RowResult> rowResults = runManyStatements(readerForFile(f), Collections.emptyMap(), false, addStatistics, timeout).collect(Collectors.toList());
+            List<RowResult> rowResults = runManyStatements(readerForFile(f), parameters, false, addStatistics, timeout).collect(Collectors.toList());
             result.addAll(rowResults);
         }
         return result.stream();

--- a/src/test/java/apoc/cypher/CypherTest.java
+++ b/src/test/java/apoc/cypher/CypherTest.java
@@ -20,6 +20,7 @@ import java.util.*;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
 import static java.util.Collections.singletonMap;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.*;
 
 /**
@@ -238,6 +239,26 @@ public class CypherTest {
                     assertEquals(-1L, row.get("row"));
                     assertEquals(3L, toLong(result.get("nodesDeleted")));
                     assertEquals(false, r.hasNext());
+                });
+    }
+    @Test
+    public void testRunFileWithParameters() throws Exception {
+        testResult(db, "CALL apoc.cypher.runFile('src/test/resources/parameterized.cypher', {statistics:false,parameters:{foo:123,bar:'baz'}})",
+                r -> {
+                    assertTrue("first row",r.hasNext());
+                    Map<String,Object> result = (Map<String,Object>)r.next().get("result");
+                    assertEquals(result.toString(), 1, result.size());
+                    assertThat( result, hasEntry("one", 123L));
+                    assertTrue("second row",r.hasNext());
+                    result = (Map<String,Object>)r.next().get("result");
+                    assertEquals(result.toString(), 1, result.size());
+                    assertThat(result, hasEntry("two", "baz"));
+                    assertTrue("third row",r.hasNext());
+                    result = (Map<String,Object>)r.next().get("result");
+                    assertEquals(result.toString(), 2, result.size());
+                    assertThat(result, hasEntry("foo", 123L));
+                    assertThat(result, hasEntry("bar", "baz"));
+                    assertFalse("fourth row",r.hasNext());
                 });
     }
 

--- a/src/test/resources/parameterized.cypher
+++ b/src/test/resources/parameterized.cypher
@@ -1,0 +1,3 @@
+RETURN $foo AS one;
+RETURN $bar AS two;
+RETURN $foo AS foo, $bar AS bar;


### PR DESCRIPTION
Parameters are passed by adding a `parameters: {...}` entry to the config parameter of the `runFile` procedure.