### PR TITLE
fixes #1016: Travis build failures

### DIFF
--- a/src/main/java/apoc/export/json/JsonFormat.java
+++ b/src/main/java/apoc/export/json/JsonFormat.java
@@ -147,7 +147,7 @@ public class JsonFormat implements Format {
                 } else {
                     jsonGenerator.writeStartArray();
                 }
-                List<Object> list = (List<Object>) value;
+                Object[] list = value.getClass().isArray() ? (Object[]) value : ((List<Object>) value).toArray();
                 for (Object elem : list) {
                     write(reporter, jsonGenerator, config, keyName, elem, false);
                 }

--- a/src/test/java/apoc/gephi/GephiTest.java
+++ b/src/test/java/apoc/gephi/GephiTest.java
@@ -1,15 +1,21 @@
 package apoc.gephi;
 
-import apoc.util.TestUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-import static apoc.util.TestUtil.serverListening;
-import static org.junit.Assert.*;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
+
+import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.registerProcedure;
+import static apoc.util.Util.map;
 
 /**
  * @author mh
@@ -17,13 +23,28 @@ import static org.junit.Assume.assumeTrue;
  */
 public class GephiTest {
 
+    private static final String GEPHI_WORKSPACE = "workspace1";
+
     private static GraphDatabaseService db;
+
+    private static boolean isGephiRunning() {
+        try {
+            URL url = new URL(String.format("http://localhost:8080/%s", GEPHI_WORKSPACE));
+            HttpURLConnection con = (HttpURLConnection) url.openConnection();
+            con.setRequestMethod("HEAD");
+            try (InputStream in = con.getInputStream()) {
+                return true;
+            }
+        } catch (Exception e) {
+            return false;
+        }
+    }
 
     @BeforeClass
     public static void setUp() throws Exception {
-        assumeTrue(serverListening("localhost", 8080));
+        assumeTrue(isGephiRunning());
         db = new TestGraphDatabaseFactory().newImpermanentDatabase();
-        TestUtil.registerProcedure(db,Gephi.class);
+        registerProcedure(db,Gephi.class);
         db.execute("CREATE (:Foo {name:'Foo'})-[:KNOWS{weight:7.2,foo:'foo',bar:3.0,directed:'error',label:'foo'}]->(:Bar {name:'Bar'})").close();
     }
 
@@ -36,54 +57,66 @@ public class GephiTest {
 
     @Test
     public void testAdd() throws Exception {
-            TestUtil.testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,'workspace1',p) yield nodes, relationships, format return *", r -> {
-                assertEquals(2L, r.get("nodes"));
-                assertEquals(1L, r.get("relationships"));
-                assertEquals("gephi", r.get("format"));
-            });
+        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,{workspace},p) yield nodes, relationships, format return *",
+                map("workspace", GEPHI_WORKSPACE),
+                r -> {
+                    assertEquals(2L, r.get("nodes"));
+                    assertEquals(1L, r.get("relationships"));
+                    assertEquals("gephi", r.get("format"));
+                });
     }
     @Test
     public void testWeightParameter() throws Exception {
-            TestUtil.testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,'workspace1',p,'weight') yield nodes, relationships, format return *", r -> {
-                assertEquals(2L, r.get("nodes"));
-                assertEquals(1L, r.get("relationships"));
-                assertEquals("gephi", r.get("format"));
-            });
+        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,{workspace},p,'weight') yield nodes, relationships, format return *",
+                map("workspace", GEPHI_WORKSPACE),
+                r -> {
+                    assertEquals(2L, r.get("nodes"));
+                    assertEquals(1L, r.get("relationships"));
+                    assertEquals("gephi", r.get("format"));
+                });
     }
 
     @Test
     public void testWrongWeightParameter() throws Exception {
-            TestUtil.testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,'workspace1',p,'test') yield nodes, relationships, format return *", r -> {
-                assertEquals(2L, r.get("nodes"));
-                assertEquals(1L, r.get("relationships"));
-                assertEquals("gephi", r.get("format"));
-            });
+        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,{workspace},p,'test') yield nodes, relationships, format return *",
+                map("workspace", GEPHI_WORKSPACE),
+                r -> {
+                    assertEquals(2L, r.get("nodes"));
+                    assertEquals(1L, r.get("relationships"));
+                    assertEquals("gephi", r.get("format"));
+                });
     }
 
     @Test
     public void testRightExportParameter() throws Exception {
-            TestUtil.testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,'workspace1',p,'weight',['foo']) yield nodes, relationships, format return *", r -> {
-                assertEquals(2L, r.get("nodes"));
-                assertEquals(1L, r.get("relationships"));
-                assertEquals("gephi", r.get("format"));
-            });
+        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,{workspace},p,'weight',['foo']) yield nodes, relationships, format return *",
+                map("workspace", GEPHI_WORKSPACE),
+                r -> {
+                    assertEquals(2L, r.get("nodes"));
+                    assertEquals(1L, r.get("relationships"));
+                    assertEquals("gephi", r.get("format"));
+                });
     }
 
     @Test
     public void testWrongExportParameter() throws Exception {
-            TestUtil.testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,'workspace1',p,'weight',['faa','fee']) yield nodes, relationships, format return *", r -> {
-                assertEquals(2L, r.get("nodes"));
-                assertEquals(1L, r.get("relationships"));
-                assertEquals("gephi", r.get("format"));
-            });
+        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,{workspace},p,'weight',['faa','fee']) yield nodes, relationships, format return *",
+                map("workspace", GEPHI_WORKSPACE),
+                r -> {
+                    assertEquals(2L, r.get("nodes"));
+                    assertEquals(1L, r.get("relationships"));
+                    assertEquals("gephi", r.get("format"));
+                });
     }
 
     @Test
     public void reservedExportParameter() throws Exception {
-            TestUtil.testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,'workspace1',p,'weight',['directed','label']) yield nodes, relationships, format return *", r -> {
-                assertEquals(2L, r.get("nodes"));
-                assertEquals(1L, r.get("relationships"));
-                assertEquals("gephi", r.get("format"));
-            });
+        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,{workspace},p,'weight',['directed','label']) yield nodes, relationships, format return *",
+                map("workspace", GEPHI_WORKSPACE),
+                r -> {
+                    assertEquals(2L, r.get("nodes"));
+                    assertEquals(1L, r.get("relationships"));
+                    assertEquals("gephi", r.get("format"));
+                });
     }
 }

--- a/src/test/java/apoc/util/TestUtil.java
+++ b/src/test/java/apoc/util/TestUtil.java
@@ -152,7 +152,7 @@ public class TestUtil {
     }
 
     public static GraphDatabaseBuilder apocEnterpriseGraphDatabaseBuilder() throws Exception {
-        File storeDir = Paths.get(System.getProperty( "java.io.tmpdir").concat(File.pathSeparator).concat("neo4j-enterprise")).toFile();
+        File storeDir = Paths.get(System.getProperty( "java.io.tmpdir").concat(File.separator).concat("neo4j-enterprise")).toFile();
         FileDeleteStrategy.FORCE.delete(storeDir);
         return new EnterpriseGraphDatabaseFactory().newEmbeddedDatabaseBuilder(storeDir)
                 .setConfig("dbms.backup.enabled","false")


### PR DESCRIPTION
Fixes #1016
One sentence summary of the change.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:
  - Change the way that `GephiTest` resolve a running Gephi instance the old way could return a false positive if there is a running service at port `8080`
  - Correct the path separator of the Enterprise Edition instance
  - fixed the LIST management in the json export with a `Meta.Types.LIST` after the #1000 
