### PR TITLE
fixes #1100: graphml export: sort property keys for consistency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,6 +154,7 @@ dependencies {
 
     testCompile group: 'org.testcontainers', name: 'mysql', version: '1.10.2'
 
+    testCompile group: 'org.xmlunit', name: 'xmlunit-core', version: '2.2.1'
 
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'


### PR DESCRIPTION
Fixes #1100
Instead of change the Code I used the `XmlUnit` library in order to identify the elements `byNameAndAllAttributes`

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Used the `XmlUnit` library in order to test the XML comparison
