### PR TITLE
Inform users what's wrong when triggers are not enabled

### DIFF
--- a/src/main/java/apoc/trigger/Trigger.java
+++ b/src/main/java/apoc/trigger/Trigger.java
@@ -56,23 +56,6 @@ public class Trigger {
 
     @Context public GraphDatabaseService db;
 
-    public static final String NOT_ENABLED_ERROR = "Triggers have not been enabled." +
-            " Set 'apoc.trigger.enabled=true' in your neo4j.conf file located in the $NEO4J_HOME/conf/ directory.";
-
-    public static boolean enabled = false;
-
-    public static void setEnabled(boolean enabled) {
-        Trigger.enabled = enabled;
-    }
-
-    public static boolean isEnabled() { return enabled; }
-
-    public void checkEnabled() {
-        if (!Trigger.isEnabled()) {
-            throw new RuntimeException(NOT_ENABLED_ERROR);
-        }
-    }
-
     @UserFunction
     @Description("function to filter labelEntries by label, to be used within a trigger kernelTransaction with {assignedLabels}, {removedLabels}, {assigned/removedNodeProperties}")
     public List<Node> nodesByLabel(@Name("labelEntries") Object entries, @Name("label") String labelString) {
@@ -119,8 +102,6 @@ public class Trigger {
     @Procedure(mode = Mode.WRITE)
     @Description("add a trigger kernelTransaction under a name, in the kernelTransaction you can use {createdNodes}, {deletedNodes} etc., the selector is {phase:'before/after/rollback'} returns previous and new trigger information. Takes in an optional configuration.")
     public Stream<TriggerInfo> add(@Name("name") String name, @Name("kernelTransaction") String statement, @Name(value = "selector"/*, defaultValue = "{}"*/)  Map<String,Object> selector, @Name(value = "config", defaultValue = "{}") Map<String,Object> config) {
-        checkEnabled();
-
         Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());
         Map<String, Object> removed = TriggerHandler.add(name, statement, selector, params);
         if (removed != null) {
@@ -134,8 +115,6 @@ public class Trigger {
     @Procedure(mode = Mode.WRITE)
     @Description("remove previously added trigger, returns trigger information")
     public Stream<TriggerInfo> remove(@Name("name")String name) {
-        checkEnabled();
-
         Map<String, Object> removed = TriggerHandler.remove(name);
         if (removed == null) {
             Stream.of(new TriggerInfo(name, null, null, false, false));
@@ -146,8 +125,6 @@ public class Trigger {
     @Procedure(mode = Mode.WRITE)
     @Description("list all installed triggers")
     public Stream<TriggerInfo> list() {
-        checkEnabled();
-
         return TriggerHandler.list().entrySet().stream()
                 .map( (e) -> new TriggerInfo(e.getKey(),(String)e.getValue().get("kernelTransaction"),(Map<String,Object>)e.getValue().get("selector"), (Map<String, Object>) e.getValue().get("params"),true, (Boolean) e.getValue().get("paused")));
     }
@@ -155,8 +132,6 @@ public class Trigger {
     @Procedure(mode = Mode.WRITE)
     @Description("CALL apoc.trigger.pause(name) | it pauses the trigger")
     public Stream<TriggerInfo> pause(@Name("name")String name) {
-        checkEnabled();
-
         Map<String, Object> paused = TriggerHandler.paused(name);
 
         return Stream.of(new TriggerInfo(name,(String)paused.get("kernelTransaction"), (Map<String,Object>) paused.get("selector"), (Map<String,Object>) paused.get("params"),true, true));
@@ -165,8 +140,6 @@ public class Trigger {
     @Procedure(mode = Mode.WRITE)
     @Description("CALL apoc.trigger.resume(name) | it resumes the paused trigger")
     public Stream<TriggerInfo> resume(@Name("name")String name) {
-        checkEnabled();
-
         Map<String, Object> resume = TriggerHandler.resume(name);
 
         return Stream.of(new TriggerInfo(name,(String)resume.get("kernelTransaction"), (Map<String,Object>) resume.get("selector"), (Map<String,Object>) resume.get("params"),true, false));
@@ -178,17 +151,30 @@ public class Trigger {
         private static GraphProperties properties;
         private final Log log;
 
+        public static final String NOT_ENABLED_ERROR = "Triggers have not been enabled." +
+                " Set 'apoc.trigger.enabled=true' in your neo4j.conf file located in the $NEO4J_HOME/conf/ directory.";
+
         public TriggerHandler(GraphDatabaseAPI api, Log log) {
             properties = api.getDependencyResolver().resolveDependency(EmbeddedProxySPI.class).newGraphPropertiesProxy();
 //            Pools.SCHEDULED.submit(() -> updateTriggers(null,null));
             this.log = log;
         }
 
+        public static void checkEnabled() {
+            if (properties == null) {
+                throw new RuntimeException(NOT_ENABLED_ERROR);
+            }
+        }
+
         public static Map<String, Object> add(String name, String statement, Map<String,Object> selector) {
+            checkEnabled();
+
             return add(name, statement, selector, Collections.emptyMap());
         }
 
         public static Map<String, Object> add(String name, String statement, Map<String,Object> selector, Map<String,Object> params) {
+            checkEnabled();
+
             return updateTriggers(name, map("kernelTransaction", statement, "selector", selector, "params", params, "paused", false));
         }
 
@@ -197,21 +183,24 @@ public class Trigger {
         }
 
         public static Map<String, Object> paused(String name) {
+            checkEnabled();
+
             Map<String, Object> triggerToPause = triggers.get(name);
             updateTriggers(name, map("kernelTransaction", triggerToPause.get("kernelTransaction"), "selector", triggerToPause.get("selector"), "params", triggerToPause.get("params"), "paused", true));
             return triggers.get(name);
         }
 
         public static Map<String, Object> resume(String name) {
+            checkEnabled();
+
             Map<String, Object> triggerToResume = triggers.get(name);
             updateTriggers(name, map("kernelTransaction", triggerToResume.get("kernelTransaction"), "selector", triggerToResume.get("selector"), "params", triggerToResume.get("params"), "paused", false));
             return triggers.get(name);
         }
 
         private synchronized static Map<String, Object> updateTriggers(String name, Map<String, Object> value) {
-            if (properties == null ) {
-                throw new RuntimeException(NOT_ENABLED_ERROR);
-            }
+            checkEnabled();
+
             try (Transaction tx = properties.getGraphDatabase().beginTx()) {
                 triggers.clear();
                 String triggerProperty = (String) properties.getProperty(APOC_TRIGGER, "{}");
@@ -229,6 +218,8 @@ public class Trigger {
         }
 
         public static Map<String,Map<String,Object>> list() {
+            checkEnabled();
+
             updateTriggers(null,null);
             return triggers;
         }
@@ -345,11 +336,9 @@ public class Trigger {
         public void start() {
             boolean enabled = Util.toBoolean(ApocConfiguration.get("trigger.enabled", null));
             if (!enabled) {
-                Trigger.setEnabled(false);
                 return;
             }
 
-            Trigger.setEnabled(true);
             triggerHandler = new Trigger.TriggerHandler(db,log);
             db.registerTransactionEventHandler(triggerHandler);
         }

--- a/src/test/java/apoc/trigger/TriggerDisabledTest.java
+++ b/src/test/java/apoc/trigger/TriggerDisabledTest.java
@@ -64,6 +64,10 @@ public class TriggerDisabledTest
         // We expect a RuntimeException to be thrown.
         catch ( RuntimeException e )
         {
+            // Give the user a specific message that hints at what setting they need to change to fix
+            // this problem.
+            String msg = e.getMessage();
+            assertTrue(msg.indexOf("apoc.trigger.enabled") >= 0);
         }
         // Any other exception causes the test to fail.
         catch ( Exception e )


### PR DESCRIPTION
At present, if apoc.trigger.enabled is not set, or set to false, and a user calls any of the APOC trigger procedures, they get a stacktrace and a NullPointerException.

This PR just sets a flag and checks prior to executing any trigger related function whether triggers are enabled.  If they are not, a RuntimeException is thrown that gives a meaningful message the user can act on.

Submitting this PR because I've run into it twice recently, it confused me both times.  Internal neo4j slack #apoc channel had two other users who got caught by same confusion, raising questions.