### PR TITLE
fixes #1047 - apoc.refactor.mergeNodes don't overwrite properties of relationships

### DIFF
--- a/docs/refactor.adoc
+++ b/docs/refactor.adoc
@@ -29,7 +29,7 @@ This config option also works for `apoc.refactor.mergeRelationships([rels],{conf
 |===
 
 For mergeNodes you can Merge relationships with same type and direction, you can spacify this with property mergeRels.
-Relationships properties are combined.
+Relationships properties are managed with the same nodes' method, if properties parameter isn't set relationships properties are combined.
 
 .example1 - Relationships with same start and end nodes
 

--- a/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -346,9 +346,12 @@ public class GraphRefactoring {
             copyRelationships(source, copyLabels(source, target), delete);
             PropertiesManager.mergeProperties(properties, target, conf);
             if (conf.getMergeRelsAllowed()) {
-                Map<String, Object> map = Collections.singletonMap("properties", "combine");
-                mergeRelsWithSameTypeAndDirectionInMergeNodes(target, new RefactorConfig(map), Direction.OUTGOING);
-                mergeRelsWithSameTypeAndDirectionInMergeNodes(target, new RefactorConfig(map), Direction.INCOMING);
+                if(!conf.hasProperties()) {
+                    Map<String, Object> map = Collections.singletonMap("properties", "combine");
+                    conf = new RefactorConfig(map);
+                }
+                mergeRelsWithSameTypeAndDirectionInMergeNodes(target, conf, Direction.OUTGOING);
+                mergeRelsWithSameTypeAndDirectionInMergeNodes(target, conf, Direction.INCOMING);
             }
             if (delete) source.delete();
         } catch (NotFoundException e) {

--- a/src/main/java/apoc/refactor/util/RefactorConfig.java
+++ b/src/main/java/apoc/refactor/util/RefactorConfig.java
@@ -20,8 +20,11 @@ public class RefactorConfig {
 
 	private Object mergeRelsAllowed;
 
+	private boolean hasProperties;
+
 	public RefactorConfig(Map<String,Object> config) {
 		Object value = config.get("properties");
+		hasProperties = value != null;
 		if (value instanceof String) {
 			this.propertiesManagement = Collections.singletonMap(MATCH_ALL, value.toString());
 		} else if (value instanceof Map) {
@@ -44,5 +47,11 @@ public class RefactorConfig {
 	public boolean getMergeRelsAllowed(){
 		return mergeRelsAllowed == null ? false : (boolean) mergeRelsAllowed;
 	}
+
+	public boolean hasProperties() {
+		return hasProperties;
+	}
+
+
 
 }


### PR DESCRIPTION
Fixes #1047 

apoc.refactor.mergeNodes don't overwrite properties of relationships

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - now properties of merged relationships in mergeNodes are managed like properties nodes with config parameter `properties`
  - if `properties` isn't set, properties of merged relationships are combined
 
