### PR TITLE
fixes #478 - Export graphml missing labels of Nodes and Edges

### DIFF
--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -278,7 +278,27 @@ GraphML is used by other tools, like Gephi and CytoScape to read graph data.
 | apoc.export.graphml.graph(graph,file,config) | exports given graph object as graphml to the provided file
 | apoc.export.graphml.query(query,file,config) | exports nodes and relationships from the Cypher statement as graphml to the provided file
 |===
+
+All `Point` or `Temporal` data types are exported formatted as a String
+
+e.g:
+[cols="1m,2"]
+|===
+|Point 3d | {"crs":"wgs-84-3d","latitude":56.7,"longitude":12.78,"height":100.0}
+|Point 2d | {"crs":"wgs-84-3d","latitude":56.7,"longitude":12.78,"height":null}
+|Date | 2018-10-10
+|LocalDateTime | 2018-10-10T00:00
+|===
 // end::export.graphml[]
+
+.configuration options
+[options=header]
+|===
+| param | default | description
+| format | | In export to Graphml script define the export format. Possible value is: "gephi"
+| caption | | It's an array of string (i.e. ['name','title']) that define an ordered set of properties eligible as value for the `Label` value, if no match is found the there is a fallback to the node label, if the node label is missing the then the ID is used
+| useTypes | false | Write the attribute type information to the graphml output
+|===
 
 ==== Note:
 

--- a/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/src/main/java/apoc/export/csv/CsvFormat.java
@@ -1,32 +1,17 @@
 package apoc.export.csv;
 
-import apoc.export.util.ExportConfig;
-import apoc.export.util.Format;
-import apoc.export.util.FormatUtils;
-import apoc.export.util.MetaInformation;
-import apoc.export.util.Reporter;
+import apoc.export.util.*;
 import apoc.result.ProgressInfo;
 import com.opencsv.CSVWriter;
 import org.neo4j.cypher.export.SubGraph;
-import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.PropertyContainer;
-import org.neo4j.graphdb.Relationship;
-import org.neo4j.graphdb.Result;
-import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.*;
 
 import java.io.Reader;
 import java.io.Writer;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
-import static apoc.export.util.MetaInformation.collectPropTypesForNodes;
-import static apoc.export.util.MetaInformation.collectPropTypesForRelationships;
-import static apoc.export.util.MetaInformation.getLabelsString;
+import static apoc.export.util.MetaInformation.*;
 
 /**
  * @author mh

--- a/src/main/java/apoc/export/util/ExportConfig.java
+++ b/src/main/java/apoc/export/util/ExportConfig.java
@@ -1,12 +1,13 @@
 package apoc.export.util;
 
 import apoc.export.cypher.formatter.CypherFormat;
+import apoc.gephi.Gephi;
 import apoc.util.Util;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.*;
 
 import static apoc.util.Util.toBoolean;
+import static java.util.Arrays.asList;
 
 /**
  * @author mh
@@ -28,6 +29,7 @@ public class ExportConfig {
     private String delim = DEFAULT_DELIM;
     private String quotes = DEFAULT_QUOTES;
     private boolean useTypes = false;
+    private Set<String> caption;
     private boolean writeNodeProperties = false;
     private boolean nodesOfRelationships;
     private ExportFormat format;
@@ -61,9 +63,9 @@ public class ExportConfig {
 
     public ExportFormat getFormat() { return format; }
 
-    public CypherFormat getCypherFormat() {
-        return cypherFormat;
-    }
+    public Set<String> getCaption() { return caption; }
+
+    public CypherFormat getCypherFormat() { return cypherFormat; }
 
     public ExportConfig(Map<String,Object> config) {
         config = config != null ? config : Collections.emptyMap();
@@ -71,6 +73,7 @@ public class ExportConfig {
         this.batchSize = ((Number)config.getOrDefault("batchSize", DEFAULT_BATCH_SIZE)).intValue();
         this.delim = delim(config.getOrDefault("d", String.valueOf(DEFAULT_DELIM)).toString());
         this.useTypes = toBoolean(config.get("useTypes"));
+        this.caption = convertCaption(config.getOrDefault("caption", asList("name", "title", "label", "id")));
         this.nodesOfRelationships = toBoolean(config.get("nodesOfRelationships"));
         this.format = ExportFormat.fromString((String) config.getOrDefault("format", "neo4j-shell"));
         this.cypherFormat = CypherFormat.fromString((String) config.getOrDefault("cypherFormat", "create"));
@@ -128,6 +131,13 @@ public class ExportConfig {
 
     private ExportFormat format(Object format) {
         return format != null && format instanceof String ? ExportFormat.fromString((String)format) : ExportFormat.NEO4J_SHELL;
+    }
+
+    private static Set<String> convertCaption(Object value) {
+        if (value == null) return null;
+        if (!(value instanceof List)) throw new RuntimeException("Only array of Strings are allowed!");
+        List<String> strings = (List<String>) value;
+        return new HashSet<>(strings);
     }
 
     public boolean streamStatements() {

--- a/src/main/java/apoc/export/util/ExportFormat.java
+++ b/src/main/java/apoc/export/util/ExportFormat.java
@@ -1,6 +1,5 @@
 package apoc.export.util;
 
-import apoc.export.cypher.formatter.CypherFormatter;
 import apoc.export.cypher.formatter.CypherFormatterUtils;
 
 import static java.lang.String.format;
@@ -18,7 +17,10 @@ public enum ExportFormat {
     CYPHER_SHELL("cypher-shell",
             format(":commit%n"), format(":begin%n"), "", "CALL db.awaitIndex('%s(%s)');%n"),
 
-    PLAIN_FORMAT("plain", "", "", "", "");
+    PLAIN_FORMAT("plain", "", "", "", ""),
+
+    GEPHI("gephi", "", "", "", "");
+
 
     private final String format;
 

--- a/src/main/java/apoc/export/util/FormatUtils.java
+++ b/src/main/java/apoc/export/util/FormatUtils.java
@@ -1,7 +1,10 @@
 package apoc.export.util;
 
+import apoc.util.JsonUtil;
 import apoc.util.Util;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.spatial.Point;
 
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
@@ -73,7 +76,18 @@ public class FormatUtils {
         if (value instanceof Number) {
             return formatNumber((Number)value);
         }
+        if (value instanceof Point) {
+            return formatPoint((Point) value);
+        }
         return value.toString();
+    }
+
+    public static String formatPoint(Point value) {
+        try {
+            return JsonUtil.OBJECT_MAPPER.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static List<String> getLabelsSorted(Node node) {

--- a/src/main/java/apoc/gephi/GephiFormatUtils.java
+++ b/src/main/java/apoc/gephi/GephiFormatUtils.java
@@ -1,0 +1,41 @@
+package apoc.gephi;
+
+import org.neo4j.graphdb.Node;
+
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.BiPredicate;
+
+public class GephiFormatUtils {
+
+    public static String getCaption(Node n, Set<String> captions) {
+        for (String caption : captions) { //first do one loop with the exact names
+            if (n.hasProperty(caption))
+                return n.getProperty(caption).toString();
+        }
+
+        String result = filterCaption(n, captions, (key, caption) -> key.equalsIgnoreCase(caption)); //2nd loop with lowercase
+        if (result == null) {
+            result = filterCaption(n, captions, (key, caption) -> key.toLowerCase().contains(caption) || key.toLowerCase().endsWith(caption)); //3rd loop with contains or endsWith
+            if (result == null) {
+                Iterator<String> iterator = n.getPropertyKeys().iterator();
+                if (iterator.hasNext()) {
+                    result = n.getProperty(iterator.next()).toString(); // get the first property
+                }
+            }
+        }
+        return result == null ? String.valueOf(n.getId()) : result; // if the node has no property return the ID
+    }
+
+    public static String filterCaption(Node n, Set<String> captions, BiPredicate<String, String> predicate) {
+
+        for (String caption : captions) {
+            for (String key : n.getPropertyKeys()) {
+                if (predicate.test(key, caption))
+                    return n.getProperty(key).toString();
+            }
+
+        }
+        return null;
+    }
+}

--- a/src/test/java/apoc/util/TestUtil.java
+++ b/src/test/java/apoc/util/TestUtil.java
@@ -15,6 +15,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.io.File;
 import java.net.Socket;
+import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
@@ -166,5 +167,9 @@ public class TestUtil {
         } catch (Exception e) {
             return false;
         }
+    }
+
+    public static URL getUrlFileName(String filename) {
+        return Thread.currentThread().getContextClassLoader().getResource(filename);
     }
 }


### PR DESCRIPTION
fixes #478 #466

- #478 Export graphml missing labels of Nodes and Edges
- #466 APOC GraphML attributes not loadable by Gephi

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - All attributes/key are exported and generated
  - By deafult key are generated, for types use `useTypes:true`
