### PR TITLE
Added temporal subpackage for formatting temporal values

### DIFF
--- a/docs/temporal.adoc
+++ b/docs/temporal.adoc
@@ -1,0 +1,31 @@
+= Temporal Functions
+
+These functions can be used to format temporal values using a valid `DateTimeFormatter` pattern.
+
+
+== Formatting Temporal Types
+
+You can pass through any temporal type (Date, Time, DateTime, LocalTime, LocalDateTime, Duration) along with a pattern.
+Please note that if the pattern is invalid for the value that you pass in (for example `HH` for hours on a Date value or `DD` for day on a Time value),
+an Exception will be thrown.
+
+[source,cypher]
+----
+apoc.temporal.format( date(), 'YYYY-MM-dd')
+apoc.temporal.format( datetime(), 'YYYY-MM-dd HH:mm:ss.SSSSZ')
+apoc.temporal.format( localtime(), 'HH:mm:ss.SSSS')
+apoc.temporal.format( localtime(), 'HH:mm:ss.SSSS')
+----
+
+https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html[View full pattern listing]
+
+
+== Formatting Durations
+
+When attempting to format a duration, the procedure will attempt to create a date (01/01/0000) and add the duration.  This allows you to provide a consistent format as above.
+
+
+[source,cypher]
+----
+apoc.temporal.format( duration.between( datetime.transaction(), datetime.realtime() ) , 'HH:mm:ss.SSSS')
+----

--- a/src/main/java/apoc/temporal/TemporalProcedures.java
+++ b/src/main/java/apoc/temporal/TemporalProcedures.java
@@ -1,0 +1,77 @@
+package apoc.temporal;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.UserFunction;
+import org.neo4j.values.storable.DurationValue;
+
+public class TemporalProcedures
+{
+
+    /**
+     * Format a temporal value to a String
+     *
+     * @param input     Any temporal type
+     * @param format    A valid DateTime format pattern (ie yyyy-MM-dd'T'HH:mm:ss.SSSS)
+     * @return
+     */
+    @UserFunction( "apoc.temporal.format" )
+    @Description( "apoc.temporal.format(input, format) | Format a temporal value" )
+    public String format(
+            @Name( "temporal" ) Object input,
+            @Name( value = "format", defaultValue = "yyyy-MM-dd") String format
+    ) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
+
+        if ( input instanceof LocalDate ) {
+            return ((LocalDate) input).format(formatter);
+        }
+        else if ( input instanceof ZonedDateTime ) {
+            return ((ZonedDateTime) input).format(formatter);
+        }
+        else if ( input instanceof LocalDateTime ) {
+            return ((LocalDateTime) input).format(formatter);
+        }
+        else if ( input instanceof LocalTime ) {
+            return ((LocalTime) input).format(formatter);
+        }
+        else if ( input instanceof OffsetTime ) {
+            return ((OffsetTime) input).format(formatter);
+        }
+        else if ( input instanceof DurationValue ) {
+            return formatDuration( input, format);
+        }
+
+        return input.toString();
+    }
+
+    /**
+     * Convert a Duration into a LocalTime and format the value as a String
+     *
+     * @param input
+     * @param format
+     * @return
+     */
+    @UserFunction( "apoc.temporal.formatDuration" )
+    @Description( "apoc.temporal.formatDuration(input, format) | Format a Duration" )
+    public String formatDuration(
+            @Name("input") Object input,
+            @Name("format") String format
+    ) {
+        LocalDateTime midnight = LocalDateTime.of(0, 1, 1, 0, 0, 0, 0);
+        LocalDateTime newDuration = midnight.plus( (DurationValue) input );
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format);
+
+        return newDuration.format(formatter);
+    }
+
+
+}

--- a/src/test/java/apoc/temporal/TemporalProceduresTest.java
+++ b/src/test/java/apoc/temporal/TemporalProceduresTest.java
@@ -1,0 +1,100 @@
+package apoc.temporal;
+
+import apoc.util.TestUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import java.util.Map;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.harness.junit.Neo4jRule;
+
+import static org.junit.Assert.assertEquals;
+
+public class TemporalProceduresTest
+{
+
+
+    private static GraphDatabaseService db;
+
+    @BeforeClass public static void setUp() throws Exception {
+        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        TestUtil.registerProcedure(db, TemporalProcedures.class);
+    }
+
+    @AfterClass public static void tearDown() {
+        db.shutdown();
+    }
+
+
+    @Test
+    public void shouldFormatDate() throws Throwable
+    {
+        try (Transaction tx = db.beginTx() ) {
+            Result res = db.execute("RETURN apoc.temporal.format( date( { year: 2018, month: 12, day: 10 } ), \"yyyy-MM-dd\" ) as output");
+
+            assertEquals( res.next().get("output"), "2018-12-10" );
+        }
+    }
+
+
+    @Test
+    public void shouldFormatDateTime() throws Throwable
+    {
+        try (Transaction tx = db.beginTx() ) {
+            Result res = db.execute("RETURN apoc.temporal.format( datetime( { year: 2018, month: 12, day: 10, hour: 12, minute: 34, second: 56, nanosecond: 123456789 } ), \"yyyy-MM-dd'T'HH:mm:ss.SSSS\" ) as output");
+
+            assertEquals( res.next().get("output"), "2018-12-10T12:34:56.1234" );
+        }
+    }
+
+    @Test
+    public void shouldFormatLocalDateTime() throws Throwable
+    {
+        try (Transaction tx = db.beginTx() ) {
+            Result res = db.execute("RETURN apoc.temporal.format( localdatetime( { year: 2018, month: 12, day: 10, hour: 12, minute: 34, second: 56, nanosecond: 123456789 } ), \"yyyy-MM-dd'T'HH:mm:ss.SSSS\" ) as output");
+
+            assertEquals( res.next().get("output"), "2018-12-10T12:34:56.1234" );
+        }
+    }
+
+    @Test
+    public void shouldFormatTime() throws Throwable
+    {
+        try (Transaction tx = db.beginTx() ) {
+            Result res = db.execute("RETURN apoc.temporal.format( time( { hour: 12, minute: 34, second: 56, nanosecond: 123456789, timezone: 'Europe/London' } ), \"HH:mm:ss.SSSSZ\" ) as output");
+
+            assertEquals( res.next().get("output"), "12:34:56.1234+0100" );
+        }
+    }
+
+    @Test
+    public void shouldFormatLocalTime() throws Throwable
+    {
+        try (Transaction tx = db.beginTx() ) {
+            Result res = db.execute("RETURN apoc.temporal.format( localtime( { hour: 12, minute: 34, second: 56, nanosecond: 123456789 } ), \"HH:mm:ss.SSSS\" ) as output");
+
+            assertEquals( res.next().get("output"), "12:34:56.1234" );
+        }
+    }
+
+
+    @Test
+    public void shouldFormatDuration() throws Throwable
+    {
+        try (Transaction tx = db.beginTx() ) {
+            Result res = db.execute("RETURN apoc.temporal.format( duration('P0M0DT4820.487660000S'), \"HH:mm:ss.SSSS\" ) as output");
+
+            assertEquals( res.next().get("output"), "01:20:20.4876" );
+        }
+    }
+
+
+
+
+}


### PR DESCRIPTION
These functions can be used to format temporal values using a valid `DateTimeFormatter` pattern.

```
apoc.temporal.format( date(), 'YYYY-MM-dd')
apoc.temporal.format( datetime(), 'YYYY-MM-dd HH:mm:ss.SSSSZ')
apoc.temporal.format( localtime(), 'HH:mm:ss.SSSS')
apoc.temporal.format( localtime(), 'HH:mm:ss.SSSS')
apoc.temporal.format( duration.between( datetime.transaction(), datetime.realtime() ) , 'HH:mm:ss.SSSS')
```