### PR TITLE
fixes #994 - Provide a configuration parameter map with user/pass for JDBC

### DIFF
--- a/docs/loadjdbc.adoc
+++ b/docs/loadjdbc.adoc
@@ -377,6 +377,20 @@ CALL apoc.load.jdbc('my-hive','SELECT * PRODUCTS');
 To use other JDBC drivers use these download links and JDBC URL.
 Put the JDBC driver into the `$NEO4J_HOME/plugins` directory and configure the JDBC-URL in `$NEO4J_HOME/conf/neo4j.conf` with `apoc.jdbc.<alias>.url=<jdbc-url>`
 
+Credentials can be passed in two ways:
+
+* into url
+
+----
+CALL apoc.load.jdbc('jdbc:derby:derbyDB;user=apoc;password=Ap0c!#Db;create=true', 'PERSON')
+----
+
+* by config parameter.
+
+----
+CALL apoc.load.jdbc('jdbc:derby:derbyDB', 'PERSON',[],{credentials:{user:'apoc',password:'Ap0c!#Db'}})
+----
+
 [options="header",cols="a,3m,a"]
 |===
 |Database | JDBC-URL | Driver Source
@@ -432,7 +446,7 @@ The jdbcUpdate is use for update relational database, from a SQL statement with 
 
 [source,cypher]
 ----
-CALL apoc.load.jdbcUpdate(jdbc-url,statement, params) YIELD  row;
+CALL apoc.load.jdbcUpdate(jdbc-url,statement, params, config) YIELD  row;
 ----
 
 With this set of data you can call the procedure in two different mode:
@@ -477,6 +491,7 @@ Config param is optional, the default value is an empty map.
 [cols="3m,2"]
 |===
 |timezone| default value: null
+|credentials| default value: {}
 |===
 
 Example:
@@ -489,4 +504,15 @@ CALL apoc.load.jdbc('jdbc:derby:derbyDB','SELECT * FROM PERSON WHERE NAME = ?',[
 
 ----
 2018-10-31T01:32:25.012+09:00[Asia/Tokyo]
+----
+
+
+.with credentials
+[source,cypher]
+----
+CALL apoc.load.jdbcUpdate('jdbc:derby:derbyDB','UPDATE PERSON SET NAME = ? WHERE NAME = ?',['John','John'],{credentials:{user:'apoc',password:'Ap0c!#Db'}})
+----
+
+----
+CALL apoc.load.jdbc('jdbc:derby:derbyDB', 'PERSON',[],{credentials:{user:'apoc',password:'Ap0c!#Db'}})
 ----

--- a/src/main/java/apoc/load/util/LoadJdbcConfig.java
+++ b/src/main/java/apoc/load/util/LoadJdbcConfig.java
@@ -1,5 +1,7 @@
 package apoc.load.util;
 
+import org.apache.commons.lang.StringUtils;
+
 import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.util.Collections;
@@ -13,6 +15,8 @@ public class LoadJdbcConfig {
 
     private ZoneId zoneId = null;
 
+    private Credentials credentials;
+
     public LoadJdbcConfig(Map<String,Object> config) {
         config = config != null ? config : Collections.emptyMap();
         try {
@@ -21,10 +25,47 @@ public class LoadJdbcConfig {
         } catch (DateTimeException e) {
             throw new IllegalArgumentException(String.format("The timezone field contains an error: %s", e.getMessage()));
         }
+        this.credentials = config.containsKey("credentials") ? createCredentials((Map<String, String>) config.get("credentials")) : null;
     }
 
     public ZoneId getZoneId(){
         return this.zoneId;
+    }
+
+    public Credentials getCredentials() {
+        return this.credentials;
+    }
+
+    private Credentials createCredentials(Map<String,String> credentials) {
+        if (!credentials.getOrDefault("user", StringUtils.EMPTY).equals(StringUtils.EMPTY) && !credentials.getOrDefault("password", StringUtils.EMPTY).equals(StringUtils.EMPTY)) {
+            return new Credentials(credentials.get("user"), credentials.get("password"));
+        } else {
+            throw new IllegalArgumentException("In config param credentials must be passed both user and password.");
+        }
+    }
+
+    public class Credentials {
+        private String user;
+
+        private String password;
+
+        public Credentials(String user, String password){
+            this.user = user;
+
+            this.password = password;
+        }
+
+        public String getUser() {
+            return user;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+    }
+
+    public boolean hasCredentials() {
+        return this.credentials != null;
     }
 
 }


### PR DESCRIPTION
Fixes #994 

Provide a configuration parameter map with user/pass for JDBC

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - added a new config parameter _credentials_ in which user can write user and password 
`{credentials:{user:"",password:""}}`
