### PR TITLE
fixes #1005

### DIFF
--- a/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/src/main/java/apoc/export/csv/CsvFormat.java
@@ -47,7 +47,7 @@ public class CsvFormat implements Format {
     @Override
     public ProgressInfo dump(SubGraph graph, Writer writer, Reporter reporter, ExportConfig config) throws Exception {
         try (Transaction tx = db.beginTx()) {
-            CSVWriter out = config.isQuotes() ? new CSVWriter(writer,config.getDelimChar(), ExportConfig.QUOTECHAR) : new CSVWriter(writer,config.getDelimChar());
+            CSVWriter out = config.isQuotes() ? new CSVWriter(writer,config.getDelimChar(), ExportConfig.QUOTECHAR) : new CSVWriter(writer,config.getDelimChar(), '\0', '\0' );
             writeAll(graph, reporter, config, out);
             tx.success();
             reporter.done();
@@ -58,7 +58,7 @@ public class CsvFormat implements Format {
 
     public ProgressInfo dump(Result result, Writer writer, Reporter reporter, ExportConfig config) throws Exception {
         try (Transaction tx = db.beginTx()) {
-            CSVWriter out = new CSVWriter(writer, config.getDelimChar());
+            CSVWriter out = config.isQuotes() ? new CSVWriter(writer,config.getDelimChar(), ExportConfig.QUOTECHAR) : new CSVWriter(writer,config.getDelimChar(), '\0', '\0');
 
             String[] header = writeResultHeader(result, out);
 

--- a/src/main/java/apoc/export/util/ExportConfig.java
+++ b/src/main/java/apoc/export/util/ExportConfig.java
@@ -21,7 +21,7 @@ public class ExportConfig {
     private int batchSize = DEFAULT_BATCH_SIZE;
     private boolean silent = false;
     private String delim = DEFAULT_DELIM;
-    private boolean quotes;
+    private boolean quotes = true;
     private boolean useTypes = false;
     private boolean writeNodeProperties = false;
     private boolean nodesOfRelationships;
@@ -64,7 +64,6 @@ public class ExportConfig {
         this.silent = toBoolean(config.getOrDefault("silent",false));
         this.batchSize = ((Number)config.getOrDefault("batchSize", DEFAULT_BATCH_SIZE)).intValue();
         this.delim = delim(config.getOrDefault("d", String.valueOf(DEFAULT_DELIM)).toString());
-        this.quotes = toBoolean(config.get("quotes"));
         this.useTypes = toBoolean(config.get("useTypes"));
         this.nodesOfRelationships = toBoolean(config.get("nodesOfRelationships"));
         this.format = ExportFormat.fromString((String) config.getOrDefault("format", "neo4j-shell"));
@@ -72,6 +71,10 @@ public class ExportConfig {
         this.config = config;
         this.streamStatements = toBoolean(config.get("streamStatements")) || toBoolean(config.get("stream"));
         this.writeNodeProperties = toBoolean(config.get("writeNodeProperties"));
+
+        if ( config.get("quotes") != null ) {
+            this.quotes = toBoolean(config.get("quotes"));
+        }
     }
 
     public boolean getRelsInBetween() {

--- a/src/main/java/apoc/export/util/ExportConfig.java
+++ b/src/main/java/apoc/export/util/ExportConfig.java
@@ -16,12 +16,13 @@ public class ExportConfig {
     public static final char QUOTECHAR = '"';
     public static final int DEFAULT_BATCH_SIZE = 20000;
     public static final String DEFAULT_DELIM = ",";
+    public static final String DEFAULT_QUOTES_TYPE = "always";
     private final boolean streamStatements;
 
     private int batchSize = DEFAULT_BATCH_SIZE;
     private boolean silent = false;
     private String delim = DEFAULT_DELIM;
-    private boolean quotes = true;
+    private String quotes = "always";
     private boolean useTypes = false;
     private boolean writeNodeProperties = false;
     private boolean nodesOfRelationships;
@@ -45,7 +46,7 @@ public class ExportConfig {
         return delim;
     }
 
-    public boolean isQuotes() {
+    public String isQuotes() {
         return quotes;
     }
 
@@ -71,9 +72,19 @@ public class ExportConfig {
         this.config = config;
         this.streamStatements = toBoolean(config.get("streamStatements")) || toBoolean(config.get("stream"));
         this.writeNodeProperties = toBoolean(config.get("writeNodeProperties"));
+        exportQuotes(config);
+    }
 
-        if ( config.get("quotes") != null ) {
-            this.quotes = toBoolean(config.get("quotes"));
+    private void exportQuotes(Map<String, Object> config)
+    {
+        try {
+            this.quotes = (String) config.getOrDefault("quotes",
+                                                       DEFAULT_QUOTES_TYPE);
+            if (quotes == null) {
+                quotes = DEFAULT_QUOTES_TYPE;
+            }
+        } catch (ClassCastException e) { // backward compatibility
+            this.quotes = toBoolean(config.get("quotes")) ? "always" : "none";
         }
     }
 


### PR DESCRIPTION
`apoc.export.csv.query` do not surround every exported field
Fixes #1005

## Proposed Changes
A brief list of proposed changes in order to fix the issue:
  - In case the configuration for the export contains the pair `"quotes": true`, in the constructor of the  `CSVWriter` are specified `quotechar` and `escapechar` as `'\0'`:
         - the first avoids to migrate the call of `public void writeNext(String[] nextLine)` to `public void writeNext(String[] nextLine, boolean applyQuotesToAll)`
        - the second is used to avoid to append an extra `"`, since the default escape character is `"` (see `protected boolean stringContainsSpecialCharacters(String line)`  in `class CSVWriter` )
  - In the` ExportConfig` the default value of "quotes" configuration is `true`. 
- The export of the result of the query
```
"CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})"
```
is
       - with `"quotes": true`
```
"u.age","u.name","u.male","u.kids","labels(u)"
"42","foo","true","[""a"",""b"",""c""]","[""User1"",""User""]"
"42","bar","","","[""User""]"
"12","","","","[""User""]"
```
       - with `"quotes": false`
```
u.age,u.name,u.male,u.kids,labels(u)
42,foo,true,["a","b","c"],["User1","User"]
42,bar,,,["User"]
12,,,,["User"]
```