### PR TITLE
Revise Metrics and Log Streaming Approach

### DIFF
--- a/src/main/java/apoc/ApocConfiguration.java
+++ b/src/main/java/apoc/ApocConfiguration.java
@@ -2,6 +2,7 @@ package apoc;
 
 import apoc.cache.Static;
 import apoc.metrics.Metrics;
+import apoc.util.FileUtils;
 import apoc.util.Util;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -27,7 +28,7 @@ public class ApocConfiguration {
         PARAM_WHITELIST.put("dbms.security.allow_csv_import_from_file_urls", "import.file.allow_read_from_filesystem");
 
         // Contains list of all dbms.directories.* settings supported by Neo4j.
-        for(String directorySetting : Metrics.NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES) {
+        for(String directorySetting : FileUtils.NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES) {
             PARAM_WHITELIST.put(directorySetting, directorySetting);
         }
     }

--- a/src/main/java/apoc/load/LoadCsv.java
+++ b/src/main/java/apoc/load/LoadCsv.java
@@ -110,6 +110,12 @@ public class LoadCsv {
             this.type = Meta.Types.from(mapping.getOrDefault("type", "STRING").toString());
             this.arrayPattern = Pattern.compile(String.valueOf(this.arraySep), Pattern.LITERAL);
 
+            if (this.type == null) {
+                // Call this out to the user explicitly because deep inside of LoadCSV and others you will get
+                // NPEs that are hard to spot if this is allowed to go through.
+                throw new RuntimeException("In specified mapping, there is no type by the name " +
+                        mapping.getOrDefault("type", "STRING").toString());
+            }
         }
 
         public Object convert(String value) {

--- a/src/main/java/apoc/log/Neo4jLogStream.java
+++ b/src/main/java/apoc/log/Neo4jLogStream.java
@@ -4,6 +4,7 @@ import apoc.util.FileUtils;
 import org.neo4j.procedure.*;
 import org.neo4j.logging.Log;
 
+import java.nio.file.NoSuchFileException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -13,6 +14,10 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.stream.Stream;
 
+/**
+ * @author moxious
+ * @since 27.02.19
+ */
 public class Neo4jLogStream {
     @Context
     public Log log;
@@ -73,7 +78,11 @@ public class Neo4jLogStream {
             }
 
             return entries;
-        } catch(IOException exc) {
+        } catch(NoSuchFileException nsf) {
+            // This special case we want to throw a custom message and not let this error propagate, because the
+            // trace exposes the full path we were checking.
+            throw new RuntimeException("No log file exists by that name");
+        } catch (IOException exc) {
             throw new RuntimeException(exc);
         }
     }

--- a/src/main/java/apoc/log/Neo4jLogStream.java
+++ b/src/main/java/apoc/log/Neo4jLogStream.java
@@ -1,6 +1,5 @@
 package apoc.log;
 
-import apoc.ApocConfiguration;
 import apoc.util.FileUtils;
 import org.neo4j.procedure.*;
 import org.neo4j.logging.Log;
@@ -51,9 +50,8 @@ public class Neo4jLogStream {
         File f = new File(logDir, logName);
 
         try {
-            // This is just here as an added safety check; this proc is limited to the logs directory but it would
-            // still be possible to get cute and create symlinks from the logs directory elsewhere.
-            if (!FileUtils.canonicalPathInNeo4jHome(f)) {
+            String canonicalPath = f.getCanonicalPath();
+            if (!canonicalPath.contains(logDir.getAbsolutePath())) {
                 throw new RuntimeException("The path you are trying to access has a canonical path outside of the logs " +
                         "directory, and this procedure is only permitted to access files in the log directory.  This may " +
                         "occur if the path in question is a symlink or other link.");

--- a/src/main/java/apoc/log/Neo4jLogStream.java
+++ b/src/main/java/apoc/log/Neo4jLogStream.java
@@ -56,7 +56,7 @@ public class Neo4jLogStream {
 
         try {
             String canonicalPath = f.getCanonicalPath();
-            if (!canonicalPath.contains(logDir.getAbsolutePath())) {
+            if (!canonicalPath.startsWith(logDir.getAbsolutePath())) {
                 throw new RuntimeException("The path you are trying to access has a canonical path outside of the logs " +
                         "directory, and this procedure is only permitted to access files in the log directory.  This may " +
                         "occur if the path in question is a symlink or other link.");

--- a/src/main/java/apoc/meta/Meta.java
+++ b/src/main/java/apoc/meta/Meta.java
@@ -101,6 +101,9 @@ public class Meta {
         }
 
         public static Types from(String typeName) {
+            if (typeName == null) {
+                return STRING;
+            }
             typeName = typeName.toUpperCase();
             for (Types type : values()) {
                 if (type.name().startsWith(typeName)) return type;

--- a/src/main/java/apoc/metrics/Metrics.java
+++ b/src/main/java/apoc/metrics/Metrics.java
@@ -9,92 +9,14 @@ import org.neo4j.procedure.*;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 public class Metrics {
     @Context
     public Log log;
-
-    /**
-     * DAO for a single line in a metrics/*.csv file.
-     * Value is abstracted to double; in reality some are int, some are float, some are double.
-     */
-    public static class Neo4jMetricEntry {
-        public final long timestamp;
-        public final double value;
-        public final String metric;
-
-        public Neo4jMetricEntry(long t, double value, String metric) {
-            this.timestamp = t;
-            this.value = value;
-            this.metric = metric;
-        }
-    }
-
-    /**
-     * Metrics named neo4j.causal_clustering.core.message_processing_timer.*
-     * have a different schema:
-     * t,count,max,mean,min,stddev,p50,p75,p95,p98,p99,p999,mean_rate,m1_rate,m5_rate,m15_rate,rate_unit,duration_unit
-     */
-    public static class CausalClusterTimerMetric {
-        public final long timestamp;
-        public final long count;
-        public final double max;
-        public final double mean;
-        public final double min;
-        public final double stddev;
-        public final double p50;
-        public final double p75;
-        public final double p95;
-        public final double p98;
-        public final double p99;
-        public final double p999;
-        public final double mean_rate;
-        public final double m1_rate;
-        public final double m5_rate;
-        public final double m15_rate;
-        public final String rate_unit;
-        public final String duration_unit;
-
-        public CausalClusterTimerMetric(
-            long t, long count, double max, double mean,
-            double min, double stddev, double p50, double p75, double p95,
-            double p98, double p99, double p999, double mean_rate, double m1_rate,
-            double m5_rate, double m15_rate, String rate_unit, String duration_unit
-        ) {
-            this.timestamp = t;
-            this.count = count;
-            this.max = max;
-            this.mean = mean;
-            this.min = min;
-            this.stddev = stddev;
-            this.p50 = p50;
-            this.p75 = p75;
-            this.p95 = p95;
-            this.p98 = p98;
-            this.p99 = p99;
-            this.p999 = p999;
-            this.mean_rate = mean_rate;
-            this.m1_rate = m1_rate;
-            this.m5_rate = m5_rate;
-            this.m15_rate = m15_rate;
-            this.rate_unit = rate_unit;
-            this.duration_unit = duration_unit;
-        }
-    }
-
-
-    public static class Neo4jMetric {
-        public final String name;
-        public final long lastUpdated;
-
-        public Neo4jMetric(String name, long lastUpdated) {
-            this.name = name;
-            this.lastUpdated = lastUpdated;
-        }
-    }
 
     /** Simple DAO that pairs a config setting name with a File path that it refers to */
     public static class StoragePair {
@@ -147,9 +69,35 @@ public class Metrics {
         }
     }
 
+    /**
+     * DAO for a single line in a metrics/*.csv file.
+     * Value is abstracted to double; in reality some are int, some are float, some are double.
+     */
+    public static class GenericMetric {
+        public final long timestamp;
+        public final String metric;
+        public final Map<String,Object> map;
+
+        public GenericMetric(String metric, long t, Map<String,Object> map) {
+            this.timestamp = t;
+            this.metric = metric;
+            this.map = map;
+        }
+    }
+
+    public static class Neo4jMeasuredMetric {
+        public final String name;
+        public final long lastUpdated;
+
+        public Neo4jMeasuredMetric(String name, long lastUpdated) {
+            this.name = name;
+            this.lastUpdated = lastUpdated;
+        }
+    }
+
     @Procedure(mode=Mode.DBMS)
     @Description("apoc.metrics.list() - get a list of available metrics")
-    public Stream<Neo4jMetric> list() {
+    public Stream<Neo4jMeasuredMetric> list() {
         File metricsDir = FileUtils.getMetricsDirectory();
 
         final FilenameFilter filter = (dir, name) -> name.toLowerCase().endsWith(".csv");
@@ -159,14 +107,14 @@ public class Metrics {
                     String name = metricFile.getName();
                     String metricName = name.substring(0, name.length() - 4);
                     File f = new File(metricsDir, name);
-                    return new Neo4jMetric(metricName, f.lastModified());
+                    return new Neo4jMeasuredMetric(metricName, f.lastModified());
                 });
     }
 
-    public Stream<LoadCsv.CSVResult> loadCsvForMetric(String metricName, Map<String,Object> config) {
+    public Stream<GenericMetric> loadCsvForMetric(String metricName, Map<String,Object> config) {
         // These config parameters are generally true of Neo4j metrics.
-        config.putIfAbsent("sep", ",");
-        config.putIfAbsent("header", true);
+        config.put("sep", ",");
+        config.put("header", true);
 
         File metricsDir = FileUtils.getMetricsDirectory();
 
@@ -176,8 +124,40 @@ public class Metrics {
                     "https://neo4j.com/docs/operations-manual/current/monitoring/metrics/expose/#metrics-csv");
         }
 
+
+        /**
+         * Neo4j CSV metrics have an issue where sometimes in the middle of the CSV file you'll find an extra
+         * header row.  We want to discard those.
+         */
+        Predicate duplicatedHeaderRows = new Predicate <LoadCsv.CSVResult> () {
+            public boolean test(LoadCsv.CSVResult o) {
+                Map<String,Object> map = o.map;
+
+                // Most commonly CSV has a timestamp "t" field, if its value = "t"
+                // Then it's a repeated header.  This is just a shortcut for the most common
+                // case to avoid checking entire map every time.
+                if (map.containsKey("t") && "t".equals(map.get("t").toString())) {
+                    return false;
+                } else {
+                    Set<String> keys = map.keySet();
+                    for (String key : keys) {
+                        Object val = map.get(key);
+                        // If any key (the column header) **does not** match the value in the map,
+                        // then it's actual data and not a header row.
+                        if (val == null || !key.equals(val.toString())) {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
+        };
+
         String url = new File(metricsDir, metricName + ".csv").toURI().toString();
-        return new LoadCsv().csv(url, config);
+        return new LoadCsv().csv(url, config)
+                .filter(csvResult -> duplicatedHeaderRows.test(csvResult))
+                .map(csvResult -> new GenericMetric(metricName, longFrom(csvResult, "t"), csvResult.map));
     }
 
     @Procedure(mode=Mode.DBMS)
@@ -190,15 +170,15 @@ public class Metrics {
         // Permit case-insensitive checks.
         String input = directorySetting == null ? null : directorySetting.toLowerCase();
 
-        boolean validSetting = input == null || NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES.contains(input);
+        boolean validSetting = input == null || FileUtils.NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES.contains(input);
 
         if (!validSetting) {
-            String validOptions = String.join(", ", NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES);
+            String validOptions = String.join(", ", FileUtils.NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES);
             throw new RuntimeException("Invalid directory setting specified.  Valid options are one of: " +
                     validOptions);
         }
 
-        return NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES.stream()
+        return FileUtils.NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES.stream()
                 // If user specified a particular one, immediately cut list to just that one.
                 .filter(dirSetting -> (input == null || input.equals(dirSetting)))
                 .map(StoragePair::fromDirectorySetting)
@@ -225,93 +205,15 @@ public class Metrics {
      * outside they have no way of knowing the home path where they're located, and apoc.load.csv doesn't allow
      * relative paths.
      */
-    public Stream<Neo4jMetricEntry> get(
+    public Stream<GenericMetric> get(
             @Name("metricName") String metricName,
             @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
-
-        if (metricName != null && metricName.contains("neo4j.causal_clustering.core.message_processing_timer")) {
-            throw new RuntimeException("This procedure does not support causal clustering message processing timer metrics. " +
-                    "Please use apoc.metrics.getClusterTimerMetric");
-        }
-
-        return loadCsvForMetric(metricName, config).map(entry -> {
-            try {
-                long t = longFrom(entry, "t");
-                double v = doubleFrom(entry, "value");
-                return new Neo4jMetricEntry(t, v, metricName);
-            } catch (NumberFormatException exc) {
-                return null;
-            }
-        }).filter(p -> p != null);
-    }
-
-    @Procedure(mode=Mode.DBMS)
-    @Description("apoc.metrics.getClusterTimerMetric(metricName, {}) - retrieve a system metric by its metric name. " +
-            "This procedure is only intended for neo4j.causal_clustering.core.message_processing_timer.* metrics. " +
-            "Additional configuration options may be passed matching the options available for apoc.load.csv.")
-    public Stream<CausalClusterTimerMetric> getClusterTimerMetric(
-            @Name("metricName") String metricName,
-            @Name(value = "config", defaultValue="{}") Map<String,Object> config) {
-        if (metricName == null || !metricName.startsWith("neo4j.causal_clustering.core.message_processing_timer")) {
-            throw new RuntimeException("This procedure supports only neo4j.causal_clustering.core.message_processing_timer.* metrics" +
-                    " - for all other metrics please use apoc.metrics.get");
-        }
-
-        return loadCsvForMetric(metricName, config).map(entry -> {
-            try {
-                long timestamp = longFrom(entry, "t");
-                long count = longFrom(entry, "count");
-                double max = doubleFrom(entry, "max");
-                double mean = doubleFrom(entry, "mean");
-                double min = doubleFrom(entry, "min");
-                double stddev = doubleFrom(entry, "stddev");
-                double p50 = doubleFrom(entry, "p50");
-                double p75 = doubleFrom(entry, "p75");
-                double p95 = doubleFrom(entry, "p95");
-                double p98 = doubleFrom(entry, "p98");
-                double p99 = doubleFrom(entry, "p99");
-                double p999 = doubleFrom(entry, "p999");
-                double mean_rate = doubleFrom(entry, "mean_rate");
-                double m1_rate = doubleFrom(entry, "m1_rate");
-                double m5_rate = doubleFrom(entry, "m5_rate");
-                double m15_rate = doubleFrom(entry, "m15_rate");
-                String rate_unit = entry.map.get("rate_unit").toString();
-                String duration_unit = entry.map.get("duration_unit").toString();
-
-                return new CausalClusterTimerMetric(timestamp, count,
-                        max, mean, min, stddev, p50, p75, p95, p98, p99, p999, mean_rate,
-                        m1_rate, m5_rate, m15_rate, rate_unit, duration_unit);
-            } catch (NumberFormatException exc) {
-                return null;
-            }
-        }).filter(p -> p != null);
-    }
-
-    private final double doubleFrom(LoadCsv.CSVResult r, String column) {
-        return Double.valueOf(r.map.get(column).toString());
+        return loadCsvForMetric(metricName, config);
     }
 
     private final long longFrom(LoadCsv.CSVResult r, String column) {
-        return Long.parseLong(r.map.get(column).toString());
+        Object o = r.map.get(column);
+        if (o == null) return 0L;
+        return Long.parseLong(o.toString());
     }
-
-
-    // This is the list of dbms.directories.* valid configuration items for neo4j.
-    // https://neo4j.com/docs/operations-manual/current/reference/configuration-settings/
-    // Usually these reside under the same root but because they're separately configurable, in the worst case
-    // every one is on a different device.
-    //
-    // More likely, they'll be largely similar metrics.
-    public static final List<String> NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES = Arrays.asList(
-            "dbms.directories.certificates",
-            "dbms.directories.data",
-            "dbms.directories.import",
-            "dbms.directories.lib",
-            "dbms.directories.logs",
-            "dbms.directories.metrics",
-            "dbms.directories.plugins",
-            "dbms.directories.run",
-            "dbms.directories.tx_log",
-            "unsupported.dbms.directories.neo4j_home"
-    );
 }


### PR DESCRIPTION
- Changes metrics to return a timestamp and map of values instead of breaking those values out.  This accomodates a range of different schemas in different metric files across Neo4j versions.  In particular, there were a lot of metric schema changes between 3.4 and 3.5 which makes supporting the individual file format of particular metrics not a terribly feasible option

