### PR TITLE
Fixes #959

### DIFF
--- a/src/test/java/apoc/load/LoadS3Test.java
+++ b/src/test/java/apoc/load/LoadS3Test.java
@@ -2,9 +2,7 @@ package apoc.load;
 
 import apoc.util.TestUtil;
 import apoc.util.Util;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
@@ -15,12 +13,22 @@ import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 public class LoadS3Test {
 
     private GraphDatabaseService db;
     private MinioSetUp minio;
+
+    @BeforeClass
+    public static void init() {
+        // In test environment we skip the MD5 validation that can cause issues
+        System.setProperty("com.amazonaws.services.s3.disableGetObjectMD5Validation", "true");
+    }
+
+    @AfterClass
+    public static void destroy() {
+        System.clearProperty("com.amazonaws.services.s3.disableGetObjectMD5Validation");
+    }
 
     @Before public void setUp() throws Exception {
         db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder().setConfig("apoc.import.file.enabled","true").newGraphDatabase();


### PR DESCRIPTION
LoadS3Test fails due to an incompatibility of the md5 validation between Minio and the S3 client.
In the tests, we disable the md5 validation.