### PR TITLE
fixes #998 - Add a mode to export.cypher that batches updates

### DIFF
--- a/docs/asciidoc/big-graph-from-cypher.adoc
+++ b/docs/asciidoc/big-graph-from-cypher.adoc
@@ -53,7 +53,7 @@ The default value is 20000.
 [source,bash,subs=attributes]
 ----
 time ./cypher-shell -u yourUsername -p yourPassword
-"call apoc.export.cypher.all('yourPath/exportAll', {format:'neo4j-shell', batchSize: 10000})"
+"call apoc.export.cypher.all('yourPath/exportAll', {format:'neo4j-shell', batchSize: 10000, useOptimizations: {type: "none"}})"
 ----
 
 ==== Results
@@ -97,7 +97,7 @@ We try the different output formats, changing the `config` parameter `format`.
 [source,bash,subs=attributes]
 ----
 time ./cypher-shell -u yourUsername -p yourPassword  
-"call apoc.export.cypher.all('yourPath/exportData.cypher', {format:'neo4j-shell'})"
+"call apoc.export.cypher.all('yourPath/exportData.cypher', {format:'neo4j-shell', useOptimizations: {type: "none"}})"
 ----
 
 ==== Results
@@ -139,7 +139,7 @@ In the example below we name the exported file `exportAll.cypher` so our export 
 [source,bash,subs=attributes]
 ----
 time ./cypher-shell -u yourUsername -p yourPassword  
-"call apoc.export.cypher.all('yourPath/exportAll.cypher', {format:'neo4j-shell',separateFiles:true})"
+"call apoc.export.cypher.all('yourPath/exportAll.cypher', {format:'neo4j-shell',separateFiles:true, useOptimizations: {type: "none"}})"
 ----
 
 ==== Result
@@ -157,7 +157,7 @@ sys  0m0.084s
 ----
 time ./cypher-shell -u yourUsername -p yourPassword
 "call apoc.export.cypher.query('MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m',
-'yourPath/exportQuery.cypher', {format:'neo4j-shell', batchSize: 10000})"
+'yourPath/exportQuery.cypher', {format:'neo4j-shell', batchSize: 10000, useOptimizations: {type: "none"}})"
 ----
 
 === Result
@@ -174,7 +174,7 @@ sys     0m0.068s
 ----
 time ./cypher-shell -u yourUsername -p yourPassword  "Match (n:Person)-[r:LIKES_COMMENT]->(c:Comment)
 with collect(n) as colN, collect(c) as colC, collect(r) as colR
-CALL apoc.export.cypher.data(colN+colC,colR, 'yourPath/exportData.cypher',{format:'plain'}) YIELD nodes, relationships
+CALL apoc.export.cypher.data(colN+colC,colR, 'yourPath/exportData.cypher',{format:'plain', useOptimizations: {type: "none"}}) YIELD nodes, relationships
 RETURN nodes, relationships"
 ----
 
@@ -190,7 +190,7 @@ sys     0m0.372s
 
 [source,bash,subs=attributes]
 ----
-time ./cypher-shell -u yourUsername -p yourPassword "CALL apoc.graph.fromDB('test',{})
+time ./cypher-shell -u yourUsername -p yourPassword "CALL apoc.graph.fromDB('test',{useOptimizations: {type: "none"}})
 yield graph CALL apoc.export.cypher.graph(graph, 'yourPath/exportGraph.cypher',null)
 YIELD nodes, relationships
 RETURN nodes, relationships"
@@ -313,11 +313,11 @@ sys     37m35.852s
 
 For the new implementations and the test of the exportCypher we used this characteristics:
 
-* 2 cores
+* 6 cores
 
-* Intel(R) CPU I5-5200U @ 2.70GHz
+* Intel(R) CPU I7-8750H @ 2.2GHz
 
-* 8 GB of RAM
+* 16 GB of RAM
 
 
 .Neo4j configuration
@@ -330,7 +330,7 @@ For the new implementations and the test of the exportCypher we used this charac
 
 .Graph info
 
-we use the Northwind Graph (:play northwind-graph)
+we use the `MusicBrainz dataset`, you can download from this link: http://example-data.neo4j.org/3.0-datasets/musicbrainz.tgz?_ga=2.224357650.84486006.1547734927-1971869821.1541933587[musicBrainz dataset]
 
 * total *nodes* -> 1035
 
@@ -345,15 +345,30 @@ We try the different output formats, changing the `config` parameter `format`.
 [source,bash,subs=attributes]
 ----
 time ./cypher-shell -u yourUsername -p yourPassword  
-"call apoc.export.cypher.all('yourPath/exportData.cypher', {format:'plain'})"
+"call apoc.export.cypher.all('yourPath/exportData.cypher', {format:'plain', useOptimizations: {unwindBatch: true}})"
 ----
 
 ==== Results
 
+.With Optimizations
 ----
-real	0m1,740s
-user	0m1,907s
-sys	    0m0,141s
+real	0m1,838s
+user	0m1,251s
+sys	    0m0,136s
+----
+
+[source,bash,subs=attributes]
+----
+time ./cypher-shell -u yourUsername -p yourPassword  
+"call apoc.export.cypher.all('yourPath/exportData.cypher', {useOptimizations: {type: "none"}, format:'plain'})"
+----
+==== Results
+
+.Without Optimizations
+----
+real	0m1,539s
+user	0m1,304s
+sys	    0m0,170s
 ----
 
 .cypher-shell
@@ -361,15 +376,31 @@ sys	    0m0,141s
 [source,bash,subs=attributes]
 ----
 time ./cypher-shell -u yourUsername -p yourPassword  
-"call apoc.export.cypher.all('yourPath/exportData.cypher', {format:'cypher-shell'})"
+"call apoc.export.cypher.all('yourPath/exportData.cypher', {format:'cypher-shell', useOptimizations: {unwindBatch: true}})"
 ----
 
 ==== Results
-
+.With Optimizations
 ----
-real	0m1,634s
-user	0m1,851s
-sys	    0m0,139s
+real	0m1,351s
+user	0m1,214s
+sys	    0m0,137s
+----
+
+.cypher-shell
+
+[source,bash,subs=attributes]
+----
+time ./cypher-shell -u yourUsername -p yourPassword  
+"call apoc.export.cypher.all('yourPath/exportData.cypher', {useOptimizations: {useOptimizations: {type: "none"}}, format:'cypher-shell'})"
+----
+
+==== Results
+.Without Optimizations
+----
+real	0m1,259s
+user	0m1,222s
+sys	    0m0,137s
 ----
 
 .neo4j-shell
@@ -377,15 +408,32 @@ sys	    0m0,139s
 [source,bash,subs=attributes]
 ----
 time ./cypher-shell -u yourUsername -p yourPassword  
-"call apoc.export.cypher.all('yourPath/exportData.cypher', {format:'neo4j-shell'})"
+"call apoc.export.cypher.all('yourPath/exportData.cypher', {format:'neo4j-shell', useOptimizations: {unwindBatch: true}})"
+----
+
+==== Results
+.With Optimizations
+----
+real	0m1,297s
+user	0m1,227s
+sys	    0m0,133s
+----
+
+.neo4j-shell
+
+[source,bash,subs=attributes]
+----
+time ./cypher-shell -u yourUsername -p yourPassword  
+"call apoc.export.cypher.all('yourPath/exportData.cypher', {useOptimizations: {type: "none"}, format:'neo4j-shell'})"
 ----
 
 ==== Results
 
+.Without Optimizations
 ----
-real	0m2,095s
-user	0m1,908s
-sys	    0m0,108s
+real	0m1,232s
+user	0m1,236s
+sys	    0m0,133s
 ----
 
 == Import from file
@@ -398,11 +446,16 @@ time ./cypher-shell -u yourUsername -p yourPassword
 "call apoc.cypher.runFile('yourPath/import/exportPlain.cypher')"
 ----
 
-.Result
+.Result with optimizaions
 ----
-real	0m42,578s
-user	0m1,833s
-sys	    0m0,135s
+real	0m28,186s
+user	0m1,321s
+sys	    0m0,175s
+----
+
+.Result without optimizaions
+----
+it's import 1 nodes every 10 seconds
 ----
 
 === Import cypher-shell
@@ -414,11 +467,18 @@ time ./cypher-shell -u yourUsername -p yourPassword
 > 'yourPath/cypherShellOutput'
 ----
 
-.Result
+.Result with optimizaions
 ----
-real	0m29,475s
-user	0m2,825s
-sys	    0m0,167s
+real	0m17,820s
+user	0m1,909s
+sys	    0m0,222s
+----
+
+.Result without optimizaions
+----
+real	0m19,087s
+user	0m5,026s
+sys	    0m0,473s
 ----
 
 === Import neo4j-shell
@@ -430,9 +490,16 @@ time ./neo4j-shell -u yourUsername -p yourPassword -file
 > 'yourPath/neo4jShellOutput'
 ----
 
-.Result
+.Result with optimizaions
 ----
-real	0m54,581s
-user	0m7,472s
-sys	    0m1,896s
+real	0m41,546s
+user	0m10,124s
+sys	    0m5,423s
+----
+
+.Result without optimizaions
+----
+real	0m53,398s
+user	0m20,157s
+sys	    0m12,572s
 ----

--- a/docs/asciidoc/big-graph-from-cypher.adoc
+++ b/docs/asciidoc/big-graph-from-cypher.adoc
@@ -253,6 +253,7 @@ time ./cypher-shell -u yourUsername -p yourPassword
 
 With this command we import not more than 10/15 nodes per second.
 
+
 === Import cypher-shell
 
 [source,bash,subs=attributes]
@@ -306,4 +307,132 @@ Neo4j-shell
 real    98m54.617s
 user    21m5.140s
 sys     37m35.852s
+----
+
+=== New implementation of exportCypher
+
+For the new implementations and the test of the exportCypher we used this characteristics:
+
+* 2 cores
+
+* Intel(R) CPU I5-5200U @ 2.70GHz
+
+* 8 GB of RAM
+
+
+.Neo4j configuration
+
+* dbms.memory.heap.initial_size=1024m
+
+* dbms.memory.heap.max_size=2048m
+
+* dbms.memory.pagecache.size=1g
+
+.Graph info
+
+we use the Northwind Graph (:play northwind-graph)
+
+* total *nodes* -> 1035
+
+* total *relationships* -> 3139
+
+=== Different output formats
+
+We try the different output formats, changing the `config` parameter `format`.
+
+.plain
+
+[source,bash,subs=attributes]
+----
+time ./cypher-shell -u yourUsername -p yourPassword  
+"call apoc.export.cypher.all('yourPath/exportData.cypher', {format:'plain'})"
+----
+
+==== Results
+
+----
+real	0m1,740s
+user	0m1,907s
+sys	    0m0,141s
+----
+
+.cypher-shell
+
+[source,bash,subs=attributes]
+----
+time ./cypher-shell -u yourUsername -p yourPassword  
+"call apoc.export.cypher.all('yourPath/exportData.cypher', {format:'cypher-shell'})"
+----
+
+==== Results
+
+----
+real	0m1,634s
+user	0m1,851s
+sys	    0m0,139s
+----
+
+.neo4j-shell
+
+[source,bash,subs=attributes]
+----
+time ./cypher-shell -u yourUsername -p yourPassword  
+"call apoc.export.cypher.all('yourPath/exportData.cypher', {format:'neo4j-shell'})"
+----
+
+==== Results
+
+----
+real	0m2,095s
+user	0m1,908s
+sys	    0m0,108s
+----
+
+== Import from file
+
+=== runFile
+
+[source,bash,subs=attributes]
+----
+time ./cypher-shell -u yourUsername -p yourPassword
+"call apoc.cypher.runFile('yourPath/import/exportPlain.cypher')"
+----
+
+.Result
+----
+real	0m42,578s
+user	0m1,833s
+sys	    0m0,135s
+----
+
+=== Import cypher-shell
+
+[source,bash,subs=attributes]
+----
+time ./cypher-shell -u yourUsername -p yourPassword
+< 'yourPath/import/exportCypherShell.cypher'
+> 'yourPath/cypherShellOutput'
+----
+
+.Result
+----
+real	0m29,475s
+user	0m2,825s
+sys	    0m0,167s
+----
+
+=== Import neo4j-shell
+
+[source,bash,subs=attributes]
+----
+time ./neo4j-shell -u yourUsername -p yourPassword -file
+< 'yourPath/import/exportNeo4jShell.cypher'
+> 'yourPath/neo4jShellOutput'
+----
+
+.Result
+----
+real	0m54,581s
+user	0m7,472s
+sys	    0m1,896s
 ----

--- a/docs/asciidoc/big-graph-from-cypher.adoc
+++ b/docs/asciidoc/big-graph-from-cypher.adoc
@@ -1,6 +1,8 @@
 
 == Import and Export to Cypher
 
+=== Create Statements
+
 Refers to the issue https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/439/[#439] we documented some performance tests of export and import of a big graph into Cypher format file.
 For the test we used a server with this characteristics:
 
@@ -29,7 +31,7 @@ They have not be noticed significative difference with 4 GB of heap memory.
 
 Download here https://dl.dropboxusercontent.com/u/14493611/ldbc_sf001_p006.tgz/[LDBC SF1]
 
-== Script to execute all the tests
+=== Script to execute all the tests
 
 We created a script that execute all the tests explained below, you can run it like in this example:
 
@@ -43,9 +45,9 @@ If you use the LDBC SF1 graph, or another big one is better to change the `open 
 
 Download link:{script}/performanceCypherTest.sh[performanceCypherTest.sh]
 
-== Export all
+==== Export all
 
-=== Batch size
+===== Batch size
 
 With the use of the config param `batchSize` we done some tests with different batch size.
 The default value is 20000.
@@ -56,7 +58,7 @@ time ./cypher-shell -u yourUsername -p yourPassword
 "call apoc.export.cypher.all('yourPath/exportAll', {format:'neo4j-shell', batchSize: 10000, useOptimizations: {type: "none"}})"
 ----
 
-==== Results
+===== Results
 
 .Default 20.000
 
@@ -90,7 +92,7 @@ user    0m0.928s
 sys     0m0.088s
 ----
 
-=== Different output formats
+==== Different output formats
 
 We try the different output formats, changing the `config` parameter `format`.
 
@@ -100,7 +102,7 @@ time ./cypher-shell -u yourUsername -p yourPassword  
 "call apoc.export.cypher.all('yourPath/exportData.cypher', {format:'neo4j-shell', useOptimizations: {type: "none"}})"
 ----
 
-==== Results
+===== Results
 
 .neo4j-shell
 
@@ -309,197 +311,178 @@ user    21m5.140s
 sys     37m35.852s
 ----
 
-=== New implementation of exportCypher
+=== UNWIND Batch Statements
 
-For the new implementations and the test of the exportCypher we used this characteristics:
+This mode use the optimizations explained in this https://medium.com/neo4j/5-tips-tricks-for-fast-batched-updates-of-graph-structures-with-neo4j-and-cypher-73c7f693c8cc[article]
+and leverages the `UNWIND` mode in order to speed-up the import process.
 
-* 6 cores
+This mode group:
 
-* Intel(R) CPU I7-8750H @ 2.2GHz
+* nodes by the same labels
+* relationship by the same type and the same labels for start/end nodes in order to provide the `UNWIND` operation
 
-* 16 GB of RAM
+[source,cypher]
+----
+UNWIND [
+    {_id: 0, properties: {born:date('2018-10-31'), name:"foo"}},
+    {_id: 1, properties: {born:date('2017-09-29'), name:"foo2"}}
+] as row
+CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id})
+    SET n += row.properties SET n:Foo;
+----
+
+[source,cypher]
+----
+UNWIND [{start: {_id: 0}, end: {name: "bar"}, properties: {since:2016}}] as row
+MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})
+MATCH (end:Bar{name: row.end.name})
+CREATE (start)-[r:KNOWS]->(end) SET r += row.properties;
+----
+
+==== UNWIND Batch Params
+
+In case of you choose CYPHER-SHELL as format you can also choose the UNWIND_BATCH_PARAMS optimization that enables the following
+so the generated file looks like the following
+[source,cypher]
+----
+:param rows => [{_id: 0, properties: {born:date('2018-10-31'), name:"foo"}}, {_id: 1, properties: {born:date('2017-09-29'), name:"foo2"}}]
+:begin
+UNWIND $rows AS row
+CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;
+:commit
+:param rows => [{_id: 2, properties: {born:date('2016-03-12'), name:"foo3"}}]
+:begin
+UNWIND $rows AS row
+CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;
+:commit
+:param rows => [{_id: 4, properties: {age:12}}, {_id: 5, properties: {age:12}}]
+:begin
+UNWIND $rows AS row
+CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar;
+:commit
+:param rows => [{name: "bar", properties: {age:42}}, {name: "bar2", properties: {age:44}}]
+:begin
+UNWIND $rows AS row
+CREATE (n:Bar{name: row.name}) SET n += row.properties;
+:commit
+----
+
+
+=== Environment
+
+* CPU 2,2 GHz Intel Core i7
+
+* 32 GB of RAM
 
 
 .Neo4j configuration
 
-* dbms.memory.heap.initial_size=1024m
+* dbms.memory.heap.initial_size=8192m
 
-* dbms.memory.heap.max_size=2048m
+* dbms.memory.heap.max_size=8192m
 
 * dbms.memory.pagecache.size=1g
 
 .Graph info
 
-we use the `MusicBrainz dataset`, you can download from this link: http://example-data.neo4j.org/3.0-datasets/musicbrainz.tgz?_ga=2.224357650.84486006.1547734927-1971869821.1541933587[musicBrainz dataset]
+* total *nodes* 4.713.605
 
-* total *nodes* -> 1035
+* total *relationships* 4.549.134
 
-* total *relationships* -> 3139
+You can download the dataset from https://github.com/albertodelazzari/datatasets/blob/master/README.md[here]
 
-=== Different output formats
+=== Performance Comparision
 
-We try the different output formats, changing the `config` parameter `format`.
-
-.plain
+==== Create statements export ("Old"):
 
 [source,bash,subs=attributes]
 ----
-time ./cypher-shell -u yourUsername -p yourPassword  
-"call apoc.export.cypher.all('yourPath/exportData.cypher', {format:'plain', useOptimizations: {unwindBatch: true}})"
+time ./bin/cypher-shell -u neo4j -p andrea "call apoc.export.cypher.all('import/exportDataCypherShellOld.cypher',{format:'cypher-shell', useOptimizations: {type: 'none'}, batchSize:100})"
 ----
 
-==== Results
+.Results
+[source,bash,subs=attributes]
+----
+real	1m9.180s
+user	0m1.351s
+sys	    0m0.209s
+----
 
-.With Optimizations
-----
-real	0m1,838s
-user	0m1,251s
-sys	    0m0,136s
-----
+==== UNWIND Batch export ("New"):
 
 [source,bash,subs=attributes]
 ----
-time ./cypher-shell -u yourUsername -p yourPassword  
-"call apoc.export.cypher.all('yourPath/exportData.cypher', {useOptimizations: {type: "none"}, format:'plain'})"
-----
-==== Results
-
-.Without Optimizations
-----
-real	0m1,539s
-user	0m1,304s
-sys	    0m0,170s
+time ./bin/cypher-shell -u neo4j -p andrea "call apoc.export.cypher.all('import/exportDataCypherShell.cypher',{format:'cypher-shell', useOptimizations: {type: 'unwind_batch', unwindBatchSize: 20}, batchSize:100})"
 ----
 
-.cypher-shell
+.Results
+[source,bash,subs=attributes]
+----
+real	1m9.103s
+user	0m1.348s
+sys	    0m0.204s
+----
+
+==== UNWIND Batch export with Cypher-Shell params ("New"):
+
+In case of the Cypher-Shell with params the batchSize is not considered because the data gets committed every UNWIND operation
 
 [source,bash,subs=attributes]
 ----
-time ./cypher-shell -u yourUsername -p yourPassword  
-"call apoc.export.cypher.all('yourPath/exportData.cypher', {format:'cypher-shell', useOptimizations: {unwindBatch: true}})"
+time ./bin/cypher-shell -u neo4j -p andrea "call apoc.export.cypher.all('import/exportDataCypherShellParams.cypher',{format:'cypher-shell', useOptimizations: {type: 'unwind_batch_params', unwindBatchSize:100}})"
 ----
 
-==== Results
-.With Optimizations
+.Results
+[source,bash,subs=attributes]
 ----
-real	0m1,351s
-user	0m1,214s
-sys	    0m0,137s
+real	1m2.391s
+user	0m1.272s
+sys	    0m0.173s
 ----
 
-.cypher-shell
+But let's see the import process:
+
+==== Create statements import ("Old"):
 
 [source,bash,subs=attributes]
 ----
-time ./cypher-shell -u yourUsername -p yourPassword  
-"call apoc.export.cypher.all('yourPath/exportData.cypher', {useOptimizations: {useOptimizations: {type: "none"}}, format:'cypher-shell'})"
+time ./bin/cypher-shell -u neo4j -p andrea < 'import/exportDataCypherShellOld.cypher' > 'import/output.exportDataCypherShellOld.log'
 ----
 
-==== Results
-.Without Optimizations
+.Results
+[source,bash,subs=attributes]
 ----
-real	0m1,259s
-user	0m1,222s
-sys	    0m0,137s
+real	252m33.279s
+user	13m53.566s
+sys	    6m3.110s
 ----
 
-.neo4j-shell
+==== UNWIND Batch import ("New"):
 
 [source,bash,subs=attributes]
 ----
-time ./cypher-shell -u yourUsername -p yourPassword  
-"call apoc.export.cypher.all('yourPath/exportData.cypher', {format:'neo4j-shell', useOptimizations: {unwindBatch: true}})"
+time ./bin/cypher-shell -u neo4j -p andrea < 'import/exportDataCypherShell.cypher' > 'import/output.exportDataCypherShell.log'
 ----
 
-==== Results
-.With Optimizations
+.Results
+[source,bash,subs=attributes]
 ----
-real	0m1,297s
-user	0m1,227s
-sys	    0m0,133s
+real	114m38.406s
+user	2m56.627s
+sys	    0m56.695s
 ----
 
-.neo4j-shell
+==== UNWIND Batch import with Cypher-Shell params ("New"):
 
 [source,bash,subs=attributes]
 ----
-time ./cypher-shell -u yourUsername -p yourPassword  
-"call apoc.export.cypher.all('yourPath/exportData.cypher', {useOptimizations: {type: "none"}, format:'neo4j-shell'})"
+time ./bin/cypher-shell -u neo4j -p andrea < 'import/exportDataCypherShellParams.cypher' > 'import/output.exportDataCypherShellParams.log'
 ----
 
-==== Results
-
-.Without Optimizations
-----
-real	0m1,232s
-user	0m1,236s
-sys	    0m0,133s
-----
-
-== Import from file
-
-=== runFile
-
+.Results
 [source,bash,subs=attributes]
 ----
-time ./cypher-shell -u yourUsername -p yourPassword
-"call apoc.cypher.runFile('yourPath/import/exportPlain.cypher')"
-----
-
-.Result with optimizaions
-----
-real	0m28,186s
-user	0m1,321s
-sys	    0m0,175s
-----
-
-.Result without optimizaions
-----
-it's import 1 nodes every 10 seconds
-----
-
-=== Import cypher-shell
-
-[source,bash,subs=attributes]
-----
-time ./cypher-shell -u yourUsername -p yourPassword
-< 'yourPath/import/exportCypherShell.cypher'
-> 'yourPath/cypherShellOutput'
-----
-
-.Result with optimizaions
-----
-real	0m17,820s
-user	0m1,909s
-sys	    0m0,222s
-----
-
-.Result without optimizaions
-----
-real	0m19,087s
-user	0m5,026s
-sys	    0m0,473s
-----
-
-=== Import neo4j-shell
-
-[source,bash,subs=attributes]
-----
-time ./neo4j-shell -u yourUsername -p yourPassword -file
-< 'yourPath/import/exportNeo4jShell.cypher'
-> 'yourPath/neo4jShellOutput'
-----
-
-.Result with optimizaions
-----
-real	0m41,546s
-user	0m10,124s
-sys	    0m5,423s
-----
-
-.Result without optimizaions
-----
-real	0m53,398s
-user	0m20,157s
-sys	    0m12,572s
+real	157m32.906s
+user	4m5.758s
+sys	    0m55.485s
 ----

--- a/docs/asciidoc/exportCypher.adoc
+++ b/docs/asciidoc/exportCypher.adoc
@@ -17,6 +17,8 @@ It is possible to choose between three export formats:
 * `cypher-shell`: for Cypher shell
 * `plain`: doesn't output begin / commit / await just plain Cypher
 
+You can also use the Optimizations like: `{useOptimizations: true}`. (default: false)
+
 To change the export format, you have to set it on the config params like `{format : "cypher-shell"}`.
 
 By default the format is `neo4j-shell`.
@@ -40,6 +42,7 @@ call apoc.export.cypher.query(
 "/tmp/friendships.cypher", 
 {format:'plain',cypherFormat:'updateStructure'})`
 ----
+
 
 // tag::export.cypher[]
 `YIELD file, source, format, nodes, relationships, properties, time`
@@ -134,6 +137,10 @@ CALL apoc.export.cypher.all(null,{streamStatements:true,batchSize:100}) YIELD cy
 
 .exportAll (neo4j-shell format)
 
+==== Old method:
+
+Without the optimizations
+
 [source,cypher]
 ----
 CALL apoc.export.cypher.all({fileName},{config})
@@ -175,4 +182,48 @@ CREATE INDEX ON :`Foo`(`name`);
 CREATE CONSTRAINT ON (node:`Bar`) ASSERT node.`name` IS UNIQUE;
 commit
 schema await
+----
+
+==== New method:
+
+With the optimizations
+
+[source,cypher]
+----
+CALL apoc.export.cypher.all({fileName},{config})
+----
+Result:
+[source,cypher]
+----
+BEGIN
+UNWIND [{`UNIQUE IMPORT ID`: 0, properties: {`born`:date('2018-10-31'), `name`:"foo"}}, {`UNIQUE IMPORT ID`: 4, properties: {`born`:date('2017-09-29'), `name`:"foo2"}}] as row
+MERGE (n:`Foo`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;
+UNWIND [{`name`: "bar", properties: {`age`:42, `name`:"bar"}}, {`name`: "bar2", properties: {`age`:44, `name`:"bar2"}}] as row
+MERGE (n:`Bar`{`name`: row.`name`}) SET n += row.properties;
+UNWIND [{`UNIQUE IMPORT ID`: 2, properties: {`age`:12}}] as row
+MERGE (n:`Bar`:`Person`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;
+UNWIND [{`UNIQUE IMPORT ID`: 6, properties: {`age`:99}}] as row
+MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;
+UNWIND [{`UNIQUE IMPORT ID`: 3, properties: {`age`:12}}] as row
+MERGE (n:`Bar`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;
+COMMIT
+BEGIN
+CREATE INDEX ON :`Bar`(`first_name`,`last_name`);
+CREATE INDEX ON :`Foo`(`name`);
+CREATE CONSTRAINT ON (node:`Bar`) ASSERT node.`name` IS UNIQUE;
+CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT node.`UNIQUE IMPORT ID` IS UNIQUE;
+COMMIT
+SCHEMA AWAIT
+BEGIN
+UNWIND [{start: {`UNIQUE IMPORT ID`: 0}, end: {`name`: "bar"}, properties: {`since`:2016}}, {start: {`UNIQUE IMPORT ID`: 4}, end: {`name`: "bar2"}, properties: {`since`:2015}}] as row
+MATCH (start:`Foo`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start.`UNIQUE IMPORT ID`}), (end:`Bar`{`name`: row.end.`name`})
+MERGE (start)-[r:`KNOWS`]->(end) SET r += row.properties;
+COMMIT
+BEGIN
+MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;
+COMMIT
+BEGIN
+DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT node.`UNIQUE IMPORT ID` IS UNIQUE;
+COMMIT
+
 ----

--- a/docs/asciidoc/exportCypher.adoc
+++ b/docs/asciidoc/exportCypher.adoc
@@ -17,7 +17,16 @@ It is possible to choose between three export formats:
 * `cypher-shell`: for Cypher shell
 * `plain`: doesn't output begin / commit / await just plain Cypher
 
-You can also use the Optimizations like: `{useOptimizations: true}`. (default: false)
+You can also use the Optimizations like: `useOptimizations: {config}`
+Config could have this params:
+
+* `batchSize`:  (default 100)
+* `type`: possible values ('NONE', 'UNWIND_BATCH') (default 'UNWIND_BATCH')
+
+With `NONE` it will export the file with `CREATE` statement;
+
+With 'UNWIND_BATCH` it will export the file by batching the entities with the `UNWIND` method as explained in this
+https://medium.com/neo4j/5-tips-tricks-for-fast-batched-updates-of-graph-structures-with-neo4j-and-cypher-73c7f693c8cc[article].
 
 To change the export format, you have to set it on the config params like `{format : "cypher-shell"}`.
 
@@ -196,6 +205,13 @@ Result:
 [source,cypher]
 ----
 BEGIN
+CREATE INDEX ON :`Bar`(`first_name`,`last_name`);
+CREATE INDEX ON :`Foo`(`name`);
+CREATE CONSTRAINT ON (node:`Bar`) ASSERT node.`name` IS UNIQUE;
+CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT node.`UNIQUE IMPORT ID` IS UNIQUE;
+COMMIT
+SCHEMA AWAIT
+BEGIN
 UNWIND [{`UNIQUE IMPORT ID`: 0, properties: {`born`:date('2018-10-31'), `name`:"foo"}}, {`UNIQUE IMPORT ID`: 4, properties: {`born`:date('2017-09-29'), `name`:"foo2"}}] as row
 MERGE (n:`Foo`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;
 UNWIND [{`name`: "bar", properties: {`age`:42, `name`:"bar"}}, {`name`: "bar2", properties: {`age`:44, `name`:"bar2"}}] as row
@@ -207,13 +223,6 @@ MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET 
 UNWIND [{`UNIQUE IMPORT ID`: 3, properties: {`age`:12}}] as row
 MERGE (n:`Bar`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;
 COMMIT
-BEGIN
-CREATE INDEX ON :`Bar`(`first_name`,`last_name`);
-CREATE INDEX ON :`Foo`(`name`);
-CREATE CONSTRAINT ON (node:`Bar`) ASSERT node.`name` IS UNIQUE;
-CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT node.`UNIQUE IMPORT ID` IS UNIQUE;
-COMMIT
-SCHEMA AWAIT
 BEGIN
 UNWIND [{start: {`UNIQUE IMPORT ID`: 0}, end: {`name`: "bar"}, properties: {`since`:2016}}, {start: {`UNIQUE IMPORT ID`: 4}, end: {`name`: "bar2"}, properties: {`since`:2015}}] as row
 MATCH (start:`Foo`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start.`UNIQUE IMPORT ID`}), (end:`Bar`{`name`: row.end.`name`})

--- a/docs/asciidoc/exportCypher.adoc
+++ b/docs/asciidoc/exportCypher.adoc
@@ -20,8 +20,8 @@ It is possible to choose between three export formats:
 You can also use the Optimizations like: `useOptimizations: {config}`
 Config could have this params:
 
-* `batchSize`:  (default 100)
-* `type`: possible values ('NONE', 'UNWIND_BATCH') (default 'UNWIND_BATCH')
+* `unwindBatchSize`:  (default 100)
+* `type`: possible values ('NONE', 'UNWIND_BATCH', 'UNWIND_BATCH_PARAMS') (default 'UNWIND_BATCH')
 
 With `NONE` it will export the file with `CREATE` statement;
 
@@ -158,18 +158,18 @@ Result:
 [source,cypher]
 ----
 begin
-CREATE (:`Foo`:`UNIQUE IMPORT LABEL` {`name`:"foo", `UNIQUE IMPORT ID`:0});
-CREATE (:`Bar` {`name`:"bar", `age`:42});
-CREATE (:`Bar`:`UNIQUE IMPORT LABEL` {`age`:12, `UNIQUE IMPORT ID`:2});
+CREATE (:Foo:`UNIQUE IMPORT LABEL` {name:"foo", `UNIQUE IMPORT ID`:0});
+CREATE (:Bar {name:"bar", age:42});
+CREATE (:Bar:`UNIQUE IMPORT LABEL` {age:12, `UNIQUE IMPORT ID`:2});
 commit
 begin
-CREATE INDEX ON :`Foo`(`name`);
-CREATE CONSTRAINT ON (node:`Bar`) ASSERT node.`name` IS UNIQUE;
+CREATE INDEX ON :Foo(name);
+CREATE CONSTRAINT ON (node:Bar) ASSERT node.name IS UNIQUE;
 CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT node.`UNIQUE IMPORT ID` IS UNIQUE;
 commit
 schema await
 begin
-MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`Bar`{`name`:"bar"}) CREATE (n1)-[:`KNOWS`]->(n2);
+MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:Bar{name:"bar"}) CREATE (n1)-[:KNOWS]->(n2);
 commit
 begin
 MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;
@@ -187,8 +187,8 @@ Result:
 [source,cypher]
 ----
 begin
-CREATE INDEX ON :`Foo`(`name`);
-CREATE CONSTRAINT ON (node:`Bar`) ASSERT node.`name` IS UNIQUE;
+CREATE INDEX ON :Foo(name);
+CREATE CONSTRAINT ON (node:Bar) ASSERT node.name IS UNIQUE;
 commit
 schema await
 ----
@@ -205,34 +205,34 @@ Result:
 [source,cypher]
 ----
 BEGIN
-CREATE INDEX ON :`Bar`(`first_name`,`last_name`);
-CREATE INDEX ON :`Foo`(`name`);
-CREATE CONSTRAINT ON (node:`Bar`) ASSERT node.`name` IS UNIQUE;
+CREATE INDEX ON :Bar(first_name,last_name);
+CREATE INDEX ON :Foo(name);
+CREATE CONSTRAINT ON (node:Bar) ASSERT node.name IS UNIQUE;
 CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT node.`UNIQUE IMPORT ID` IS UNIQUE;
 COMMIT
 SCHEMA AWAIT
 BEGIN
-UNWIND [{`UNIQUE IMPORT ID`: 0, properties: {`born`:date('2018-10-31'), `name`:"foo"}}, {`UNIQUE IMPORT ID`: 4, properties: {`born`:date('2017-09-29'), `name`:"foo2"}}] as row
-MERGE (n:`Foo`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;
-UNWIND [{`name`: "bar", properties: {`age`:42, `name`:"bar"}}, {`name`: "bar2", properties: {`age`:44, `name`:"bar2"}}] as row
-MERGE (n:`Bar`{`name`: row.`name`}) SET n += row.properties;
-UNWIND [{`UNIQUE IMPORT ID`: 2, properties: {`age`:12}}] as row
-MERGE (n:`Bar`:`Person`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;
-UNWIND [{`UNIQUE IMPORT ID`: 6, properties: {`age`:99}}] as row
-MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;
-UNWIND [{`UNIQUE IMPORT ID`: 3, properties: {`age`:12}}] as row
-MERGE (n:`Bar`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;
+UNWIND [{_id:3, properties:{age:12}}] as row
+CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar;
+UNWIND [{_id:2, properties:{age:12}}] as row
+CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar:Person;
+UNWIND [{_id:0, properties:{born:date('2018-10-31'), name:"foo"}}, {_id:4, properties:{born:date('2017-09-29'), name:"foo2"}}] as row
+CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;
+UNWIND [{name:"bar", properties:{age:42}}, {name:"bar2", properties:{age:44}}] as row
+CREATE (n:Bar{name: row.name}) SET n += row.properties;
+UNWIND [{_id:6, properties:{age:99}}] as row
+CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties;
 COMMIT
 BEGIN
-UNWIND [{start: {`UNIQUE IMPORT ID`: 0}, end: {`name`: "bar"}, properties: {`since`:2016}}, {start: {`UNIQUE IMPORT ID`: 4}, end: {`name`: "bar2"}, properties: {`since`:2015}}] as row
-MATCH (start:`Foo`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start.`UNIQUE IMPORT ID`}), (end:`Bar`{`name`: row.end.`name`})
-MERGE (start)-[r:`KNOWS`]->(end) SET r += row.properties;
+UNWIND [{start: {_id:0}, end: {name:"bar"}, properties:{since:2016}}, {start: {_id:4}, end: {name:"bar2"}, properties:{since:2015}}] as row
+MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})
+MATCH (end:Bar{name: row.end.name})
+CREATE (start)-[r:KNOWS]->(end) SET r += row.properties;
 COMMIT
 BEGIN
 MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;
 COMMIT
 BEGIN
-DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT node.`UNIQUE IMPORT ID` IS UNIQUE;
+DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;
 COMMIT
-
 ----

--- a/docs/script/performanceCypherTest.sh
+++ b/docs/script/performanceCypherTest.sh
@@ -55,6 +55,23 @@ export exportAllPlain="call apoc.export.cypher.all('$neo4j_home/import/exportAll
 echo $exportAllPlain
 time ./cypher-shell -a $url -u $user -p $password  "$exportAllPlain"
 
+#NEW METHOD
+
+#Neo4j Shell
+export exportAllNeo4jShellOptimized="call apoc.export.cypher.all('$neo4j_home/import/exportAllNeo4jShellOptimized.cypher',  {format:'neo4j-shell', useOptimizations: true})"
+echo $exportAllNeo4jShellOptimized
+time ./cypher-shell -a $url -u $user -p $password  "$exportAllNeo4jShellOptimized"
+
+#Cypher Shell
+export exportAllCypherShellOptimized="call apoc.export.cypher.all('$neo4j_home/import/exportAllCypherShellOptimized.cypher',  {format:'cypher-shell', useOptimizations: true})"
+echo $exportAllCypherShellOptimized
+time ./cypher-shell -a $url -u $user -p $password  "$exportAllCypherShellOptimized"
+
+#Plain
+export exportAllPlainOptimized="call apoc.export.cypher.all('$neo4j_home/import/exportAllPlainOptimized.cypher',  {format:'plain', useOptimizations: true})"
+echo $exportAllPlainOptimized
+time ./cypher-shell -a $url -u $user -p $password  "$exportAllPlainOptimized"
+
 #Many files
 export exportAllSeparateFiles="call apoc.export.cypher.all('$neo4j_home/import/exportAllDifferentFile.cypher',  {format:'plain', separateFiles:true})"
 echo $exportAllSeparateFiles
@@ -113,12 +130,25 @@ export outputFile="$neo4j_home/import/cypherShellOutput"
 echo $importCypherShell "<" $outputFile
 time ./cypher-shell -a $url -u $user -p $password < "$importCypherShell">"$outputFile"
 
+
+#import cypher-shell Optimized
+export importCypherShell="$neo4j_home/import/exportAllCypherShellOptimized.cypher"
+export outputFile="$neo4j_home/import/cypherShellOutput"
+echo $importCypherShell "<" $outputFile
+time ./cypher-shell -a $url -u $user -p $password < "$importCypherShell">"$outputFile"
+
 #Drop DB
 echo "drop db"
 time ./cypher-shell -a $url -u $user -p $password "$dropDb"
 
 #import neo4j-shell
 export importNeo4jShell="$neo4j_home/import/exportAllNeo4jShell.cypher"
+export outputFile="$neo4j_home/import/neo4jShellOutput"
+echo $importNeo4jShell "<" $outputFile
+time ./neo4j-shell -a $url -u $user -p $password '-file' "$importNeo4jShell">"$outputFile"
+
+#import neo4j-shell Optimized
+export importNeo4jShell="$neo4j_home/import/exportAllNeo4jShellOptimized.cypher"
 export outputFile="$neo4j_home/import/neo4jShellOutput"
 echo $importNeo4jShell "<" $outputFile
 time ./neo4j-shell -a $url -u $user -p $password '-file' "$importNeo4jShell">"$outputFile"

--- a/docs/script/performanceCypherTest.sh
+++ b/docs/script/performanceCypherTest.sh
@@ -20,65 +20,65 @@ fi
 cd $neo4j_home/bin
 
 #Export all batch size default
-export exportAllDefaultBatch="call apoc.export.cypher.all('$neo4j_home/import/exportAll.cypher', null)"
+export exportAllDefaultBatch="call apoc.export.cypher.all('$neo4j_home/import/exportAll.cypher', {useOptimizations: {type: "none"}])"
 echo $exportAllDefaultBatch
 time ./cypher-shell -a $url -u $user -p $password "$exportAllDefaultBatch"
 
 #Export all batch size 10000
-export exportAllBatchSize10000="call apoc.export.cypher.all('$neo4j_home/import/exportAll.cypher',  {batchSize: 10000})"
+export exportAllBatchSize10000="call apoc.export.cypher.all('$neo4j_home/import/exportAll.cypher',  {batchSize: 10000, useOptimizations: {type: "none"}})"
 echo $exportAllBatchSize10000
 time ./cypher-shell -a $url -u $user -p $password "$exportAllBatchSize10000"
 
 #Export all batch size 1000
-export exportAllBatchSize1000="call apoc.export.cypher.all('$neo4j_home/import/exportAll.cypher',  {batchSize: 1000})"
+export exportAllBatchSize1000="call apoc.export.cypher.all('$neo4j_home/import/exportAll.cypher',  {batchSize: 1000, useOptimizations: {type: "none"}})"
 echo $exportAllBatchSize1000
 time ./cypher-shell -a $url -u $user -p $password "$exportAllBatchSize1000"
 
 #Export all batch size 100
-export exportAllBatchSize100="call apoc.export.cypher.all('$neo4j_home/import/exportAll.cypher',  {batchSize: 100})"
+export exportAllBatchSize100="call apoc.export.cypher.all('$neo4j_home/import/exportAll.cypher',  {batchSize: 100, useOptimizations: {type: "none"}})"
 echo $exportAllBatchSize100
 time ./cypher-shell -a $url -u $user -p $password "$exportAllBatchSize100"
 
 #Different output formats
 #Neo4j Shell
-export exportAllNeo4jShell="call apoc.export.cypher.all('$neo4j_home/import/exportAllNeo4jShell.cypher',  {format:'neo4j-shell'})"
+export exportAllNeo4jShell="call apoc.export.cypher.all('$neo4j_home/import/exportAllNeo4jShell.cypher',  {format:'neo4j-shell', useOptimizations: {type: "none"}})"
 echo $exportAllNeo4jShell
 time ./cypher-shell -a $url -u $user -p $password  "$exportAllNeo4jShell"
 
 #Cypher Shell
-export exportAllCypherShell="call apoc.export.cypher.all('$neo4j_home/import/exportAllCypherShell.cypher',  {format:'cypher-shell'})"
+export exportAllCypherShell="call apoc.export.cypher.all('$neo4j_home/import/exportAllCypherShell.cypher',  {format:'cypher-shell', useOptimizations: {type: "none"}})"
 echo $exportAllCypherShell
 time ./cypher-shell -a $url -u $user -p $password  "$exportAllCypherShell"
 
 #Plain
-export exportAllPlain="call apoc.export.cypher.all('$neo4j_home/import/exportAllPlain.cypher',  {format:'plain'})"
+export exportAllPlain="call apoc.export.cypher.all('$neo4j_home/import/exportAllPlain.cypher',  {format:'plain',useOptimizations: {type: "none"}})"
 echo $exportAllPlain
 time ./cypher-shell -a $url -u $user -p $password  "$exportAllPlain"
 
 #NEW METHOD
 
 #Neo4j Shell
-export exportAllNeo4jShellOptimized="call apoc.export.cypher.all('$neo4j_home/import/exportAllNeo4jShellOptimized.cypher',  {format:'neo4j-shell', useOptimizations: true})"
+export exportAllNeo4jShellOptimized="call apoc.export.cypher.all('$neo4j_home/import/exportAllNeo4jShellOptimized.cypher',  {format:'neo4j-shell'})"
 echo $exportAllNeo4jShellOptimized
 time ./cypher-shell -a $url -u $user -p $password  "$exportAllNeo4jShellOptimized"
 
 #Cypher Shell
-export exportAllCypherShellOptimized="call apoc.export.cypher.all('$neo4j_home/import/exportAllCypherShellOptimized.cypher',  {format:'cypher-shell', useOptimizations: true})"
+export exportAllCypherShellOptimized="call apoc.export.cypher.all('$neo4j_home/import/exportAllCypherShellOptimized.cypher',  {format:'cypher-shell'})"
 echo $exportAllCypherShellOptimized
 time ./cypher-shell -a $url -u $user -p $password  "$exportAllCypherShellOptimized"
 
 #Plain
-export exportAllPlainOptimized="call apoc.export.cypher.all('$neo4j_home/import/exportAllPlainOptimized.cypher',  {format:'plain', useOptimizations: true})"
+export exportAllPlainOptimized="call apoc.export.cypher.all('$neo4j_home/import/exportAllPlainOptimized.cypher',  {format:'plain'})"
 echo $exportAllPlainOptimized
 time ./cypher-shell -a $url -u $user -p $password  "$exportAllPlainOptimized"
 
 #Many files
-export exportAllSeparateFiles="call apoc.export.cypher.all('$neo4j_home/import/exportAllDifferentFile.cypher',  {format:'plain', separateFiles:true})"
+export exportAllSeparateFiles="call apoc.export.cypher.all('$neo4j_home/import/exportAllDifferentFile.cypher',  {useOptimizations: {type: "none"}, format:'plain', separateFiles:true})"
 echo $exportAllSeparateFiles
 time ./cypher-shell -a $url -u $user -p $password  "$exportAllSeparateFiles"
 
 #Export from query
-export exportQuery="call apoc.export.cypher.query('MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m', '$neo4j_home/import/exportQuery.cypher', null)"
+export exportQuery="call apoc.export.cypher.query('MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m', '$neo4j_home/import/exportQuery.cypher', {useOptimizations: {type: "none"}})"
 echo $exportQuery
 time ./cypher-shell -a $url -u $user -p $password  "$exportQuery"
 
@@ -87,17 +87,17 @@ export exportData="Match (n:Person)-[r:LIKES_COMMENT]->(c:Comment) with collect(
 time ./cypher-shell -a $url -u $user -p $password "$exportData"
 
 #Export from graph object
-export exportGraph="CALL apoc.graph.fromDB('test',{}) yield graph CALL apoc.export.cypher.graph(graph, '$neo4j_home/import/exportGraph.cypher',null) YIELD nodes, relationships RETURN nodes, relationships"
+export exportGraph="CALL apoc.graph.fromDB('test',{}) yield graph CALL apoc.export.cypher.graph(graph, '$neo4j_home/import/exportGraph.cypher',{useOptimizations: {type: "none"}}) YIELD nodes, relationships RETURN nodes, relationships"
 echo $exportGraph
 time ./cypher-shell -a $url -u $user -p $password "$exportGraph"
 
 #Graph Cypher shell format
-export exportGraphCypherShell="CALL apoc.graph.fromDB('test',{}) yield graph CALL apoc.export.cypher.graph(graph, '$neo4j_home/import/exportGraph.cypher',{format:'cypher-shell'}) YIELD nodes, relationships RETURN nodes, relationships"
+export exportGraphCypherShell="CALL apoc.graph.fromDB('test',{}) yield graph CALL apoc.export.cypher.graph(graph, '$neo4j_home/import/exportGraph.cypher',{format:'cypher-shell', useOptimizations: {type: "none"}}) YIELD nodes, relationships RETURN nodes, relationships"
 echo $exportGraphCypherShell
 time ./cypher-shell -a $url -u $user -p $password "$exportGraphCypherShell"
 
 #Graph batch size 1000
-export exportGraphBatchSize1000="CALL apoc.graph.fromDB('test',{}) yield graph CALL apoc.export.cypher.graph(graph, '$neo4j_home/import/exportGraph.cypher',{batchSize: 1000}) YIELD nodes, relationships RETURN nodes, relationships"
+export exportGraphBatchSize1000="CALL apoc.graph.fromDB('test',{}) yield graph CALL apoc.export.cypher.graph(graph, '$neo4j_home/import/exportGraph.cypher',{batchSize: 1000, useOptimizations: {type: "none"}}) YIELD nodes, relationships RETURN nodes, relationships"
 echo $exportGraphBatchSize1000
 time ./cypher-shell -a $url -u $user -p $password "$exportGraphBatchSize1000"
 

--- a/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -18,9 +18,7 @@ import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.procedure.*;
 
 import java.io.IOException;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.stream.Stream;
@@ -117,7 +115,7 @@ public class ExportCypher {
     }
 
     private void doExport(SubGraph graph, ExportConfig c, boolean onlySchema, ProgressReporter reporter, ExportFileManager cypherFileManager) throws IOException {
-        MultiStatementCypherSubGraphExporter exporter = new MultiStatementCypherSubGraphExporter(graph, c);
+        MultiStatementCypherSubGraphExporter exporter = new MultiStatementCypherSubGraphExporter(graph, c, db);
 
         if (onlySchema)
             exporter.exportOnlySchema(cypherFileManager);

--- a/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -1,17 +1,22 @@
 package apoc.export.cypher.formatter;
 
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Relationship;
+import apoc.export.util.ExportConfig;
+import apoc.export.util.ExportFormat;
+import apoc.export.util.Reporter;
+import apoc.util.Util;
+import org.apache.commons.lang3.StringUtils;
+import org.neo4j.graphdb.*;
 import org.neo4j.helpers.collection.Iterables;
 
-import java.util.Map;
-import java.util.Set;
+import java.io.PrintWriter;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static apoc.export.cypher.formatter.CypherFormatterUtils.Q_UNIQUE_ID_LABEL;
-import static apoc.export.cypher.formatter.CypherFormatterUtils.UNIQUE_ID_PROP;
-import static apoc.export.cypher.formatter.CypherFormatterUtils.quote;
+import static apoc.export.cypher.formatter.CypherFormatterUtils.*;
 
 /**
  * @author AgileLARUS
@@ -31,7 +36,7 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 
 	@Override
 	public String statementForIndex(String label, Iterable<String> keys) {
-		return "CREATE INDEX ON :" + CypherFormatterUtils.quote(label) + "(" + CypherFormatterUtils.quote(keys) + ");";
+		return "CREATE INDEX ON :" + Util.quote(label) + "(" + CypherFormatterUtils.quote(keys) + ");";
 	}
 
 	@Override
@@ -41,7 +46,7 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 				.map(key -> "node." + CypherFormatterUtils.quote(key))
 				.collect(Collectors.joining(", "));
 
-		return  String.format(STATEMENT_CONSTRAINTS, CypherFormatterUtils.quote(label), keysString, Iterables.count(keys) > 1 ? "IS NODE KEY" : "IS UNIQUE");
+		return  String.format(STATEMENT_CONSTRAINTS, Util.quote(label), keysString, Iterables.count(keys) > 1 ? "IS NODE KEY" : "IS UNIQUE");
 	}
 
 	protected String mergeStatementForNode(CypherFormat cypherFormat, Node node, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
@@ -75,6 +80,362 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 		}
 		result.append(";");
 		return result.toString();
+	}
+
+	public void buildStatementForNodes(String nodeClause, String setClause,
+									   Iterable<Node> nodes, Map<String, Set<String>> uniqueConstraints,
+									   ExportConfig exportConfig,
+									   PrintWriter out, Reporter reporter,
+									   GraphDatabaseService db) {
+		ExportConfig.OptimizationType exportType = exportConfig.getOptimizationType();
+
+		AtomicInteger nodeCount = new AtomicInteger(0);
+		Function<Node, Map.Entry<Set<String>, Set<String>>> keyMapper = (node) -> {
+			try (Transaction tx = db.beginTx()) {
+				Set<String> idProperties = CypherFormatterUtils.getNodeIdProperties(node, uniqueConstraints).keySet();
+				Set<String> labels = getLabels(node);
+				tx.success();
+				return new AbstractMap.SimpleImmutableEntry<>(labels, idProperties);
+			}
+		};
+		Map<Map.Entry<Set<String>, Set<String>>, List<Node>> groupedData = StreamSupport.stream(nodes.spliterator(), true)
+				.collect(Collectors.groupingByConcurrent(keyMapper));
+
+		AtomicInteger propertiesCount = new AtomicInteger(0);
+		AtomicInteger batchCount = new AtomicInteger(0);
+
+		int batchSize = exportConfig.getBatchSize();
+		int unwindBatchSize = exportConfig.getUnwindBatchSize();
+		groupedData.forEach((key, nodeList) -> {
+			final int nodeListSize = nodeList.size();
+			final Node last = nodeList.get(nodeListSize - 1);
+			nodeCount.addAndGet(nodeListSize);
+			for (int i = 0; i < nodeListSize; i++) {
+				writeUnwindStart(exportConfig, out, batchCount);
+				batchCount.incrementAndGet();
+
+				Node node = nodeList.get(i);
+
+				Map<String, Object> props = node.getAllProperties();
+				// start element
+				out.append("{");
+
+				// id
+				Map<String, Object> idMap = CypherFormatterUtils.getNodeIdProperties(node, uniqueConstraints);
+				writeNodeIds(out, idMap);
+
+				// properties
+				out.append(", ");
+				out.append("properties:");
+				writeProperties(out, props, (es) -> !idMap.containsKey(es.getKey()));
+				propertiesCount.addAndGet(props.size());
+
+				// end element
+				out.append("}");
+				boolean isEnd = last.equals(node);
+				if (isEnd || batchCount.get() % unwindBatchSize == 0 || batchCount.get() % batchSize == 0) {
+					int unwindLength = (i + 1) % unwindBatchSize;
+					int unwindLeftOver = (unwindBatchSize - unwindLength) % unwindBatchSize;
+					batchCount.addAndGet(unwindLeftOver);
+					writeUnwindEnd(exportConfig, out, batchCount, isEnd);
+					if(isEnd || writeClosingStatements(exportConfig, batchCount)) {
+						out.append(StringUtils.LF);
+						out.append(nodeClause);
+
+						String label = getUniqueConstrainedLabel(node, uniqueConstraints);
+						out.append("(n:");
+						out.append(Util.quote(label));
+						out.append("{");
+						int size = key.getValue().size();
+						for (String s: key.getValue()) {
+							--size;
+							out.append(Util.quote(s) + ": row." + formatNodeId(s));
+							if (size > 0) {
+								out.append(", ");
+							}
+						}
+						out.append("}) ");
+						out.append(setClause);
+						out.append("n += row.properties");
+						String addLabels = key.getKey().stream()
+								.filter(l -> !l.equals(label))
+								.map(Util::quote)
+								.collect(Collectors.joining(":"));
+						if (!addLabels.isEmpty()) {
+							out.append(" SET n:");
+							out.append(addLabels);
+						}
+						out.append(";");
+						out.append(StringUtils.LF);
+						if(exportType == ExportConfig.OptimizationType.UNWIND_BATCH_PARAMS || (batchCount.get() % batchSize == 0)){
+							out.append(exportConfig.getFormat().commit());
+						}
+					}
+
+				} else {
+					out.append(", ");
+				}
+			}
+		});
+		addCommitToEnd(exportConfig, out, batchCount);
+
+		reporter.update(nodeCount.get(), 0, propertiesCount.longValue());
+	}
+
+	public void buildStatementForRelationships(String relationshipClause,
+											   String setClause, Iterable<Relationship> relationship,
+											   Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig,
+											   PrintWriter out, Reporter reporter,
+											   GraphDatabaseService db) {
+		int batchSize = exportConfig.getBatchSize();
+		ExportConfig.OptimizationType exportType = exportConfig.getOptimizationType();
+
+		AtomicInteger relCount = new AtomicInteger(0);
+
+
+		Function<Relationship, Map<String, Object>> keyMapper = (rel) -> {
+			try (Transaction tx = db.beginTx()) {
+				Node start = rel.getStartNode();
+				Set<String> startLabels = getLabels(start);
+
+				// define the end labels
+				Node end = rel.getEndNode();
+				Set<String> endLabels = getLabels(end);
+
+				// define the type
+				String type = rel.getType().name();
+
+				// create the path
+				Map<String, Object> key = Util.map("type", type,
+						"start", new AbstractMap.SimpleImmutableEntry<>(startLabels, CypherFormatterUtils.getNodeIdProperties(start, uniqueConstraints).keySet()),
+						"end", new AbstractMap.SimpleImmutableEntry<>(endLabels, CypherFormatterUtils.getNodeIdProperties(end, uniqueConstraints).keySet()));
+
+				tx.success();
+				return key;
+			}
+		};
+		Map<Map<String, Object>, List<Relationship>> groupedData = StreamSupport.stream(relationship.spliterator(), true)
+				.collect(Collectors.groupingByConcurrent(keyMapper));
+
+		AtomicInteger propertiesCount = new AtomicInteger(0);
+		AtomicInteger batchCount = new AtomicInteger(0);
+
+		int unwindBatchSize = exportConfig.getUnwindBatchSize();
+
+		String start = "start";
+		String end = "end";
+		groupedData.forEach((path, relationshipList) -> {
+			final int relSize = relationshipList.size();
+			relCount.addAndGet(relSize);
+			final Relationship last = relationshipList.get(relSize - 1);
+			for (int i = 0; i < relSize; i++) {
+				writeUnwindStart(exportConfig, out, batchCount);
+				batchCount.incrementAndGet();
+				Relationship rel = relationshipList.get(i);
+
+				Map<String, Object> props = rel.getAllProperties();
+				// start element
+				out.append("{");
+
+				// start node
+				Node startNode = rel.getStartNode();
+				writeRelationshipNodeIds(uniqueConstraints, out, start, startNode);
+
+				out.append(", ");
+
+				// end node
+				Node endNode = rel.getEndNode();
+				writeRelationshipNodeIds(uniqueConstraints, out, end, endNode);
+
+				// properties
+				out.append(", ");
+				out.append("properties:");
+				writeProperties(out, props, null);
+				propertiesCount.addAndGet(props.size());
+
+				// end element
+				out.append("}");
+
+				boolean isEnd = last.equals(rel);
+				if (isEnd || batchCount.get() % unwindBatchSize == 0) {
+					int unwindLength = (i + 1) % unwindBatchSize;
+					int unwindLeftOver = (unwindBatchSize - unwindLength) % unwindBatchSize;
+					batchCount.addAndGet(unwindLeftOver);
+					writeUnwindEnd(exportConfig, out, batchCount, isEnd);
+					if(isEnd || writeClosingStatements(exportConfig, batchCount)) {
+						// match start node
+						writeRelationshipMatchAsciiNode(startNode, out, start, path, uniqueConstraints);
+
+						// match end node
+						writeRelationshipMatchAsciiNode(endNode, out, end, path, uniqueConstraints);
+
+						out.append(StringUtils.LF);
+
+						// create the relationship (depends on the strategy)
+						out.append(relationshipClause);
+						out.append("(start)-[r:" + Util.quote(path.get("type").toString()) + "]->(end) ");
+						out.append(setClause);
+						out.append("r += row.properties;");
+						out.append(StringUtils.LF);
+						if (exportType == ExportConfig.OptimizationType.UNWIND_BATCH_PARAMS || (batchCount.get() % batchSize == 0)) {
+							out.append(exportConfig.getFormat().commit());
+						}
+					}
+				} else {
+					out.append(", ");
+				}
+			}
+		});
+		addCommitToEnd(exportConfig, out, batchCount);
+
+		reporter.update(0, relCount.get(), propertiesCount.longValue());
+	}
+
+	public void writeProperties(PrintWriter out, Map<String, Object> props, Predicate<Map.Entry<String, Object>> predicate) {
+		out.append("{");
+		if (!props.isEmpty()) {
+			int size = props.size();
+			for (Map.Entry<String, Object> es : props.entrySet()) {
+				--size;
+				if (predicate != null && !predicate.test(es)) {
+					continue;
+				}
+				out.append(Util.quote(es.getKey()));
+				out.append(":");
+				out.append(CypherFormatterUtils.toString(es.getValue()));
+				if (size > 0) {
+					out.append(", ");
+				}
+			}
+		}
+		out.append("}");
+	}
+
+	private String formatNodeId(String key) {
+		if (CypherFormatterUtils.UNIQUE_ID_PROP.equals(key)) {
+			key = "_id";
+		}
+		return Util.quote(key);
+	}
+
+	private boolean writeClosingStatements(ExportConfig exportConfig, AtomicInteger batchCount) {
+		if (exportConfig.getOptimizationType() == ExportConfig.OptimizationType.UNWIND_BATCH_PARAMS) {
+			return batchCount.get() % exportConfig.getUnwindBatchSize() == 0;
+		} else {
+			return batchCount.get() % exportConfig.getBatchSize() == 0 || batchCount.get() % exportConfig.getUnwindBatchSize() == 0;
+		}
+	}
+
+	private void addCommitToEnd(ExportConfig exportConfig, PrintWriter out, AtomicInteger batchCount) {
+		if (exportConfig.getOptimizationType() == ExportConfig.OptimizationType.UNWIND_BATCH_PARAMS) {
+			if (batchCount.get() % exportConfig.getUnwindBatchSize() != 0) {
+				out.append(exportConfig.getFormat().commit());
+			}
+		} else {
+			if (batchCount.get() % exportConfig.getBatchSize() != 0) {
+				out.append(exportConfig.getFormat().commit());
+			}
+		}
+
+	}
+
+	private void writeUnwindStart(ExportConfig exportConfig, PrintWriter out, AtomicInteger batchCount) {
+		if (exportConfig.getFormat() == ExportFormat.CYPHER_SHELL
+				&& exportConfig.getOptimizationType() == ExportConfig.OptimizationType.UNWIND_BATCH_PARAMS) {
+			if (batchCount.get() % exportConfig.getUnwindBatchSize() == 0) {
+				out.append(":param rows => [");
+			}
+		} else {
+			if (batchCount.get() % exportConfig.getUnwindBatchSize() == 0) {
+				if (batchCount.get() % exportConfig.getBatchSize() == 0) {
+					out.append(exportConfig.getFormat().begin());
+				}
+				out.append("UNWIND [");
+			}
+		}
+	}
+
+	private void writeUnwindEnd(ExportConfig exportConfig, PrintWriter out, AtomicInteger batchCount, boolean isEnd) {
+		if (exportConfig.getFormat() == ExportFormat.CYPHER_SHELL
+				&& exportConfig.getOptimizationType() == ExportConfig.OptimizationType.UNWIND_BATCH_PARAMS) {
+			if (isEnd || batchCount.get() % exportConfig.getUnwindBatchSize() == 0) {
+				out.append("]");
+				out.append(StringUtils.LF);
+				out.append(exportConfig.getFormat().begin());
+				out.append("UNWIND $rows AS row");
+			} else {
+				out.append(", ");
+			}
+		} else {
+			out.append("] as row");
+		}
+	}
+
+	private String getUniqueConstrainedLabel(Node node, Map<String, Set<String>> uniqueConstraints) {
+		return uniqueConstraints.entrySet().stream()
+				.filter(e -> node.hasLabel(Label.label(e.getKey())) && e.getValue().stream().anyMatch(k -> node.hasProperty(k)))
+				.map(e -> e.getKey())
+				.findFirst()
+				.orElse(CypherFormatterUtils.UNIQUE_ID_LABEL);
+	}
+
+	private Set<String> getLabels(Node node) {
+		Set<String> labels = StreamSupport.stream(node.getLabels().spliterator(), false)
+				.map(Label::name)
+				.collect(Collectors.toSet());
+		if (labels.isEmpty()) {
+			labels.add(CypherFormatterUtils.UNIQUE_ID_LABEL);
+		}
+		return labels;
+	}
+
+	private void writeRelationshipMatchAsciiNode(Node node, PrintWriter out, String key, Map<String, Object> path, Map<String, Set<String>> uniqueConstraints) {
+		Map.Entry<Set<String>, Set<String>> entry = (Map.Entry<Set<String>, Set<String>>) path.get(key);
+		out.append(StringUtils.LF);
+		out.append("MATCH ");
+		out.append("(");
+		out.append(key);
+		out.append(":");
+		out.append(Util.quote(getUniqueConstrainedLabel(node, uniqueConstraints)));
+		out.append("{");
+		int size = entry.getValue().size();
+		for (String s: entry.getValue()) {
+			--size;
+			out.append(Util.quote(s) + ": row." + key + "." + formatNodeId(s));
+			if (size > 0) {
+				out.append(", ");
+			}
+		}
+		out.append("})");
+	}
+
+	private void writeRelationshipNodeIds(Map<String, Set<String>> uniqueConstraints, PrintWriter out, String key, Node node) {
+		out.append(key + ": ");
+		Set<String> props = uniqueConstraints.get(getUniqueConstrainedLabel(node, uniqueConstraints));
+		Map<String, Object> properties;
+		if (props != null && !props.isEmpty()) {
+			String[] propsArray = props.toArray(new String[props.size()]);
+			properties = node.getProperties(propsArray);
+
+		} else {
+			properties = Util.map(UNIQUE_ID_PROP, node.getId());
+		}
+		out.append("{");
+		writeNodeIds(out, properties);
+		out.append("}");
+	}
+
+	private void writeNodeIds(PrintWriter out, Map<String, Object> properties) {
+		int size = properties.size();
+		for (Map.Entry<String, Object> es : properties.entrySet()) {
+			--size;
+			out.append(formatNodeId(es.getKey()));
+			out.append(":");
+			out.append(CypherFormatterUtils.toString(es.getValue()));
+			if (size > 0) {
+				out.append(", ");
+			}
+		}
 	}
 }
 

--- a/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -1,8 +1,11 @@
 package apoc.export.cypher.formatter;
 
+import apoc.export.util.ExportConfig;
+import apoc.export.util.Reporter;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
+import java.io.PrintWriter;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,13 +32,11 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
-	public Map<String,Object> statementForSameNodes(Iterable<Node> node, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
-		return null;
+	public void statementForSameNodes(Iterable<Node> node, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter) {
 	}
 
 	@Override
-	public Map<String,Object> statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
-		return null;
+	public void statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter) {
 	}
 
 	@Override

--- a/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -29,6 +29,16 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
+	public Map<String,Object> statementForSameNodes(Iterable<Node> node, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
+		return null;
+	}
+
+	@Override
+	public Map<String,Object> statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
+		return null;
+	}
+
+	@Override
 	public String statementForIndex(String label, Iterable<String> key) {
 		return "";
 	}

--- a/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -2,6 +2,7 @@ package apoc.export.cypher.formatter;
 
 import apoc.export.util.ExportConfig;
 import apoc.export.util.Reporter;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
@@ -32,14 +33,6 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
-	public void statementForSameNodes(Iterable<Node> node, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter) {
-	}
-
-	@Override
-	public void statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter) {
-	}
-
-	@Override
 	public String statementForIndex(String label, Iterable<String> key) {
 		return "";
 	}
@@ -47,5 +40,15 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	@Override
 	public String statementForConstraint(String label, Iterable<String> keys) {
 		return "";
+	}
+
+	@Override
+	public void statementForNodes(Iterable<Node> node, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
+		buildStatementForNodes("MERGE ", "ON CREATE SET ", node, uniqueConstraints, exportConfig, out, reporter, db);
+	}
+
+	@Override
+	public void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
+		buildStatementForRelationships("CREATE ", " SET ", relationship, uniqueConstraints, exportConfig, out, reporter, db);
 	}
 }

--- a/src/main/java/apoc/export/cypher/formatter/CreateCypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/CreateCypherFormatter.java
@@ -1,10 +1,14 @@
 package apoc.export.cypher.formatter;
 
+import org.neo4j.helpers.collection.Iterables;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 /**
  * @author AgileLARUS
@@ -40,10 +44,206 @@ public class CreateCypherFormatter extends AbstractCypherFormatter implements Cy
 		result.append(" CREATE (n1)-[r:" + CypherFormatterUtils.quote(relationship.getType().name()));
 		if (relationship.getPropertyKeys().iterator().hasNext()) {
 			result.append(" {");
-            result.append(CypherFormatterUtils.formatRelationshipProperties("", relationship, true));
+			result.append(CypherFormatterUtils.formatRelationshipProperties("", relationship, true));
 			result.append("}");
 		}
 		result.append("]->(n2);");
-		return result.toString();
+        return result.toString();
 	}
+
+    @Override
+    public Map<String,Object> statementForSameNodes(Iterable<Node> nodes, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
+        StringBuilder result = new StringBuilder(100);
+        Map<String,Object> resultMap = new HashMap<>();
+
+        // Map<Labels, NodeList>
+        Map<String, List<Node>> map = new HashMap<>();
+
+        // Map<Labels, Ids>
+        Map<String, Set<String>> mapIds = new HashMap<>();
+
+        nodes.forEach(node -> {
+            String key = CypherFormatterUtils.formatAllLabels(node, uniqueConstraints, indexNames);
+            map.compute(key, (k, v) -> {
+                if (v == null) {
+                    v = new ArrayList<>();
+                }
+                v.add(node);
+                return v;
+            });
+            mapIds.put(key, CypherFormatterUtils.getNodeIdProperties(node, uniqueConstraints).keySet());
+        });
+
+        AtomicReference<Long> count = new AtomicReference<>(0L);
+        AtomicInteger propertiesCount = new AtomicInteger();
+        map.forEach((labels, nodeList) -> {
+            result.append("UNWIND [");
+
+            int nodeListSize = nodeList.size();
+            for (int i = 0; i < nodeListSize; i++) {
+                Node node = nodeList.get(i);
+
+                Map<String, Object> props = node.getAllProperties();
+                // start element
+                result.append("{");
+
+                // id
+                result.append(CypherFormatterUtils.getNodeIdProperties(node, uniqueConstraints).entrySet().stream()
+                        .map(e -> String.format("`%s`: %s", e.getKey(), CypherFormatterUtils.toString(e.getValue()))).collect(Collectors.joining(",")));
+
+
+                // properties
+                result.append(", ");
+                result.append("properties: ");
+                result.append("{");
+                if (!props.isEmpty()) {
+                    result.append(CypherFormatterUtils.formatProperties("", props, true).substring(2));
+                }
+                result.append("}");
+
+                // end element
+                result.append("}");
+                if (i != nodeListSize - 1) {
+                    result.append(", ");
+                }
+                propertiesCount.addAndGet(props.size());
+            }
+
+            result.append("] as row ");
+
+            result.append(StringUtils.LF);
+            result.append("MERGE ");
+            result.append(String.format("(n%s{", labels));
+            result.append(mapIds.get(labels).stream().map(s -> String.format("`%s`: row.`%s`", s, s)).collect(Collectors.joining(",")));
+            result.append("}) SET n += row.properties;");
+            result.append(StringUtils.LF);
+//            result.append(StringUtils.LF);
+//            result.append(String.format("WITH n%d ", count.get()));
+            count.getAndSet(count.get() + 1);
+        });
+
+        resultMap.put("statement", result.toString());
+        resultMap.put("properties", propertiesCount.longValue());
+
+        return resultMap;
+    }
+
+    @Override
+    public Map<String,Object> statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
+        StringBuilder result = new StringBuilder(100);
+        Map<String,Object> resultMap = new HashMap<>();
+
+        // Map<Path(map{start,rel,end}),RelList>
+        Map<Map<String, String>, List<Relationship>> map = new HashMap<>();
+
+        // Map<Labels, Ids>
+        Map<String, Set<String>> mapIds = new HashMap<>();
+
+
+        relationship.forEach(rel -> {
+            // define the start labels
+            Node start = rel.getStartNode();
+            String startLabels = CypherFormatterUtils.formatAllLabels(start, uniqueConstraints, indexNames);
+            mapIds.put(startLabels, CypherFormatterUtils.getNodeIdProperties(start, uniqueConstraints).keySet());
+
+            // define the end labels
+            Node end = rel.getEndNode();
+            String endLabels = CypherFormatterUtils.formatAllLabels(end, uniqueConstraints, indexNames);
+            mapIds.put(endLabels, CypherFormatterUtils.getNodeIdProperties(end, uniqueConstraints).keySet());
+
+            // define the type
+            String type = rel.getType().name();
+
+            // create the path
+            Map<String,String> key = new HashMap<>();
+            key.put("start", startLabels);
+            key.put("type", type);
+            key.put("end", endLabels);
+
+            map.compute(key, (k, v) -> {
+                if (v == null) {
+                    v = new ArrayList<>();
+                }
+                v.add(rel);
+                return v;
+            });
+        });
+
+        AtomicReference<Long> count = new AtomicReference<>(0L);
+        AtomicInteger propertiesCount = new AtomicInteger();
+        map.forEach((path, relationshipList) -> {
+            result.append("UNWIND [");
+
+            for (int i = 0; i < relationshipList.size(); i++) {
+                Relationship rel = relationshipList.get(i);
+
+                Map<String, Object> props = rel.getAllProperties();
+                // start element
+                result.append("{");
+
+                // start node
+                result.append("start: ");
+                result.append("{");
+                result.append(CypherFormatterUtils.getNodeIdProperties(rel.getStartNode(), uniqueConstraints).entrySet().stream()
+                        .map(e -> String.format("`%s`: %s", e.getKey(), CypherFormatterUtils.toString(e.getValue()))).collect(Collectors.joining(",")));
+                result.append("}");
+
+                result.append(", ");
+
+                // end node
+                result.append("end: ");
+                result.append("{");
+
+                result.append(CypherFormatterUtils.getNodeIdProperties(rel.getEndNode(), uniqueConstraints).entrySet().stream()
+                        .map(e -> String.format("`%s`: %s", e.getKey(), CypherFormatterUtils.toString(e.getValue()))).collect(Collectors.joining(",")));
+                result.append("}");
+
+                // properties
+                result.append(", ");
+                result.append("properties: ");
+                result.append("{");
+                if (!props.isEmpty()) {
+                    result.append(CypherFormatterUtils.formatProperties("", props, true).substring(2));
+                }
+                result.append("}");
+
+                // end element
+                result.append("}");
+                if (i != relationshipList.size() - 1) {
+                    result.append(", ");
+                }
+                propertiesCount.addAndGet(props.size());
+            }
+            result.append("] as row ");
+
+            result.append(StringUtils.LF);
+            result.append("MATCH ");
+
+            // match start node
+            result.append(String.format("(start%s{", path.get("start")));
+            result.append(mapIds.get(path.get("start")).stream().map(s -> String.format("`%s`: row.start.`%s`", s, s)).collect(Collectors.joining(",")));
+            result.append("})");
+
+            result.append(", ");
+
+            // match end node
+            result.append(String.format("(end%s{", path.get("end")));
+            result.append(mapIds.get(path.get("end")).stream().map(s -> String.format("`%s`: row.end.`%s`", s, s)).collect(Collectors.joining(",")));
+            result.append("})");
+
+            result.append(StringUtils.LF);
+
+            // merge relationship
+            result.append(String.format("MERGE (start)-[r:`%s`]->(end) SET r += row.properties;", path.get("type")));
+            result.append(StringUtils.LF);
+//            result.append(String.format("WITH r%d ", count.get()));
+            count.getAndSet(count.get() + 1);
+        });
+
+        resultMap.put("statement", result.toString());
+        resultMap.put("properties", propertiesCount.longValue());
+
+        return resultMap;
+
+    }
 }

--- a/src/main/java/apoc/export/cypher/formatter/CreateCypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/CreateCypherFormatter.java
@@ -2,14 +2,13 @@ package apoc.export.cypher.formatter;
 
 import apoc.export.util.ExportConfig;
 import apoc.export.util.Reporter;
-import org.apache.commons.lang3.StringUtils;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
 import java.io.PrintWriter;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author AgileLARUS
@@ -18,263 +17,49 @@ import java.util.stream.Collectors;
  */
 public class CreateCypherFormatter extends AbstractCypherFormatter implements CypherFormatter {
 
-	@Override
-    public String statementForNode(Node node, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
-		StringBuilder result = new StringBuilder(100);
-		result.append("CREATE (");
-		String labels = CypherFormatterUtils.formatAllLabels(node, uniqueConstraints, indexNames);
-		if (!labels.isEmpty()) {
-			result.append(labels);
-		}
-		if (node.getPropertyKeys().iterator().hasNext()) {
-			result.append(" {");
-			result.append(CypherFormatterUtils.formatNodeProperties("", node, uniqueConstraints, indexNames, true));
-			result.append("}");
-		}
-		result.append(");");
-		return result.toString();
-	}
 
-	@Override
-    public String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties) {
-		StringBuilder result = new StringBuilder(100);
-		result.append("MATCH ");
-		result.append(CypherFormatterUtils.formatNodeLookup("n1", relationship.getStartNode(), uniqueConstraints, indexedProperties));
-		result.append(", ");
-		result.append(CypherFormatterUtils.formatNodeLookup("n2", relationship.getEndNode(), uniqueConstraints, indexedProperties));
-		result.append(" CREATE (n1)-[r:" + CypherFormatterUtils.quote(relationship.getType().name()));
-		if (relationship.getPropertyKeys().iterator().hasNext()) {
-			result.append(" {");
-			result.append(CypherFormatterUtils.formatRelationshipProperties("", relationship, true));
-			result.append("}");
-		}
-		result.append("]->(n2);");
+    @Override
+    public String statementForNode(Node node, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
+        StringBuilder result = new StringBuilder(100);
+        result.append("CREATE (");
+        String labels = CypherFormatterUtils.formatAllLabels(node, uniqueConstraints, indexNames);
+        if (!labels.isEmpty()) {
+            result.append(labels);
+        }
+        if (node.getPropertyKeys().iterator().hasNext()) {
+            result.append(" {");
+            result.append(CypherFormatterUtils.formatNodeProperties("", node, uniqueConstraints, indexNames, true));
+            result.append("}");
+        }
+        result.append(");");
         return result.toString();
     }
 
     @Override
-    public void statementForSameNodes(Iterable<Node> nodes, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter) {
-        // Map<Labels, NodeList>
-        Map<String, List<Node>> map = new HashMap<>();
-
-        // Map<Labels, Ids>
-        Map<String, Set<String>> mapIds = new HashMap<>();
-
-        int batchSize = exportConfig.getBatchSize();
-
-        AtomicInteger nodeCount = new AtomicInteger(0);
-        nodes.forEach(node -> {
-            nodeCount.incrementAndGet();
-            String key = CypherFormatterUtils.formatAllLabels(node, uniqueConstraints, indexNames);
-            map.compute(key, (k, v) -> {
-                if (v == null) {
-                    v = new ArrayList<>();
-                }
-                v.add(node);
-                return v;
-            });
-            mapIds.put(key, CypherFormatterUtils.getNodeIdProperties(node, uniqueConstraints).keySet());
-        });
-
-        AtomicInteger propertiesCount = new AtomicInteger(0);
-        AtomicInteger batchCountBegin = new AtomicInteger(0);
-        AtomicInteger batchCountCommit = new AtomicInteger(0);
-
-        int unwindBatchSize = exportConfig.getUnwindBatchSize();
-
-        map.forEach((labels, nodeList) -> {
-            boolean begin = batchCountBegin.getAndAdd(nodeList.size()) % batchSize == 0;
-            boolean commit = batchCountCommit.addAndGet(nodeList.size()) % batchSize == 0;
-
-            if (begin) {
-                out.append(exportConfig.getFormat().begin());
-            }
-
-            int nodeListSize = nodeList.size();
-            for (int i = 0; i < nodeListSize; i++) {
-                if (i % unwindBatchSize == 0) {
-                    out.append("UNWIND [");
-                }
-
-                Node node = nodeList.get(i);
-
-                Map<String, Object> props = node.getAllProperties();
-                // start element
-                out.append("{");
-
-                // id
-                out.append(CypherFormatterUtils.getNodeIdProperties(node, uniqueConstraints).entrySet().stream()
-                        .map(e -> String.format("`%s`: %s", e.getKey(), CypherFormatterUtils.toString(e.getValue()))).collect(Collectors.joining(",")));
-
-                // properties
-                out.append(", ");
-                out.append("properties: ");
-                out.append("{");
-                if (!props.isEmpty()) {
-                    out.append(CypherFormatterUtils.formatProperties("", props, true).substring(2));
-                    propertiesCount.addAndGet(props.size());
-                }
-                out.append("}");
-
-                // end element
-                out.append("}");
-                boolean isEnd = i == nodeListSize - 1;
-                if (isEnd || (i + 1) % unwindBatchSize == 0) {
-                    out.append("] as row ");
-                    out.append(StringUtils.LF);
-                    out.append("MERGE ");
-                    out.append(String.format("(n%s{", labels));
-                    out.append(mapIds.get(labels).stream().map(s -> String.format("`%s`: row.`%s`", s, s)).collect(Collectors.joining(",")));
-                    out.append("}) SET n += row.properties;");
-                    out.append(StringUtils.LF);
-                } else {
-                    out.append(", ");
-                }
-            }
-            if (commit) {
-                out.append(exportConfig.getFormat().commit());
-            }
-        });
-
-        if (batchCountCommit.get() % batchSize != 0) {
-            out.append(exportConfig.getFormat().commit());
+    public String statementForRelationship(Relationship relationship,  Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties) {
+        StringBuilder result = new StringBuilder(100);
+        result.append("MATCH ");
+        result.append(CypherFormatterUtils.formatNodeLookup("n1", relationship.getStartNode(), uniqueConstraints, indexedProperties));
+        result.append(", ");
+        result.append(CypherFormatterUtils.formatNodeLookup("n2", relationship.getEndNode(), uniqueConstraints, indexedProperties));
+        result.append(" CREATE (n1)-[r:" + CypherFormatterUtils.quote(relationship.getType().name()));
+        if (relationship.getPropertyKeys().iterator().hasNext()) {
+            result.append(" {");
+            result.append(CypherFormatterUtils.formatRelationshipProperties("", relationship, true));
+            result.append("}");
         }
-
-        reporter.update(nodeCount.get(), 0, propertiesCount.longValue());
+        result.append("]->(n2);");
+        return result.toString();
     }
 
     @Override
-    public void statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter) {
-        // Map<Path(map{start,rel,end}),RelList>
-        Map<Map<String, String>, List<Relationship>> map = new HashMap<>();
-
-        // Map<Labels, Ids>
-        Map<String, Set<String>> mapIds = new HashMap<>();
-
-        int batchSize = exportConfig.getBatchSize();
-
-        AtomicInteger relCount = new AtomicInteger(0);
-
-        relationship.forEach(rel -> {
-            relCount.incrementAndGet();
-            // define the start labels
-            Node start = rel.getStartNode();
-            String startLabels = CypherFormatterUtils.formatAllLabels(start, uniqueConstraints, indexNames);
-            mapIds.put(startLabels, CypherFormatterUtils.getNodeIdProperties(start, uniqueConstraints).keySet());
-
-            // define the end labels
-            Node end = rel.getEndNode();
-            String endLabels = CypherFormatterUtils.formatAllLabels(end, uniqueConstraints, indexNames);
-            mapIds.put(endLabels, CypherFormatterUtils.getNodeIdProperties(end, uniqueConstraints).keySet());
-
-            // define the type
-            String type = rel.getType().name();
-
-            // create the path
-            Map<String,String> key = new HashMap<>();
-            key.put("start", startLabels);
-            key.put("type", type);
-            key.put("end", endLabels);
-
-            map.compute(key, (k, v) -> {
-                if (v == null) {
-                    v = new ArrayList<>();
-                }
-                v.add(rel);
-                return v;
-            });
-        });
-
-        AtomicInteger propertiesCount = new AtomicInteger(0);
-        AtomicInteger batchCountBegin = new AtomicInteger(0);
-        AtomicInteger batchCountCommit = new AtomicInteger(0);
-
-        int unwindBatchSize = exportConfig.getUnwindBatchSize();
-
-        map.forEach((path, relationshipList) -> {
-            boolean begin = batchCountBegin.getAndAdd(relationshipList.size()) % batchSize == 0;
-            boolean commit = batchCountCommit.addAndGet(relationshipList.size()) % batchSize == 0;
-
-            if (begin) {
-                out.append(exportConfig.getFormat().begin());
-            }
-
-            for (int i = 0; i < relationshipList.size(); i++) {
-                if (i % unwindBatchSize == 0) {
-                    out.append("UNWIND [");
-                }
-                Relationship rel = relationshipList.get(i);
-
-                Map<String, Object> props = rel.getAllProperties();
-                // start element
-                out.append("{");
-
-                // start node
-                out.append("start: ");
-                out.append("{");
-                out.append(CypherFormatterUtils.getNodeIdProperties(rel.getStartNode(), uniqueConstraints).entrySet().stream()
-                        .map(e -> String.format("`%s`: %s", e.getKey(), CypherFormatterUtils.toString(e.getValue()))).collect(Collectors.joining(",")));
-                out.append("}");
-
-                out.append(", ");
-
-                // end node
-                out.append("end: ");
-                out.append("{");
-
-                out.append(CypherFormatterUtils.getNodeIdProperties(rel.getEndNode(), uniqueConstraints).entrySet().stream()
-                        .map(e -> String.format("`%s`: %s", e.getKey(), CypherFormatterUtils.toString(e.getValue()))).collect(Collectors.joining(",")));
-                out.append("}");
-
-                // properties
-                out.append(", ");
-                out.append("properties: ");
-                out.append("{");
-                if (!props.isEmpty()) {
-                    out.append(CypherFormatterUtils.formatProperties("", props, true).substring(2));
-                    propertiesCount.addAndGet(props.size());
-                }
-                out.append("}");
-
-                // end element
-                out.append("}");
-
-                boolean isEnd = i == relationshipList.size() - 1;
-                if (isEnd || (i + 1) % unwindBatchSize == 0) {
-                    out.append("] as row ");
-
-                    out.append(StringUtils.LF);
-                    out.append("MATCH ");
-
-                    // match start node
-                    out.append(String.format("(start%s{", path.get("start")));
-                    out.append(mapIds.get(path.get("start")).stream().map(s -> String.format("`%s`: row.start.`%s`", s, s)).collect(Collectors.joining(",")));
-                    out.append("})");
-
-                    out.append(", ");
-
-                    // match end node
-                    out.append(String.format("(end%s{", path.get("end")));
-                    out.append(mapIds.get(path.get("end")).stream().map(s -> String.format("`%s`: row.end.`%s`", s, s)).collect(Collectors.joining(",")));
-                    out.append("})");
-
-                    out.append(StringUtils.LF);
-
-                    // merge relationship
-                    out.append(String.format("MERGE (start)-[r:`%s`]->(end) SET r += row.properties;", path.get("type")));
-                    out.append(StringUtils.LF);
-                } else {
-                    out.append(", ");
-                }
-            }
-            if (commit) {
-                out.append(exportConfig.getFormat().commit());
-            }
-        });
-
-        if (batchCountCommit.get() % batchSize != 0) {
-            out.append(exportConfig.getFormat().commit());
-        }
-        reporter.update(0, relCount.get(), propertiesCount.longValue());
+    public void statementForNodes(Iterable<Node> node, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
+        buildStatementForNodes("CREATE ", "SET ", node, uniqueConstraints, exportConfig, out, reporter, db);
     }
+
+    @Override
+    public void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
+        buildStatementForRelationships("CREATE ", "SET ", relationship, uniqueConstraints, exportConfig, out, reporter, db);
+    }
+
 }

--- a/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -22,4 +22,8 @@ public interface CypherFormatter {
 	String statementForConstraint(String label, Iterable<String> keys);
 
 	String statementForCleanUp(int batchSize);
+
+	Map<String,Object> statementForSameNodes(Iterable<Node> node, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames);
+
+	Map<String,Object> statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames);
 }

--- a/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -1,8 +1,11 @@
 package apoc.export.cypher.formatter;
 
+import apoc.export.util.ExportConfig;
+import apoc.export.util.Reporter;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
+import java.io.PrintWriter;
 import java.util.Map;
 import java.util.Set;
 
@@ -23,7 +26,8 @@ public interface CypherFormatter {
 
 	String statementForCleanUp(int batchSize);
 
-	Map<String,Object> statementForSameNodes(Iterable<Node> node, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames);
+	void statementForSameNodes(Iterable<Node> node, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter);
 
-	Map<String,Object> statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames);
+	void statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter);
+
 }

--- a/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -2,6 +2,7 @@ package apoc.export.cypher.formatter;
 
 import apoc.export.util.ExportConfig;
 import apoc.export.util.Reporter;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
@@ -26,8 +27,8 @@ public interface CypherFormatter {
 
 	String statementForCleanUp(int batchSize);
 
-	void statementForSameNodes(Iterable<Node> node, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter);
+	void statementForNodes(Iterable<Node> node, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db);
 
-	void statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter);
+	void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db);
 
 }

--- a/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
+++ b/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
@@ -51,7 +51,7 @@ public class CypherFormatterUtils {
         return result.toString();
     }
 
-    private static Map<String, Object> getNodeIdProperties(Node node, Map<String, Set<String>> uniqueConstraints) {
+    public static Map<String, Object> getNodeIdProperties(Node node, Map<String, Set<String>> uniqueConstraints) {
         Map<String, Object> nodeIdProperties = new LinkedHashMap<>();
         boolean uniqueLabelFound = false;
         List<String> list = getLabelsSorted(node);
@@ -175,7 +175,7 @@ public class CypherFormatterUtils {
         return result.length() > 0 ? result.substring(2) : "";
     }
 
-    private static StringBuilder formatProperties(String id, Map<String, Object> properties, boolean jsonStyle) {
+    public static StringBuilder formatProperties(String id, Map<String, Object> properties, boolean jsonStyle) {
         StringBuilder result = new StringBuilder(100);
         List<String> keys = Iterables.asList(properties.keySet());
         Collections.sort(keys);

--- a/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
+++ b/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
@@ -1,6 +1,7 @@
 package apoc.export.cypher.formatter;
 
 import apoc.export.util.FormatUtils;
+import apoc.util.Util;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.helpers.collection.Iterables;
@@ -186,8 +187,8 @@ public class CypherFormatterUtils {
         return result;
     }
 
-    private static String formatPropertyName(String id, String prop, Object value, boolean jsonStyle) {
-        return (id != null && !"".equals(id) ? id + "." : "") + "`" + prop + "`" + (jsonStyle ? ":" : "=" ) + toString(value);
+    public static String formatPropertyName(String id, String prop, Object value, boolean jsonStyle) {
+        return (id != null && !"".equals(id) ? id + "." : "") + quote(prop) + (jsonStyle ? ":" : "=" ) + toString(value);
     }
 
     // ---- to string ----
@@ -204,8 +205,12 @@ public class CypherFormatterUtils {
         return builder.toString();
     }
 
+    @Deprecated
+    /**
+     * use {@link Util#quote()}
+     */
     public static String quote(String id) {
-        return "`" + id + "`";
+        return Util.quote(id);
     }
 
     public static String label(String id) {

--- a/src/main/java/apoc/export/cypher/formatter/UpdateAllCypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/UpdateAllCypherFormatter.java
@@ -1,8 +1,11 @@
 package apoc.export.cypher.formatter;
 
+import apoc.export.util.ExportConfig;
+import apoc.export.util.Reporter;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
+import java.io.PrintWriter;
 import java.util.Map;
 import java.util.Set;
 
@@ -24,12 +27,10 @@ public class UpdateAllCypherFormatter extends AbstractCypherFormatter implements
 	}
 
 	@Override
-	public Map<String,Object> statementForSameNodes(Iterable<Node> node, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
-		return null;
+	public void statementForSameNodes(Iterable<Node> node, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter) {
 	}
 
 	@Override
-	public Map<String,Object> statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
-		return null;
+	public void statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter) {
 	}
 }

--- a/src/main/java/apoc/export/cypher/formatter/UpdateAllCypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/UpdateAllCypherFormatter.java
@@ -22,4 +22,14 @@ public class UpdateAllCypherFormatter extends AbstractCypherFormatter implements
 	public String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties) {
         return super.mergeStatementForRelationship(CypherFormat.UPDATE_ALL, relationship, uniqueConstraints, indexedProperties);
 	}
+
+	@Override
+	public Map<String,Object> statementForSameNodes(Iterable<Node> node, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
+		return null;
+	}
+
+	@Override
+	public Map<String,Object> statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
+		return null;
+	}
 }

--- a/src/main/java/apoc/export/cypher/formatter/UpdateAllCypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/UpdateAllCypherFormatter.java
@@ -2,6 +2,7 @@ package apoc.export.cypher.formatter;
 
 import apoc.export.util.ExportConfig;
 import apoc.export.util.Reporter;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
@@ -27,10 +28,12 @@ public class UpdateAllCypherFormatter extends AbstractCypherFormatter implements
 	}
 
 	@Override
-	public void statementForSameNodes(Iterable<Node> node, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter) {
+	public void statementForNodes(Iterable<Node> node, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
+		buildStatementForNodes("MERGE ", "SET ", node, uniqueConstraints, exportConfig, out, reporter, db);
 	}
 
 	@Override
-	public void statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter) {
+	public void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
+		buildStatementForRelationships("MERGE ", "SET ", relationship, uniqueConstraints, exportConfig, out, reporter, db);
 	}
 }

--- a/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -29,6 +29,16 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	}
 
 	@Override
+	public Map<String,Object> statementForSameNodes(Iterable<Node> node, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
+		return null;
+	}
+
+	@Override
+	public Map<String,Object> statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
+		return null;
+	}
+
+	@Override
 	public String statementForIndex(String label, Iterable<String> key) {
 		return "";
 	}

--- a/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -1,8 +1,11 @@
 package apoc.export.cypher.formatter;
 
+import apoc.export.util.ExportConfig;
+import apoc.export.util.Reporter;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
+import java.io.PrintWriter;
 import java.util.Map;
 import java.util.Set;
 
@@ -29,13 +32,11 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	}
 
 	@Override
-	public Map<String,Object> statementForSameNodes(Iterable<Node> node, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
-		return null;
+	public void statementForSameNodes(Iterable<Node> node, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter) {
 	}
 
 	@Override
-	public Map<String,Object> statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames) {
-		return null;
+	public void statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter) {
 	}
 
 	@Override

--- a/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -2,6 +2,7 @@ package apoc.export.cypher.formatter;
 
 import apoc.export.util.ExportConfig;
 import apoc.export.util.Reporter;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 
@@ -32,14 +33,6 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	}
 
 	@Override
-	public void statementForSameNodes(Iterable<Node> node, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter) {
-	}
-
-	@Override
-	public void statementForSameRelationship(Iterable<Relationship> relationship, Map<String, String> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames, ExportConfig exportConfig, PrintWriter out, Reporter reporter) {
-	}
-
-	@Override
 	public String statementForIndex(String label, Iterable<String> key) {
 		return "";
 	}
@@ -47,5 +40,14 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	@Override
 	public String statementForConstraint(String label, Iterable<String> key) {
 		return "";
+	}
+
+	@Override
+	public void statementForNodes(Iterable<Node> node, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
+	}
+
+	@Override
+	public void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
+		buildStatementForRelationships("MERGE ", "SET ", relationship, uniqueConstraints, exportConfig, out, reporter, db);
 	}
 }

--- a/src/main/java/apoc/export/util/ExportConfig.java
+++ b/src/main/java/apoc/export/util/ExportConfig.java
@@ -19,26 +19,29 @@ public class ExportConfig {
     public static final String IF_NEEDED_QUUOTES = "ifNeeded";
 
     public static final int DEFAULT_BATCH_SIZE = 20000;
+    private static final int DEFAULT_UNWIND_BATCH_SIZE = 20;
     public static final String DEFAULT_DELIM = ",";
     public static final String DEFAULT_ARRAY_DELIM = ";";
     public static final String DEFAULT_QUOTES = ALWAYS_QUOTES;
     private final boolean streamStatements;
 
-    private int batchSize = DEFAULT_BATCH_SIZE;
-    private boolean silent = false;
+    private int batchSize;
+    private boolean silent;
     private boolean bulkImport = false;
-    private String delim = DEFAULT_DELIM;
-    private String quotes = DEFAULT_QUOTES;
-    private boolean useTypes = false;
+    private String delim;
+    private String quotes;
+    private boolean useTypes;
     private Set<String> caption;
-    private boolean writeNodeProperties = false;
+    private boolean writeNodeProperties;
     private boolean nodesOfRelationships;
     private ExportFormat format;
     private CypherFormat cypherFormat;
     private final Map<String, Object> config;
     private boolean separateHeader;
     private String arrayDelim;
-
+    private Map<String, Object> optimizations;
+    public enum OptimizationType {NONE, UNWIND_BATCH, UNWIND_BATCH_PARAMS}
+    private OptimizationType optimizationType;
 
     public int getBatchSize() {
         return batchSize;
@@ -77,7 +80,6 @@ public class ExportConfig {
     public ExportConfig(Map<String,Object> config) {
         config = config != null ? config : Collections.emptyMap();
         this.silent = toBoolean(config.getOrDefault("silent",false));
-        this.batchSize = ((Number)config.getOrDefault("batchSize", DEFAULT_BATCH_SIZE)).intValue();
         this.delim = delim(config.getOrDefault("delim", DEFAULT_DELIM).toString());
         this.arrayDelim = delim(config.getOrDefault("arrayDelim", DEFAULT_ARRAY_DELIM).toString());
         this.useTypes = toBoolean(config.get("useTypes"));
@@ -91,6 +93,20 @@ public class ExportConfig {
         this.streamStatements = toBoolean(config.get("streamStatements")) || toBoolean(config.get("stream"));
         this.writeNodeProperties = toBoolean(config.get("writeNodeProperties"));
         exportQuotes(config);
+        this.optimizations = (Map<String, Object>) config.getOrDefault("useOptimizations", Collections.emptyMap());
+        this.optimizationType = OptimizationType.valueOf(optimizations.getOrDefault("type", OptimizationType.UNWIND_BATCH.toString()).toString().toUpperCase());
+        validate();
+        if (optimizationType.equals(OptimizationType.UNWIND_BATCH_PARAMS)) {
+            this.batchSize = getUnwindBatchSize(); // batchSize is not considered because the data gets committed every UNWIND operation
+        } else {
+            this.batchSize = ((Number)config.getOrDefault("batchSize", DEFAULT_BATCH_SIZE)).intValue();
+        }
+    }
+
+    private void validate() {
+        if (OptimizationType.UNWIND_BATCH_PARAMS.equals(this.optimizationType) && !ExportFormat.CYPHER_SHELL.equals(this.format)) {
+            throw new RuntimeException("`useOptimizations: 'UNWIND_BATCH_PARAMS'` can be used only in combination with `format: 'CYPHER_SHELL'`");
+        }
     }
 
     private void exportQuotes(Map<String, Object> config)
@@ -118,11 +134,6 @@ public class ExportConfig {
         throw new RuntimeException("Illegal delimiter '"+value+"'");
     }
 
-    public ExportConfig withTypes() {
-        this.useTypes =true;
-        return this;
-    }
-
     public String defaultRelationshipType() {
         return config.getOrDefault("defaultRelationshipType","RELATED").toString();
     }
@@ -137,10 +148,6 @@ public class ExportConfig {
 
     public boolean separateFiles() {
         return toBoolean(config.getOrDefault("separateFiles", false));
-    }
-
-    private ExportFormat format(Object format) {
-        return format != null && format instanceof String ? ExportFormat.fromString((String)format) : ExportFormat.NEO4J_SHELL;
     }
 
     private static Set<String> convertCaption(Object value) {
@@ -162,6 +169,14 @@ public class ExportConfig {
         return Util.toLong(config.getOrDefault("timeoutSeconds",100));
     }
 
+    public int getUnwindBatchSize() {
+        return ((Number)getOptimizations().getOrDefault("unwindBatchSize", DEFAULT_UNWIND_BATCH_SIZE)).intValue();
+    }
+
+    public Map<String, Object> getOptimizations() {
+        return optimizations;
+    }
+
     public boolean isSeparateHeader() {
         return this.separateHeader;
     }
@@ -169,4 +184,9 @@ public class ExportConfig {
     public String getArrayDelim() {
         return arrayDelim;
     }
+
+    public OptimizationType getOptimizationType() {
+        return optimizationType;
+    }
+
 }

--- a/src/main/java/apoc/export/util/FormatUtils.java
+++ b/src/main/java/apoc/export/util/FormatUtils.java
@@ -40,7 +40,11 @@ public class FormatUtils {
     }
 
     public static String formatString(Object value) {
-        return "\"" + String.valueOf(value).replaceAll("\\\\", "\\\\\\\\").replaceAll("\n","\\\\n").replaceAll("\t","\\\\t").replaceAll("\"","\\\\\"") + "\"";
+        return "\"" + String.valueOf(value).replaceAll("\\\\", "\\\\\\\\")
+                .replaceAll("\n","\\\\n")
+                .replaceAll("\r","\\\\r")
+                .replaceAll("\t","\\\\t")
+                .replaceAll("\"","\\\\\"") + "\"";
     }
 
     public static String joinLabels(Node node, String delimiter) {

--- a/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -14,7 +14,6 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Scanner;
 
@@ -29,7 +28,7 @@ import static org.junit.Assert.*;
  */
 public class ExportCypherTest {
 
-    private static final Map<String, Object> exportConfig = Collections.singletonMap("separateFiles", true);
+    private static final Map<String, Object> exportConfig = Util.map("useOptimizations", Util.map("type", "none"),"separateFiles", true);
     private static GraphDatabaseService db;
     private static File directory = new File("target/import");
 
@@ -69,7 +68,7 @@ public class ExportCypherTest {
 
     @Test
     public void testExportAllCypherResults() {
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all(null,null)", (r) -> {
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all(null,{useOptimizations: { type: 'none'}})", (r) -> {
             assertResults(null, r, "database");
             assertEquals(EXPECTED_NEO4J_SHELL, r.get("cypherStatements"));
         });
@@ -78,7 +77,7 @@ public class ExportCypherTest {
     @Test
     public void testExportAllCypherStreaming() {
         StringBuilder sb = new StringBuilder();
-        TestUtil.testResult(db, "CALL apoc.export.cypher.all(null,{streamStatements:true,batchSize:3})", (res) -> {
+        TestUtil.testResult(db, "CALL apoc.export.cypher.all(null,{useOptimizations: { type: 'none'}, streamStatements:true,batchSize:3})", (res) -> {
             Map<String, Object> r = res.next();
             assertEquals(3L, r.get("batchSize"));
             assertEquals(1L, r.get("batches"));
@@ -107,7 +106,7 @@ public class ExportCypherTest {
     @Test
     public void testExportAllCypherDefault() throws Exception {
         File output = new File(directory, "all.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},null)", map("file", output.getAbsolutePath()), (r) -> assertResults(output, r, "database"));
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{useOptimizations: { type: 'none'}})", map("file", output.getAbsolutePath()), (r) -> assertResults(output, r, "database"));
         assertEquals(EXPECTED_NEO4J_SHELL, readFile(output));
     }
 
@@ -115,7 +114,7 @@ public class ExportCypherTest {
     public void testExportAllCypherForCypherShell() throws Exception {
         File output = new File(directory, "all.cypher");
         TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{config})",
-                map("file", output.getAbsolutePath(), "config", Util.map("format", "cypher-shell")), (r) -> assertResults(output, r, "database"));
+                map("file", output.getAbsolutePath(), "config", Util.map("useOptimizations", Util.map("type", "none"), "format", "cypher-shell")), (r) -> assertResults(output, r, "database"));
         assertEquals(EXPECTED_CYPHER_SHELL, readFile(output));
     }
 
@@ -124,7 +123,7 @@ public class ExportCypherTest {
         File output = new File(directory, "all.cypher");
         String query = "MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("format", "neo4j-shell")), (r) -> {
+                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"), "format", "neo4j-shell")), (r) -> {
                 });
         assertEquals(EXPECTED_NEO4J_SHELL, readFile(output));
     }
@@ -137,7 +136,7 @@ public class ExportCypherTest {
     public void testExportGraphCypher() throws Exception {
         File output = new File(directory, "graph.cypher");
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
-                "CALL apoc.export.cypher.graph(graph, {file},null) " +
+                "CALL apoc.export.cypher.graph(graph, {file},{useOptimizations: { type: 'none'}}) " +
                 "YIELD nodes, relationships, properties, file, source,format, time " +
                 "RETURN *", map("file", output.getAbsolutePath()), (r) -> assertResults(output, r, "graph"));
         assertEquals(EXPECTED_NEO4J_SHELL, readFile(output));
@@ -234,7 +233,7 @@ public class ExportCypherTest {
         File output = new File(directory, "all.cypher");
         String query = "MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("format", "plain")), (r) -> {
+                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"), "format", "plain")), (r) -> {
                 });
         assertEquals(EXPECTED_PLAIN, readFile(output));
     }
@@ -244,7 +243,7 @@ public class ExportCypherTest {
         File output = new File(directory, "all.cypher");
         String query = "MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("format", "neo4j-shell", "cypherFormat", "updateAll")), (r) -> {
+                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"), "format", "neo4j-shell", "cypherFormat", "updateAll")), (r) -> {
                 });
         assertEquals(EXPECTED_NEO4J_MERGE, readFile(output));
     }
@@ -254,7 +253,7 @@ public class ExportCypherTest {
         File output = new File(directory, "all.cypher");
         String query = "MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("format", "neo4j-shell", "cypherFormat", "addStructure")), (r) -> {
+                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"), "format", "neo4j-shell", "cypherFormat", "addStructure")), (r) -> {
                 });
         assertEquals(EXPECTED_NODES_MERGE_ON_CREATE_SET + EXPECTED_SCHEMA_EMPTY + EXPECTED_RELATIONSHIPS + EXPECTED_CLEAN_UP_EMPTY, readFile(output));
     }
@@ -264,7 +263,7 @@ public class ExportCypherTest {
         File output = new File(directory, "all.cypher");
         String query = "MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("format", "neo4j-shell", "cypherFormat", "updateStructure")), (r) -> {
+                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"), "format", "neo4j-shell", "cypherFormat", "updateStructure")), (r) -> {
                 });
         assertEquals(EXPECTED_NODES_EMPTY + EXPECTED_SCHEMA_EMPTY + EXPECTED_RELATIONSHIPS_MERGE_ON_CREATE_SET + EXPECTED_CLEAN_UP_EMPTY, readFile(output));
     }
@@ -280,7 +279,7 @@ public class ExportCypherTest {
     @Test
     public void testExportSchemaCypherShell() throws Exception {
         File output = new File(directory, "onlySchema.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.schema({file},{exportConfig})", map("file", output.getAbsolutePath(), "exportConfig", Util.map("format", "cypher-shell")), (r) -> {
+        TestUtil.testCall(db, "CALL apoc.export.cypher.schema({file},{exportConfig})", map("file", output.getAbsolutePath(), "exportConfig", Util.map("useOptimizations", Util.map("type", "none"), "format", "cypher-shell")), (r) -> {
         });
         assertEquals(EXPECTED_ONLY_SCHEMA_CYPHER_SHELL, readFile(new File(directory, "onlySchema.cypher")));
     }
@@ -295,7 +294,7 @@ public class ExportCypherTest {
         File output = new File(directory, "temporalPoint.cypher");
         String query = "MATCH (n:Test)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("format", "neo4j-shell")), (r) -> {
+                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"),"format", "neo4j-shell")), (r) -> {
                 });
         assertEquals(EXPECTED_CYPHER_POINT, readFile(output));
     }
@@ -311,7 +310,7 @@ public class ExportCypherTest {
         File output = new File(directory, "temporalDate.cypher");
         String query = "MATCH (n:Test)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("format", "neo4j-shell")), (r) -> {
+                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"),"format", "neo4j-shell")), (r) -> {
                 });
         assertEquals(EXPECTED_CYPHER_DATE, readFile(output));
     }
@@ -326,7 +325,7 @@ public class ExportCypherTest {
         File output = new File(directory, "temporalTime.cypher");
         String query = "MATCH (n:Test)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("format", "neo4j-shell")), (r) -> {
+                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"),"format", "neo4j-shell")), (r) -> {
                 });
         assertEquals(EXPECTED_CYPHER_TIME, readFile(output));
     }
@@ -340,7 +339,7 @@ public class ExportCypherTest {
         File output = new File(directory, "temporalDuration.cypher");
         String query = "MATCH (n:Test)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("format", "neo4j-shell")), (r) -> {
+                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"),"format", "neo4j-shell")), (r) -> {
                 });
         assertEquals(EXPECTED_CYPHER_DURATION, readFile(output));
     }
@@ -351,38 +350,81 @@ public class ExportCypherTest {
         File output = new File(directory, "ascendingLabels.cypher");
         String query = "MATCH (f:User) WHERE f.name='Alan' RETURN f";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("format", "neo4j-shell")), (r) -> {
+                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"),"format", "neo4j-shell")), (r) -> {
                 });
         assertEquals(EXPECTED_CYPHER_LABELS_ASCENDEND, readFile(output));
     }
 
     @Test
+    public void testExportAllCypherDefaultWithUnwindBatchSizeOptimized() throws Exception {
+        File output = new File(directory, "allDefaultOptimized.cypher");
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{useOptimizations: { type: 'unwind_batch', batchSize: 2}})", map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r));
+        assertEquals(EXPECTED_NEO4J_OPTIMIZED_BATCH_SIZE, readFile(output));
+    }
+
+    @Test
     public void testExportAllCypherDefaultOptimized() throws Exception {
         File output = new File(directory, "allDefaultOptimized.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{useOptimizations:true})", map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r, "database"));
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file})", map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r));
         assertEquals(EXPECTED_NEO4J_OPTIMIZED, readFile(output));
+    }
+
+    @Test
+    public void testExportAllCypherCypherShellWithUnwindBatchSizeOptimized() throws Exception {
+        File output = new File(directory, "allCypherShellOptimized.cypher");
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'cypher-shell', useOptimizations: {type: 'unwind_batch'}})", map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r));
+        assertEquals(EXPECTED_CYPHER_SHELL_OPTIMIZED_BATCH_SIZE, readFile(output));
     }
 
     @Test
     public void testExportAllCypherCypherShellOptimized() throws Exception {
         File output = new File(directory, "allCypherShellOptimized.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'cypher-shell', useOptimizations:true})", map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r, "database"));
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'cypher-shell'})", map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r));
         assertEquals(EXPECTED_CYPHER_SHELL_OPTIMIZED, readFile(output));
     }
 
     @Test
-    public void testExportAllCypherPlainOptimized() throws Exception {
+    public void testExportAllCypherPlainWithUnwindBatchSizeOptimized() throws Exception {
         File output = new File(directory, "allPlainOptimized.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'plain', useOptimizations:true})", map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r, "database"));
-        assertEquals(EXPECTED_PLAIN_OPTIMIZED, readFile(output));
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'plain', useOptimizations: { type: 'unwind_batch', batchSize: 2}})", map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r));
+        assertEquals(EXPECTED_PLAIN_OPTIMIZED_BATCH_SIZE, readFile(output));
     }
 
-    private void assertResultsOptimized(File output, Map<String, Object> r, final String source) {
+    @Test
+    public void testExportQueryCypherPlainWithUnwindBatchSizeOptimized() throws Exception {
+        File output = new File(directory, "allPlainOptimized.cypher");
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'plain', useOptimizations: { type: 'unwind_batch', batchSize: 2}})", map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r));
+        assertEquals(EXPECTED_PLAIN_OPTIMIZED_BATCH_SIZE, readFile(output));
+    }
+
+    @Test
+    public void testExportQueryCypherShellWithUnwindBatchSizeWithBatchSizeOptimized() throws Exception {
+        File output = new File(directory, "allPlainOptimized.cypher");
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'cypher-shell', useOptimizations: { type: 'unwind_batch', batchSize: 100}, batchSize: 2})", map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r));
+        assertEquals(EXPECTED_QUERY_CYPHER_SHELL_OPTIMIZED_UNWIND, readFile(output));
+    }
+
+    @Test
+    public void testExportAllCypherPlainOptimized() throws Exception {
+        File output = new File(directory, "queryPlainOptimized.cypher");
+        TestUtil.testCall(db, "CALL apoc.export.cypher.query('MATCH (f:Foo)-[r:KNOWS]->(b:Bar) return f,r,b', {file},{format:'cypher-shell', useOptimizations: { type: 'unwind_batch'}})", map("file", output.getAbsolutePath()), (r) -> {
+            assertEquals(4L, r.get("nodes"));
+            assertEquals(2L, r.get("relationships"));
+            assertEquals(10L, r.get("properties"));
+            assertEquals(output.getAbsolutePath(), r.get("file"));
+            assertEquals("statement: nodes(4), rels(2)", r.get("source"));
+            assertEquals("cypher", r.get("format"));
+            assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
+        });
+        assertEquals(EXPECTED_QUERY_CYPHER_SHELL_OPTIMIZED, readFile(output));
+    }
+
+    private void assertResultsOptimized(File output, Map<String, Object> r) {
         assertEquals(7L, r.get("nodes"));
         assertEquals(2L, r.get("relationships"));
         assertEquals(13L, r.get("properties"));
         assertEquals(output == null ? null : output.getAbsolutePath(), r.get("file"));
-        assertEquals(source + ": nodes(7), rels(2)", r.get("source"));
+        assertEquals("database" + ": nodes(7), rels(2)", r.get("source"));
         assertEquals("cypher", r.get("format"));
         assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
     }
@@ -422,6 +464,10 @@ public class ExportCypherTest {
         private static final String EXPECTED_INDEXES_AWAIT = String.format("CALL db.awaitIndex(':`Foo`(`name`)');%n" +
                 "CALL db.awaitIndex(':`Bar`(`first_name`,`last_name`)');%n" +
                 "CALL db.awaitIndex(':`Bar`(`name`)');%n");
+
+        private static final String EXPECTED_INDEXES_AWAIT_QUERY = String.format("CALL db.awaitIndex(':`Foo`(`name`)');%n" +
+                "CALL db.awaitIndex(':`Bar`(`name`)');%n" +
+                "CALL db.awaitIndex(':`Bar`(`first_name`,`last_name`)');%n");
 
         static final String EXPECTED_RELATIONSHIPS = String.format("BEGIN%n" +
                 "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`Bar`{`name`:\"bar\"}) CREATE (n1)-[r:`KNOWS` {`since`:2016}]->(n2);%n" +
@@ -547,6 +593,19 @@ public class ExportCypherTest {
                 "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT node.`UNIQUE IMPORT ID` IS UNIQUE;%n" +
                 "COMMIT%n");
 
+        static final String EXPECTED_NODES_OPTIMIZED_BATCH_SIZE = String.format("BEGIN%n" +
+                "UNWIND [{`UNIQUE IMPORT ID`: 0, properties: {`born`:date('2018-10-31'), `name`:\"foo\"}}, {`UNIQUE IMPORT ID`: 4, properties: {`born`:date('2017-09-29'), `name`:\"foo2\"}}] as row %n" +
+                "MERGE (n:`Foo`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;%n" +
+                "UNWIND [{`name`: \"bar\", properties: {`age`:42, `name`:\"bar\"}}, {`name`: \"bar2\", properties: {`age`:44, `name`:\"bar2\"}}] as row %n" +
+                "MERGE (n:`Bar`{`name`: row.`name`}) SET n += row.properties;%n" +
+                "UNWIND [{`UNIQUE IMPORT ID`: 2, properties: {`age`:12}}] as row %n" +
+                "MERGE (n:`Bar`:`Person`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;%n" +
+                "UNWIND [{`UNIQUE IMPORT ID`: 6, properties: {`age`:99}}] as row %n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;%n" +
+                "UNWIND [{`UNIQUE IMPORT ID`: 3, properties: {`age`:12}}] as row %n" +
+                "MERGE (n:`Bar`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;%n" +
+                "COMMIT%n");
+
         static final String EXPECTED_NODES_OPTIMIZED = String.format("BEGIN%n" +
                 "UNWIND [{`UNIQUE IMPORT ID`: 0, properties: {`born`:date('2018-10-31'), `name`:\"foo\"}}, {`UNIQUE IMPORT ID`: 4, properties: {`born`:date('2017-09-29'), `name`:\"foo2\"}}] as row %n" +
                 "MERGE (n:`Foo`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;%n" +
@@ -558,7 +617,13 @@ public class ExportCypherTest {
                 "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;%n" +
                 "UNWIND [{`UNIQUE IMPORT ID`: 3, properties: {`age`:12}}] as row %n" +
                 "MERGE (n:`Bar`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;%n" +
-                "%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_QUERY_NODES_OPTIMIZED = String.format("BEGIN%n" +
+                "UNWIND [{`UNIQUE IMPORT ID`: 0, properties: {`born`:date('2018-10-31'), `name`:\"foo\"}}, {`UNIQUE IMPORT ID`: 4, properties: {`born`:date('2017-09-29'), `name`:\"foo2\"}}] as row %n" +
+                "MERGE (n:`Foo`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;%n" +
+                "UNWIND [{`name`: \"bar\", properties: {`age`:42, `name`:\"bar\"}}, {`name`: \"bar2\", properties: {`age`:44, `name`:\"bar2\"}}] as row %n" +
+                "MERGE (n:`Bar`{`name`: row.`name`}) SET n += row.properties;%n" +
                 "COMMIT%n");
 
         static final String EXPECTED_SCHEMA_OPTIMIZED = String.format("BEGIN%n" +
@@ -573,12 +638,7 @@ public class ExportCypherTest {
                 "UNWIND [{start: {`UNIQUE IMPORT ID`: 0}, end: {`name`: \"bar\"}, properties: {`since`:2016}}, {start: {`UNIQUE IMPORT ID`: 4}, end: {`name`: \"bar2\"}, properties: {`since`:2015}}] as row %n" +
                 "MATCH (start:`Foo`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start.`UNIQUE IMPORT ID`}), (end:`Bar`{`name`: row.end.`name`})%n" +
                 "MERGE (start)-[r:`KNOWS`]->(end) SET r += row.properties;%n" +
-                "%n" +
                 "COMMIT%n");
-
-        static final String EXPECTED_INDEXES_AWAIT_OPTIMIZED = String.format("CALL db.awaitIndex(':`Foo`(`name`)');%n" +
-                "CALL db.awaitIndex(':`Bar`(`first_name`,`last_name`)');%n" +
-                "CALL db.awaitIndex(':`Bar`(`name`)');%n");
 
         static final String DROP_UNIQUE_OPTIMIZED = String.format("BEGIN%n" +
                 "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
@@ -587,9 +647,61 @@ public class ExportCypherTest {
                 "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT node.`UNIQUE IMPORT ID` IS UNIQUE;%n" +
                 "COMMIT%n");
 
-        static final String EXPECTED_NEO4J_OPTIMIZED = EXPECTED_NODES_OPTIMIZED + EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_RELATIONSHIPS_OPTIMIZED + DROP_UNIQUE_OPTIMIZED;
+        static final String DROP_UNIQUE_OPTIMIZED_BATCH = String.format("BEGIN%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 2 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 2 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 2 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT node.`UNIQUE IMPORT ID` IS UNIQUE;%n" +
+                "COMMIT%n");
 
-        static final String EXPECTED_NEO4J_SHELL_OPTIMIZED = EXPECTED_NODES_OPTIMIZED + EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_RELATIONSHIPS_OPTIMIZED + DROP_UNIQUE_OPTIMIZED;
+        static final String EXPECTED_NODES_OPTIMIZED_BATCH_SIZE_UNWIND = String.format("BEGIN%n" +
+                "UNWIND [{`UNIQUE IMPORT ID`: 0, properties: {`born`:date('2018-10-31'), `name`:\"foo\"}}, {`UNIQUE IMPORT ID`: 4, properties: {`born`:date('2017-09-29'), `name`:\"foo2\"}}] as row %n" +
+                "MERGE (n:`Foo`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "UNWIND [{`name`: \"bar\", properties: {`age`:42, `name`:\"bar\"}}, {`name`: \"bar2\", properties: {`age`:44, `name`:\"bar2\"}}] as row %n" +
+                "MERGE (n:`Bar`{`name`: row.`name`}) SET n += row.properties;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "UNWIND [{`UNIQUE IMPORT ID`: 2, properties: {`age`:12}}] as row %n" +
+                "MERGE (n:`Bar`:`Person`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;%n" +
+                "UNWIND [{`UNIQUE IMPORT ID`: 6, properties: {`age`:99}}] as row %n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "UNWIND [{`UNIQUE IMPORT ID`: 3, properties: {`age`:12}}] as row %n" +
+                "MERGE (n:`Bar`:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.`UNIQUE IMPORT ID`}) SET n += row.properties;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_NEO4J_OPTIMIZED = EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_NODES_OPTIMIZED + EXPECTED_RELATIONSHIPS_OPTIMIZED + DROP_UNIQUE_OPTIMIZED;
+
+        static final String EXPECTED_NEO4J_OPTIMIZED_BATCH_SIZE = EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_NODES_OPTIMIZED_BATCH_SIZE + EXPECTED_RELATIONSHIPS_OPTIMIZED + DROP_UNIQUE_OPTIMIZED;
+
+        static final String EXPECTED_NEO4J_SHELL_OPTIMIZED = EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_NODES_OPTIMIZED + EXPECTED_RELATIONSHIPS_OPTIMIZED + DROP_UNIQUE_OPTIMIZED;
+
+        static final String EXPECTED_NEO4J_SHELL_OPTIMIZED_BATCH_SIZE = EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_NODES_OPTIMIZED_BATCH_SIZE + EXPECTED_RELATIONSHIPS_OPTIMIZED + DROP_UNIQUE_OPTIMIZED;
+
+        static final String EXPECTED_QUERY_NODES =  EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_QUERY_NODES_OPTIMIZED + EXPECTED_RELATIONSHIPS_OPTIMIZED + DROP_UNIQUE_OPTIMIZED;
+
+        static final String EXPECTED_CYPHER_OPTIMIZED_BATCH_SIZE_UNWIND = EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_NODES_OPTIMIZED_BATCH_SIZE_UNWIND + EXPECTED_RELATIONSHIPS_OPTIMIZED + DROP_UNIQUE_OPTIMIZED_BATCH;
+
+        static final String EXPECTED_QUERY_CYPHER_SHELL_OPTIMIZED_UNWIND = EXPECTED_CYPHER_OPTIMIZED_BATCH_SIZE_UNWIND
+                .replace(NEO4J_SHELL.begin(), CYPHER_SHELL.begin())
+                .replace(NEO4J_SHELL.commit(), CYPHER_SHELL.commit())
+                .replace(NEO4J_SHELL.schemaAwait(), EXPECTED_INDEXES_AWAIT)
+                .replace(NEO4J_SHELL.schemaAwait(), CYPHER_SHELL.schemaAwait());
+
+        static final String EXPECTED_QUERY_CYPHER_SHELL_OPTIMIZED = EXPECTED_QUERY_NODES
+                .replace(NEO4J_SHELL.begin(), CYPHER_SHELL.begin())
+                .replace(NEO4J_SHELL.commit(), CYPHER_SHELL.commit())
+                .replace(NEO4J_SHELL.schemaAwait(), EXPECTED_INDEXES_AWAIT_QUERY)
+                .replace(NEO4J_SHELL.schemaAwait(), CYPHER_SHELL.schemaAwait());
 
         static final String EXPECTED_CYPHER_SHELL_OPTIMIZED = EXPECTED_NEO4J_SHELL_OPTIMIZED
                 .replace(NEO4J_SHELL.begin(), CYPHER_SHELL.begin())
@@ -597,7 +709,13 @@ public class ExportCypherTest {
                 .replace(NEO4J_SHELL.schemaAwait(), EXPECTED_INDEXES_AWAIT)
                 .replace(NEO4J_SHELL.schemaAwait(), CYPHER_SHELL.schemaAwait());
 
-        static final String EXPECTED_PLAIN_OPTIMIZED = EXPECTED_NEO4J_SHELL_OPTIMIZED
+        static final String EXPECTED_CYPHER_SHELL_OPTIMIZED_BATCH_SIZE = EXPECTED_NEO4J_SHELL_OPTIMIZED_BATCH_SIZE
+                .replace(NEO4J_SHELL.begin(), CYPHER_SHELL.begin())
+                .replace(NEO4J_SHELL.commit(), CYPHER_SHELL.commit())
+                .replace(NEO4J_SHELL.schemaAwait(), EXPECTED_INDEXES_AWAIT)
+                .replace(NEO4J_SHELL.schemaAwait(), CYPHER_SHELL.schemaAwait());
+
+        static final String EXPECTED_PLAIN_OPTIMIZED_BATCH_SIZE = EXPECTED_NEO4J_SHELL_OPTIMIZED_BATCH_SIZE
                 .replace(NEO4J_SHELL.begin(), PLAIN_FORMAT.begin())
                 .replace(NEO4J_SHELL.commit(), PLAIN_FORMAT.commit())
                 .replace(NEO4J_SHELL.schemaAwait(), PLAIN_FORMAT.schemaAwait());


### PR DESCRIPTION
Fixes #998

- Add a mode to export.cypher that batches updates

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Add new config `useOptimizations` (true or false), that create a file with batch update
  - By default the method export the data with `useOptimizations` false
