### PR TITLE
Add missing cases in #1005

### DIFF
--- a/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/src/main/java/apoc/export/csv/CsvFormat.java
@@ -47,7 +47,7 @@ public class CsvFormat implements Format {
     @Override
     public ProgressInfo dump(SubGraph graph, Writer writer, Reporter reporter, ExportConfig config) throws Exception {
         try (Transaction tx = db.beginTx()) {
-            CSVWriter out = config.isQuotes() ? new CSVWriter(writer,config.getDelimChar(), ExportConfig.QUOTECHAR) : new CSVWriter(writer,config.getDelimChar());
+            CSVWriter out = config.isQuotes() ? new CSVWriter(writer,config.getDelimChar(), ExportConfig.QUOTECHAR) : new CSVWriter(writer,config.getDelimChar(), '\0', '\0' );
             writeAll(graph, reporter, config, out);
             tx.success();
             reporter.done();
@@ -58,7 +58,7 @@ public class CsvFormat implements Format {
 
     public ProgressInfo dump(Result result, Writer writer, Reporter reporter, ExportConfig config) throws Exception {
         try (Transaction tx = db.beginTx()) {
-            CSVWriter out = new CSVWriter(writer, config.getDelimChar());
+            CSVWriter out = config.isQuotes() ? new CSVWriter(writer,config.getDelimChar(), ExportConfig.QUOTECHAR) : new CSVWriter(writer,config.getDelimChar(), '\0', '\0');
 
             String[] header = writeResultHeader(result, out);
 

--- a/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/src/main/java/apoc/export/csv/CsvFormat.java
@@ -225,7 +225,7 @@ public class CsvFormat implements Format {
             out.writeNext(row);
             rels++;
             if (batchSize==-1 || rels % batchSize == 0) {
-                reporter.update(0, 1, 0);
+                reporter.update(0, rels, 0);
                 rels = 0;
             }
         }

--- a/src/main/java/apoc/export/util/ExportConfig.java
+++ b/src/main/java/apoc/export/util/ExportConfig.java
@@ -21,7 +21,7 @@ public class ExportConfig {
     private int batchSize = DEFAULT_BATCH_SIZE;
     private boolean silent = false;
     private String delim = DEFAULT_DELIM;
-    private boolean quotes;
+    private boolean quotes = true;
     private boolean useTypes = false;
     private boolean writeNodeProperties = false;
     private boolean nodesOfRelationships;
@@ -64,7 +64,6 @@ public class ExportConfig {
         this.silent = toBoolean(config.getOrDefault("silent",false));
         this.batchSize = ((Number)config.getOrDefault("batchSize", DEFAULT_BATCH_SIZE)).intValue();
         this.delim = delim(config.getOrDefault("d", String.valueOf(DEFAULT_DELIM)).toString());
-        this.quotes = toBoolean(config.get("quotes"));
         this.useTypes = toBoolean(config.get("useTypes"));
         this.nodesOfRelationships = toBoolean(config.get("nodesOfRelationships"));
         this.format = ExportFormat.fromString((String) config.getOrDefault("format", "neo4j-shell"));
@@ -72,6 +71,10 @@ public class ExportConfig {
         this.config = config;
         this.streamStatements = toBoolean(config.get("streamStatements")) || toBoolean(config.get("stream"));
         this.writeNodeProperties = toBoolean(config.get("writeNodeProperties"));
+
+        if ( config.get("quotes") != null ) {
+            this.quotes = toBoolean(config.get("quotes"));
+        }
     }
 
     public boolean getRelsInBetween() {

--- a/src/main/java/apoc/export/util/ExportConfig.java
+++ b/src/main/java/apoc/export/util/ExportConfig.java
@@ -27,7 +27,6 @@ public class ExportConfig {
     private boolean silent = false;
     private String delim = DEFAULT_DELIM;
     private String quotes = DEFAULT_QUOTES;
-    private boolean quoteIfNeeded = false;
     private boolean useTypes = false;
     private boolean writeNodeProperties = false;
     private boolean nodesOfRelationships;
@@ -55,7 +54,6 @@ public class ExportConfig {
         return quotes;
     }
 
-    public boolean isQuotesNeeded() { return quoteIfNeeded; }
 
     public boolean useTypes() {
         return useTypes;
@@ -86,10 +84,6 @@ public class ExportConfig {
     {
         try {
             this.quotes = (String) config.getOrDefault("quotes", DEFAULT_QUOTES);
-
-            if ( this.quotes.equals(IF_NEEDED_QUUOTES) ) {
-                quoteIfNeeded = true;
-            }
 
             if ( !quotes.equals(ALWAYS_QUOTES) && !quotes.equals(NONE_QUOTES) && !quotes.equals(IF_NEEDED_QUUOTES) ) {
                 throw new RuntimeException("The string value of the field quote is not valid");

--- a/src/main/java/apoc/export/util/ExportConfig.java
+++ b/src/main/java/apoc/export/util/ExportConfig.java
@@ -16,12 +16,13 @@ public class ExportConfig {
     public static final char QUOTECHAR = '"';
     public static final int DEFAULT_BATCH_SIZE = 20000;
     public static final String DEFAULT_DELIM = ",";
+    public static final String DEFAULT_QUOTES_TYPE = "always";
     private final boolean streamStatements;
 
     private int batchSize = DEFAULT_BATCH_SIZE;
     private boolean silent = false;
     private String delim = DEFAULT_DELIM;
-    private boolean quotes = true;
+    private String quotes = "always";
     private boolean useTypes = false;
     private boolean writeNodeProperties = false;
     private boolean nodesOfRelationships;
@@ -45,7 +46,7 @@ public class ExportConfig {
         return delim;
     }
 
-    public boolean isQuotes() {
+    public String isQuotes() {
         return quotes;
     }
 
@@ -71,9 +72,19 @@ public class ExportConfig {
         this.config = config;
         this.streamStatements = toBoolean(config.get("streamStatements")) || toBoolean(config.get("stream"));
         this.writeNodeProperties = toBoolean(config.get("writeNodeProperties"));
+        exportQuotes(config);
+    }
 
-        if ( config.get("quotes") != null ) {
-            this.quotes = toBoolean(config.get("quotes"));
+    private void exportQuotes(Map<String, Object> config)
+    {
+        try {
+            this.quotes = (String) config.getOrDefault("quotes",
+                                                       DEFAULT_QUOTES_TYPE);
+            if (quotes == null) {
+                quotes = DEFAULT_QUOTES_TYPE;
+            }
+        } catch (ClassCastException e) { // backward compatibility
+            this.quotes = toBoolean(config.get("quotes")) ? "always" : "none";
         }
     }
 

--- a/src/main/java/apoc/export/util/ExportConfig.java
+++ b/src/main/java/apoc/export/util/ExportConfig.java
@@ -14,15 +14,20 @@ import static apoc.util.Util.toBoolean;
  */
 public class ExportConfig {
     public static final char QUOTECHAR = '"';
+    public static final String NONE_QUOTES = "none";
+    public static final String ALWAYS_QUOTES = "always";
+    public static final String IF_NEEDED_QUUOTES = "ifNeeded";
+
     public static final int DEFAULT_BATCH_SIZE = 20000;
     public static final String DEFAULT_DELIM = ",";
-    public static final String DEFAULT_QUOTES_TYPE = "always";
+    public static final String DEFAULT_QUOTES = ALWAYS_QUOTES;
     private final boolean streamStatements;
 
     private int batchSize = DEFAULT_BATCH_SIZE;
     private boolean silent = false;
     private String delim = DEFAULT_DELIM;
-    private String quotes = "always";
+    private String quotes = DEFAULT_QUOTES;
+    private boolean quoteIfNeeded = false;
     private boolean useTypes = false;
     private boolean writeNodeProperties = false;
     private boolean nodesOfRelationships;
@@ -49,6 +54,8 @@ public class ExportConfig {
     public String isQuotes() {
         return quotes;
     }
+
+    public boolean isQuotesNeeded() { return quoteIfNeeded; }
 
     public boolean useTypes() {
         return useTypes;
@@ -78,13 +85,18 @@ public class ExportConfig {
     private void exportQuotes(Map<String, Object> config)
     {
         try {
-            this.quotes = (String) config.getOrDefault("quotes",
-                                                       DEFAULT_QUOTES_TYPE);
-            if (quotes == null) {
-                quotes = DEFAULT_QUOTES_TYPE;
+            this.quotes = (String) config.getOrDefault("quotes", DEFAULT_QUOTES);
+
+            if ( this.quotes.equals(IF_NEEDED_QUUOTES) ) {
+                quoteIfNeeded = true;
             }
+
+            if ( !quotes.equals(ALWAYS_QUOTES) && !quotes.equals(NONE_QUOTES) && !quotes.equals(IF_NEEDED_QUUOTES) ) {
+                throw new RuntimeException("The string value of the field quote is not valid");
+            }
+
         } catch (ClassCastException e) { // backward compatibility
-            this.quotes = toBoolean(config.get("quotes")) ? "always" : "none";
+            this.quotes = toBoolean(config.get("quotes")) ? ALWAYS_QUOTES : NONE_QUOTES;
         }
     }
 

--- a/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -189,7 +189,7 @@ public class ExportCsvTest {
     }
 
     @Test
-    public void testExportGraphCsvWithouQuotes() throws Exception {
+    public void testExportGraphCsvWithoutQuotes() throws Exception {
         File output = new File(directory, "graph.csv");
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
                         "CALL apoc.export.csv.graph(graph, {file},null) " +

--- a/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -53,8 +53,8 @@ public class ExportCsvTest {
             "\"\",\"\",\"via Benni\",\"[\"\"Address\"\"]\"");
     private static final String EXPECTED_QUERY_QUOTES_NEEDED= String.format( "a.name,a.city,a.street,labels(a)%n" +
             "Andrea,Milano,\"Via Garibaldi, 7\",\"[\"Address1\",\"Address\"]\"%n" +
-            "Bar Sport,,,[\"Address\"]%n" +
-            ",,via Benni,[\"Address\"]");
+            "Bar Sport,,,\"[\"Address\"]\"%n" +
+            ",,via Benni,\"[\"Address\"]\"");
     private static final String EXPECTED = String.format("\"_id\",\"_labels\",\"name\",\"age\",\"male\",\"kids\",\"street\",\"city\",\"_start\",\"_end\",\"_type\"%n" +
             "\"0\",\":User:User1\",\"foo\",\"42\",\"true\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"\",\"\",,,%n" +
             "\"1\",\":User\",\"bar\",\"42\",\"\",\"\",\"\",\"\",,,%n" +

--- a/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -1,14 +1,8 @@
 package apoc.export.csv;
 
-import static apoc.util.MapUtil.map;
-import static org.junit.Assert.*;
-
-import java.io.File;
-import java.nio.file.Files;
-import java.util.Map;
-import java.util.Scanner;
-import java.util.function.Consumer;
-
+import apoc.graph.Graphs;
+import apoc.util.HdfsTestUtils;
+import apoc.util.TestUtil;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
@@ -22,10 +16,14 @@ import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-import apoc.graph.Graphs;
-import apoc.util.HdfsTestUtils;
-import apoc.util.TestUtil;
-import org.omg.SendingContext.RunTime;
+import java.io.File;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.function.Consumer;
+
+import static apoc.util.MapUtil.map;
+import static org.junit.Assert.*;
 
 /**
  * @author mh
@@ -304,8 +302,8 @@ public class ExportCsvTest {
             assertEquals(2L, r.get("batchSize"));
             assertEquals(4L, r.get("batches"));
             assertEquals(6L, r.get("nodes"));
-            assertEquals(7L, r.get("rows"));
-            assertEquals(1L, r.get("relationships"));
+            assertEquals(8L, r.get("rows"));
+            assertEquals(2L, r.get("relationships"));
             assertEquals(12L, r.get("properties"));
             assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
             sb.append(r.get("data"));


### PR DESCRIPTION
Complement of the Fixes #1005

## Proposed Changes (Mandatory)
- Fixes in #1005 did not applied for export all graph, quotes rules should be now valid for all types of csv export
- counter of the exported relationships has been fixed