### PR TITLE
Fixes #931

### DIFF
--- a/src/main/java/apoc/load/Xml.java
+++ b/src/main/java/apoc/load/Xml.java
@@ -65,6 +65,7 @@ public class Xml {
             DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
             documentBuilderFactory.setNamespaceAware(true);
             documentBuilderFactory.setIgnoringElementContentWhitespace(true);
+            documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
             DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
 
             FileUtils.checkReadAllowed(url);

--- a/src/test/resources/xml/xxe.xml
+++ b/src/test/resources/xml/xxe.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<!DOCTYPE GVI [<!ENTITY xxe SYSTEM "file:///etc/passwd" >]>
+<catalog>
+    <book id="bk101">
+        <author>Gambardella, Matthew</author>
+        <title>XML Developer's Guide</title>
+        <genre>Computer</genre>
+        <price>44.95</price>
+        <publish_date>2000-10-01</publish_date>
+        <description>&xxe;</description>
+    </book>
+</catalog>


### PR DESCRIPTION
Doc types are now disabled in order to prevent almost all XML entity attacks.