### PR TITLE
fixes #899 - make apoc.meta.* sample at batches

### DIFF
--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -150,8 +150,8 @@ Returns a virtual graph that represents the labels and relationship-types availa
 | CALL apoc.meta.graphSample() | examines the database statistics to build the meta graph, very fast, might report extra relationships
 | CALL apoc.meta.graph | examines the database statistics to create the meta-graph, post filters extra relationships by sampling
 | CALL apoc.meta.subGraph({labels:[labels],rels:[rel-types],excludes:[label,rel-type,...]}) | examines a sample sub graph to create the meta-graph
-| CALL apoc.meta.data({sample:<number>}) | examines a subset of the graph to provide a tabular meta information, with sample config the dataset is sampled by the provided number
-| CALL apoc.meta.schema({sample:<number>}) | examines a subset of the graph to provide a map-like meta information, with sample config the dataset is sampled by the provided number
+| CALL apoc.meta.data([{sample:1000,maxRels:100}]) | examines a subset of the graph to provide a tabular meta information, with sample config the dataset is sampled by the provided number  (default 1000 nodes per label, -1 for all)
+| CALL apoc.meta.schema([{sample:1000>,maxRels:100}]) | examines a subset of the graph to provide a map-like meta information, with sample config the dataset is sampled by the provided number (default 1000 nodes per label, -1 for all)
 | CALL apoc.meta.stats  yield labelCount, relTypeCount, propertyKeyCount, nodeCount, relCount, labels, relTypes, stats | returns the information stored in the transactional database statistics
 |===
 

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -150,8 +150,8 @@ Returns a virtual graph that represents the labels and relationship-types availa
 | CALL apoc.meta.graphSample() | examines the database statistics to build the meta graph, very fast, might report extra relationships
 | CALL apoc.meta.graph | examines the database statistics to create the meta-graph, post filters extra relationships by sampling
 | CALL apoc.meta.subGraph({labels:[labels],rels:[rel-types],excludes:[label,rel-type,...]}) | examines a sample sub graph to create the meta-graph
-| CALL apoc.meta.data | examines a subset of the graph to provide a tabular meta information
-| CALL apoc.meta.schema | examines a subset of the graph to provide a map-like meta information
+| CALL apoc.meta.data({sample:{label1:<number of each elements>, label2:<number of each elements>, ...}}) | examines a subset of the graph to provide a tabular meta information, with sample config the dataset is sampling by label
+| CALL apoc.meta.schema({sample:{label1:<number of each elements>, label2:<number of each elements>, ...}}) | examines a subset of the graph to provide a map-like meta information, with sample config the dataset is sampling by label
 | CALL apoc.meta.stats  yield labelCount, relTypeCount, propertyKeyCount, nodeCount, relCount, labels, relTypes, stats | returns the information stored in the transactional database statistics
 |===
 

--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -150,8 +150,8 @@ Returns a virtual graph that represents the labels and relationship-types availa
 | CALL apoc.meta.graphSample() | examines the database statistics to build the meta graph, very fast, might report extra relationships
 | CALL apoc.meta.graph | examines the database statistics to create the meta-graph, post filters extra relationships by sampling
 | CALL apoc.meta.subGraph({labels:[labels],rels:[rel-types],excludes:[label,rel-type,...]}) | examines a sample sub graph to create the meta-graph
-| CALL apoc.meta.data({sample:{label1:<number of each elements>, label2:<number of each elements>, ...}}) | examines a subset of the graph to provide a tabular meta information, with sample config the dataset is sampling by label
-| CALL apoc.meta.schema({sample:{label1:<number of each elements>, label2:<number of each elements>, ...}}) | examines a subset of the graph to provide a map-like meta information, with sample config the dataset is sampling by label
+| CALL apoc.meta.data({sample:<number>}) | examines a subset of the graph to provide a tabular meta information, with sample config the dataset is sampled by the provided number
+| CALL apoc.meta.schema({sample:<number>}) | examines a subset of the graph to provide a map-like meta information, with sample config the dataset is sampled by the provided number
 | CALL apoc.meta.stats  yield labelCount, relTypeCount, propertyKeyCount, nodeCount, relCount, labels, relTypes, stats | returns the information stored in the transactional database statistics
 |===
 

--- a/src/main/java/apoc/meta/Meta.java
+++ b/src/main/java/apoc/meta/Meta.java
@@ -451,7 +451,6 @@ public class Meta {
                 while (nodes.hasNext()) {
                     Node node = nodes.next();
                     if(count++ % sample == 0) {
-                        sample = getSampleForLabelCount(labelCount, config.getSample());
                         addRelationships(metaData, nodeMeta, labelName, node, relConstraints);
                         addProperties(nodeMeta, labelName, constraints, indexed, node, node);
                     }
@@ -829,7 +828,6 @@ public class Meta {
             while (nodes.hasNext()) {
                 count++;
                 if(count % sample == 0) {
-                    sample = getSampleForLabelCount(labelCount, metaConfig.getSample());
                     Node node = nodes.next();
                     long maxRels = metaConfig.getMaxRels();
                     for (Relationship rel : node.getRelationships(direction, relationshipType)) {

--- a/src/main/java/apoc/meta/MetaConfig.java
+++ b/src/main/java/apoc/meta/MetaConfig.java
@@ -15,8 +15,8 @@ public class MetaConfig {
         this.includesLabels = new HashSet<>((Collection<String>)config.getOrDefault("labels",Collections.EMPTY_SET));
         this.includesRels = new HashSet<>((Collection<String>)config.getOrDefault("rels",Collections.EMPTY_SET));
         this.excludes = new HashSet<>((Collection<String>)config.getOrDefault("excludes",Collections.EMPTY_SET));
-        this.sample = (long) config.getOrDefault("sample", -1L);
-        this.maxRels = (long) config.getOrDefault("maxRels", -1L);
+        this.sample = (long) config.getOrDefault("sample", 1000L);
+        this.maxRels = (long) config.getOrDefault("maxRels", 100L);
     }
 
     public Set<String> getIncludesLabels() {

--- a/src/main/java/apoc/meta/MetaConfig.java
+++ b/src/main/java/apoc/meta/MetaConfig.java
@@ -1,0 +1,46 @@
+package apoc.meta;
+
+import java.util.*;
+
+public class MetaConfig {
+
+    private Set<String> includesLabels;
+    private Set<String> includesRels;
+    private Set<String> excludes;
+    private long maxRels;
+    private long sample;
+
+    public MetaConfig(Map<String,Object> config) {
+        config = config != null ? config : Collections.emptyMap();
+        this.includesLabels = new HashSet<>((Collection<String>)config.getOrDefault("labels",Collections.EMPTY_SET));
+        this.includesRels = new HashSet<>((Collection<String>)config.getOrDefault("rels",Collections.EMPTY_SET));
+        this.excludes = new HashSet<>((Collection<String>)config.getOrDefault("excludes",Collections.EMPTY_SET));
+        this.sample = (long) config.getOrDefault("sample", -1L);
+        this.maxRels = (long) config.getOrDefault("maxRels", -1L);
+    }
+
+    public Set<String> getIncludesLabels() {
+        return includesLabels;
+    }
+
+    public Set<String> getIncludesRels() {
+        return includesRels;
+    }
+
+    public Set<String> getExcludes() {
+        return excludes;
+    }
+
+    public void setExcludes(Set<String> excludes) {
+        this.excludes = excludes;
+    }
+
+    public long getSample() {
+        return sample;
+    }
+
+
+    public long getMaxRels() {
+        return maxRels;
+    }
+}

--- a/src/test/java/apoc/meta/MetaTest.java
+++ b/src/test/java/apoc/meta/MetaTest.java
@@ -488,4 +488,168 @@ public class MetaTest {
 
         TestUtil.testCall(db, "MATCH (t:TEST) WITH t.duration as duration RETURN apoc.meta.cypher.type(duration) AS value", row -> assertEquals("DURATION", row.get("value")));
     }
+
+    @Test
+    public void testMetaDataWithSample() throws Exception {
+        db.execute("create index on :Person(name)").close();
+        db.execute("CREATE (:Person {name:'Tom'})").close();
+        db.execute("CREATE (:Person {name:'John', surname:'Brown'})").close();
+        db.execute("CREATE (:Person {name:'Nick'})").close();
+        db.execute("CREATE (:Person {name:'Daisy', surname:'Bob'})").close();
+        db.execute("CREATE (:Person {name:'Elizabeth'})").close();
+        db.execute("CREATE (:Person {name:'Jack', surname:'White'})").close();
+        db.execute("CREATE (:Person {name:'Joy'})").close();
+        db.execute("CREATE (:Person {name:'Sarah', surname:'Taylor'})").close();
+        db.execute("CREATE (:Person {name:'Jane'})").close();
+        db.execute("CREATE (:Person {name:'Jeff', surname:'Logan'})").close();
+        TestUtil.testResult(db, "CALL apoc.meta.data({sample:2})",
+                (r) -> {
+                    Map<String, Object>  personNameProperty = r.next();
+                    Map<String, Object>  personSurnameProperty = r.next();
+                    assertEquals("name", personNameProperty.get("property"));
+                    assertEquals("surname", personSurnameProperty.get("property"));
+                });
+    }
+
+
+
+    @Test
+    public void testMetaDataWithSampleNormalized() throws Exception {
+        db.execute("create index on :Person(name)").close();
+        db.execute("CREATE (:Person {name:'Tom'})").close();
+        db.execute("CREATE (:Person {name:'John'})").close();
+        db.execute("CREATE (:Person {name:'Nick'})").close();
+        db.execute("CREATE (:Person {name:'Daisy', surname:'Bob'})").close();
+        db.execute("CREATE (:Person {name:'Elizabeth'})").close();
+        db.execute("CREATE (:Person {name:'Jack'})").close();
+        db.execute("CREATE (:Person {name:'Joy'})").close();
+        db.execute("CREATE (:Person {name:'Sarah'})").close();
+        db.execute("CREATE (:Person {name:'Jane'})").close();
+        db.execute("CREATE (:Person {name:'Jeff', surname:'Logan'})").close();
+        db.execute("CREATE (:City {name:'Milano'})").close();
+        db.execute("CREATE (:City {name:'Roma'})").close();
+        db.execute("CREATE (:City {name:'Firenze'})").close();
+        db.execute("CREATE (:City {name:'Taormina', region:'Sicilia'})").close();
+        TestUtil.testResult(db, "CALL apoc.meta.data({sample:5})",
+                (r) -> {
+                    Map<String, Object>  personNameProperty = r.next();
+                    Map<String, Object>  personSurnameProperty = r.next();
+                    assertEquals("Person", personNameProperty.get("label"));
+                    assertEquals("name", personNameProperty.get("property"));
+                    assertEquals("Person", personSurnameProperty.get("label"));
+                    assertEquals("surname", personSurnameProperty.get("property"));
+
+                    Map<String, Object>  cityNameProperty = r.next();
+                    Map<String, Object>  cityRegionProperty = r.next();
+                    assertEquals("City", cityNameProperty.get("label"));
+                    assertEquals("name", cityNameProperty.get("property"));
+                    assertEquals("City", cityRegionProperty.get("label"));
+                    assertEquals("region", cityRegionProperty.get("property"));
+                });
+    }
+
+    @Test
+    public void testMetaDataWithSample5() throws Exception {
+        db.execute("create index on :Person(name)").close();
+        db.execute("CREATE (:Person {name:'John', surname:'Brown'})").close();
+        db.execute("CREATE (:Person {name:'Daisy', surname:'Bob'})").close();
+        db.execute("CREATE (:Person {name:'Nick'})").close();
+        db.execute("CREATE (:Person {name:'Jack', surname:'White'})").close();
+        db.execute("CREATE (:Person {name:'Elizabeth'})").close();
+        db.execute("CREATE (:Person {name:'Joy'})").close();
+        db.execute("CREATE (:Person {name:'Sarah', surname:'Taylor'})").close();
+        db.execute("CREATE (:Person {name:'Jane'})").close();
+        db.execute("CREATE (:Person {name:'Jeff', surname:'Logan'})").close();
+        db.execute("CREATE (:Person {name:'Tom'})").close();
+        TestUtil.testResult(db, "CALL apoc.meta.data({sample:5})",
+                (r) -> {
+                    Map<String, Object>  personNameProperty = r.next();
+                    assertEquals("name", personNameProperty.get("property"));
+                });
+    }
+
+    @Test
+    public void testSchemaWithSample() {
+        db.execute("create constraint on (p:Person) assert p.name is unique").close();
+        db.execute("CREATE (:Person {name:'Tom'})").close();
+        db.execute("CREATE (:Person {name:'John', surname:'Brown'})").close();
+        db.execute("CREATE (:Person {name:'Nick'})").close();
+        db.execute("CREATE (:Person {name:'Daisy', surname:'Bob'})").close();
+        db.execute("CREATE (:Person {name:'Elizabeth'})").close();
+        db.execute("CREATE (:Person {name:'Jack', surname:'White'})").close();
+        db.execute("CREATE (:Person {name:'Joy'})").close();
+        db.execute("CREATE (:Person {name:'Sarah', surname:'Taylor'})").close();
+        db.execute("CREATE (:Person {name:'Jane'})").close();
+        db.execute("CREATE (:Person {name:'Jeff', surname:'Logan'})").close();
+        testCall(db, "CALL apoc.meta.schema({sample:2})",
+                (row) -> {
+
+                    Map<String, Object> o = (Map<String, Object>) row.get("value");
+                    assertEquals(1, o.size());
+
+                    Map<String, Object>  person = (Map<String, Object>) o.get("Person");
+                    Map<String, Object>  personProperties = (Map<String, Object>) person.get("properties");
+                    Map<String, Object>  personNameProperty = (Map<String, Object>) personProperties.get("name");
+                    Map<String, Object>  personSurnameProperty = (Map<String, Object>) personProperties.get("surname");
+                    assertNotNull(person);
+                    assertEquals("node", person.get("type"));
+                    assertEquals(10L, person.get("count"));
+                    assertEquals("STRING", personNameProperty.get("type"));
+                    assertEquals(false, personSurnameProperty.get("unique"));
+                    assertEquals("STRING", personSurnameProperty.get("type"));
+                    assertEquals(2, personProperties.size());
+
+                });
+    }
+
+    @Test
+    public void testSchemaWithSample5() {
+        db.execute("create constraint on (p:Person) assert p.name is unique").close();
+        db.execute("CREATE (:Person {name:'Tom'})").close();
+        db.execute("CREATE (:Person {name:'John', surname:'Brown'})").close();
+        db.execute("CREATE (:Person {name:'Nick'})").close();
+        db.execute("CREATE (:Person {name:'Daisy', surname:'Bob'})").close();
+        db.execute("CREATE (:Person {name:'Elizabeth'})").close();
+        db.execute("CREATE (:Person {name:'Jack', surname:'White'})").close();
+        db.execute("CREATE (:Person {name:'Joy'})").close();
+        db.execute("CREATE (:Person {name:'Sarah', surname:'Taylor'})").close();
+        db.execute("CREATE (:Person {name:'Jane'})").close();
+        db.execute("CREATE (:Person {name:'Jeff', surname:'Logan'})").close();
+        testCall(db, "CALL apoc.meta.schema({sample:5})",
+                (row) -> {
+
+                    Map<String, Object> o = (Map<String, Object>) row.get("value");
+                    assertEquals(1, o.size());
+                    Map<String, Object>  person = (Map<String, Object>) o.get("Person");
+                    Map<String, Object>  personProperties = (Map<String, Object>) person.get("properties");
+                    Map<String, Object>  personNameProperty = (Map<String, Object>) personProperties.get("name");
+                    assertNotNull(person);
+                    assertEquals("node", person.get("type"));
+                    assertEquals(10L, person.get("count"));
+                    assertEquals("STRING", personNameProperty.get("type"));
+                    assertEquals(true, personNameProperty.get("unique"));
+                    assertEquals(1, personProperties.size());
+
+                });
+    }
+
+    @Test
+    public void testMetaGraphExtraRelsWithSample() throws Exception {
+        db.execute("CREATE (:S1 {name:'Tom'})").close();
+        db.execute("CREATE (:S2 {name:'John', surname:'Brown'})-[:KNOWS{since:2012}]->(:S7)").close();
+        db.execute("CREATE (:S1 {name:'Nick'})").close();
+        db.execute("CREATE (:S3 {name:'Daisy', surname:'Bob'})-[:KNOWS{since:2012}]->(:S7)").close();
+        db.execute("CREATE (:S1 {name:'Elizabeth'})").close();
+        db.execute("CREATE (:S4 {name:'Jack', surname:'White'})-[:KNOWS{since:2012}]->(:S7)").close();
+        db.execute("CREATE (:S1 {name:'Joy'})").close();
+        db.execute("CREATE (:S5 {name:'Sarah', surname:'Taylor'})-[:KNOWS{since:2012}]->(:S7)").close();
+        db.execute("CREATE (:S1 {name:'Jane'})").close();
+        db.execute("CREATE (:S6 {name:'Jeff', surname:'Logan'})-[:KNOWS{since:2012}]->(:S7)").close();
+
+        testCall(db, "call apoc.meta.graph({sample:2})",(row) -> {
+            List<Node> nodes = (List<Node>) row.get("nodes");
+            assertEquals(7,nodes.size());
+        });
+    }
+
 }


### PR DESCRIPTION
Fixes #899 

make apoc.meta.* sample at batches

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - add `sample` config on apoc.meta procedures for sample the dataset
