### PR TITLE
fixes #1044 - Drop Duplicate Neighbors

### DIFF
--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -928,6 +928,7 @@ Sometimes type information gets lost, these functions help you to coerce an "Any
 | apoc.coll.insertAll(coll, index, values) | insert values at index
 | apoc.coll.remove(coll, index, [length=1]) | remove range of values from index to length
 | apoc.coll.different(values) | returns true if value are different
+| apoc.coll.dropDuplicateNeighbors(coll) | drop duplicate neighbors on collection (nodes, rels, numbers, strings ...)
 |===
 
 === Lookup and Manipulation Procedures

--- a/src/main/java/apoc/coll/Coll.java
+++ b/src/main/java/apoc/coll/Coll.java
@@ -828,4 +828,22 @@ public class Coll {
 		if (values == null) return false;
         return new HashSet(values).size() == values.size();
     }
+
+
+
+    @UserFunction
+    @Description("apoc.coll.dropDuplicateNeighbors(list) - remove duplicate consecutive objects in a list")
+    public List<Object> dropDuplicateNeighbors(@Name("list") List<Object> list){
+        List<Object> newList = new ArrayList<>();
+
+        Object last = null;
+        for (Object element : list) {
+            if (!element.equals(last)) {
+                newList.add(element);
+                last = element;
+            }
+        }
+
+        return newList;
+    }
 }

--- a/src/main/java/apoc/coll/Coll.java
+++ b/src/main/java/apoc/coll/Coll.java
@@ -834,11 +834,12 @@ public class Coll {
     @UserFunction
     @Description("apoc.coll.dropDuplicateNeighbors(list) - remove duplicate consecutive objects in a list")
     public List<Object> dropDuplicateNeighbors(@Name("list") List<Object> list){
-        List<Object> newList = new ArrayList<>();
+        if (list == null) return null;
+	List<Object> newList = new ArrayList<>(list.size());
 
         Object last = null;
         for (Object element : list) {
-            if (!element.equals(last)) {
+            if (element == null && last != null || element != null && !element.equals(last)) {
                 newList.add(element);
                 last = element;
             }


### PR DESCRIPTION
Fixes #1044 

Drop Duplicate Neighbors

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - new procedure which drop duplicate neighbors in a list of elements (node, relationships, numbers, strings ..)
 
