### PR TITLE
fixes #1040 - apoc.convert.toTree config option to include/exclude certain properties

### DIFF
--- a/docs/overview.adoc
+++ b/docs/overview.adoc
@@ -219,12 +219,20 @@ RETURN apoc.meta.isType(n.age,"INTEGER") as ageType
 | apoc.convert.toSortedJsonMap(node\|map, ignoreCase:true ) | returns a JSON map with keys sorted alphabetically, with optional case sensitivity
 | apoc.convert.fromJsonList('[1,2,3]') | converts json list to Cypher list
 | apoc.convert.fromJsonMap( '{"a":42,"b":"foo","c":[1,2,3]}') | converts json map to Cypher map
-| apoc.convert.toTree([paths],[lowerCaseRels=true]) | creates a stream of nested documents representing the at least one root of these paths
+| apoc.convert.toTree([paths],[lowerCaseRels=true], {config}) | creates a stream of nested documents representing the at least one root of these paths
 | apoc.convert.getJsonProperty(node,key) | converts serialized JSON in property back to original object
 | apoc.convert.getJsonPropertyMap(node,key) | converts serialized JSON in property back to map
 | CALL apoc.convert.toTree([paths]) yield value | creates a stream of nested documents representing the at least one root of these paths
 | CALL apoc.convert.setJsonProperty(node,key,complexValue) | sets value serialized to JSON as property with the given name on the node
 |===
+
+For `apoc.convert.toTree` config can set as follow:
+
+* nodes: map of list<String>, a key is the name of the label, value is a list of properties that can be included or excluded. e.g `nodes:{LABEL:<[prop1, prop2]/[-prop1, -prop2]>}`
+* rels: map of list<String>, a key is the name of the type, value is a list of properties that can be included or excluded. e.g `rels:{TYPE:<[prop1, prop2]/[-prop1, -prop2]>}`
+
+`nodes` and `rels` accept only include or exlude properties
+
 
 == Export / Import
 

--- a/src/main/java/apoc/convert/ConvertConfig.java
+++ b/src/main/java/apoc/convert/ConvertConfig.java
@@ -1,0 +1,43 @@
+package apoc.convert;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * @author AgileLARUS
+ *
+ * @since 28-01-2019
+ */
+public class ConvertConfig {
+
+    private Map<String, List<String>> nodes;
+    private Map<String, List<String>> rels;
+
+    public ConvertConfig(Map<String,Object> config) {
+
+        this.nodes = (Map<String, List<String>>) config.getOrDefault("nodes", Collections.EMPTY_MAP);
+        this.rels = (Map<String, List<String>>) config.getOrDefault("rels", Collections.EMPTY_MAP);
+
+        this.nodes.values().forEach(s -> validateListProperties(s));
+        this.rels.values().forEach(s -> validateListProperties(s));
+    }
+
+    public Map<String, List<String>> getNodes() {
+        return nodes;
+    }
+
+    public Map<String, List<String>> getRels() {
+        return rels;
+    }
+
+    private void validateListProperties(List<String> list) {
+        boolean isFirstExclude = list.get(0).startsWith("-");
+        Optional<String> hasMixedProp = list.stream().skip(1).filter(prop ->
+                (isFirstExclude && !prop.startsWith("-")) || (!isFirstExclude && prop.startsWith("-"))).findFirst();
+        if (hasMixedProp.isPresent()) {
+            throw new RuntimeException("Only include or exclude attribute are possible!");
+        }
+    }
+}

--- a/src/test/java/apoc/convert/ConvertJsonTest.java
+++ b/src/test/java/apoc/convert/ConvertJsonTest.java
@@ -1,22 +1,24 @@
 package apoc.convert;
 
 import apoc.util.TestUtil;
+import junit.framework.TestCase;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testResult;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class ConvertJsonTest {
 
@@ -235,6 +237,172 @@ public class ConvertJsonTest {
                     /*USER*/
 
                 });
+    }
 
+    @Test
+    public void testToTreeLeafNodesWithConfigInclude() {
+        statementForConfig(db);
+        String call = "MATCH p=(n:Category)-[:subcategory*]->(m)\n" +
+                "WHERE NOT (m)-[:subcategory]->() AND NOT ()-[:subcategory]->(n)\n" +
+                "WITH COLLECT(p) AS ps\n" +
+                "CALL apoc.convert.toTree(ps, true, {nodes: {Category: ['name']}, rels: {subcategory:['id']}}) yield value\n" +
+                "RETURN value;";
+        testCall(db, call,
+                (row) -> {
+                    Map root = (Map) row.get("value");
+                    assertEquals("Category", root.get("_type"));
+                    assertEquals("PC", root.get("name"));
+                    assertNull(root.get("surname"));
+                    List<Map> parts = (List<Map>) root.get("subcategory");
+                    assertEquals(1,parts.size());
+                    Map pcParts = parts.get(0);
+                    assertEquals("Category", pcParts.get("_type"));
+                    assertEquals("Parts", pcParts.get("name"));
+                    assertEquals(1L, pcParts.get("subcategory.id"));
+                    assertNull(pcParts.get("subcategory.subCat"));
+                    List<Map> subParts = (List<Map>)pcParts.get("subcategory");
+                    Map cpu = subParts.get(0);
+                    assertEquals("Category", pcParts.get("_type"));
+                    assertEquals("CPU", cpu.get("name"));
+                    assertEquals(2L, cpu.get("subcategory.id"));
+                    assertNull(cpu.get("subcategory.subCat"));
+                });
+    }
+
+    @Test
+    public void testToTreeLeafNodesWithConfigExclude() {
+        statementForConfig(db);
+        String call = "MATCH p=(n:Category)-[:subcategory*]->(m)\n" +
+                "WHERE NOT (m)-[:subcategory]->() AND NOT ()-[:subcategory]->(n)\n" +
+                "WITH COLLECT(p) AS ps\n" +
+                "CALL apoc.convert.toTree(ps, true,{nodes: {Category: ['-name']}, rels: {subcategory:['-id']}}) yield value\n" +
+                "RETURN value;";
+        testCall(db, call,
+                (row) -> {
+                    Map root = (Map) row.get("value");
+                    assertEquals("Category", root.get("_type"));
+                    assertFalse("Should not contain key `name`",root.containsKey("name"));
+                    assertEquals("computer",root.get("surname"));
+                    List<Map> parts = (List<Map>) root.get("subcategory");
+                    assertEquals(1,parts.size());
+                    Map pcParts = parts.get(0);
+                    assertEquals("Category", pcParts.get("_type"));
+                    assertFalse("Should not contain key `name`",pcParts.containsKey("name"));
+                    assertFalse("Should not contain key `subcategory.id`",pcParts.containsKey("subcategory.id"));
+                    assertEquals("gen", pcParts.get("subcategory.subCat"));
+                    List<Map> subParts = (List<Map>)pcParts.get("subcategory");
+                    Map cpu = subParts.get(0);
+                    assertEquals("Category", pcParts.get("_type"));
+                    assertFalse("Should not contain key `name`",cpu.containsKey("name"));
+                    assertFalse("Should not contain key `subcategory.id`",cpu.containsKey("subcategory.id"));
+                    assertEquals("ex",cpu.get("subcategory.subCat"));
+                });
+    }
+
+    @Test
+    public void testToTreeLeafNodesWithConfigExcludeInclude() {
+        statementForConfig(db);
+        String call = "MATCH p=(n:Category)-[:subcategory*]->(m)\n" +
+                "WHERE NOT (m)-[:subcategory]->() AND NOT ()-[:subcategory]->(n)\n" +
+                "WITH COLLECT(p) AS ps\n" +
+                "CALL apoc.convert.toTree(ps, true, {nodes: {Category: ['name']}, rels: {subcategory:['-id']}}) yield value\n" +
+                "RETURN value;";
+        testCall(db, call,
+                (row) -> {
+                    Map root = (Map) row.get("value");
+                    assertEquals("Category", root.get("_type"));
+                    assertEquals("PC",root.get("name"));
+                    assertFalse("Should not contain key `surname`",root.containsKey("surname"));
+                    List<Map> parts = (List<Map>) root.get("subcategory");
+                    assertEquals(1,parts.size());
+                    Map pcParts = parts.get(0);
+                    assertEquals("Category", pcParts.get("_type"));
+                    assertEquals("Parts", pcParts.get("name"));
+                    assertFalse("Should not contain key `subcategory.id`",pcParts.containsKey("subcategory.id"));
+                    assertEquals("gen", pcParts.get("subcategory.subCat"));
+                    List<Map> subParts = (List<Map>)pcParts.get("subcategory");
+                    Map cpu = subParts.get(0);
+                    assertEquals("Category", pcParts.get("_type"));
+                    assertEquals("CPU", cpu.get("name"));
+                    assertFalse("Should not contain key `subcategory.id`",cpu.containsKey("subcategory.id"));
+                    assertEquals("ex",cpu.get("subcategory.subCat"));
+                });
+    }
+
+    @Test
+    public void testToTreeLeafNodesWithConfigOnlyInclude() {
+        statementForConfig(db);
+        String call = "MATCH p=(n:Category)-[:subcategory*]->(m)\n" +
+                "WHERE NOT (m)-[:subcategory]->() AND NOT ()-[:subcategory]->(n)\n" +
+                "WITH COLLECT(p) AS ps\n" +
+                "CALL apoc.convert.toTree(ps, true, {nodes: {Category: ['name', 'surname']}}) yield value\n" +
+                "RETURN value;";
+        testCall(db, call,
+                (row) -> {
+                    Map root = (Map) row.get("value");
+                    assertEquals("Category", root.get("_type"));
+                    assertEquals("PC",root.get("name"));
+                    assertEquals("computer",root.get("surname"));
+                    List<Map> parts = (List<Map>) root.get("subcategory");
+                    assertEquals(1,parts.size());
+                    Map pcParts = parts.get(0);
+                    assertEquals("Category", pcParts.get("_type"));
+                    assertEquals("Parts", pcParts.get("name"));
+                    assertEquals(1L, pcParts.get("subcategory.id"));
+                    assertEquals("gen", pcParts.get("subcategory.subCat"));
+                    List<Map> subParts = (List<Map>)pcParts.get("subcategory");
+                    Map cpu = subParts.get(0);
+                    assertEquals("Category", pcParts.get("_type"));
+                    assertEquals("CPU", cpu.get("name"));
+                    assertEquals(2L, cpu.get("subcategory.id"));
+                    assertEquals("ex",cpu.get("subcategory.subCat"));
+                });
+    }
+
+    @Test
+    public void testToTreeLeafNodesWithConfigErrorInclude() {
+        statementForConfig(db);
+        String call = "MATCH p=(n:Category)-[:subcategory*]->(m)\n" +
+                "WHERE NOT (m)-[:subcategory]->() AND NOT ()-[:subcategory]->(n)\n" +
+                "WITH COLLECT(p) AS ps\n" +
+                "CALL apoc.convert.toTree(ps, true, {nodes: {Category: ['-name','name']}, rels: {subcategory:['-id']}}) yield value\n" +
+                "RETURN value;";
+        try {
+            testResult(db, call, (row) -> { });
+        } catch (QueryExecutionException e) {
+            Throwable except = ExceptionUtils.getRootCause(e);
+            TestCase.assertTrue(except instanceof RuntimeException);
+            assertEquals("Only include or exclude attribute are possible!", except.getMessage());
+            throw e;
+        }
+
+    }
+
+    @Test
+    public void testToTreeLeafNodesWithConfigErrorExclude() {
+        statementForConfig(db);
+        String call = "MATCH p=(n:Category)-[:subcategory*]->(m)\n" +
+                "WHERE NOT (m)-[:subcategory]->() AND NOT ()-[:subcategory]->(n)\n" +
+                "WITH COLLECT(p) AS ps\n" +
+                "CALL apoc.convert.toTree(ps, true, {nodes: {Category: ['-name']}, rels: {subcategory:['-id','name']}}) yield value\n" +
+                "RETURN value;";
+        try {
+            testResult(db, call, (row) -> { });
+        } catch (QueryExecutionException e) {
+            Throwable except = ExceptionUtils.getRootCause(e);
+            TestCase.assertTrue(except instanceof RuntimeException);
+            assertEquals("Only include or exclude attribute are possible!", except.getMessage());
+            throw e;
+        }
+
+    }
+
+    private static void statementForConfig(GraphDatabaseService db) {
+        String createStatement = "CREATE\n" +
+                "  (c1:Category {name: 'PC', surname: 'computer'}),\n" +
+                "    (c1)-[:subcategory {id:1, subCat: 'gen'}]->(c2:Category {name: 'Parts'}),\n" +
+                "      (c2)-[:subcategory {id:2, subCat: 'ex'}]->(c3:Category {name: 'CPU'})";
+
+        db.execute(createStatement).close();
     }
 }


### PR DESCRIPTION
Fixes #1040

apoc.convert.toTree config option to include/exclude certain properties

## Proposed Changes (Mandatory)
A brief list of proposed changes in order to fix the issue:
  - Add config to include/exclude certain properties by label/type
