### PR TITLE
fixes #928 - Round-trip for apoc.export.csv.all

### DIFF
--- a/docs/asciidoc/_export_import.adoc
+++ b/docs/asciidoc/_export_import.adoc
@@ -152,6 +152,7 @@ The output of `labels()` function is not sorted, use it in combination with `apo
 | batchSize | 20000 | define the batch size
 // | silent | false | if enabled write progress output
 | delim | "," | define the delimiter character (export csv)
+| arrayDelim | ";" | define the delimiter character for arrays (used in the bulk import)
 | quotes | 'always' | quote-character used for CSV, possible values are: 'always', 'none', 'ifNeeded'
 | useTypes | false | add type on file header (export csv and graphml export)
 | format | "neo4j-shell" | In export to Cypher script define the export format. Possible values are: "cypher-shell","neo4j-shell" and "plain"
@@ -161,7 +162,7 @@ The output of `labels()` function is not sorted, use it in combination with `apo
 | defaultRelationshipType | "RELATED" | set relationship type (import/export graphml)
 | separateFiles | false | export results in separated file by type (nodes, relationships..)
 | cypherFormat | create | In export to cypher script, define the cypher format (for example use `MERGE` instead of `CREATE`). Possible values are: "create", "updateAll", "addStructure", "updateStructure".
-| neo4jAdminTool | true | In export it creates files for Neo4j Admin import
+| bulkImport | true | In export it creates files for Neo4j Admin import
 | separateHeader | false | In export it creates two file one for header and one for data
 |===
 
@@ -170,7 +171,7 @@ Values for the `quotes` configuration:
 * `always`:  the same behaviour of the current `true`
 * `ifNeeded`: it applies quotes only when it's necessary;
 
-When the config `neo4jAdminTool` is enable it create a list of file that can be used for Neoj4AdminTool import.
+When the config `bulkImport` is enable it create a list of file that can be used for Neo4j Bulk Import.
 
 *This config can be used only with `apoc.export.csv.all` and `apoc.export.csv.graph`*
 

--- a/docs/asciidoc/_export_import.adoc
+++ b/docs/asciidoc/_export_import.adoc
@@ -161,9 +161,22 @@ The output of `labels()` function is not sorted, use it in combination with `apo
 | defaultRelationshipType | "RELATED" | set relationship type (import/export graphml)
 | separateFiles | false | export results in separated file by type (nodes, relationships..)
 | cypherFormat | create | In export to cypher script, define the cypher format (for example use `MERGE` instead of `CREATE`). Possible values are: "create", "updateAll", "addStructure", "updateStructure".
+| neo4jAdminTool | true | In export it creates files for Neo4j Admin import
+| separateHeader | false | In export it creates two file one for header and one for data
 |===
 
 Values for the `quotes` configuration:
 * `none`: the same behaviour of the current `false`
 * `always`:  the same behaviour of the current `true`
 * `ifNeeded`: it applies quotes only when it's necessary;
+
+When the config `neo4jAdminTool` is enable it create a list of file that can be used for Neoj4AdminTool import.
+
+*This config can be used only with `apoc.export.csv.all` and `apoc.export.csv.graph`*
+
+All file create are named as follow:
+
+* Nodes file are construct with the name of the input file append with `.nodes.[LABEL_NAME].csv`
+* Rel file are construct with the name of the input file append with `.relationships.[TYPE_NAME].csv`
+
+If Node or Relationship have more than one Label/Type it will create one file for Label/Type.

--- a/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/src/main/java/apoc/export/csv/CsvFormat.java
@@ -1,17 +1,23 @@
 package apoc.export.csv;
 
+import apoc.export.cypher.FileManagerFactory;
 import apoc.export.util.*;
 import apoc.result.ProgressInfo;
 import com.opencsv.CSVWriter;
 import org.neo4j.cypher.export.SubGraph;
 import org.neo4j.graphdb.*;
 
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import static apoc.export.util.MetaInformation.*;
+import static apoc.export.util.Neo4jAdminImportUtil.formatHeader;
+import static apoc.util.Util.joinLabels;
 
 /**
  * @author mh
@@ -31,13 +37,18 @@ public class CsvFormat implements Format {
     }
 
     @Override
-    public ProgressInfo dump(SubGraph graph, Writer writer, Reporter reporter, ExportConfig config) throws Exception {
+    public ProgressInfo dump(SubGraph graph, FileManagerFactory.ExportCypherFileManager writer, Reporter reporter, ExportConfig config) throws Exception {
         try (Transaction tx = db.beginTx()) {
-            CSVWriter out = getCsvWriter(writer, config);
-            writeAll(graph, reporter, config, out);
+            if (config.isNeo4jImport()) {
+                writeAllNeo4jAdmin(graph, reporter, config, writer);
+            } else {
+                try (PrintWriter printWriter = writer.getPrintWriter("csv")) {
+                    CSVWriter out = getCsvWriter(printWriter, config);
+                    writeAll(graph, reporter, config, out);
+                }
+            }
             tx.success();
             reporter.done();
-            writer.close();
             return reporter.getTotal();
         }
     }
@@ -75,10 +86,9 @@ public class CsvFormat implements Format {
         return out;
     }
 
-    public ProgressInfo dump(Result result, Writer writer, Reporter reporter, ExportConfig config) throws Exception {
-        try (Transaction tx = db.beginTx()) {
-            CSVWriter out = getCsvWriter(writer, config);
-
+    public ProgressInfo dump(Result result, FileManagerFactory.ExportCypherFileManager writer, Reporter reporter, ExportConfig config) throws Exception {
+        try (Transaction tx = db.beginTx(); PrintWriter printWriter = writer.getPrintWriter("csv");) {
+            CSVWriter out = getCsvWriter(printWriter, config);
             String[] header = writeResultHeader(result, out);
 
             String[] data = new String[header.length];
@@ -94,7 +104,6 @@ public class CsvFormat implements Format {
             });
             tx.success();
             reporter.done();
-            writer.close();
             return reporter.getTotal();
         }
     }
@@ -120,6 +129,111 @@ public class CsvFormat implements Format {
         writeNodes(graph, out, reporter, nodePropTypes, cols, config.getBatchSize(), config.getDelim());
         writeRels(graph, out, reporter, relPropTypes, cols, nodeHeader.size(), config.getBatchSize(), config.getDelim());
     }
+
+    private void writeAllNeo4jAdmin(SubGraph graph, Reporter reporter, ExportConfig config, FileManagerFactory.ExportCypherFileManager writer) {
+        Map<Iterable<Label>, List<Node>> objectNodes = StreamSupport.stream(graph.getNodes().spliterator(), false)
+                .collect(Collectors.groupingBy(Node::getLabels));
+        Map<RelationshipType, List<Relationship>> objectRels = StreamSupport.stream(graph.getRelationships().spliterator(), false)
+                .collect(Collectors.groupingBy(Relationship::getType));
+        writeNodesNeo4jAdmin(reporter, config, writer, objectNodes);
+        writeRelsNeo4jAdmin(reporter, config, writer, objectRels);
+    }
+
+    private void writeNodesNeo4jAdmin(Reporter reporter, ExportConfig config, FileManagerFactory.ExportCypherFileManager writer, Map<Iterable<Label>, List<Node>> objectNode) {
+        objectNode.entrySet().forEach(entrySet -> {
+            Set<String> headerNode = generateHeaderNode(entrySet);
+
+            List<List<String>> rows = entrySet.getValue()
+                    .stream()
+                    .map(n -> {
+                        reporter.update(1, 0, n.getAllProperties().size());
+                        return headerNode.stream().map(s -> {
+                            if (s.equals(":LABEL")) {
+                                return joinLabels(entrySet.getKey(), ";");
+                            }
+                            String prop = s.split(":")[0];
+                            return prop.equals("id") ? String.valueOf(n.getId()) : cleanPoint(FormatUtils.toString(n.getProperty(prop, "")));
+                        }).collect(Collectors.toList());
+                    })
+                    .collect(Collectors.toList());
+
+            String type = joinLabels(entrySet.getKey(), ".");
+            writeRow(config, writer, headerNode, rows, "nodes." + type);
+        });
+    }
+
+    private void writeRelsNeo4jAdmin(Reporter reporter, ExportConfig config, FileManagerFactory.ExportCypherFileManager writer, Map<RelationshipType, List<Relationship>> objectRel) {
+        objectRel.entrySet().forEach(entrySet -> {
+            Set<String> headerRel = generateHeaderRelationship(entrySet);
+
+            List<List<String>> rows = entrySet.getValue()
+                    .stream()
+                    .map(r -> {
+                        reporter.update(0, 1, r.getAllProperties().size());
+                        return headerRel.stream().map(s -> {
+                            switch (s) {
+                                case ":START_ID":
+                                    return String.valueOf(r.getStartNodeId());
+                                case ":END_ID":
+                                    return String.valueOf(r.getEndNodeId());
+                                case ":TYPE":
+                                    return entrySet.getKey().name();
+                                default:
+                                    String prop = s.split(":")[0];
+                                    return prop.equals("id") ? String.valueOf(r.getId()) : cleanPoint(FormatUtils.toString(r.getProperty(prop, "")));
+                            }
+                        }).collect(Collectors.toList());
+                    })
+                    .collect(Collectors.toList());
+            writeRow(config, writer, headerRel, rows, "relationships." + entrySet.getKey().name());
+        });
+    }
+
+    private String cleanPoint(String point) {
+        point = point.replace(",\"z\":null", "");
+        point = point.replace(",\"heigth\":null", "");
+        point = point.replace("\"", "");
+        return point;
+    }
+
+    private Set<String> generateHeaderNode(Map.Entry<Iterable<Label>, List<Node>> entrySet) {
+        Set<String> headerNode = new LinkedHashSet<>();
+        headerNode.add("id:ID");
+        Map<String,Class> keyTypes = new LinkedHashMap<>();
+        entrySet.getValue().forEach(node -> updateKeyTypes(keyTypes, node));
+        headerNode.addAll(keyTypes.entrySet().stream().map(stringClassEntry -> formatHeader(stringClassEntry)).collect(Collectors.toCollection(LinkedHashSet::new)));
+        headerNode.add(":LABEL");
+        return headerNode;
+    }
+
+    private Set<String> generateHeaderRelationship(Map.Entry<RelationshipType, List<Relationship>> entrySet) {
+        Set<String> headerNode = new LinkedHashSet<>();
+        Map<String,Class> keyTypes = new LinkedHashMap<>();
+        entrySet.getValue().forEach(relationship -> updateKeyTypes(keyTypes, relationship));
+        headerNode.addAll(keyTypes.entrySet().stream().map(stringClassEntry -> formatHeader(stringClassEntry)).collect(Collectors.toCollection(LinkedHashSet::new)));
+        headerNode.add(":START_ID");
+        headerNode.add(":END_ID");
+        headerNode.add(":TYPE");
+        return headerNode;
+    }
+
+    private void writeRow(ExportConfig config, FileManagerFactory.ExportCypherFileManager writer, Set<String> headerNode, List<List<String>> rows, String name) {
+        try (PrintWriter pw = writer.getPrintWriter(name);
+             CSVWriter csvWriter = getCsvWriter(pw, config)) {
+            if (config.isSeparateHeader()) {
+                try (PrintWriter pwHeader = writer.getPrintWriter("header." + name)) {
+                    CSVWriter csvWriterHeader = getCsvWriter(pwHeader, config);
+                    csvWriterHeader.writeNext(headerNode.toArray(new String[0]), false);
+                }
+            } else {
+                csvWriter.writeNext(headerNode.toArray(new String[0]), false);
+            }
+            rows.forEach(row -> csvWriter.writeNext(row.toArray(new String[0]), false));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public void writeAll2(SubGraph graph, Reporter reporter, ExportConfig config, CSVWriter out) {
         writeNodes(graph, out, reporter,config);
         writeRels(graph, out, reporter,config);

--- a/src/main/java/apoc/export/csv/ExportCSV.java
+++ b/src/main/java/apoc/export/csv/ExportCSV.java
@@ -2,6 +2,7 @@ package apoc.export.csv;
 
 import apoc.Description;
 import apoc.Pools;
+import apoc.export.cypher.FileManagerFactory;
 import apoc.export.util.ExportConfig;
 import apoc.export.util.NodesAndRelsSubGraph;
 import apoc.export.util.ProgressReporter;
@@ -19,20 +20,15 @@ import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.TerminationGuard;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.io.Writer;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.Future;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static apoc.util.FileUtils.checkWriteAllowed;
-import static apoc.util.FileUtils.getPrintWriter;
 
 /**
  * @author mh
@@ -63,14 +59,14 @@ public class ExportCSV {
     @Procedure
     @Description("apoc.export.csv.data(nodes,rels,file,config) - exports given nodes and relationships as csv to the provided file")
     public Stream<ProgressInfo> data(@Name("nodes") List<Node> nodes, @Name("rels") List<Relationship> rels, @Name("file") String fileName, @Name("config") Map<String, Object> config) throws Exception {
-
+        checkConfig(config);
         String source = String.format("data: nodes(%d), rels(%d)", nodes.size(), rels.size());
         return exportCsv(fileName, source, new NodesAndRelsSubGraph(db, nodes, rels), config);
     }
     @Procedure
     @Description("apoc.export.csv.graph(graph,file,config) - exports given graph object as csv to the provided file")
     public Stream<ProgressInfo> graph(@Name("graph") Map<String,Object> graph, @Name("file") String fileName, @Name("config") Map<String, Object> config) throws Exception {
-
+//        checkConfig(config);
         Collection<Node> nodes = (Collection<Node>) graph.get("nodes");
         Collection<Relationship> rels = (Collection<Relationship>) graph.get("relationships");
         String source = String.format("graph: nodes(%d), rels(%d)", nodes.size(), rels.size());
@@ -80,11 +76,16 @@ public class ExportCSV {
     @Procedure
     @Description("apoc.export.csv.query(query,file,{config,...,params:{params}}) - exports results from the cypher statement as csv to the provided file")
     public Stream<ProgressInfo> query(@Name("query") String query, @Name("file") String fileName, @Name("config") Map<String, Object> config) throws Exception {
+        checkConfig(config);
         Map<String,Object> params = config == null ? Collections.emptyMap() : (Map<String,Object>)config.getOrDefault("params", Collections.emptyMap());
         Result result = db.execute(query,params);
 
         String source = String.format("statement: cols(%d)", result.columns().size());
         return exportCsv(fileName, source,result,config);
+    }
+
+    private void checkConfig(@Name("config") Map<String, Object> config) {
+        if (config != null && config.containsKey("neo4jImport")) throw new RuntimeException("Only apoc.export.all can have the `neo4jAdmin` config");
     }
 
     private Stream<ProgressInfo> exportCsv(@Name("file") String fileName, String source, Object data, Map<String,Object> config) throws Exception {
@@ -93,27 +94,32 @@ public class ExportCSV {
         ProgressInfo progressInfo = new ProgressInfo(fileName, source, "csv");
         progressInfo.batchSize = c.getBatchSize();
         ProgressReporter reporter = new ProgressReporter(null, null, progressInfo);
-        PrintWriter printWriter = getPrintWriter(fileName, null);
         CsvFormat exporter = new CsvFormat(db);
+
+        FileManagerFactory.ExportCypherFileManager cypherFileManager = FileManagerFactory.createFileManager(fileName, c.isNeo4jImport(), c.streamStatements());
+
         if (c.streamStatements()) {
             long timeout = c.getTimeoutSeconds();
-            StringWriter writer = new StringWriter(10_000);
             final ArrayBlockingQueue<ProgressInfo> queue = new ArrayBlockingQueue<>(1000);
             ProgressReporter reporterWithConsumer = reporter.withConsumer(
-                    (pi) -> Util.put(queue, pi == ProgressInfo.EMPTY ? ProgressInfo.EMPTY : new ProgressInfo(pi).drain(writer),timeout));
-            Util.inTxFuture(Pools.DEFAULT, db, () -> { dump(data, c, reporterWithConsumer, writer, exporter); return true; });
+                    (pi) -> Util.put(queue, pi == ProgressInfo.EMPTY ? ProgressInfo.EMPTY : new ProgressInfo(pi).drain(cypherFileManager.getStringWriter("csv")), timeout)
+            );
+            Util.inTxFuture(Pools.DEFAULT, db, () -> {
+                dump(data, c, reporterWithConsumer, cypherFileManager, exporter);
+                return true;
+            });
             QueueBasedSpliterator<ProgressInfo> spliterator = new QueueBasedSpliterator<>(queue, ProgressInfo.EMPTY, terminationGuard, timeout);
             return StreamSupport.stream(spliterator, false);
         } else {
-            dump(data, c, reporter, printWriter, exporter);
+            dump(data, c, reporter, cypherFileManager, exporter);
             return reporter.stream();
         }
     }
 
-    private void dump(Object data, ExportConfig c, ProgressReporter reporter, Writer printWriter, CsvFormat exporter) throws Exception {
+    private void dump(Object data, ExportConfig c, ProgressReporter reporter, FileManagerFactory.ExportCypherFileManager printWriter, CsvFormat exporter) throws Exception {
         if (data instanceof SubGraph)
-            exporter.dump(((SubGraph)data),printWriter,reporter,c);
+            exporter.dump((SubGraph)data,printWriter,reporter,c);
         if (data instanceof Result)
-            exporter.dump(((Result)data),printWriter,reporter,c);
+            exporter.dump((Result)data,printWriter,reporter,c);
     }
 }

--- a/src/main/java/apoc/export/csv/ExportCSV.java
+++ b/src/main/java/apoc/export/csv/ExportCSV.java
@@ -2,6 +2,7 @@ package apoc.export.csv;
 
 import apoc.Description;
 import apoc.Pools;
+import apoc.export.cypher.ExportFileManager;
 import apoc.export.cypher.FileManagerFactory;
 import apoc.export.util.ExportConfig;
 import apoc.export.util.NodesAndRelsSubGraph;
@@ -51,72 +52,74 @@ public class ExportCSV {
     @Procedure
     @Description("apoc.export.csv.all(file,config) - exports whole database as csv to the provided file")
     public Stream<ProgressInfo> all(@Name("file") String fileName, @Name("config") Map<String, Object> config) throws Exception {
-
         String source = String.format("database: nodes(%d), rels(%d)", Util.nodeCount(db), Util.relCount(db));
-        return exportCsv(fileName, source, new DatabaseSubGraph(db), config);
+        return exportCsv(fileName, source, new DatabaseSubGraph(db), new ExportConfig(config));
     }
 
     @Procedure
     @Description("apoc.export.csv.data(nodes,rels,file,config) - exports given nodes and relationships as csv to the provided file")
     public Stream<ProgressInfo> data(@Name("nodes") List<Node> nodes, @Name("rels") List<Relationship> rels, @Name("file") String fileName, @Name("config") Map<String, Object> config) throws Exception {
-        checkConfig(config);
+        ExportConfig exportConfig = new ExportConfig(config);
+        preventBulkImport(exportConfig);
         String source = String.format("data: nodes(%d), rels(%d)", nodes.size(), rels.size());
-        return exportCsv(fileName, source, new NodesAndRelsSubGraph(db, nodes, rels), config);
+        return exportCsv(fileName, source, new NodesAndRelsSubGraph(db, nodes, rels), exportConfig);
     }
     @Procedure
     @Description("apoc.export.csv.graph(graph,file,config) - exports given graph object as csv to the provided file")
     public Stream<ProgressInfo> graph(@Name("graph") Map<String,Object> graph, @Name("file") String fileName, @Name("config") Map<String, Object> config) throws Exception {
-//        checkConfig(config);
         Collection<Node> nodes = (Collection<Node>) graph.get("nodes");
         Collection<Relationship> rels = (Collection<Relationship>) graph.get("relationships");
         String source = String.format("graph: nodes(%d), rels(%d)", nodes.size(), rels.size());
-        return exportCsv(fileName, source, new NodesAndRelsSubGraph(db, nodes, rels), config);
+        return exportCsv(fileName, source, new NodesAndRelsSubGraph(db, nodes, rels), new ExportConfig(config));
     }
 
     @Procedure
     @Description("apoc.export.csv.query(query,file,{config,...,params:{params}}) - exports results from the cypher statement as csv to the provided file")
     public Stream<ProgressInfo> query(@Name("query") String query, @Name("file") String fileName, @Name("config") Map<String, Object> config) throws Exception {
-        checkConfig(config);
+        ExportConfig exportConfig = new ExportConfig(config);
+        preventBulkImport(exportConfig);
         Map<String,Object> params = config == null ? Collections.emptyMap() : (Map<String,Object>)config.getOrDefault("params", Collections.emptyMap());
         Result result = db.execute(query,params);
 
         String source = String.format("statement: cols(%d)", result.columns().size());
-        return exportCsv(fileName, source,result,config);
+        return exportCsv(fileName, source,result, exportConfig);
     }
 
-    private void checkConfig(@Name("config") Map<String, Object> config) {
-        if (config != null && config.containsKey("neo4jImport")) throw new RuntimeException("Only apoc.export.all can have the `neo4jAdmin` config");
+    private void preventBulkImport(ExportConfig config) {
+        if (config.isBulkImport()) {
+            throw new RuntimeException("You can use the `bulkImport` only with apoc.export.all and apoc.export.csv.graph");
+        }
     }
 
-    private Stream<ProgressInfo> exportCsv(@Name("file") String fileName, String source, Object data, Map<String,Object> config) throws Exception {
+    private Stream<ProgressInfo> exportCsv(@Name("file") String fileName, String source, Object data, ExportConfig exportConfig) throws Exception {
         checkWriteAllowed();
-        ExportConfig c = new ExportConfig(config);
         ProgressInfo progressInfo = new ProgressInfo(fileName, source, "csv");
-        progressInfo.batchSize = c.getBatchSize();
+        progressInfo.batchSize = exportConfig.getBatchSize();
         ProgressReporter reporter = new ProgressReporter(null, null, progressInfo);
         CsvFormat exporter = new CsvFormat(db);
 
-        FileManagerFactory.ExportCypherFileManager cypherFileManager = FileManagerFactory.createFileManager(fileName, c.isNeo4jImport(), c.streamStatements());
+        ExportFileManager cypherFileManager = FileManagerFactory
+                .createFileManager(fileName, exportConfig.isBulkImport(), exportConfig.streamStatements());
 
-        if (c.streamStatements()) {
-            long timeout = c.getTimeoutSeconds();
+        if (exportConfig.streamStatements()) {
+            long timeout = exportConfig.getTimeoutSeconds();
             final ArrayBlockingQueue<ProgressInfo> queue = new ArrayBlockingQueue<>(1000);
             ProgressReporter reporterWithConsumer = reporter.withConsumer(
                     (pi) -> Util.put(queue, pi == ProgressInfo.EMPTY ? ProgressInfo.EMPTY : new ProgressInfo(pi).drain(cypherFileManager.getStringWriter("csv")), timeout)
             );
             Util.inTxFuture(Pools.DEFAULT, db, () -> {
-                dump(data, c, reporterWithConsumer, cypherFileManager, exporter);
+                dump(data, exportConfig, reporterWithConsumer, cypherFileManager, exporter);
                 return true;
             });
             QueueBasedSpliterator<ProgressInfo> spliterator = new QueueBasedSpliterator<>(queue, ProgressInfo.EMPTY, terminationGuard, timeout);
             return StreamSupport.stream(spliterator, false);
         } else {
-            dump(data, c, reporter, cypherFileManager, exporter);
+            dump(data, exportConfig, reporter, cypherFileManager, exporter);
             return reporter.stream();
         }
     }
 
-    private void dump(Object data, ExportConfig c, ProgressReporter reporter, FileManagerFactory.ExportCypherFileManager printWriter, CsvFormat exporter) throws Exception {
+    private void dump(Object data, ExportConfig c, ProgressReporter reporter, ExportFileManager printWriter, CsvFormat exporter) throws Exception {
         if (data instanceof SubGraph)
             exporter.dump((SubGraph)data,printWriter,reporter,c);
         if (data instanceof Result)

--- a/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -18,11 +18,11 @@ import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.procedure.*;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -100,7 +100,7 @@ public class ExportCypher {
         progressInfo.batchSize = c.getBatchSize();
         ProgressReporter reporter = new ProgressReporter(null, null, progressInfo);
         boolean separatedFiles = !onlySchema && c.separateFiles();
-        FileManagerFactory.ExportCypherFileManager cypherFileManager = FileManagerFactory.createFileManager(fileName, separatedFiles, c.streamStatements());
+        ExportFileManager cypherFileManager = FileManagerFactory.createFileManager(fileName, separatedFiles, c.streamStatements());
 
         if (c.streamStatements()) {
             long timeout = c.getTimeoutSeconds();
@@ -116,7 +116,7 @@ public class ExportCypher {
         }
     }
 
-    private void doExport(SubGraph graph, ExportConfig c, boolean onlySchema, ProgressReporter reporter, FileManagerFactory.ExportCypherFileManager cypherFileManager) throws IOException {
+    private void doExport(SubGraph graph, ExportConfig c, boolean onlySchema, ProgressReporter reporter, ExportFileManager cypherFileManager) throws IOException {
         MultiStatementCypherSubGraphExporter exporter = new MultiStatementCypherSubGraphExporter(graph, c);
 
         if (onlySchema)
@@ -154,7 +154,7 @@ public class ExportCypher {
             this.batchSize = pi.batchSize;
             this.batches = pi.batches;
         }
-        public DataProgressInfo enrich(FileManagerFactory.ExportCypherFileManager fileInfo) {
+        public DataProgressInfo enrich(ExportFileManager fileInfo) {
             cypherStatements = fileInfo.drain("cypher");
             nodeStatements = fileInfo.drain("nodes");
             relationshipStatements = fileInfo.drain("relationships");

--- a/src/main/java/apoc/export/cypher/ExportFileManager.java
+++ b/src/main/java/apoc/export/cypher/ExportFileManager.java
@@ -1,0 +1,15 @@
+package apoc.export.cypher;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public interface ExportFileManager {
+    PrintWriter getPrintWriter(String type) throws IOException;
+
+    StringWriter getStringWriter(String type);
+
+    String drain(String type);
+
+    String getFileName();
+}

--- a/src/main/java/apoc/export/cypher/FileManagerFactory.java
+++ b/src/main/java/apoc/export/cypher/FileManagerFactory.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ConcurrentMap;
  * @since 06.12.17
  */
 public class FileManagerFactory {
-    public static ExportCypherFileManager createFileManager(String fileName, boolean separatedFiles, boolean b) {
+    public static ExportFileManager createFileManager(String fileName, boolean separatedFiles, boolean b) {
         if (fileName == null) {
             return new StringExportCypherFileManager(separatedFiles);
         }
@@ -23,58 +23,7 @@ public class FileManagerFactory {
         return new PhysicalExportFileManager(fileType, fileName, separatedFiles);
     }
 
-    public interface ExportCypherFileManager {
-        PrintWriter getPrintWriter(String type) throws IOException;
-
-        StringWriter getStringWriter(String type);
-
-        String drain(String type);
-
-        String getFileName();
-    }
-
-    private static class StringExportCypherFileManager implements ExportCypherFileManager {
-
-        private boolean separatedFiles;
-        private ConcurrentMap<String, StringWriter> writers = new ConcurrentHashMap<>();
-
-        public StringExportCypherFileManager(boolean separatedFiles) {
-            this.separatedFiles = separatedFiles;
-        }
-
-        @Override
-        public PrintWriter getPrintWriter(String type) throws IOException {
-            if (this.separatedFiles) {
-                return new PrintWriter(writers.compute(type, (key, writer) -> writer == null ? new StringWriter() : writer));
-            } else {
-                return new PrintWriter(writers.compute(type.equals("csv") ? type : "cypher", (key, writer) -> writer == null ? new StringWriter() : writer));
-            }
-        }
-
-        @Override
-        public StringWriter getStringWriter(String type) {
-            return writers.get(type);
-        }
-
-        @Override
-        public synchronized String drain(String type) {
-            StringWriter writer = writers.get(type);
-            if (writer != null) {
-                String text = writer.toString();
-                writer.getBuffer().setLength(0);
-                return text;
-            }
-            else return null;
-        }
-
-        @Override
-        public String getFileName() {
-            return null;
-        }
-    }
-
-
-    private static class PhysicalExportFileManager implements ExportCypherFileManager {
+    private static class PhysicalExportFileManager implements ExportFileManager {
 
         private final String fileName;
         private final String fileType;
@@ -118,6 +67,46 @@ public class FileManagerFactory {
         @Override
         public String getFileName() {
             return this.fileName;
+        }
+    }
+
+    private static class StringExportCypherFileManager implements ExportFileManager {
+
+        private boolean separatedFiles;
+        private ConcurrentMap<String, StringWriter> writers = new ConcurrentHashMap<>();
+
+        public StringExportCypherFileManager(boolean separatedFiles) {
+            this.separatedFiles = separatedFiles;
+        }
+
+        @Override
+        public PrintWriter getPrintWriter(String type) throws IOException {
+            if (this.separatedFiles) {
+                return new PrintWriter(writers.compute(type, (key, writer) -> writer == null ? new StringWriter() : writer));
+            } else {
+                return new PrintWriter(writers.compute(type.equals("csv") ? type : "cypher", (key, writer) -> writer == null ? new StringWriter() : writer));
+            }
+        }
+
+        @Override
+        public StringWriter getStringWriter(String type) {
+            return writers.get(type);
+        }
+
+        @Override
+        public synchronized String drain(String type) {
+            StringWriter writer = writers.get(type);
+            if (writer != null) {
+                String text = writer.toString();
+                writer.getBuffer().setLength(0);
+                return text;
+            }
+            else return null;
+        }
+
+        @Override
+        public String getFileName() {
+            return null;
         }
     }
 

--- a/src/main/java/apoc/export/cypher/FileManagerFactory.java
+++ b/src/main/java/apoc/export/cypher/FileManagerFactory.java
@@ -14,68 +14,46 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class FileManagerFactory {
     public static ExportCypherFileManager createFileManager(String fileName, boolean separatedFiles, boolean b) {
-        return fileName == null ?
-                new StringExportCypherFileManager(fileName, separatedFiles) :
-                new PhysicalExportCypherFileManager(fileName, separatedFiles);
+        if (fileName == null) {
+            return new StringExportCypherFileManager(separatedFiles);
+        }
+
+        int indexOfDot = fileName.lastIndexOf(".");
+        String fileType = fileName.substring(indexOfDot + 1);
+        return new PhysicalExportFileManager(fileType, fileName, separatedFiles);
     }
 
-    interface ExportCypherFileManager {
+    public interface ExportCypherFileManager {
         PrintWriter getPrintWriter(String type) throws IOException;
 
+        StringWriter getStringWriter(String type);
+
         String drain(String type);
-    }
 
-    private static class PhysicalExportCypherFileManager implements ExportCypherFileManager {
-
-        private final String fileName;
-        private boolean separatedFiles;
-        private PrintWriter writer;
-
-        public PhysicalExportCypherFileManager(String fileName, boolean separatedFiles) {
-            this.fileName = fileName;
-            this.separatedFiles = separatedFiles;
-        }
-
-        public PrintWriter getPrintWriter(String type) throws IOException {
-
-            if (this.separatedFiles) {
-                return FileUtils.getPrintWriter(normalizeFileName(fileName, type), null);
-            } else {
-                if (this.writer == null) {
-                    this.writer = FileUtils.getPrintWriter(normalizeFileName(fileName, null), null);
-                }
-                return this.writer;
-            }
-        }
-
-        private String normalizeFileName(final String fileName, String suffix) {
-            // TODO check if this should be follow the same rules of FileUtils.readerFor
-            return fileName.replace(".cypher", suffix != null ? "." + suffix + ".cypher" : ".cypher");
-        }
-
-        @Override
-        public String drain(String type) {
-            return null;
-        }
+        String getFileName();
     }
 
     private static class StringExportCypherFileManager implements ExportCypherFileManager {
 
-        private final String fileName;
         private boolean separatedFiles;
         private ConcurrentMap<String, StringWriter> writers = new ConcurrentHashMap<>();
 
-        public StringExportCypherFileManager(String fileName, boolean separatedFiles) {
-            this.fileName = fileName;
+        public StringExportCypherFileManager(boolean separatedFiles) {
             this.separatedFiles = separatedFiles;
         }
 
+        @Override
         public PrintWriter getPrintWriter(String type) throws IOException {
             if (this.separatedFiles) {
                 return new PrintWriter(writers.compute(type, (key, writer) -> writer == null ? new StringWriter() : writer));
             } else {
-                return new PrintWriter(writers.compute("cypher", (key, writer) -> writer == null ? new StringWriter() : writer));
+                return new PrintWriter(writers.compute(type.equals("csv") ? type : "cypher", (key, writer) -> writer == null ? new StringWriter() : writer));
             }
+        }
+
+        @Override
+        public StringWriter getStringWriter(String type) {
+            return writers.get(type);
         }
 
         @Override
@@ -88,5 +66,59 @@ public class FileManagerFactory {
             }
             else return null;
         }
+
+        @Override
+        public String getFileName() {
+            return null;
+        }
     }
+
+
+    private static class PhysicalExportFileManager implements ExportCypherFileManager {
+
+        private final String fileName;
+        private final String fileType;
+        private boolean separatedFiles;
+        private PrintWriter writer;
+
+        public PhysicalExportFileManager(String fileType, String fileName, boolean separatedFiles) {
+            this.fileType = fileType;
+            this.fileName = fileName;
+            this.separatedFiles = separatedFiles;
+        }
+
+        @Override
+        public PrintWriter getPrintWriter(String type) throws IOException {
+
+            if (this.separatedFiles) {
+                return FileUtils.getPrintWriter(normalizeFileName(fileName, type), null);
+            } else {
+                if (this.writer == null) {
+                    this.writer = FileUtils.getPrintWriter(normalizeFileName(fileName, null), null);
+                }
+                return this.writer;
+            }
+        }
+
+        @Override
+        public StringWriter getStringWriter(String type) {
+            return null;
+        }
+
+        private String normalizeFileName(final String fileName, String suffix) {
+            // TODO check if this should be follow the same rules of FileUtils.readerFor
+            return fileName.replace("." + fileType, "." + (suffix != null ? suffix + "." +fileType : fileType));
+        }
+
+        @Override
+        public String drain(String type) {
+            return null;
+        }
+
+        @Override
+        public String getFileName() {
+            return this.fileName;
+        }
+    }
+
 }

--- a/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -59,7 +59,7 @@ public class MultiStatementCypherSubGraphExporter {
      * @param reporter
      * @param cypherFileManager
      */
-    public void export(ExportConfig config, Reporter reporter, FileManagerFactory.ExportCypherFileManager cypherFileManager) throws IOException {
+    public void export(ExportConfig config, Reporter reporter, ExportFileManager cypherFileManager) throws IOException {
 
         int batchSize = config.getBatchSize();
 
@@ -70,7 +70,7 @@ public class MultiStatementCypherSubGraphExporter {
         reporter.done();
     }
 
-    public void exportOnlySchema(FileManagerFactory.ExportCypherFileManager cypherFileManager) throws IOException {
+    public void exportOnlySchema(ExportFileManager cypherFileManager) throws IOException {
         exportSchema(cypherFileManager.getPrintWriter("schema"));
     }
 

--- a/src/main/java/apoc/export/graphml/XmlGraphMLFormat.java
+++ b/src/main/java/apoc/export/graphml/XmlGraphMLFormat.java
@@ -1,6 +1,6 @@
 package apoc.export.graphml;
 
-import apoc.export.cypher.FileManagerFactory;
+import apoc.export.cypher.ExportFileManager;
 import apoc.export.util.ExportConfig;
 import apoc.export.util.Format;
 import apoc.export.util.Reporter;
@@ -28,7 +28,7 @@ public class XmlGraphMLFormat implements Format {
     }
 
     @Override
-    public ProgressInfo dump(SubGraph graph, FileManagerFactory.ExportCypherFileManager writer, Reporter reporter, ExportConfig config) throws Exception {
+    public ProgressInfo dump(SubGraph graph, ExportFileManager writer, Reporter reporter, ExportConfig config) throws Exception {
         try (Transaction tx = db.beginTx()) {
             XmlGraphMLWriter graphMlWriter = new XmlGraphMLWriter();
             graphMlWriter.write(graph, writer.getPrintWriter("graphml"), reporter, config);

--- a/src/main/java/apoc/export/graphml/XmlGraphMLFormat.java
+++ b/src/main/java/apoc/export/graphml/XmlGraphMLFormat.java
@@ -1,5 +1,6 @@
 package apoc.export.graphml;
 
+import apoc.export.cypher.FileManagerFactory;
 import apoc.export.util.ExportConfig;
 import apoc.export.util.Format;
 import apoc.export.util.Reporter;
@@ -9,7 +10,6 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 
 import java.io.Reader;
-import java.io.Writer;
 
 /**
  * @author mh
@@ -28,14 +28,13 @@ public class XmlGraphMLFormat implements Format {
     }
 
     @Override
-    public ProgressInfo dump(SubGraph graph, Writer writer, Reporter reporter, ExportConfig config) throws Exception {
+    public ProgressInfo dump(SubGraph graph, FileManagerFactory.ExportCypherFileManager writer, Reporter reporter, ExportConfig config) throws Exception {
         try (Transaction tx = db.beginTx()) {
             XmlGraphMLWriter graphMlWriter = new XmlGraphMLWriter();
-            graphMlWriter.write(graph, writer, reporter, config);
+            graphMlWriter.write(graph, writer.getPrintWriter("graphml"), reporter, config);
             tx.success();
         }
         return reporter.getTotal();
     }
 }
-
 

--- a/src/main/java/apoc/export/json/ExportJson.java
+++ b/src/main/java/apoc/export/json/ExportJson.java
@@ -1,6 +1,7 @@
 package apoc.export.json;
 
 import apoc.Description;
+import apoc.export.cypher.FileManagerFactory;
 import apoc.export.util.ExportConfig;
 import apoc.export.util.NodesAndRelsSubGraph;
 import apoc.export.util.ProgressReporter;
@@ -24,7 +25,6 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static apoc.util.FileUtils.checkWriteAllowed;
-import static apoc.util.FileUtils.getPrintWriter;
 
 public class ExportJson {
     @Context
@@ -76,13 +76,15 @@ public class ExportJson {
         ExportConfig c = new ExportConfig(config);
         ProgressReporter reporter = new ProgressReporter(null, null, new ProgressInfo(fileName, source, "json"));
         JsonFormat exporter = new JsonFormat(db);
-        try (PrintWriter printWriter = getPrintWriter(fileName, null);) {
+
+        FileManagerFactory.ExportCypherFileManager cypherFileManager = FileManagerFactory.createFileManager(fileName, false, c.streamStatements());
+
+        try (PrintWriter printWriter = cypherFileManager.getPrintWriter("json")) {
             if (data instanceof SubGraph)
-                exporter.dump(((SubGraph)data),printWriter,reporter,c);
+                exporter.dump(((SubGraph)data),cypherFileManager,reporter,c);
             if (data instanceof Result)
                 exporter.dump(((Result)data),printWriter,reporter,c);
         }
         return reporter.stream();
     }
 }
-

--- a/src/main/java/apoc/export/json/ExportJson.java
+++ b/src/main/java/apoc/export/json/ExportJson.java
@@ -1,6 +1,7 @@
 package apoc.export.json;
 
 import apoc.Description;
+import apoc.export.cypher.ExportFileManager;
 import apoc.export.cypher.FileManagerFactory;
 import apoc.export.util.ExportConfig;
 import apoc.export.util.NodesAndRelsSubGraph;
@@ -77,7 +78,7 @@ public class ExportJson {
         ProgressReporter reporter = new ProgressReporter(null, null, new ProgressInfo(fileName, source, "json"));
         JsonFormat exporter = new JsonFormat(db);
 
-        FileManagerFactory.ExportCypherFileManager cypherFileManager = FileManagerFactory.createFileManager(fileName, false, c.streamStatements());
+        ExportFileManager cypherFileManager = FileManagerFactory.createFileManager(fileName, false, c.streamStatements());
 
         try (PrintWriter printWriter = cypherFileManager.getPrintWriter("json")) {
             if (data instanceof SubGraph)

--- a/src/main/java/apoc/export/json/JsonFormat.java
+++ b/src/main/java/apoc/export/json/JsonFormat.java
@@ -1,6 +1,6 @@
 package apoc.export.json;
 
-import apoc.export.cypher.FileManagerFactory;
+import apoc.export.cypher.ExportFileManager;
 import apoc.export.util.ExportConfig;
 import apoc.export.util.Format;
 import apoc.export.util.Reporter;
@@ -44,7 +44,7 @@ public class JsonFormat implements Format {
     }
 
     @Override
-    public ProgressInfo dump(SubGraph graph, FileManagerFactory.ExportCypherFileManager writer, Reporter reporter, ExportConfig config) throws Exception {
+    public ProgressInfo dump(SubGraph graph, ExportFileManager writer, Reporter reporter, ExportConfig config) throws Exception {
         Consumer<JsonGenerator> consumer = (jsonGenerator) -> {
             try {
                 writeNodes(graph.getNodes(), reporter, jsonGenerator, config);

--- a/src/main/java/apoc/export/json/JsonFormat.java
+++ b/src/main/java/apoc/export/json/JsonFormat.java
@@ -1,5 +1,6 @@
 package apoc.export.json;
 
+import apoc.export.cypher.FileManagerFactory;
 import apoc.export.util.ExportConfig;
 import apoc.export.util.Format;
 import apoc.export.util.Reporter;
@@ -43,7 +44,7 @@ public class JsonFormat implements Format {
     }
 
     @Override
-    public ProgressInfo dump(SubGraph graph, Writer writer, Reporter reporter, ExportConfig config) throws Exception {
+    public ProgressInfo dump(SubGraph graph, FileManagerFactory.ExportCypherFileManager writer, Reporter reporter, ExportConfig config) throws Exception {
         Consumer<JsonGenerator> consumer = (jsonGenerator) -> {
             try {
                 writeNodes(graph.getNodes(), reporter, jsonGenerator, config);
@@ -52,7 +53,7 @@ public class JsonFormat implements Format {
                 throw new RuntimeException(e);
             }
         };
-        return dump(writer, reporter, consumer);
+        return dump(writer.getPrintWriter("json"), reporter, consumer);
     }
 
     public ProgressInfo dump(Result result, Writer writer, Reporter reporter, ExportConfig config) throws Exception {

--- a/src/main/java/apoc/export/util/BulkImportUtil.java
+++ b/src/main/java/apoc/export/util/BulkImportUtil.java
@@ -4,12 +4,13 @@ import org.neo4j.values.storable.DurationValue;
 import org.neo4j.values.storable.PointValue;
 
 import java.time.*;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-public class Neo4jAdminImportUtil {
+public class BulkImportUtil {
 
-    private static Map<Class<?>, String> allowedMapping = new HashMap(){{
+    private static Map<Class<?>, String> allowedMapping = Collections.unmodifiableMap(new HashMap(){{
         put(Double.class, "double");
         put(Float.class, "float");
         put(Integer.class, "int");
@@ -25,11 +26,10 @@ public class Neo4jAdminImportUtil {
         put(LocalTime.class, "localtime");
         put(ZonedDateTime.class, "datetime");
         put(OffsetTime.class, "time");
-    }};
+    }});
 
 
     public static String formatHeader(Map.Entry<String, Class> r) {
-
         if (allowedMapping.containsKey(r.getValue())) {
             return r.getKey() + ":" + allowedMapping.get(r.getValue());
         } else {

--- a/src/main/java/apoc/export/util/ExportConfig.java
+++ b/src/main/java/apoc/export/util/ExportConfig.java
@@ -1,7 +1,6 @@
 package apoc.export.util;
 
 import apoc.export.cypher.formatter.CypherFormat;
-import apoc.gephi.Gephi;
 import apoc.util.Util;
 
 import java.util.*;
@@ -26,6 +25,7 @@ public class ExportConfig {
 
     private int batchSize = DEFAULT_BATCH_SIZE;
     private boolean silent = false;
+    private boolean neo4jImport = false;
     private String delim = DEFAULT_DELIM;
     private String quotes = DEFAULT_QUOTES;
     private boolean useTypes = false;
@@ -35,6 +35,7 @@ public class ExportConfig {
     private ExportFormat format;
     private CypherFormat cypherFormat;
     private final Map<String, Object> config;
+    private boolean separateHeader;
 
     public int getBatchSize() {
         return batchSize;
@@ -42,6 +43,10 @@ public class ExportConfig {
 
     public boolean isSilent() {
         return silent;
+    }
+
+    public boolean isNeo4jImport() {
+        return neo4jImport;
     }
 
     public char getDelimChar() {
@@ -71,10 +76,12 @@ public class ExportConfig {
         config = config != null ? config : Collections.emptyMap();
         this.silent = toBoolean(config.getOrDefault("silent",false));
         this.batchSize = ((Number)config.getOrDefault("batchSize", DEFAULT_BATCH_SIZE)).intValue();
-        this.delim = delim(config.getOrDefault("d", String.valueOf(DEFAULT_DELIM)).toString());
+        this.delim = delim(config.getOrDefault("delim", String.valueOf(DEFAULT_DELIM)).toString());
         this.useTypes = toBoolean(config.get("useTypes"));
         this.caption = convertCaption(config.getOrDefault("caption", asList("name", "title", "label", "id")));
         this.nodesOfRelationships = toBoolean(config.get("nodesOfRelationships"));
+        this.neo4jImport = toBoolean(config.get("neo4jImport"));
+        this.separateHeader = toBoolean(config.get("separateHeader"));
         this.format = ExportFormat.fromString((String) config.getOrDefault("format", "neo4j-shell"));
         this.cypherFormat = CypherFormat.fromString((String) config.getOrDefault("cypherFormat", "create"));
         this.config = config;
@@ -150,5 +157,9 @@ public class ExportConfig {
 
     public long getTimeoutSeconds() {
         return Util.toLong(config.getOrDefault("timeoutSeconds",100));
+    }
+
+    public boolean isSeparateHeader() {
+        return this.separateHeader;
     }
 }

--- a/src/main/java/apoc/export/util/ExportConfig.java
+++ b/src/main/java/apoc/export/util/ExportConfig.java
@@ -20,12 +20,13 @@ public class ExportConfig {
 
     public static final int DEFAULT_BATCH_SIZE = 20000;
     public static final String DEFAULT_DELIM = ",";
+    public static final String DEFAULT_ARRAY_DELIM = ";";
     public static final String DEFAULT_QUOTES = ALWAYS_QUOTES;
     private final boolean streamStatements;
 
     private int batchSize = DEFAULT_BATCH_SIZE;
     private boolean silent = false;
-    private boolean neo4jImport = false;
+    private boolean bulkImport = false;
     private String delim = DEFAULT_DELIM;
     private String quotes = DEFAULT_QUOTES;
     private boolean useTypes = false;
@@ -36,6 +37,8 @@ public class ExportConfig {
     private CypherFormat cypherFormat;
     private final Map<String, Object> config;
     private boolean separateHeader;
+    private String arrayDelim;
+
 
     public int getBatchSize() {
         return batchSize;
@@ -45,8 +48,8 @@ public class ExportConfig {
         return silent;
     }
 
-    public boolean isNeo4jImport() {
-        return neo4jImport;
+    public boolean isBulkImport() {
+        return bulkImport;
     }
 
     public char getDelimChar() {
@@ -60,7 +63,6 @@ public class ExportConfig {
     public String isQuotes() {
         return quotes;
     }
-
 
     public boolean useTypes() {
         return useTypes;
@@ -76,11 +78,12 @@ public class ExportConfig {
         config = config != null ? config : Collections.emptyMap();
         this.silent = toBoolean(config.getOrDefault("silent",false));
         this.batchSize = ((Number)config.getOrDefault("batchSize", DEFAULT_BATCH_SIZE)).intValue();
-        this.delim = delim(config.getOrDefault("delim", String.valueOf(DEFAULT_DELIM)).toString());
+        this.delim = delim(config.getOrDefault("delim", DEFAULT_DELIM).toString());
+        this.arrayDelim = delim(config.getOrDefault("arrayDelim", DEFAULT_ARRAY_DELIM).toString());
         this.useTypes = toBoolean(config.get("useTypes"));
         this.caption = convertCaption(config.getOrDefault("caption", asList("name", "title", "label", "id")));
         this.nodesOfRelationships = toBoolean(config.get("nodesOfRelationships"));
-        this.neo4jImport = toBoolean(config.get("neo4jImport"));
+        this.bulkImport = toBoolean(config.get("bulkImport"));
         this.separateHeader = toBoolean(config.get("separateHeader"));
         this.format = ExportFormat.fromString((String) config.getOrDefault("format", "neo4j-shell"));
         this.cypherFormat = CypherFormat.fromString((String) config.getOrDefault("cypherFormat", "create"));
@@ -161,5 +164,9 @@ public class ExportConfig {
 
     public boolean isSeparateHeader() {
         return this.separateHeader;
+    }
+
+    public String getArrayDelim() {
+        return arrayDelim;
     }
 }

--- a/src/main/java/apoc/export/util/Format.java
+++ b/src/main/java/apoc/export/util/Format.java
@@ -1,12 +1,10 @@
 package apoc.export.util;
 
-import apoc.export.cypher.FileManagerFactory;
+import apoc.export.cypher.ExportFileManager;
 import apoc.result.ProgressInfo;
 import org.neo4j.cypher.export.SubGraph;
-import org.neo4j.graphdb.Result;
 
 import java.io.Reader;
-import java.io.Writer;
 
 /**
  * @author mh
@@ -14,5 +12,5 @@ import java.io.Writer;
  */
 public interface Format {
     ProgressInfo load(Reader reader, Reporter reporter, ExportConfig config) throws Exception;
-    ProgressInfo dump(SubGraph graph, FileManagerFactory.ExportCypherFileManager writer, Reporter reporter, ExportConfig config) throws Exception;
+    ProgressInfo dump(SubGraph graph, ExportFileManager writer, Reporter reporter, ExportConfig config) throws Exception;
 }

--- a/src/main/java/apoc/export/util/Format.java
+++ b/src/main/java/apoc/export/util/Format.java
@@ -1,7 +1,9 @@
 package apoc.export.util;
 
+import apoc.export.cypher.FileManagerFactory;
 import apoc.result.ProgressInfo;
 import org.neo4j.cypher.export.SubGraph;
+import org.neo4j.graphdb.Result;
 
 import java.io.Reader;
 import java.io.Writer;
@@ -12,5 +14,5 @@ import java.io.Writer;
  */
 public interface Format {
     ProgressInfo load(Reader reader, Reporter reporter, ExportConfig config) throws Exception;
-    ProgressInfo dump(SubGraph graph, Writer writer, Reporter reporter, ExportConfig config) throws Exception;
+    ProgressInfo dump(SubGraph graph, FileManagerFactory.ExportCypherFileManager writer, Reporter reporter, ExportConfig config) throws Exception;
 }

--- a/src/main/java/apoc/export/util/Neo4jAdminImportUtil.java
+++ b/src/main/java/apoc/export/util/Neo4jAdminImportUtil.java
@@ -1,0 +1,40 @@
+package apoc.export.util;
+
+import org.neo4j.values.storable.DurationValue;
+import org.neo4j.values.storable.PointValue;
+
+import java.time.*;
+import java.util.HashMap;
+import java.util.Map;
+
+public class Neo4jAdminImportUtil {
+
+    private static Map<Class<?>, String> allowedMapping = new HashMap(){{
+        put(Double.class, "double");
+        put(Float.class, "float");
+        put(Integer.class, "int");
+        put(Long.class, "long");
+        put(Short.class, "short");
+        put(Character.class, "char");
+        put(Byte.class, "byte");
+        put(Boolean.class, "boolean");
+        put(DurationValue.class, "duration");
+        put(PointValue.class, "point");
+        put(LocalDate.class, "date");
+        put(LocalDateTime.class, "localdatetime");
+        put(LocalTime.class, "localtime");
+        put(ZonedDateTime.class, "datetime");
+        put(OffsetTime.class, "time");
+    }};
+
+
+    public static String formatHeader(Map.Entry<String, Class> r) {
+
+        if (allowedMapping.containsKey(r.getValue())) {
+            return r.getKey() + ":" + allowedMapping.get(r.getValue());
+        } else {
+            return r.getKey();
+        }
+    }
+
+}

--- a/src/main/java/apoc/util/Util.java
+++ b/src/main/java/apoc/util/Util.java
@@ -47,7 +47,10 @@ public class Util {
     public static final String COMPILED = "interpreted"; // todo handle enterprise properly
 
     public static String labelString(Node n) {
-        return StreamSupport.stream(n.getLabels().spliterator(),false).map(Label::name).sorted().collect(Collectors.joining(":"));
+        return joinLabels(n.getLabels(), ":");
+    }
+    public static String joinLabels(Iterable<Label> labels, String s) {
+        return StreamSupport.stream(labels.spliterator(), false).map(Label::name).collect(Collectors.joining(s));
     }
     public static List<String> labelStrings(Node n) {
         return StreamSupport.stream(n.getLabels().spliterator(),false).map(Label::name).sorted().collect(Collectors.toList());


### PR DESCRIPTION
Fixes #928

Round-trip for apoc.export.csv.all

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:
  - Add the the config to export the csv for the adminImportTool
