### PR TITLE
3.4 filter duplicate nodes

### DIFF
--- a/docs/loadcsv.adoc
+++ b/docs/loadcsv.adoc
@@ -165,9 +165,10 @@ The `<config>` parameter is a map
 
 [opts=header,cols="m,a,m,m"]
 |===
-| name | description | default | import tool counterpart
+| name | description | default | https://neo4j.com/docs/operations-manual/current/tools/import/options/[import tool counterpart]
 | delimiter | delimiter character between columns | , | --delimiter=,
 | arrayDelimiter | delimiter character in arrays | ; | --array-delimiter=;
+| ignoreDuplicateNodes | for duplicate nodes, only load the first one and skip the rest (true) or fail the import (false) | false | --ignore-duplicate-nodes=false
 | quotationCharacter | quotation character | " | --quote='"'
 | stringIds | treat ids as strings | true | --id-type=STRING
 | skipLines | lines to skip (incl. header) | 1 | N/A

--- a/src/main/java/apoc/export/csv/CsvEntityLoader.java
+++ b/src/main/java/apoc/export/csv/CsvEntityLoader.java
@@ -92,10 +92,22 @@ public class CsvEntityLoader {
                         loadCsvCompatibleHeader, line, lineNo, false, mapping, Collections.emptyList(), results
                 );
 
-                // create node and add id to the mapping
+                final String nodeCsvId = result.map.get(idAttribute.get()).toString();
+
+                // if 'ignore duplicate nodes' is false, there is an id field and the mapping already has the current id,
+                // we either fail the loading process or skip it depending on the 'ignore duplicate nodes' setting
+                if (idField.isPresent() && idspaceIdMapping.containsKey(nodeCsvId)) {
+                    if (clc.getIgnoreDuplicateNodes()) {
+                        continue;
+                    } else {
+                        throw new IllegalStateException("Duplicate node with id " + nodeCsvId + " found/");
+                    }
+                }
+
+                // create node and add its id to the mapping
                 final Node node = db.createNode();
                 if (idField.isPresent()) {
-                    idspaceIdMapping.put(result.map.get(idAttribute.get()).toString(), node.getId());
+                    idspaceIdMapping.put(nodeCsvId, node.getId());
                 }
 
                 // add labels

--- a/src/main/java/apoc/export/csv/CsvLoaderConfig.java
+++ b/src/main/java/apoc/export/csv/CsvLoaderConfig.java
@@ -14,6 +14,7 @@ public class CsvLoaderConfig {
     public static final String STRING_IDS = "stringIds";
     public static final String SKIP_LINES = "skipLines";
     public static final String BATCH_SIZE = "batchSize";
+    public static final String IGNORE_DUPLICATE_NODES = "ignoreDuplicateNodes";
 
     public static char DELIMITER_DEFAULT = ',';
     public static char ARRAY_DELIMITER_DEFAULT = ';';
@@ -21,6 +22,7 @@ public class CsvLoaderConfig {
     public static boolean STRING_IDS_DEFAULT = true;
     public static int SKIP_LINES_DEFAULT = 1;
     public static int BATCH_SIZE_DEFAULT = 2000;
+    public static boolean IGNORE_DUPLICATE_NODES_DEFAULT = false;
 
     private final char delimiter;
     private final char arrayDelimiter;
@@ -28,6 +30,7 @@ public class CsvLoaderConfig {
     private final boolean stringIds;
     private final int skipLines;
     private final int batchSize;
+    private final boolean ignoreDuplicateNodes;
 
     private CsvLoaderConfig(Builder builder) {
         this.delimiter = builder.delimiter;
@@ -36,6 +39,7 @@ public class CsvLoaderConfig {
         this.stringIds = builder.stringIds;
         this.skipLines = builder.skipLines;
         this.batchSize = builder.batchSize;
+        this.ignoreDuplicateNodes = builder.ignoreDuplicateNodes;
     }
 
     public char getDelimiter() {
@@ -61,6 +65,8 @@ public class CsvLoaderConfig {
     public int getBatchSize() {
         return batchSize;
     }
+
+    public boolean getIgnoreDuplicateNodes() { return ignoreDuplicateNodes; }
 
     /**
      * Creates builder to build {@link CsvLoaderConfig}.
@@ -95,6 +101,7 @@ public class CsvLoaderConfig {
         if (config.get(STRING_IDS) != null) builder.stringIds((boolean) config.get(STRING_IDS));
         if (config.get(SKIP_LINES) != null) builder.skipLines((int) config.get(SKIP_LINES));
         if (config.get(BATCH_SIZE) != null) builder.batchSize((int) config.get(BATCH_SIZE));
+        if (config.get(IGNORE_DUPLICATE_NODES) != null) builder.ignoreDuplicateNodes((boolean) config.get(IGNORE_DUPLICATE_NODES));
 
         return builder.build();
     }
@@ -109,6 +116,7 @@ public class CsvLoaderConfig {
         private boolean stringIds = STRING_IDS_DEFAULT;
         private int skipLines = SKIP_LINES_DEFAULT;
         private int batchSize = BATCH_SIZE_DEFAULT;
+        private boolean ignoreDuplicateNodes = IGNORE_DUPLICATE_NODES_DEFAULT;
 
         private Builder() {
         }
@@ -140,6 +148,11 @@ public class CsvLoaderConfig {
 
         public Builder batchSize(int batchSize) {
             this.batchSize = batchSize;
+            return this;
+        }
+
+        public Builder ignoreDuplicateNodes(boolean ignoreDuplicateNodes) {
+            this.ignoreDuplicateNodes = ignoreDuplicateNodes;
             return this;
         }
 

--- a/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -1,7 +1,10 @@
 package apoc.export.csv;
 
 import apoc.util.TestUtil;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Result;
@@ -397,9 +400,10 @@ public class ImportCsvTest {
     }
 
     @Test(expected = QueryExecutionException.class)
-    public void testNoDuplicationsCreated() {
-
-        db.execute("CALL apoc.import.CSV([{fileName: {nodeFile}, labels: ['Person']}], [{fileName: {relFile}, type: 'KNOWS'}], {config})",
+    public void testNoDuplicateEndpointsCreated() {
+        // some of the endpoints of the edges in 'knows.csv' do not exist,
+        // hence this should throw an exception
+        db.execute("CALL apoc.import.csv([{fileName: {nodeFile}, labels: ['Person']}], [{fileName: {relFile}, type: 'KNOWS'}], {config})",
                 map("nodeFile", "file:/persons.csv",
                     "relFile", "file:/knows.csv",
                     "config", map("stringIds", false))).close();


### PR DESCRIPTION
Fixes #1038

Adapt the [`--ignore-duplicate-nodes` option](https://neo4j.com/docs/operations-manual/current/tools/import/options/#import-tool-option-ignore-duplicate-nodes) from the offline import tool.

## Proposed Changes

- Add `ignoreDuplicateNodes` option to the `CsvLoaderConfig` class
- When detecting a duplicate node id, based on the value of `ignoreDuplicateNodes`, the import either crashes (throws an `IllegalStateException`) or ignores the duplicate.
- Added relevant tests.