### PR TITLE
Fixes #845 - Message fix for Triggers when 'apoc.trigger.enabled=true' is not set in neo4j.conf 

### DIFF
--- a/src/main/java/apoc/trigger/Trigger.java
+++ b/src/main/java/apoc/trigger/Trigger.java
@@ -181,6 +181,10 @@ public class Trigger {
         }
 
         private synchronized static Map<String, Object> updateTriggers(String name, Map<String, Object> value) {
+            if (properties == null ) {
+                throw new RuntimeException("Triggers have not been enabled." +
+                        " Set 'apoc.trigger.enabled=true' in your neo4j.conf file located in the $NEO4J_HOME/conf/ directory.");
+            }
             try (Transaction tx = properties.getGraphDatabase().beginTx()) {
                 triggers.clear();
                 String triggerProperty = (String) properties.getProperty(APOC_TRIGGER, "{}");

--- a/src/test/java/apoc/trigger/TriggerDisabledTest.java
+++ b/src/test/java/apoc/trigger/TriggerDisabledTest.java
@@ -1,0 +1,189 @@
+package apoc.trigger;
+
+import apoc.util.TestUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author alexiudice
+ * @since 14.07.18
+ *
+ * Tests for fix of #845.
+ *
+ * Testing disabled triggers needs to be a different test file from 'TriggerTest.java' since
+ *  Trigger classes and methods are static and 'TriggerTest.java' instantiates a class that enables triggers.
+ *
+ */
+public class TriggerDisabledTest
+{
+    private GraphDatabaseService db;
+    private long start;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        db = new TestGraphDatabaseFactory()
+                .newImpermanentDatabaseBuilder()
+                .setConfig( "apoc.trigger.enabled", "false" )
+                .newGraphDatabase();
+        start = System.currentTimeMillis();
+        TestUtil.registerProcedure( db, Trigger.class );
+    }
+
+    @After
+    public void tearDown()
+    {
+        if ( db != null )
+        {
+            db.shutdown();
+        }
+    }
+
+    @Test
+    public void testTriggerDisabledList() throws Exception
+    {
+        try
+        {
+            db.execute( "CALL apoc.trigger.list() YIELD name RETURN name" ).close();
+            // If no error is thrown, then the test fails.
+            assertTrue( false );
+        }
+        // Catches NullPointerExceptions since they are a subclass of a RuntimeException
+        //  and they were the original error thrown (see #845). We do not expected one, so
+        //  it causes test failure.
+        catch ( NullPointerException e )
+        {
+            assertTrue( false );
+        }
+        // We expect a RuntimeException to be thrown.
+        catch ( RuntimeException e )
+        {
+        }
+        // Any other exception causes the test to fail.
+        catch ( Exception e )
+        {
+            assertTrue( false );
+        }
+    }
+
+    @Test
+    public void testTriggerDisabledAdd() throws Exception
+    {
+        try
+        {
+            db.execute( "CALL apoc.trigger.add('test-trigger', 'RETURN 1', {phase: 'before'}) YIELD name RETURN name" ).close();
+            // If no error is thrown, then the test fails.
+            assertTrue( false );
+        }
+        // Catches NullPointerExceptions since they are a subclass of a RuntimeException
+        //  and they were the original error thrown (see #845). We do not expected one, so
+        //  it causes test failure.
+        catch ( NullPointerException e )
+        {
+            assertTrue( false );
+        }
+        // We expect a RuntimeException to be thrown.
+        catch ( RuntimeException e )
+        {
+
+        }
+        // Any other exception causes the test to fail.
+        catch ( Exception e )
+        {
+            assertTrue( false );
+        }
+    }
+
+    @Test
+    public void testTriggerDisabledRemove() throws Exception
+    {
+
+        try
+        {
+            db.execute( "CALL apoc.trigger.REMOVE('test-trigger')" ).close();
+            // If no error is thrown, then the test fails.
+            assertTrue( false );
+        }
+        // Catches NullPointerExceptions since they are a subclass of a RuntimeException
+        //  and they were the original error thrown (see #845). We do not expected one, so
+        //  it causes test failure.
+        catch ( NullPointerException e )
+        {
+            assertTrue( false );
+        }
+        // We expect a RuntimeException to be thrown.
+        catch ( RuntimeException e )
+        {
+
+        }
+        // Any other exception causes the test to fail.
+        catch ( Exception e )
+        {
+            assertTrue( false );
+        }
+    }
+
+    @Test
+    public void testTriggerDisabledResume() throws Exception
+    {
+
+        try
+        {
+            db.execute( "CALL apoc.trigger.resume('test-trigger')" ).close();
+            // If no error is thrown, then the test fails.
+            assertTrue( false );
+        }
+        // Catches NullPointerExceptions since they are a subclass of a RuntimeException
+        //  and they were the original error thrown (see #845). We do not expected one, so
+        //  it causes test failure.
+        catch ( NullPointerException e )
+        {
+            assertTrue( false );
+        }
+        // We expect a RuntimeException to be thrown.
+        catch ( RuntimeException e )
+        {
+
+        }
+        // Any other exception causes the test to fail.
+        catch ( Exception e )
+        {
+            assertTrue( false );
+        }
+    }
+
+    @Test
+    public void testTriggerDisabledPause() throws Exception
+    {
+
+        try
+        {
+            db.execute( "CALL apoc.trigger.pause('test-trigger')" ).close();
+            // If no error is thrown, then the test fails.
+            assertTrue( false );
+        }
+        // Catches NullPointerExceptions since they are a subclass of a RuntimeException
+        //  and they were the original error thrown (see #845). We do not expected one, so
+        //  it causes test failure.
+        catch ( NullPointerException e )
+        {
+            assertTrue( false );
+        }
+        // We expect a RuntimeException to be thrown.
+        catch ( RuntimeException e )
+        {
+
+        }
+        // Any other exception causes the test to fail.
+        catch ( Exception e )
+        {
+            assertTrue( false );
+        }
+    }
+}


### PR DESCRIPTION
Added runtime exception if an `apoc.trigger.*` procedure is called but `apoc.trigger.enabled=true` has not been set in the neo4j.conf file.

This PR includes a separate test file 'TriggerDisabledTest.java' for fix of #845. Testing the disabled triggers needs to be in a different test file from 'TriggerTest.java' since trigger classes and methods are static and 'TriggerTest.java' instantiates a class that enables triggers.

**Technicals:**
This works due to the `start()` method located in the static LifeCycle class in 'Trigger.java'. If `apoc.trigger.enabled=true` is set in the neo4j.conf then the `properties` data member will be set from line 321 `triggerHandler = new Trigger.TriggerHandler(db,log);`. If `apoc.trigger.enabled=false` or it is not set in the neo4j.conf then line 321 will never be executed and thus, `properties` will be `null`.