### PR TITLE
Expect failure for 'testRelationshipEndNodesNotExist'. Fixes #992

### DIFF
--- a/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -1,8 +1,12 @@
 package apoc.export.csv;
 
 import apoc.util.TestUtil;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -395,9 +399,8 @@ public class ImportCsvTest {
         Assert.assertEquals("John 25 <3> Jane 26", result2.next().get("pair"));
     }
 
-    @Test
-    @Ignore
-    public void testNoDuplicationsCreated() {
+    @Test(expected = QueryExecutionException.class)
+    public void testRelationshipEndNodesNotExist() {
         TestUtil.testCall(
                 db,
                 "CALL apoc.import.csv([{fileName: {nodeFile}, labels: ['Person']}], [{fileName: {relFile}, type: 'KNOWS'}], {config})",
@@ -406,10 +409,7 @@ public class ImportCsvTest {
                         "relFile", "file:/knows.csv",
                         "config", map("stringIds", false)
                 ),
-                (r) -> {
-                    assertEquals(2L, r.get("nodes"));
-                    assertEquals(1L, r.get("relationships"));
-                }
+                (r) -> {}
         );
     }
 


### PR DESCRIPTION
Fixes #992 

Expect test `testRelationshipEndNodesNotExist` to fail.

## Proposed Changes (Mandatory)

- This test was added in #976 as a followup to #951. It is expected to fail, but my previous implementation was sloppy and it only `@Ignore`d the test.
- Imports were reorganized by IntelliJ.