### PR TITLE
Fixes #852 - Added optional 4th parameter to procedure 'apoc.periodic.repeat'. (Branch 3.3)

### DIFF
--- a/src/main/java/apoc/periodic/Periodic.java
+++ b/src/main/java/apoc/periodic/Periodic.java
@@ -159,9 +159,10 @@ public class Periodic {
     }
 
     @Procedure(mode = Mode.WRITE)
-    @Description("apoc.periodic.repeat('name',statement,repeat-rate-in-seconds) submit a repeatedly-called background statement")
-    public Stream<JobInfo> repeat(@Name("name") String name, @Name("statement") String statement, @Name("rate") long rate) {
-        JobInfo info = schedule(name, () -> Iterators.count(db.execute(statement)),0,rate);
+    @Description("apoc.periodic.repeat('name',statement,repeat-rate-in-seconds, config) submit a repeatedly-called background statement. Fourth parameter 'config' is optional.")
+    public Stream<JobInfo> repeat(@Name("name") String name, @Name("statement") String statement, @Name("rate") long rate, @Name(value = "config", defaultValue = "{}") Map<String,Object> config ) {
+        Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());
+        JobInfo info = schedule(name, () -> Iterators.count(db.execute(statement, params)),0,rate);
         return Stream.of(info);
     }
 

--- a/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/src/test/java/apoc/periodic/PeriodicTest.java
@@ -348,6 +348,21 @@ public class PeriodicTest {
         });
     }
 
+    @Test
+    public void testRepeatParams() {
+        db.execute(
+                "CALL apoc.periodic.repeat('repeat-params', 'MERGE (person:Person {name: {nameValue}})', 2, {params: {nameValue: 'John Doe'}} ) YIELD name RETURN name" );
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+
+        }
+
+        testCall(db,
+                "MATCH (p:Person {name: 'John Doe'}) RETURN p.name AS name",
+                row -> assertEquals( row.get( "name" ), "John Doe" )
+        );
+    }
 
     private long tryReadCount(int maxAttempts, String statement, long expected) throws InterruptedException {
         int attempts = 0;


### PR DESCRIPTION
Added optional 4th parameter to procedure 'apoc.periodic.repeat' that allows for configuration to be passed in.
   
Added test for apoc.periodic.repeat that makes sure parameters passed in work as expected. Named testRepeatParams(). This PR is for branch 3.3