### PR TITLE
Read headers from config object

### DIFF
--- a/docs/loadxml.adoc
+++ b/docs/loadxml.adoc
@@ -95,6 +95,21 @@ RETURN key, apoc.meta.type(value[key]);
 ----
 image::{img}/apoc.load.xmlSimple.ex2.png[width=800]
 
+
+
+=== HTTP Headers
+
+You can provide a map of HTTP headers to the config property.
+
+[source,cypher]
+----
+WITH { `X-API-KEY`: 'abc123' } as headers,
+WITH "https://myapi.com/api/v1/" AS url
+CALL apoc.load.xml(url, '', { headers: headers }) YIELD value
+UNWIND keys(value) AS key
+RETURN key, apoc.meta.type(value[key]);
+----
+
 == xPath
 
 It's possible to define a xPath (optional) to selecting nodes from the XML document.

--- a/src/main/java/apoc/load/Xml.java
+++ b/src/main/java/apoc/load/Xml.java
@@ -68,7 +68,10 @@ public class Xml {
             DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 
             FileUtils.checkReadAllowed(url);
-            Document doc = documentBuilder.parse(Util.openInputStream(url, Collections.emptyMap(), null));
+
+            Map<String, Object> headers = (HashMap) config.getOrDefault( "headers", Collections.emptyMap() );
+
+            Document doc = documentBuilder.parse(Util.openInputStream(url, headers, null));
             XPathFactory xPathFactory = XPathFactory.newInstance();
 
             XPath xPath = xPathFactory.newXPath();


### PR DESCRIPTION
Gives the ability to provide a map of HTTP headers on the config property for HTTP requests.

```
WITH { `X-API-KEY`: 'abc123' } as headers,
WITH "https://myapi.com/api/v1/" AS url
CALL apoc.load.xml(url, '', { headers: headers }) YIELD value
UNWIND keys(value) AS key
RETURN key, apoc.meta.type(value[key]);
```