### PR TITLE
fixes #991 - Add ability to provide label to schema functions for filtered results

### DIFF
--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -193,9 +193,8 @@ RETURN apoc.meta.isType(n.age,"INTEGER") as ageType
 [cols="1m,5"]
 |===
 | apoc.schema.assert({indexLabel:[indexKeys],...},{constraintLabel:[constraintKeys],...}, dropExisting : true) yield label, key, unique, action | drops all other existing indexes and constraints when `dropExisting` is `true` (default is `true`), and asserts that at the end of the operation the given indexes and unique constraints are there, each label:key pair is considered one constraint/label.
-| apoc.schema.nodes() yield name, label, properties, status, type | get all indexes and constraints information for all the node labels in your database
-| apoc.schema.relationships() yield name, type, properties, status | return all the constraint information for all the relationship types in your database
-| apoc.schema.node.indexExists(labelName, properties) | return the indexes existence on node
+| apoc.schema.nodes([config]) yield name, label, properties, status, type | get all indexes and constraints information for all the node labels in your database, in optional config param could be define a set of labels to include or exclude
+| apoc.schema.relationships([config]) yield name, type, properties, status | return all the constraint information for all the relationship types in your database, in optional config param could be define a set of types to include or exclude
 | apoc.schema.node.constraintExists(labelName, properties) | return the constraints existence on node
 | apoc.schema.relationship.constraintExists(type, properties) | return the constraints existence on relationship
 |===

--- a/docs/schema.adoc
+++ b/docs/schema.adoc
@@ -49,6 +49,21 @@ Where the outputs are:
   * properties, (for Neo4j 3.1 and lower versions is a single element array) that are affected by the constraint
   * status
 
+Config optional param is a map and its possible values are:
+
+  * labels : list of labels to retrieve index/constraint information
+  * excludeLabels: list of labels to exclude from retrieve index/constraint information
+  * relationships: list of relationships type to retrieve constraint information
+  * excludeRelationships: list of relationships' type to exclude from retrieve constraint information
+
+**Exclude has more power than include, so if excludeLabels and labels are both valued, procedure considers excludeLabels only, the same for relationships.**
+
+[source,cypher]
+----
+CALL apoc.schema.nodes({labels:['Book']}) yield name, label, properties, status, type
+----
+
+
 N.B. Constraints for property existence on nodes and relationships are available only for the Enterprise Edition.
 
 To retrieve the index existence on node, you can use the following user function:

--- a/src/main/java/apoc/schema/SchemaConfig.java
+++ b/src/main/java/apoc/schema/SchemaConfig.java
@@ -1,0 +1,46 @@
+package apoc.schema;
+
+import java.util.*;
+
+/**
+ * @author ab-larus
+ * @since 17.12.18
+ */
+public class SchemaConfig {
+
+    private Set<String> labels;
+    private Set<String> excludeLabels;
+    private Set<String> relationships;
+    private Set<String> excludeRelationships;
+
+    public Set<String> getLabels() {
+        return labels;
+    }
+
+    public Set<String> getExcludeLabels() {
+        return excludeLabels;
+    }
+
+    public Set<String> getRelationships() {
+        return relationships;
+    }
+
+    public Set<String> getExcludeRelationships() {
+        return excludeRelationships;
+    }
+
+    public SchemaConfig(Map<String,Object> config) {
+        config = config != null ? config : Collections.emptyMap();
+        this.labels = new HashSet<>((Collection<String>)config.getOrDefault("labels", Collections.EMPTY_SET));
+        this.excludeLabels = new HashSet<>((Collection<String>) config.getOrDefault("excludeLabels", Collections.EMPTY_SET));
+        validateParameters(this.labels, this.excludeLabels, "labels");
+        this.relationships = new HashSet<>((Collection<String>)config.getOrDefault("relationships", Collections.EMPTY_SET));
+        this.excludeRelationships = new HashSet<>((Collection<String>)config.getOrDefault("excludeRelationships", Collections.EMPTY_SET));
+        validateParameters(this.labels, this.excludeLabels, "relationships");
+    }
+
+    private void validateParameters(Set<String> include, Set<String> exclude, String parametrType){
+        if(!include.isEmpty() && !exclude.isEmpty())
+            throw new IllegalArgumentException(String.format("Parameters %s and exclude%s are both valuated. Please check parameters and valuate only one.", parametrType, parametrType));
+    }
+}

--- a/src/main/java/apoc/schema/Schemas.java
+++ b/src/main/java/apoc/schema/Schemas.java
@@ -2,17 +2,18 @@ package apoc.schema;
 
 import apoc.result.AssertSchemaResult;
 import apoc.result.ConstraintRelationshipInfo;
+import apoc.result.GraphResult;
 import apoc.result.IndexConstraintNodeInfo;
+import apoc.util.Util;
 import org.apache.commons.lang3.StringUtils;
-import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Label;
-import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.*;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.ConstraintType;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.internal.kernel.api.*;
+import org.neo4j.internal.kernel.api.exceptions.LabelNotFoundKernelException;
 import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.SilentTokenNameLookup;
@@ -44,15 +45,15 @@ public class Schemas {
     }
 
     @Procedure(value = "apoc.schema.nodes", mode = Mode.SCHEMA)
-    @Description("CALL apoc.schema.nodes() yield name, label, properties, status, type")
-    public Stream<IndexConstraintNodeInfo> nodes() throws IndexNotFoundKernelException {
-        return indexesAndConstraintsForNode();
+    @Description("CALL apoc.schema.nodes([config]) yield name, label, properties, status, type")
+    public Stream<IndexConstraintNodeInfo> nodes(@Name(value = "config",defaultValue = "{}") Map<String,Object> config) throws IndexNotFoundKernelException {
+        return indexesAndConstraintsForNode(config);
     }
 
     @Procedure(value = "apoc.schema.relationships", mode = Mode.SCHEMA)
-    @Description("CALL apoc.schema.relationships() yield name, startLabel, type, endLabel, properties, status")
-    public Stream<ConstraintRelationshipInfo> relationships() {
-        return constraintsForRelationship();
+    @Description("CALL apoc.schema.relationships([config]) yield name, startLabel, type, endLabel, properties, status")
+    public Stream<ConstraintRelationshipInfo> relationships(@Name(value = "config",defaultValue = "{}") Map<String,Object> config) {
+        return constraintsForRelationship(config);
     }
 
     @UserFunction(value = "apoc.schema.node.indexExists")
@@ -269,15 +270,54 @@ public class Schemas {
      *
      * @return
      */
-    private Stream<IndexConstraintNodeInfo> indexesAndConstraintsForNode() throws IndexNotFoundKernelException {
+    private Stream<IndexConstraintNodeInfo> indexesAndConstraintsForNode(Map<String,Object> config) throws IndexNotFoundKernelException {
+
+        SchemaConfig schemaConfig = new SchemaConfig(config);
+        Set<String> includeLabels = schemaConfig.getLabels();
+        Set<String> excludeLabels = schemaConfig.getExcludeLabels();
+
         try ( Statement ignore = tx.acquireStatement() ) {
             TokenRead tokenRead = tx.tokenRead();
             TokenNameLookup tokens = new SilentTokenNameLookup(tokenRead);
 
             SchemaRead schemaRead = tx.schemaRead();
-            Iterable<IndexReference> indexesIterator = () -> schemaRead.indexesGetAll();
+            Iterable<IndexReference> indexesIterator;
+            Iterable<ConstraintDescriptor> constraintsIterator;
 
-            Iterable<ConstraintDescriptor> constraintsIterator = () -> schemaRead.constraintsGetAll();
+            if (includeLabels.isEmpty()) {
+                Iterable<IndexReference> allIndex = () -> schemaRead.indexesGetAll();
+                indexesIterator = StreamSupport.stream(allIndex.spliterator(),false)
+                        .filter(index -> {
+                            try {
+                                return !excludeLabels.contains(tokenRead.nodeLabelName(index.label()));
+                            } catch (LabelNotFoundKernelException e) {
+                                return false;
+                            }
+                        }).collect(Collectors.toList());
+
+                Iterable<ConstraintDescriptor> allConstraints = () -> schemaRead.constraintsGetAll();
+                constraintsIterator = StreamSupport.stream(allConstraints.spliterator(),false)
+                        .filter(constraint -> !excludeLabels.contains(constraint.schema().keyName(tokens)))
+                        .collect(Collectors.toList());
+            } else {
+                constraintsIterator = includeLabels.stream()
+                        .filter(label -> !excludeLabels.contains(label) && tokenRead.nodeLabel(label) != -1)
+                        .flatMap(label -> {
+                            Iterable<ConstraintDescriptor> indexesForLabel = () -> schemaRead.constraintsGetForLabel(tokenRead.nodeLabel(label));
+                            return StreamSupport.stream(indexesForLabel.spliterator(), false);
+                        })
+                        .collect(Collectors.toList());
+
+                indexesIterator = includeLabels.stream()
+                        .filter(label -> !excludeLabels.contains(label) && tokenRead.nodeLabel(label) != -1)
+                        .flatMap(label -> {
+                            Iterable<IndexReference> indexesForLabel = () -> schemaRead.indexesGetForLabel(tokenRead.nodeLabel(label));
+                            return StreamSupport.stream(indexesForLabel.spliterator(), false);
+                        })
+                        .collect(Collectors.toList());
+            }
+
+
             Stream<IndexConstraintNodeInfo> constraintNodeInfoStream = StreamSupport.stream(constraintsIterator.spliterator(), false)
                     .filter(constraintDescriptor -> constraintDescriptor.type().equals(ConstraintDescriptor.Type.EXISTS))
                     .map(constraintDescriptor -> this.nodeInfoFromConstraintDescriptor(constraintDescriptor, tokens))
@@ -296,14 +336,39 @@ public class Schemas {
      *
      * @return
      */
-    private Stream<ConstraintRelationshipInfo> constraintsForRelationship() {
+    private Stream<ConstraintRelationshipInfo> constraintsForRelationship(Map<String,Object> config) {
         Schema schema = db.schema();
 
-        return StreamSupport.stream(schema.getConstraints().spliterator(), false)
-                .filter(constraintDefinition -> constraintDefinition.isConstraintType(ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE))
-                .map(this::relationshipInfoFromConstraintDefinition);
-    }
+        SchemaConfig schemaConfig = new SchemaConfig(config);
+        Set<String> includeRelationships = schemaConfig.getRelationships();
+        Set<String> excludeRelationships = schemaConfig.getExcludeRelationships();
 
+        try ( Statement ignore = tx.acquireStatement() ) {
+            TokenRead tokenRead = tx.tokenRead();
+            Iterable<ConstraintDefinition> constraintsIterator;
+
+            if(!includeRelationships.isEmpty()) {
+                constraintsIterator = includeRelationships.stream()
+                        .filter(type -> !excludeRelationships.contains(type) && tokenRead.relationshipType(type) != -1)
+                        .flatMap(type -> {
+                            Iterable<ConstraintDefinition> constraintsForType = schema.getConstraints(RelationshipType.withName(type));
+                            return StreamSupport.stream(constraintsForType.spliterator(), false);
+                        })
+                        .collect(Collectors.toList());
+            } else {
+                Iterable<ConstraintDefinition> allConstraints = schema.getConstraints();
+                constraintsIterator = StreamSupport.stream(allConstraints.spliterator(),false)
+                        .filter(index -> !excludeRelationships.contains(index.getRelationshipType().name()))
+                        .collect(Collectors.toList());
+            }
+
+            Stream<ConstraintRelationshipInfo> constraintRelationshipInfoStream = StreamSupport.stream(constraintsIterator.spliterator(), false)
+                    .filter(constraintDefinition -> constraintDefinition.isConstraintType(ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE))
+                    .map(this::relationshipInfoFromConstraintDefinition);
+
+            return constraintRelationshipInfoStream;
+        }
+    }
 
     /**
      * ConstraintInfo info from ConstraintDescriptor


### PR DESCRIPTION
Fixes #991

Add ability to provide label to schema functions for filtered results

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Now it can be possible to find all the nodes contraints/Indexes by label e.g (CALL apoc.schema.nodes(labelName) yield properties)
