### PR TITLE
fixes #775 - apoc.export.graphml.all requires apoc.import.file.enabled needs to be enabled rather than apoc.export.file.enabled.

### DIFF
--- a/src/main/java/apoc/export/graphml/ExportGraphML.java
+++ b/src/main/java/apoc/export/graphml/ExportGraphML.java
@@ -1,10 +1,10 @@
 package apoc.export.graphml;
 
 import apoc.export.util.ExportConfig;
-import apoc.util.FileUtils;
 import apoc.export.util.NodesAndRelsSubGraph;
 import apoc.export.util.ProgressReporter;
 import apoc.result.ProgressInfo;
+import apoc.util.FileUtils;
 import apoc.util.Util;
 import org.neo4j.cypher.export.CypherResultSubGraph;
 import org.neo4j.cypher.export.DatabaseSubGraph;
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static apoc.util.FileUtils.checkWriteAllowed;
 import static apoc.util.FileUtils.getPrintWriter;
 
 /**
@@ -90,7 +91,7 @@ public class ExportGraphML {
     }
 
     private Stream<ProgressInfo> exportGraphML(@Name("file") String fileName, String source, SubGraph graph, ExportConfig config) throws Exception, XMLStreamException {
-        FileUtils.checkReadAllowed(fileName);
+        if (fileName != null) checkWriteAllowed();
         ProgressReporter reporter = new ProgressReporter(null, null, new ProgressInfo(fileName, source, "graphml"));
         PrintWriter printWriter = getPrintWriter(fileName, null);
         XmlGraphMLWriter exporter = new XmlGraphMLWriter();


### PR DESCRIPTION
fixes #775

apoc.export.graphml.all requires apoc.import.file.enabled needs to be enabled rather than apoc.export.file.enabled.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Import required only the `apoc.import.file.enabled`
  - Export required only the `apoc.export.file.enabled`
