### PR TITLE
fixes #985 - Provide Locale as option in apoc.text.format

### DIFF
--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -944,7 +944,7 @@ Example: `'FRIEND|MENTORS>|<REPORTS_TO'` will match to :FRIEND relationships in 
 | apoc.text.replace(text, regex, replacement)| replace each substring of the given string that matches the given regular expression with the given replacement.
 | apoc.text.regexGroups(text, regex) | returns an array containing a nested array for each match. The inner array contains all match groups.
 | apoc.text.join(['text1','text2',...], delimiter) | join the given strings with the given delimiter.
-| apoc.text.format(text,[params]) | sprintf format the string with the params given
+| apoc.text.format(text,[params],language) | sprintf format the string with the params given, and optional param language (default value is 'en').
 | apoc.text.lpad(text,count,delim) | left pad the string to the given width
 | apoc.text.rpad(text,count,delim) | right pad the string to the given width
 | apoc.text.random(length, [valid]) | returns a random string to the specified length

--- a/docs/text.adoc
+++ b/docs/text.adoc
@@ -8,6 +8,24 @@ The clean functionality can be useful for cleaning up slightly dirty text data w
 
 Cleaning will strip the string of all non-alphanumeric characters (including spaces) and convert it to lower case.
 
+== Formatting Text
+
+Format the string with the params given, and optional param language.
+
+.without language param ('en' default)
+
+[source,cypher]
+----
+RETURN apoc.text.format('ab%s %d %.1f %s%n',['cd',42,3.14,true]) AS value // abcd 42 3.1 true
+----
+
+.with language param
+
+[source,cypher]
+----
+RETURN apoc.text.format('ab%s %d %.1f %s%n',['cd',42,3.14,true],'it') AS value // abcd 42 3,1 true
+----
+
 == String Search
 
 The `indexOf` function, provides the fist occurrence of the given `lookup` string within the `text`, or -1 if not found.

--- a/src/main/java/apoc/text/Strings.java
+++ b/src/main/java/apoc/text/Strings.java
@@ -303,11 +303,11 @@ public class Strings {
     }
 
     @UserFunction
-    @Description("apoc.text.format(text,[params]) - sprintf format the string with the params given")
-    public String format(@Name("text") String text, @Name("params") List<Object> params) {
+    @Description("apoc.text.format(text,[params],language) - sprintf format the string with the params given")
+    public String format(@Name("text") String text, @Name("params") List<Object> params, @Name(value = "language",defaultValue = "en") String lang) {
         if (text == null) return null;
         if (params == null) return text;
-        return String.format(Locale.ENGLISH,text, params.toArray());
+        return String.format(new Locale(lang),text, params.toArray());
     }
 
     @UserFunction

--- a/src/test/java/apoc/text/StringsTest.java
+++ b/src/test/java/apoc/text/StringsTest.java
@@ -428,6 +428,8 @@ public class StringsTest {
         testCall(db, "RETURN apoc.text.format(null,null) AS value", row -> assertEquals(null, row.get("value")));
         testCall(db, "RETURN apoc.text.format('ab',null) AS value", row -> assertEquals("ab", row.get("value")));
         testCall(db, "RETURN apoc.text.format('ab%s %d %.1f %s%n',['cd',42,3.14,true]) AS value", row -> assertEquals("abcd 42 3.1 true\n", row.get("value")));
+        testCall(db, "RETURN apoc.text.format('ab%s %d %.1f %s%n',['cd',42,3.14,true],'it') AS value", row -> assertEquals("abcd 42 3,1 true\n", row.get("value")));
+        testCall(db, "RETURN apoc.text.format('ab%s %d %.1f %s%n',['cd',42,3.14,true],'de') AS value", row -> assertEquals("abcd 42 3,1 true\n", row.get("value")));
     }
 
     @Test


### PR DESCRIPTION
Fixes #985 

Provide Locale as option in apoc.text.format

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - added new optional param _language_ , with default value _en_
