### PR TITLE
fixes #1079: Run Ignored Enterprise Tests with TestContainers instead

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,6 +126,13 @@ dependencies {
     jmh group: 'org.neo4j', name: 'neo4j-lucene-index', version: neo4jVersionEffective
     jmh group: 'org.neo4j', name: 'neo4j-kernel', version: neo4jVersionEffective, classifier: "tests"
 
+    // Test Containers
+    testCompile group: 'org.testcontainers', name: 'testcontainers', version: '1.10.6'
+    
+    testCompile group: 'org.testcontainers', name: 'neo4j', version: '1.10.6'
+
+    compile group: 'org.gradle', name: 'gradle-tooling-api', version: '4.3'
+
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,8 @@ dependencies {
     
     testCompile group: 'org.testcontainers', name: 'neo4j', version: '1.10.6'
 
-    compile group: 'org.gradle', name: 'gradle-tooling-api', version: '4.3'
+    compileOnly group: 'org.gradle', name: 'gradle-tooling-api', version: '4.3'
+    testCompile group: 'org.gradle', name: 'gradle-tooling-api', version: '4.3'
 
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'

--- a/src/test/java/apoc/nodes/NodesTest.java
+++ b/src/test/java/apoc/nodes/NodesTest.java
@@ -2,22 +2,18 @@ package apoc.nodes;
 
 import apoc.create.Create;
 import apoc.util.TestUtil;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.ResourceIterator;
-import org.neo4j.helpers.collection.Iterators;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import static apoc.util.Util.map;
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
+import static java.util.Collections.*;
 import static org.junit.Assert.*;
 import static org.neo4j.helpers.collection.Iterators.asSet;
 
@@ -204,7 +200,6 @@ public class NodesTest {
     }
 
     @Test
-    @Ignore("Bug 3.5 org.neo4j.graphdb.NotFoundException: No column named 'xxx' was found. Found: (\"xxx\")")
     public void testId() {
         assertTrue(db.execute("CREATE (f:Foo {foo:'bar'}) RETURN apoc.node.id(f) AS id").<Long>columnAs("id").next() >= 0);
         assertTrue(db.execute("CALL apoc.create.vNode(['Foo'],{foo:'bar'}) YIELD node RETURN apoc.node.id(node) AS id").<Long>columnAs("id").next() < 0);
@@ -212,7 +207,6 @@ public class NodesTest {
         assertNull(db.execute("RETURN apoc.node.id(null) AS id").<Long>columnAs("id").next());
     }
     @Test
-    @Ignore("Bug 3.5 org.neo4j.graphdb.NotFoundException: No column named 'xxx' was found. Found: (\"xxx\")")
     public void testRelId() {
         assertTrue(db.execute("CREATE (f)-[rel:REL {foo:'bar'}]->(f) RETURN apoc.rel.id(rel) AS id").<Long>columnAs("id").next() >= 0);
         assertTrue(db.execute("CREATE (f) WITH f CALL apoc.create.vRelationship(f,'REL',{foo:'bar'},f) YIELD rel RETURN apoc.rel.id(rel) AS id").<Long>columnAs("id").next() < 0);
@@ -220,14 +214,13 @@ public class NodesTest {
         assertNull(db.execute("RETURN apoc.rel.id(null) AS id").<Long>columnAs("id").next());
     }
     @Test
-    @Ignore("Bug 3.5 org.neo4j.graphdb.NotFoundException: No column named 'xxx' was found. Found: (\"xxx\")")
     public void testLabels() {
         assertEquals(singletonList("Foo"), db.execute("CREATE (f:Foo {foo:'bar'}) RETURN apoc.node.labels(f) AS labels").columnAs("labels").next());
         assertEquals(singletonList("Foo"), db.execute("CALL apoc.create.vNode(['Foo'],{foo:'bar'}) YIELD node RETURN apoc.node.labels(node) AS labels").columnAs("labels").next());
         assertNull(db.execute("RETURN apoc.node.labels(null) AS labels").columnAs("labels").next());
     }
+
     @Test
-    @Ignore("Bug 3.5 org.neo4j.graphdb.NotFoundException: No column named 'xxx' was found. Found: (\"xxx\")")
     public void testProperties() {
         assertEquals(singletonMap("foo","bar"), db.execute("CREATE (f:Foo {foo:'bar'}) RETURN apoc.any.properties(f) AS props").columnAs("props").next());
         assertEquals(singletonMap("foo","bar"), db.execute("CALL apoc.create.vNode(['Foo'],{foo:'bar'}) YIELD node RETURN apoc.any.properties(node) AS props").columnAs("props").next());
@@ -237,8 +230,8 @@ public class NodesTest {
 
         assertNull(db.execute("RETURN apoc.any.properties(null) AS props").columnAs("props").next());
     }
+
     @Test
-    @Ignore("Bug 3.5 org.neo4j.graphdb.NotFoundException: No column named 'xxx' was found. Found: (\"xxx\")")
     public void testSubProperties() {
         assertEquals(singletonMap("foo","bar"), db.execute("CREATE (f:Foo {foo:'bar'}) RETURN apoc.any.properties(f,['foo']) AS props").columnAs("props").next());
         assertEquals(emptyMap(), db.execute("CREATE (f:Foo {foo:'bar'}) RETURN apoc.any.properties(f,['bar']) AS props").columnAs("props").next());
@@ -253,8 +246,8 @@ public class NodesTest {
 
         assertNull(db.execute("RETURN apoc.any.properties(null,['foo']) AS props").columnAs("props").next());
     }
+
     @Test
-    @Ignore("Bug 3.5 org.neo4j.graphdb.NotFoundException: No column named 'xxx' was found. Found: (\"xxx\")")
     public void testProperty() {
         assertEquals("bar", db.execute("RETURN apoc.any.property({foo:'bar'},'foo') AS props").columnAs("props").next());
         assertEquals(null, db.execute("RETURN apoc.any.property({foo:'bar'},'bar') AS props").columnAs("props").next());
@@ -274,8 +267,8 @@ public class NodesTest {
         assertNull(db.execute("RETURN apoc.any.property(null,'foo') AS props").columnAs("props").next());
         assertNull(db.execute("RETURN apoc.any.property(null,null) AS props").columnAs("props").next());
     }
+
     @Test
-    @Ignore("Bug 3.5 org.neo4j.graphdb.NotFoundException: No column named 'xxx' was found. Found: (\"xxx\")")
     public void testRelType() {
         assertEquals("REL", db.execute("CREATE (f)-[rel:REL {foo:'bar'}]->(f) RETURN apoc.rel.type(rel) AS type").columnAs("type").next());
 

--- a/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
+++ b/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
@@ -1,0 +1,245 @@
+package apoc.schema;
+
+import apoc.util.TestUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.driver.v1.*;
+import org.testcontainers.containers.Neo4jContainer;
+
+import java.util.List;
+import java.util.Map;
+
+import static apoc.util.TestContainerUtil.*;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeNotNull;
+
+/**
+ * @author as
+ * @since 12.02.19
+ */
+public class SchemasEnterpriseFeaturesTest {
+
+    private static Neo4jContainer neo4jContainer;
+    private static Session session;
+    private static Driver driver;
+
+    @BeforeClass
+    public static void beforeAll() {
+        TestUtil.ignoreException(() -> {
+            neo4jContainer = createEnterpriseDB(true);
+            neo4jContainer.start();
+        }, Exception.class);
+        assumeNotNull(neo4jContainer);
+        driver = GraphDatabase.driver(neo4jContainer.getBoltUrl(), AuthTokens.none());
+        session = driver.session();
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        if (neo4jContainer != null) {
+            session.close();
+            driver.close();
+            neo4jContainer.close();
+        }
+        cleanBuild();
+    }
+
+    @Test
+    public void testDropNodeKeyConstraintAndCreateNodeKeyConstraintWhenUsingDropExisting() {
+        session.writeTransaction(tx -> {
+            tx.run("CREATE CONSTRAINT ON (f:Foo) ASSERT (f.bar,f.foo) IS NODE KEY");
+            tx.success();
+            return null;
+        });
+        testResult(session, "CALL apoc.schema.assert(null,{Foo:[['bar','foo']]})", (result) -> {
+            Map<String, Object> r = result.next();
+            assertEquals("Foo", r.get("label"));
+            assertEquals(expectedKeys("bar","foo"), r.get("keys"));
+            assertEquals(true, r.get("unique"));
+            assertEquals("DROPPED", r.get("action"));
+
+            r = result.next();
+            assertEquals("Foo", r.get("label"));
+            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
+            assertEquals(true, r.get("unique"));
+            assertEquals("CREATED", r.get("action"));
+        });
+
+        session.readTransaction(tx -> {
+            List<Record> result = tx.run("CALL db.constraints").list();
+            assertEquals(1, result.size());
+            tx.run("DROP CONSTRAINT ON (f:Foo) ASSERT (f.bar,f.foo) IS NODE KEY").list();
+            tx.success();
+            return null;
+        });
+    }
+
+    @Test
+    public void testDropSchemaWithNodeKeyConstraintWhenUsingDropExisting() {
+        session.writeTransaction(tx -> {
+            tx.run("CREATE CONSTRAINT ON (f:Foo) ASSERT (f.foo, f.bar) IS NODE KEY");
+            tx.success();
+            return null;
+        });
+        testCall(session, "CALL apoc.schema.assert(null,null)", (r) -> {
+            assertEquals("Foo", r.get("label"));
+            assertEquals(expectedKeys("foo", "bar"), r.get("keys"));
+            assertEquals(true, r.get("unique"));
+            assertEquals("DROPPED", r.get("action"));
+        });
+
+        session.readTransaction(tx -> {
+            List<Record> result = tx.run("CALL db.constraints").list();
+            assertEquals(0, result.size());
+            tx.success();
+            return null;
+        });
+    }
+
+    @Test
+    public void testDropConstraintExistsPropertyNode() {
+        session.writeTransaction(tx -> {
+            tx.run("CREATE CONSTRAINT ON (m:Movie) ASSERT exists(m.title)");
+            tx.success();
+            return null;
+        });
+        testCall(session, "CALL apoc.schema.assert({},{})", (r) -> {
+            assertEquals("Movie", r.get("label"));
+            assertEquals(expectedKeys("title"), r.get("keys"));
+            assertTrue("should be unique", (boolean) r.get("unique"));
+            assertEquals("DROPPED", r.get("action"));
+        });
+
+        session.readTransaction(tx -> {
+            List<Record> result = tx.run("CALL db.constraints").list();
+            assertEquals(0, result.size());
+            tx.success();
+            return null;
+        });
+    }
+
+    @Test
+    public void testDropConstraintExistsPropertyRelationship() {
+        session.writeTransaction(tx -> {
+            tx.run("CREATE CONSTRAINT ON ()-[acted:Acted]->() ASSERT exists(acted.since)");
+            tx.success();
+            return null;
+        });
+
+        testCall(session, "CALL apoc.schema.assert({},{})", (r) -> {
+            assertEquals("Acted", r.get("label"));
+            assertEquals(expectedKeys("since"), r.get("keys"));
+            assertTrue("should be unique", (boolean) r.get("unique"));
+            assertEquals("DROPPED", r.get("action"));
+        });
+
+        session.readTransaction(tx -> {
+            List<Record> result = tx.run("CALL db.constraints").list();
+            assertEquals(0, result.size());
+            tx.success();
+            return null;
+        });
+    }
+
+    @Test
+    public void testIndexOnMultipleProperties() {
+        session.writeTransaction(tx -> {
+            tx.run("CREATE INDEX ON :Foo(bar, foo)");
+            tx.success();
+            return null;
+        });
+        session.writeTransaction(tx -> {
+            tx.run("CALL db.awaitIndex(':Foo(bar, foo)')");
+            tx.success();
+            return null;
+        });
+        testResult(session, "CALL apoc.schema.nodes()", (result) -> {
+            // Get the index info
+            Map<String, Object> r = result.next();
+
+            assertEquals(":Foo(bar,foo)", r.get("name"));
+            assertEquals("ONLINE", r.get("status"));
+            assertEquals("Foo", r.get("label"));
+            assertEquals("INDEX", r.get("type"));
+            assertTrue(((List<String>) r.get("properties")).contains("bar"));
+            assertTrue(((List<String>) r.get("properties")).contains("foo"));
+
+            assertTrue(!result.hasNext());
+        });
+        session.writeTransaction(tx -> {
+            tx.run("DROP INDEX ON :Foo(bar, foo)");
+            tx.success();
+            return null;
+        });
+    }
+
+    @Test
+    public void testPropertyExistenceConstraintOnNode() {
+        session.writeTransaction(tx -> {
+            tx.run("CREATE CONSTRAINT ON (bar:Bar) ASSERT exists(bar.foobar)");
+            tx.success();
+            return null;
+        });
+        testResult(session, "CALL apoc.schema.nodes()", (result) -> {
+            Map<String, Object> r = result.next();
+
+            assertEquals("Bar", r.get("label"));
+            assertEquals("NODE_PROPERTY_EXISTENCE", r.get("type"));
+            assertEquals(asList("foobar"), r.get("properties"));
+
+            assertTrue(!result.hasNext());
+        });
+        session.writeTransaction(tx -> {
+            tx.run("DROP CONSTRAINT ON (bar:Bar) ASSERT exists(bar.foobar)");
+            tx.success();
+            return null;
+        });
+    }
+
+    @Test
+    public void testConstraintExistsOnRelationship() {
+        session.writeTransaction(tx -> {
+            tx.run("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)");
+            tx.success();
+            return null;
+        });
+        testResult(session, "RETURN apoc.schema.relationship.constraintExists('LIKED', ['day'])", (result) -> {
+            Map<String, Object> r = result.next();
+            assertEquals(true, r.entrySet().iterator().next().getValue());
+        });
+        session.writeTransaction(tx -> {
+            tx.run("DROP CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)");
+            tx.success();
+            return null;
+        });
+    }
+
+    @Test
+    public void testSchemaRelationships() {
+        session.writeTransaction(tx -> {
+            tx.run("CREATE CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)");
+            tx.success();
+            return null;
+        });
+        testResult(session, "CALL apoc.schema.relationships()", (result) -> {
+            Map<String, Object> r = result.next();
+            assertEquals("CONSTRAINT ON ()-[liked:LIKED]-() ASSERT exists(liked.day)", r.get("name"));
+            assertEquals("RELATIONSHIP_PROPERTY_EXISTENCE", r.get("type"));
+            assertEquals(asList("day"), r.get("properties"));
+            assertEquals(StringUtils.EMPTY, r.get("status"));
+            assertFalse(result.hasNext());
+        });
+        session.writeTransaction(tx -> {
+            tx.run("DROP CONSTRAINT ON ()-[like:LIKED]-() ASSERT exists(like.day)");
+            tx.success();
+            return null;
+        });
+    }
+
+    private List<String> expectedKeys(String... keys){
+        return asList(keys);
+    }
+}

--- a/src/test/java/apoc/util/TestContainerUtil.java
+++ b/src/test/java/apoc/util/TestContainerUtil.java
@@ -1,0 +1,101 @@
+package apoc.util;
+
+import org.gradle.tooling.GradleConnector;
+import org.gradle.tooling.ProjectConnection;
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Neo4jContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static apoc.util.TestUtil.printFullStackTrace;
+import static org.junit.Assert.*;
+
+public class TestContainerUtil {
+
+    private TestContainerUtil() {}
+
+    private static File baseDir = Paths.get(".").toFile();
+
+    private static final Logger logger = LoggerFactory.getLogger(Neo4jContainer.class);
+
+    public static Neo4jContainer createEnterpriseDB(boolean withLogging) {
+        // We build the project, the artifact will be placed into ./build/libs
+        executeGradleTasks("clean", "shadow");
+        // We define the container with external volumes
+        Neo4jContainer neo4jContainer = (Neo4jContainer) new Neo4jContainer()
+                .withAdminPassword(null)
+                .withEnv("NEO4J_apoc_export_file_enabled", "true")
+                .withEnv("NEO4J_dbms_security_procedures_unrestricted", "apoc.*")
+                .withEnv("NEO4J_wrapper_java_additional","-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 -Xdebug-Xnoagent-Djava.compiler=NONE-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005")
+                .withFileSystemBind("./target/tests/gradle-build/libs", "/plugins") // map the apoc's artifact dir as the Neo4j's plugin dir
+                .withFileSystemBind("./target/import", "/import") // map the "target/import" dir as the Neo4j's import dir
+                .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes");
+        if (withLogging) {
+            neo4jContainer.withLogConsumer(new Slf4jLogConsumer(logger));
+        }
+        neo4jContainer.setDockerImageName("neo4j:3.5.3-enterprise");
+        return neo4jContainer;
+    }
+
+    private static void executeGradleTasks(String... tasks) {
+        ProjectConnection connection = GradleConnector.newConnector()
+                .forProjectDirectory(baseDir)
+                .useBuildDistribution()
+                .connect();
+        try {
+            connection.newBuild()
+                    .withArguments("-Dorg.gradle.project.buildDir=./target/tests/gradle-build")
+                    .forTasks(tasks)
+                    .run();
+        } finally {
+            connection.close();
+        }
+    }
+
+    public static void cleanBuild() {
+        executeGradleTasks("clean");
+    }
+
+    public static void testCall(Session session, String call, Map<String,Object> params, Consumer<Map<String, Object>> consumer) {
+        testResult(session, call, params, (res) -> {
+            try {
+                assertNotNull("result should be not null", res);
+                assertTrue("result should be not empty", res.hasNext());
+                Map<String, Object> row = res.next();
+                consumer.accept(row);
+                assertFalse("result should not have next", res.hasNext());
+            } catch(Throwable t) {
+                printFullStackTrace(t);
+                throw t;
+            }
+        });
+    }
+
+    public static void testCall(Session session, String call, Consumer<Map<String, Object>> consumer) {
+        testCall(session, call, null, consumer);
+    }
+
+    public static void testResult(Session session, String call, Consumer<Iterator<Map<String, Object>>> resultConsumer) {
+        testResult(session, call, null, resultConsumer);
+    }
+
+    public static void testResult(Session session, String call, Map<String,Object> params, Consumer<Iterator<Map<String, Object>>> resultConsumer) {
+        session.writeTransaction(tx -> {
+            Map<String, Object> p = (params == null) ? Collections.<String, Object>emptyMap() : params;
+            resultConsumer.accept(tx.run(call, p).list().stream().map(Record::asMap).collect(Collectors.toList()).iterator());
+            tx.success();
+            return null;
+        });
+    }
+
+}

--- a/src/test/java/apoc/util/TestUtil.java
+++ b/src/test/java/apoc/util/TestUtil.java
@@ -44,7 +44,7 @@ public class TestUtil {
         });
     }
 
-    private static void printFullStackTrace(Throwable e) {
+    public static void printFullStackTrace(Throwable e) {
         String padding = "";
         while (e != null) {
             if (e.getCause() == null) {


### PR DESCRIPTION
Fixes #1079 

This PR focuses on a resolution of the issue above "Run Ignored Enterprise Tests with TestContainers instead"

The enterprise tests are now managed with Testcontainers as requested, the project will be build into a directory used by Testcontainers as external volume. Every call to the Docker is made by the Neo4j Java Driver.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

 - Added the test container support 
 - created the `TestContainersUtil` class in order to support the enterprise test lifecycle
 - moved the enterprises test of `SchemaTest` to the new class `SchemasEnterpriseFeaturesTest`
 - removed the `@Ignore` inside the class `NodesTest` the now work properly.

If we plan to rebase the 3.5 with the 3.4 updates I'll provide a new PR with the management of the ExportCsv stuff related to the `NODE KEY` features. (I can do that, just let me know)