### PR TITLE
Update opencsv dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,7 @@ dependencies {
     compileOnly group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
     testCompile group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.0'
+    compile group: 'com.opencsv', name: 'opencsv', version: '4.2' 
     compileOnly group: 'org.ow2.asm', name: 'asm', version: '5.0.2'
     compile group: 'com.github.javafaker', name: 'javafaker', version: '0.10'
 

--- a/src/main/java/apoc/export/csv/CsvEntityLoader.java
+++ b/src/main/java/apoc/export/csv/CsvEntityLoader.java
@@ -5,7 +5,7 @@ import apoc.export.util.CountingReader;
 import apoc.export.util.ProgressReporter;
 import apoc.load.LoadCsv;
 import apoc.util.FileUtils;
-import au.com.bytecode.opencsv.CSVReader;
+import com.opencsv.CSVReader;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;

--- a/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/src/main/java/apoc/export/csv/CsvFormat.java
@@ -1,14 +1,27 @@
 package apoc.export.csv;
 
-import apoc.export.util.*;
+import apoc.export.util.ExportConfig;
+import apoc.export.util.Format;
+import apoc.export.util.FormatUtils;
+import apoc.export.util.MetaInformation;
+import apoc.export.util.Reporter;
 import apoc.result.ProgressInfo;
-import au.com.bytecode.opencsv.CSVWriter;
+import com.opencsv.CSVWriter;
 import org.neo4j.cypher.export.SubGraph;
-import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
 
 import java.io.Reader;
 import java.io.Writer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static apoc.export.util.MetaInformation.collectPropTypesForNodes;

--- a/src/main/java/apoc/load/LoadCsv.java
+++ b/src/main/java/apoc/load/LoadCsv.java
@@ -1,10 +1,10 @@
 package apoc.load;
 
 import apoc.export.util.CountingReader;
-import apoc.util.FileUtils;
 import apoc.meta.Meta;
+import apoc.util.FileUtils;
 import apoc.util.Util;
-import au.com.bytecode.opencsv.CSVReader;
+import com.opencsv.CSVReader;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
@@ -12,7 +12,17 @@ import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;


### PR DESCRIPTION
Previous dependency was net.sf.opencsv:opencsv:2.3 (transitively from org.neo4j:neo4j-cypher),
new one is com.opencsv:opencsv:4.2

This change is aligned with https://github.com/neo4j/neo4j/pull/12009.