### PR TITLE
fix #1071 apoc.periodic.commit should check for `limit`

### DIFF
--- a/docs/periodic.adoc
+++ b/docs/periodic.adoc
@@ -84,6 +84,8 @@ The stream of other data can also come from another source, like a different dat
 Especially for graph processing it is useful to run a query repeatedly in separate transactions until it doesn't process and generates any results anymore.
 So you can iterate in batches over elements that don't fulfill a condition and update them so that they do afterwards.
 
+NOTE: as a safety net your statement used inside `apoc.periodic.commit` *must* contain a `LIMIT` clause.
+
 The query is executed repatedly in separate transactions until it returns 0.
 
 [source,cypher]

--- a/src/main/java/apoc/periodic/Periodic.java
+++ b/src/main/java/apoc/periodic/Periodic.java
@@ -2,6 +2,7 @@ package apoc.periodic;
 
 import apoc.Pools;
 import apoc.util.Util;
+import org.apache.commons.lang.StringUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Result;
 import org.neo4j.helpers.collection.Iterators;
@@ -49,10 +50,14 @@ public class Periodic {
 
     @Procedure(mode = Mode.WRITE)
     @Description("apoc.periodic.commit(statement,params) - runs the given statement in separate transactions until it returns 0")
-    public Stream<RundownResult> commit(@Name("statement") String statement, @Name("params") Map<String,Object> parameters) throws ExecutionException, InterruptedException {
+    public Stream<RundownResult> commit(@Name("statement") String statement, @Name(value = "params", defaultValue = "") Map<String,Object> parameters) throws ExecutionException, InterruptedException {
         Map<String,Object> params = parameters == null ? Collections.emptyMap() : parameters;
         long total = 0, executions = 0, updates = 0;
         long start = nanoTime();
+
+        if (!StringUtils.containsIgnoreCase(statement, "limit")) {
+            throw new IllegalArgumentException("the statement sent to apoc.periodic.commit must contain a `limit`");
+        }
 
         AtomicInteger batches = new AtomicInteger();
         AtomicInteger failedCommits = new AtomicInteger();

--- a/src/main/java/apoc/periodic/Periodic.java
+++ b/src/main/java/apoc/periodic/Periodic.java
@@ -32,6 +32,8 @@ public class Periodic {
     @Context public Log log;
 
     final static Map<JobInfo,Future> list = new ConcurrentHashMap<>();
+
+    final static Pattern LIMIT_PATTERN = Pattern.compile("\\slimit\\s", Pattern.CASE_INSENSITIVE);
     static {
         Runnable runnable = () -> {
             for (Iterator<Map.Entry<JobInfo, Future>> it = list.entrySet().iterator(); it.hasNext(); ) {
@@ -55,7 +57,7 @@ public class Periodic {
         long total = 0, executions = 0, updates = 0;
         long start = nanoTime();
 
-        if (!StringUtils.containsIgnoreCase(statement, "limit")) {
+        if (!LIMIT_PATTERN.matcher(statement).find()) {
             throw new IllegalArgumentException("the statement sent to apoc.periodic.commit must contain a `limit`");
         }
 

--- a/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/src/test/java/apoc/periodic/PeriodicTest.java
@@ -67,7 +67,12 @@ System.out.println("call list" + db.execute(callList).resultAsString());
 
     @Test
     public void testTerminateCommit() throws Exception {
-        testTerminatePeriodicQuery("CALL apoc.periodic.commit('UNWIND range(0,1000) as id WITH id CREATE (:Foo {id: id})', {})");
+        testTerminatePeriodicQuery("CALL apoc.periodic.commit('UNWIND range(0,1000) as id WITH id CREATE (:Foo {id: id}) limit 1000', {})");
+    }
+
+    @Test(expected = QueryExecutionException.class)
+    public void testPeriodicCommitWithoutLimitShouldFail() {
+        db.execute("CALL apoc.periodic.commit('return 0')");
     }
 
     @Test


### PR DESCRIPTION
This - of course - is a somewhat breaking changes. Usages that do not have a `limit` will get an exception.