### PR TITLE
fixes #915: Corrects the number of partitions returned.

### DIFF
--- a/src/main/java/apoc/coll/Coll.java
+++ b/src/main/java/apoc/coll/Coll.java
@@ -316,7 +316,7 @@ public class Coll {
 
     private Stream<List<Object>> partitionList(@Name("values") List list, @Name("batchSize") int batchSize) {
         int total = list.size();
-        int pages = (total / batchSize) + 1;
+        int pages = total % batchSize == 0 ? total/batchSize : total/batchSize + 1;
         return IntStream.range(0, pages).parallel().boxed()
                 .map(page -> {
                     int from = page * batchSize;


### PR DESCRIPTION
Fixed a problem where `apoc.coll.partition` added an extra empty list at the end when the length of the list was divisible by the batchSize.