### PR TITLE
Issue 234 - Support reverse geocoding in apoc.spatial

### DIFF
--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -676,7 +676,7 @@ TODO:
 [cols="1m,5"]
 |===
 | CALL apoc.spatial.geocode('address') YIELD location, latitude, longitude, description, osmData | look up geographic location of location from openstreetmap geocoding service
-| CALL apoc.spatial.inverseGeocode(latitude,longitude) YIELD location, latitude, longitude, description | look up address from latitude and longitude  from openstreetmap geocoding service
+| CALL apoc.spatial.reverseGeocode(latitude,longitude) YIELD location, latitude, longitude, description | look up address from latitude and longitude  from openstreetmap geocoding service
 | CALL apoc.spatial.sortPathsByDistance(Collection<Path>) YIELD path, distance | sort a given collection of paths by geographic distance based on lat/long properties on the path nodes
 |===
 

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -676,6 +676,7 @@ TODO:
 [cols="1m,5"]
 |===
 | CALL apoc.spatial.geocode('address') YIELD location, latitude, longitude, description, osmData | look up geographic location of location from openstreetmap geocoding service
+| CALL apoc.spatial.inverseGeocode(latitude,longitude) YIELD location, latitude, longitude, description | look up address from latitude and longitude  from openstreetmap geocoding service
 | CALL apoc.spatial.sortPathsByDistance(Collection<Path>) YIELD path, distance | sort a given collection of paths by geographic distance based on lat/long properties on the path nodes
 |===
 

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -675,8 +675,8 @@ TODO:
 
 [cols="1m,5"]
 |===
-| CALL apoc.spatial.geocode('address') YIELD location, latitude, longitude, description, osmData | look up geographic location of location from openstreetmap geocoding service
-| CALL apoc.spatial.reverseGeocode(latitude,longitude) YIELD location, latitude, longitude, description | look up address from latitude and longitude  from openstreetmap geocoding service
+| CALL apoc.spatial.geocode('address') YIELD location, latitude, longitude, description, osmData | look up geographic location of location from a geocoding service (the default one is OpenStreetMap)
+| CALL apoc.spatial.reverseGeocode(latitude,longitude) YIELD location, latitude, longitude, description | look up address from latitude and longitude from a geocoding service (the default one is OpenStreetMap)
 | CALL apoc.spatial.sortPathsByDistance(Collection<Path>) YIELD path, distance | sort a given collection of paths by geographic distance based on lat/long properties on the path nodes
 |===
 

--- a/docs/spatial.adoc
+++ b/docs/spatial.adoc
@@ -2,7 +2,7 @@
 
 The spatial procedures are intended to enable geographic capabilities on your data.
 
-== geocode
+== Geocode
 
 The first procedure _geocode_ which will convert a textual address
 into a location containing _latitude_, _longitude_ and _description_. Despite being
@@ -19,18 +19,18 @@ RETURN location.latitude, location.longitude // will return 47.2221667, -1.55666
 
 There are three forms of the procedure:
 
-* geocodeOnce(address) returns zero or one result
-* geocode(address,maxResults) returns zero, one or more up to maxResults
-* inverseGeocode(latitude,longitude,maxResults) returns zero, one or more up to maxResults
+* geocodeOnce(address) returns zero or one result.
+* geocode(address,maxResults) returns zero, one or more up to maxResults.
+* reverseGeocode(latitude,longitude) returns zero or one result.
 
 This is because the backing geocoding service (OSM, Google, OpenCage or other) might return multiple
 results for the same query. GeocodeOnce() is designed to return the first, or highest
 ranking result.
 
-The third procedure _inverseGeocode_ will convert a location containing _latitude_ and _longitude_
+The third procedure _reverseGeocode_ will convert a location containing _latitude_ and _longitude_
 into a textual address.
 ----
-CALL apoc.spatial.inverseGeocode(47.2221667,-1.5566625) YIELD location
+CALL apoc.spatial.reverseGeocode(47.2221667,-1.5566625) YIELD location
 RETURN location.description; // will return 21, Rue Paul Bellamy, Talensac - Pont Morand,
 //Hauts-Pavés - Saint-Félix, Nantes, Loire-Atlantique, Pays de la Loire,
 //France métropolitaine, 44000, France
@@ -53,10 +53,17 @@ https://developers.google.com/maps/documentation/geocoding/get-api-key#key
 
 == Configuring Custom Geocode Provider
 
+*Geocode*
+
 For any provider that is not 'osm' or 'google' you get a configurable supplier that requires two
 additional settings, 'url' and 'key'. The 'url' must contain the two words 'PLACE' and 'KEY'.
 The 'KEY' will be replaced with the key you get from the provider when you register for the service.
 The 'PLACE' will be replaced with the address to geocode when the procedure is called.
+
+*Reverse Geocode*
+
+The 'url' must contain the three words 'LAT', 'LNG' and 'KEY'.
+The 'LAT' will be replaced with the latitude and 'LNG' will be replaced with the the longitude to reverse geocode when the procedure is called.
 
 For example, to get the service working with OpenCage, perform the following steps:
 
@@ -67,11 +74,14 @@ For example, to get the service working with OpenCage, perform the following ste
 apoc.spatial.geocode.provider=opencage
 apoc.spatial.geocode.opencage.key=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 apoc.spatial.geocode.opencage.url=http://api.opencagedata.com/geocode/v1/json?q=PLACE&key=KEY
+apoc.spatial.geocode.opencage.reverse.url=http://api.opencagedata.com/geocode/v1/json?q=LAT+LNG&key=KEY
 ----
 
 * make sure that the 'XXXXXXX' part above is replaced with your actual key
 * Restart the Neo4j server and then test the geocode procedures to see that they work
 * If you are unsure if the provider is correctly configured try verify with:
+
+
 
 [source,cypher]
 ----

--- a/docs/spatial.adoc
+++ b/docs/spatial.adoc
@@ -17,14 +17,24 @@ CALL apoc.spatial.geocodeOnce('21 rue Paul Bellamy 44000 NANTES FRANCE') YIELD l
 RETURN location.latitude, location.longitude // will return 47.2221667, -1.5566624
 ----
 
-There are two forms of the procedure:
+There are three forms of the procedure:
 
 * geocodeOnce(address) returns zero or one result
 * geocode(address,maxResults) returns zero, one or more up to maxResults
+* inverseGeocode(latitude,longitude,maxResults) returns zero, one or more up to maxResults
 
 This is because the backing geocoding service (OSM, Google, OpenCage or other) might return multiple
 results for the same query. GeocodeOnce() is designed to return the first, or highest
 ranking result.
+
+The third procedure _inverseGeocode_ will convert a location containing _latitude_ and _longitude_
+into a textual address.
+----
+CALL apoc.spatial.inverseGeocode(47.2221667,-1.5566625) YIELD location
+RETURN location.description; // will return 21, Rue Paul Bellamy, Talensac - Pont Morand,
+//Hauts-Pavés - Saint-Félix, Nantes, Loire-Atlantique, Pays de la Loire,
+//France métropolitaine, 44000, France
+----
 
 == Configuring Geocode
 
@@ -187,4 +197,3 @@ RETURN e.name AS event, e.datetime AS date,
 location.description AS description, distance
 ORDER BY distance
 ----
-

--- a/src/main/java/apoc/spatial/Geocode.java
+++ b/src/main/java/apoc/spatial/Geocode.java
@@ -108,9 +108,12 @@ public class Geocode {
         }
 
         @SuppressWarnings("unchecked")
-        public Stream<GeoCodeResult> geocode(String params, long maxResults) {
+        public Stream<GeoCodeResult> geocode(String address, long maxResults) {
+            if (address.isEmpty()) {
+                return Stream.empty();
+            }
             throttler.waitForThrottle();
-            String url = urlTemplate.replace("PLACE", Util.encodeUrlComponent(params));
+            String url = urlTemplate.replace("PLACE", Util.encodeUrlComponent(address));
             Object value = JsonUtil.loadJson(url).findFirst().orElse(null);
             if (value instanceof List) {
                 return findResults((List<Map<String, Object>>) value, maxResults);
@@ -125,6 +128,9 @@ public class Geocode {
 
         @Override
         public Stream<GeoCodeResult> reverseGeocode(Double latitude, Double longitude) {
+            if (latitude == null || longitude == null) {
+                return Stream.empty();
+            }
             throttler.waitForThrottle();
             String url = urlTemplateReverse.replace("LAT", latitude.toString()).replace("LNG", longitude.toString());
             Object value = JsonUtil.loadJson(url).findFirst().orElse(null);
@@ -182,6 +188,9 @@ public class Geocode {
 
         @SuppressWarnings("unchecked")
         public Stream<GeoCodeResult> geocode(String address, long maxResults) {
+            if (address.isEmpty()) {
+                return Stream.empty();
+            }
             throttler.waitForThrottle();
             Object value = JsonUtil.loadJson(OSM_URL_GEOCODE + Util.encodeUrlComponent(address)).findFirst().orElse(null);
             if (value instanceof List) {
@@ -233,12 +242,12 @@ public class Geocode {
         }
 
         @SuppressWarnings("unchecked")
-        public Stream<GeoCodeResult> geocode(String params, long maxResults) {
-            if (params.length() < 1) {
+        public Stream<GeoCodeResult> geocode(String address, long maxResults) {
+            if (address.isEmpty()) {
                 return Stream.empty();
             }
             throttler.waitForThrottle();
-            Object value = JsonUtil.loadJson(String.format(GEOCODE_URL, credentials(this.configMap)) + Util.encodeUrlComponent(params)).findFirst().orElse(null);
+            Object value = JsonUtil.loadJson(String.format(GEOCODE_URL, credentials(this.configMap)) + Util.encodeUrlComponent(address)).findFirst().orElse(null);
             if (value instanceof Map) {
                 Map map = (Map) value;
                 if (map.get("status").equals("OVER_QUERY_LIMIT")) throw new IllegalStateException("QUOTA_EXCEEDED from geocode API: "+map.get("status")+" message: "+map.get("error_message"));

--- a/src/test/java/apoc/spatial/GeocodeTest.java
+++ b/src/test/java/apoc/spatial/GeocodeTest.java
@@ -61,6 +61,10 @@ public class GeocodeTest {
 
     @Test
     public void testGeocodeOpenCage() throws Exception {
+        // If the key is not defined the test won't fail
+        String provider = ApocConfiguration.get(Geocode.PREFIX).get(Geocode.GEOCODE_PROVIDER_KEY).toString().toLowerCase();
+        Assume.assumeTrue(!"<YOUR_API_KEY>".equals(ApocConfiguration.get(Geocode.PREFIX).get(provider + ".key").toString()));
+
         // We use testGeocode() instead of testGeocodeWithThrottling() because the slow test takes less time than the fast one
         // The overall execution is strictly tight to the remote service according to quota and request policies
         testGeocode("openCage",1000, false);
@@ -68,6 +72,10 @@ public class GeocodeTest {
 
     @Test
     public void testReverseGeocodeOpenCage() throws Exception {
+        // If the key is not defined the test won't fail
+        String provider = ApocConfiguration.get(Geocode.PREFIX).get(Geocode.GEOCODE_PROVIDER_KEY).toString().toLowerCase();
+        Assume.assumeTrue(!"<YOUR_API_KEY>".equals(ApocConfiguration.get(Geocode.PREFIX).get(provider + ".key").toString()));
+
         testGeocode("openCage",1000, true);
     }
 

--- a/src/test/java/apoc/spatial/SpatialTest.java
+++ b/src/test/java/apoc/spatial/SpatialTest.java
@@ -36,6 +36,7 @@ public class SpatialTest {
 
     public static class MockGeocode {
         public static Map<String, Map> geocodeResults = null;
+        public static Map<String, Map> inverseGeocodeResults = null;
 
         public MockGeocode() {
         }
@@ -54,6 +55,17 @@ public class SpatialTest {
                 return Stream.empty();
             }
         }
+
+        @Procedure("apoc.spatial.inverseGeocode")
+        public Stream<Geocode.GeoCodeResult> inverseGeocode(@Name("latitude") double latitude, @Name("longitude") double longitude, @Name(value = "maxResults",defaultValue = "100") long maxResults) {
+            String key = latitude+","+longitude;
+            if (inverseGeocodeResults != null && inverseGeocodeResults.containsKey(key)) {
+                Map data = inverseGeocodeResults.get(key);
+                return Stream.of(new Geocode.GeoCodeResult(latitude, longitude, String.valueOf(data.get("display_name")), data));
+            } else {
+                return Stream.empty();
+            }
+        }
     }
 
     @Before
@@ -67,6 +79,7 @@ public class SpatialTest {
             addEventData((Map) event);
         }
         MockGeocode.geocodeResults = (Map<String, Map>) tests.get("geocode");
+        MockGeocode.inverseGeocodeResults = (Map<String, Map>) tests.get("inverseGeocode");
     }
 
     private void addEventData(Map<String, Object> event) {
@@ -163,5 +176,15 @@ public class SpatialTest {
             }
             assertFalse("Expected " + expectedCount + " results, but there are more ", res.hasNext());
         });
+    }
+
+    @Test
+    public void testSimpleInverseGeocode() {
+        String query = "MATCH (a:Event) \n" +
+                "WHERE exists(a.lat) AND exists(a.lon) AND exists(a.name) \n" +
+                "CALL apoc.spatial.inverseGeocode(a.lat, a.lon) YIELD latitude, longitude\n" +
+                "RETURN a.name, latitude, \n" +
+                "longitude, a.description";
+        testCallCount(db, query, null, eventNodes.size());
     }
 }

--- a/src/test/java/apoc/spatial/SpatialTest.java
+++ b/src/test/java/apoc/spatial/SpatialTest.java
@@ -36,7 +36,7 @@ public class SpatialTest {
 
     public static class MockGeocode {
         public static Map<String, Map> geocodeResults = null;
-        public static Map<String, Map> inverseGeocodeResults = null;
+        public static Map<String, Map> reverseGeocodeResults = null;
 
         public MockGeocode() {
         }
@@ -56,11 +56,11 @@ public class SpatialTest {
             }
         }
 
-        @Procedure("apoc.spatial.inverseGeocode")
-        public Stream<Geocode.GeoCodeResult> inverseGeocode(@Name("latitude") double latitude, @Name("longitude") double longitude, @Name(value = "maxResults",defaultValue = "100") long maxResults) {
+        @Procedure("apoc.spatial.reverseGeocode")
+        public Stream<Geocode.GeoCodeResult> reverseGeocode(@Name("latitude") double latitude, @Name("longitude") double longitude, @Name(value = "maxResults",defaultValue = "100") long maxResults) {
             String key = latitude+","+longitude;
-            if (inverseGeocodeResults != null && inverseGeocodeResults.containsKey(key)) {
-                Map data = inverseGeocodeResults.get(key);
+            if (reverseGeocodeResults != null && reverseGeocodeResults.containsKey(key)) {
+                Map data = reverseGeocodeResults.get(key);
                 return Stream.of(new Geocode.GeoCodeResult(latitude, longitude, String.valueOf(data.get("display_name")), data));
             } else {
                 return Stream.empty();
@@ -79,7 +79,7 @@ public class SpatialTest {
             addEventData((Map) event);
         }
         MockGeocode.geocodeResults = (Map<String, Map>) tests.get("geocode");
-        MockGeocode.inverseGeocodeResults = (Map<String, Map>) tests.get("inverseGeocode");
+        MockGeocode.reverseGeocodeResults = (Map<String, Map>) tests.get("reverseGeocode");
     }
 
     private void addEventData(Map<String, Object> event) {
@@ -179,10 +179,10 @@ public class SpatialTest {
     }
 
     @Test
-    public void testSimpleInverseGeocode() {
+    public void testSimpleReverseGeocode() {
         String query = "MATCH (a:Event) \n" +
                 "WHERE exists(a.lat) AND exists(a.lon) AND exists(a.name) \n" +
-                "CALL apoc.spatial.inverseGeocode(a.lat, a.lon) YIELD latitude, longitude\n" +
+                "CALL apoc.spatial.reverseGeocode(a.lat, a.lon) YIELD latitude, longitude\n" +
                 "RETURN a.name, latitude, \n" +
                 "longitude, a.description";
         testCallCount(db, query, null, eventNodes.size());

--- a/src/test/resources/geoSpatial.conf
+++ b/src/test/resources/geoSpatial.conf
@@ -1,0 +1,4 @@
+apoc.spatial.geocode.provider=opencage
+apoc.spatial.geocode.opencage.key=<YOUR_API_KEY>
+apoc.spatial.geocode.opencage.url=https://api.opencagedata.com/geocode/v1/json?q=PLACE&key=KEY
+apoc.spatial.geocode.opencage.reverse.url=https://api.opencagedata.com/geocode/v1/json?q=LAT+LNG&key=KEY

--- a/src/test/resources/spatial.json
+++ b/src/test/resources/spatial.json
@@ -42,14 +42,14 @@
   "_comment_2C": "No real geocoding service is used, as a service is internally mocked to provide these results.",
 
   "events": [
-    {"name": "Suffren Expo", "address": "18 Avenue de Suffren, 75007 Paris, France", "datetime": "2016-05-01 10:00:00", "toosoon": true},
-    {"name": "Bourdonnais Expo", "address": "27 Avenue de la Bourdonnais, 75007 Paris, France", "datetime": "2016-05-10 10:00:00", "toosoon": true},
-    {"name": "Franklin Expo", "address": "21 Rue Benjamin Franklin, 75116 Paris, France", "datetime": "2016-05-18 10:00:00"},
-    {"name": "Suffren Conference", "address": "18 Avenue de Suffren, 75007 Paris, France", "datetime": "2016-05-20 10:00:00"},
-    {"name": "Bourdonnais Conference", "address": "27 Avenue de la Bourdonnais, 75007 Paris, France", "datetime": "2016-05-25 10:00:00"},
-    {"name": "Villeneuve Expo", "address": "17 Rue Villeneuve, 92110 Clichy, France", "datetime": "2016-05-29 10:00:00", "toofar": true},
-    {"name": "Franklin Conference", "address": "21 Rue Benjamin Franklin, 75116 Paris, France", "datetime": "2016-06-01 10:00:00", "toolate": true},
-    {"name": "Villeneuve Conference", "address": "17 Rue Villeneuve, 92110 Clichy, France", "datetime": "2016-06-05 10:00:00", "toolate": true, "toofar": true}
+    {"name": "Suffren Expo", "address": "18 Avenue de Suffren, 75007 Paris, France", "lat": 48.851181, "lon": 2.3009296, "datetime": "2016-05-01 10:00:00", "toosoon": true},
+    {"name": "Bourdonnais Expo", "address": "27 Avenue de la Bourdonnais, 75007 Paris, France", "lat": 48.8590261, "lon": 2.2982381, "datetime": "2016-05-10 10:00:00", "toosoon": true},
+    {"name": "Franklin Expo", "address": "21 Rue Benjamin Franklin, 75116 Paris, France", "lat": 48.8602507, "lon": 2.285639, "datetime": "2016-05-18 10:00:00"},
+    {"name": "Suffren Conference", "address": "18 Avenue de Suffren, 75007 Paris, France", "lat": 48.851181, "lon": 2.3009296, "datetime": "2016-05-20 10:00:00"},
+    {"name": "Bourdonnais Conference", "address": "27 Avenue de la Bourdonnais, 75007 Paris, France", "lat": 48.8590261, "lon": 2.2982381, "datetime": "2016-05-25 10:00:00"},
+    {"name": "Villeneuve Expo", "address": "17 Rue Villeneuve, 92110 Clichy, France", "lat": 48.9031474, "lon": 2.3049003, "datetime": "2016-05-29 10:00:00", "toofar": true},
+    {"name": "Franklin Conference", "address": "21 Rue Benjamin Franklin, 75116 Paris, France", "lat": 48.8602507, "lon": 2.285639, "datetime": "2016-06-01 10:00:00", "toolate": true},
+    {"name": "Villeneuve Conference", "address": "17 Rue Villeneuve, 92110 Clichy, France", "lat": 48.9031474, "lon": 2.3049003, "datetime": "2016-06-05 10:00:00", "toolate": true, "toofar": true}
   ],
   "geocode": {
     "18 Avenue de Suffren, 75007 Paris, France": {
@@ -119,6 +119,84 @@
       ],
       "lat": "48.9031474",
       "lon": "2.3049003",
+      "display_name": "Rue Villeneuve, Clichy, Nanterre, Hauts-de-Seine, Ile-de-France, Metropolitan France, 92110, France",
+      "class": "highway",
+      "type": "residential",
+      "importance": 0.52
+    }
+  },
+  "inverseGeocode": {
+    "48.851181,2.3009296" : {
+      "place_id": "71721231",
+      "licence": "Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright",
+      "osm_type": "way",
+      "osm_id": "51260152",
+      "boundingbox": [
+        "48.851181",
+        "48.8511907",
+        "2.300904",
+        "2.3009296"
+      ],
+      "lat": "48.851181",
+      "lon": "2.3009296",
+      "address" : "18 Avenue de Suffren, 75007 Paris, France",
+      "display_name": "Avenue de Suffren, Grenelle, 15th Arrondissement, Paris, Ile-de-France, Metropolitan France, 75015, France",
+      "class": "highway",
+      "type": "tertiary",
+      "importance": 0.62
+    },
+    "48.8590261,2.2982381" : {
+      "place_id": "11734823",
+      "licence": "Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright",
+      "osm_type": "node",
+      "osm_id": "1181635043",
+      "boundingbox": [
+        "48.8589761",
+        "48.8590761",
+        "2.2981881",
+        "2.2982881"
+      ],
+      "lat": "48.8590261",
+      "lon": "2.2982381",
+      "address": "27 Avenue de la Bourdonnais, 75007 Paris, France",
+      "display_name": "27, Avenue de la Bourdonnais, Gros-Caillou, 7th Arrondissement, Paris, Ile-de-France, Metropolitan France, 75007, France",
+      "class": "place",
+      "type": "house",
+      "importance": 0.621
+    },
+    "48.8602507,2.285639": {
+      "place_id": "9864688",
+      "licence": "Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright",
+      "osm_type": "node",
+      "osm_id": "963924738",
+      "boundingbox": [
+        "48.8602007",
+        "48.8603007",
+        "2.285589",
+        "2.285689"
+      ],
+      "lat": "48.8602507",
+      "lon": "2.285639",
+      "address" : "21 Rue Benjamin Franklin, 75116 Paris, France",
+      "display_name": "21, Rue Benjamin Franklin, Muette, 16th Arrondissement, Paris, Ile-de-France, Metropolitan France, 75016;75116, France",
+      "class": "place",
+      "type": "house",
+      "importance": 0.521
+    },
+    "48.9031474,2.3049003": {
+      "place_id": "99446390",
+      "licence": "Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright",
+      "osm_type": "way",
+      "osm_id": "173213868",
+      "boundingbox": [
+        "48.9028417",
+        "48.9034881",
+        "2.3039654",
+        "2.3057864"
+      ],
+      "lat": "48.9031474",
+      "lon": "2.3049003",
+      "address": "17 Rue Villeneuve, 92110 Clichy, France",
       "display_name": "Rue Villeneuve, Clichy, Nanterre, Hauts-de-Seine, Ile-de-France, Metropolitan France, 92110, France",
       "class": "highway",
       "type": "residential",

--- a/src/test/resources/spatial.json
+++ b/src/test/resources/spatial.json
@@ -125,7 +125,7 @@
       "importance": 0.52
     }
   },
-  "inverseGeocode": {
+  "reverseGeocode": {
     "48.851181,2.3009296" : {
       "place_id": "71721231",
       "licence": "Data © OpenStreetMap contributors, ODbL 1.0. http://www.openstreetmap.org/copyright",


### PR DESCRIPTION
- added a new method `reverseGeocode(Double latitude, Double longitude)`
- reviewed all the variables and methods changing "inverseGeocode" with "reverseGeocode"
- documentation updated
- added a new property for reverse geocoding when using a custom GeoProvider
- tests for the custom GeoProvider assert the existence of a key otherwise they don't run anything