### PR TITLE
fixes #510 - add index selectivity to apoc.meta.data apoc.meta.schema  and the apoc.index procedures

### DIFF
--- a/src/main/java/apoc/result/IndexConstraintNodeInfo.java
+++ b/src/main/java/apoc/result/IndexConstraintNodeInfo.java
@@ -17,6 +17,16 @@ public class IndexConstraintNodeInfo {
 
     public final String type;
 
+    public final String failure;
+
+    public final double populationProgress;
+
+    public final long size;
+
+    public final double valuesSelectivity;
+
+    public final String userDescription;
+
     /**
      * Default constructor
      *
@@ -25,12 +35,21 @@ public class IndexConstraintNodeInfo {
      * @param properties
      * @param status status of the index, if it's a constraint it will be empty
      * @param type if it is an index type will be "INDEX" otherwise it will be the type of constraint
+     * @param failure
+     * @param populationProgress
+     * @param size
+     * @param userDescription
      */
-    public IndexConstraintNodeInfo(String name, String label, List<String> properties, String status, String type) {
+    public IndexConstraintNodeInfo(String name, String label, List<String> properties, String status, String type, String failure, float populationProgress, long size, double valuesSelectivity, String userDescription) {
         this.name = name;
         this.label = label;
         this.properties = properties;
         this.status = status;
         this.type = type;
+        this.failure = failure;
+        this.populationProgress = populationProgress;
+        this.size = size;
+        this.valuesSelectivity = valuesSelectivity;
+        this.userDescription = userDescription;
     }
 }

--- a/src/test/java/apoc/schema/SchemasTest.java
+++ b/src/test/java/apoc/schema/SchemasTest.java
@@ -265,6 +265,10 @@ public class SchemasTest {
             assertEquals("Foo", r.get("label"));
             assertEquals("INDEX", r.get("type"));
             assertEquals("bar", ((List<String>) r.get("properties")).get(0));
+            assertEquals("NO FAILURE", r.get("failure"));
+            assertEquals(new Double(100), r.get("populationProgress"));
+            assertEquals(new Double(1), r.get("valuesSelectivity"));
+            assertEquals("Index( GENERAL, bar )", r.get("userDescription"));
 
             assertTrue(!result.hasNext());
         });
@@ -318,7 +322,7 @@ public class SchemasTest {
         testResult(db, "CALL apoc.schema.nodes()", (result) -> {
             Map<String, Object> r = result.next();
 
-            assertEquals("CONSTRAINT ON (bar:Bar) ASSERT bar.foo IS UNIQUE", r.get("name"));
+            assertEquals(":Bar(foo)", r.get("name"));
             assertEquals("Bar", r.get("label"));
             assertEquals("UNIQUENESS", r.get("type"));
             assertEquals("foo", ((List<String>) r.get("properties")).get(0));
@@ -334,15 +338,15 @@ public class SchemasTest {
         testResult(db, "CALL apoc.schema.nodes()", (result) -> {
             Map<String, Object> r = result.next();
 
+            assertEquals("Bar", r.get("label"));
+            assertEquals("UNIQUENESS", r.get("type"));
+            assertEquals("bar", ((List<String>) r.get("properties")).get(0));
+
+            r = result.next();
             assertEquals("Foo", r.get("label"));
             assertEquals("INDEX", r.get("type"));
             assertEquals("foo", ((List<String>) r.get("properties")).get(0));
             assertEquals("ONLINE", r.get("status"));
-
-            r = result.next();
-            assertEquals("Bar", r.get("label"));
-            assertEquals("UNIQUENESS", r.get("type"));
-            assertEquals("bar", ((List<String>) r.get("properties")).get(0));
 
             assertTrue(!result.hasNext());
         });


### PR DESCRIPTION
@jexp this is the new response. Constraints are reported by the attribute *type* with value *UNIQUENESS*

<img width="1316" alt="schermata 2018-06-27 alle 12 48 19" src="https://user-images.githubusercontent.com/14560890/41985913-ec12c0b6-7a34-11e8-85b8-a56829a35f0a.png">