### PR TITLE
fixes #981 - apoc.meta.type should give consistent type info

### DIFF
--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -158,10 +158,24 @@ Returns a virtual graph that represents the labels and relationship-types availa
 .Functions
 [cols="1m,5"]
 |===
-| apoc.meta.type(value) | type name of a value (`INTEGER,FLOAT,STRING,BOOLEAN,RELATIONSHIP,NODE,PATH,NULL,UNKNOWN,MAP,LIST`)
+| apoc.meta.cypher.type(value) | type name of a value (`INTEGER,FLOAT,STRING,BOOLEAN,RELATIONSHIP,NODE,PATH,NULL,MAP,LIST OF <TYPE>,POINT,DATE,DATE_TIME,LOCAL_TIME,LOCAL_DATE_TIME,TIME,DURATION`)
+| apoc.meta.cypher.isType(value,type) | returns a row if type name matches none if not
+| apoc.meta.cypher.types(node or relationship or map) | returns a a map of property-keys to their names
+|===
+
+In the case of `LIST` you may have many results, depending on the content. In the event that all contents are of the same type, will you have the `LIST OF <TYPE>`, otherwise if the type is different, will you get `LIST OF ANY`
+
+If no type was found, the function return name of the class.
+
+.Functions Deprecated
+[cols="1m,5"]
+|===
+| apoc.meta.type(value) | type name of a value (`INTEGER,FLOAT,STRING,BOOLEAN,RELATIONSHIP,NODE,PATH,NULL,MAP,LIST`)
 | apoc.meta.isType(value,type) | returns a row if type name matches none if not
 | apoc.meta.types(node or relationship or map) | returns a a map of property-keys to their names
 |===
+
+If no type was found, the function return name of the class.
 
 ++++
 <iframe width="560" height="315" src="https://www.youtube.com/embed/yEN6TCL8WGk" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>

--- a/src/main/java/apoc/convert/Convert.java
+++ b/src/main/java/apoc/convert/Convert.java
@@ -1,17 +1,8 @@
 package apoc.convert;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import apoc.coll.SetBackedList;
+import apoc.meta.Meta.Types;
+import apoc.util.Util;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
@@ -23,11 +14,9 @@ import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.UserFunction;
 
-import apoc.coll.SetBackedList;
-import apoc.meta.Meta.Types;
-import apoc.util.Util;
-
-import static apoc.meta.Meta.Types.UNKNOWN;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 /**

--- a/src/main/java/apoc/meta/Meta.java
+++ b/src/main/java/apoc/meta/Meta.java
@@ -109,7 +109,7 @@ public class Meta {
         }
 
         public static String inferType(List<?> list) {
-            Set<String> set = list.stream().map(e -> of(e).name()).collect(Collectors.toSet());
+            Set<String> set = list.stream().limit(10).map(e -> of(e).name()).collect(Collectors.toSet());
             return set.size() != 1 ? "ANY" : set.iterator().next();
         }
     }


### PR DESCRIPTION
Fixes #981

apoc.meta.type should give consistent type info

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Add new function `apoc.meta.v2.type(value)`, `apoc.meta.v2.isType`, `apoc.meta.v2.types`
  - New types (`INTEGER,FLOAT,STRING,BOOLEAN,RELATIONSHIP,NODE,PATH,NULL,MAP,LIST,POINT,DATE,DATE_TIME,LOCAL_TIME,LOCAL_DATE_TIME,TIME,DURATION`)
  - Deprecated `apoc.meta.type(value)`, `apoc.meta.isType`, `apoc.meta.types`
