### PR TITLE
fix #1055 adding includeFailedBatches for apoc.periodic.iterate

### DIFF
--- a/docs/asciidoc/periodic.adoc
+++ b/docs/asciidoc/periodic.adoc
@@ -79,6 +79,7 @@ The results of the outer statement are passed into the inner statement as parame
 | iterateList | false | the inner statement is only executed once but the whole batchSize list is passed in as parameter {_batch}
 | params | {} | externally passed in map of params
 | concurrency | 50 | How many concurrent tasks are generate when using `parallel:true`
+| failedParams | -1 | If set to a non-negative value, for each failed batch up to `failedParams` parameter sets are returned in in `yield failedParams`.
 |===
 
 NOTE: We plan to make `iterateList:true` the default in upcoming releases, due to the automatic UNWINDing and providing of nested results as variables,

--- a/src/main/java/apoc/periodic/Periodic.java
+++ b/src/main/java/apoc/periodic/Periodic.java
@@ -349,7 +349,7 @@ public class Periodic {
                     } catch (Exception e) {
                         failedOps.addAndGet(batchsize);
                         if (failedParams >= 0) {
-                            failedParamsMap.put(Long.toString(finalBatches), batch.subList(0, Math.min(failedParams+1, batch.size())));
+                            failedParamsMap.put(Long.toString(finalBatches), new ArrayList<Map<String,Object>>>(batch.subList(0, Math.min(failedParams+1, batch.size()))));
                         }
                         recordError(operationErrors, e);
                     }
@@ -369,7 +369,7 @@ public class Periodic {
                             } catch (Exception e) {
                                 failedOps.incrementAndGet();
                                 if (failedParams >= 0) {
-                                    failedParamsMap.put(Long.toString(finalBatches), batch.subList(0, Math.min(failedParams+1, batch.size())));
+                                    failedParamsMap.put(Long.toString(finalBatches), new ArrayList<Map<String,Object>>>(batch.subList(0, Math.min(failedParams+1, batch.size()))));
                                 }
                                 recordError(operationErrors, e);
                             }

--- a/src/main/java/apoc/periodic/Periodic.java
+++ b/src/main/java/apoc/periodic/Periodic.java
@@ -349,7 +349,7 @@ public class Periodic {
                     } catch (Exception e) {
                         failedOps.addAndGet(batchsize);
                         if (failedParams >= 0) {
-                            failedParamsMap.put(Long.toString(finalBatches), new ArrayList<Map<String,Object>>>(batch.subList(0, Math.min(failedParams+1, batch.size()))));
+                            failedParamsMap.put(Long.toString(finalBatches), new ArrayList<Map<String,Object>>(batch.subList(0, Math.min(failedParams+1, batch.size()))));
                         }
                         recordError(operationErrors, e);
                     }
@@ -369,7 +369,7 @@ public class Periodic {
                             } catch (Exception e) {
                                 failedOps.incrementAndGet();
                                 if (failedParams >= 0) {
-                                    failedParamsMap.put(Long.toString(finalBatches), new ArrayList<Map<String,Object>>>(batch.subList(0, Math.min(failedParams+1, batch.size()))));
+                                    failedParamsMap.put(Long.toString(finalBatches), new ArrayList<Map<String,Object>>(batch.subList(0, Math.min(failedParams+1, batch.size()))));
                                 }
                                 recordError(operationErrors, e);
                             }

--- a/src/main/java/apoc/periodic/Periodic.java
+++ b/src/main/java/apoc/periodic/Periodic.java
@@ -2,7 +2,6 @@ package apoc.periodic;
 
 import apoc.Pools;
 import apoc.util.Util;
-import org.apache.commons.lang.StringUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Result;
 import org.neo4j.helpers.collection.Iterators;
@@ -241,7 +240,7 @@ public class Periodic {
             log.info("starting batched operation using iteration `%s` in separate thread", cypherIterate);
             try (Result result = db.execute(cypherIterate)) {
                 Stream<BatchAndTotalResult> oneResult =
-                    iterateAndExecuteBatchedInSeparateThread((int) batchSize, false, false,0, result, params -> db.execute(cypherAction, params), 50);
+                    iterateAndExecuteBatchedInSeparateThread((int) batchSize, false, false,0, result, params -> db.execute(cypherAction, params), 50, -1);
                 final Object loopParam = value;
                 allResults = Stream.concat(allResults, oneResult.map(r -> r.inLoop(loopParam)));
             }
@@ -266,12 +265,13 @@ public class Periodic {
         boolean iterateList = Util.toBoolean(config.getOrDefault("iterateList", true));
         long retries = Util.toLong(config.getOrDefault("retries", 0)); // todo sleep/delay or push to end of batch to try again or immediate ?
         Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());
+        int failedParams = Util.toInteger(config.getOrDefault("failedParams", -1));
         try (Result result = db.execute(cypherIterate,params)) {
             Pair<String,Boolean> prepared = prepareInnerStatement(cypherAction, iterateList, result.columns(), "_batch");
             String innerStatement = prepared.first();
             iterateList=prepared.other();
             log.info("starting batching from `%s` operation using iteration `%s` in separate thread", cypherIterate,cypherAction);
-            return iterateAndExecuteBatchedInSeparateThread((int)batchSize, parallel, iterateList, retries, result, (p) -> db.execute(innerStatement, merge(params, p)).close(), concurrency);
+            return iterateAndExecuteBatchedInSeparateThread((int)batchSize, parallel, iterateList, retries, result, (p) -> db.execute(innerStatement, merge(params, p)).close(), concurrency, failedParams);
         }
     }
 
@@ -314,12 +314,12 @@ public class Periodic {
 
         log.info("starting batched operation using iteration `%s` in separate thread", cypherIterate);
         try (Result result = db.execute(cypherIterate)) {
-            return iterateAndExecuteBatchedInSeparateThread((int)batchSize, false, false, 0, result, p -> db.execute(cypherAction, p).close(), 50);
+            return iterateAndExecuteBatchedInSeparateThread((int)batchSize, false, false, 0, result, p -> db.execute(cypherAction, p).close(), 50, -1);
         }
     }
 
     private Stream<BatchAndTotalResult> iterateAndExecuteBatchedInSeparateThread(int batchsize, boolean parallel, boolean iterateList, long retries,
-                                                                                 Iterator<Map<String, Object>> iterator, Consumer<Map<String, Object>> consumer, int concurrency) {
+                                                                                 Iterator<Map<String, Object>> iterator, Consumer<Map<String, Object>> consumer, int concurrency, int failedParams) {
         ExecutorService pool = parallel ? Pools.DEFAULT : Pools.SINGLE;
         List<Future<Long>> futures = new ArrayList<>(concurrency);
         long batches = 0;
@@ -330,6 +330,7 @@ public class Periodic {
         Map<String,Long> operationErrors = new ConcurrentHashMap<>();
         AtomicInteger failedBatches = new AtomicInteger();
         Map<String,Long> batchErrors = new HashMap<>();
+        Map<String, List<Map<String,Object>>> failedParamsMap = new ConcurrentHashMap<>();
         long successes = 0;
         do {
             if (Util.transactionIsTerminated(terminationGuard)) break;
@@ -338,6 +339,7 @@ public class Periodic {
             long currentBatchSize = batch.size();
             Callable<Long> task;
             if (iterateList) {
+                long finalBatches = batches;
                 task = () -> {
                     long c = count.addAndGet(currentBatchSize);
                     if (Util.transactionIsTerminated(terminationGuard)) return 0L;
@@ -346,11 +348,15 @@ public class Periodic {
                         retried.addAndGet(retry(consumer,params,0,retries));
                     } catch (Exception e) {
                         failedOps.addAndGet(batchsize);
+                        if (failedParams >= 0) {
+                            failedParamsMap.put(Long.toString(finalBatches), batch.subList(0, Math.min(failedParams+1, batch.size())));
+                        }
                         recordError(operationErrors, e);
                     }
                     return currentBatchSize;
                 };
             } else {
+                final long finalBatches = batches;
                 task = () -> {
                     if (Util.transactionIsTerminated(terminationGuard)) return 0L;
                     return batch.stream().map(
@@ -362,6 +368,9 @@ public class Periodic {
                                 retried.addAndGet(retry(consumer,params,0,retries));
                             } catch (Exception e) {
                                 failedOps.incrementAndGet();
+                                if (failedParams >= 0) {
+                                    failedParamsMap.put(Long.toString(finalBatches), batch.subList(0, Math.min(failedParams+1, batch.size())));
+                                }
                                 recordError(operationErrors, e);
                             }
                             return 1;
@@ -394,7 +403,7 @@ public class Periodic {
         Util.logErrors("Error during iterate.execute:", operationErrors, log);
         long timeTaken = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - start);
         BatchAndTotalResult result =
-                new BatchAndTotalResult(batches, count.get(), timeTaken, successes, failedOps.get(), failedBatches.get(), retried.get(), operationErrors, batchErrors, wasTerminated);
+                new BatchAndTotalResult(batches, count.get(), timeTaken, successes, failedOps.get(), failedBatches.get(), retried.get(), operationErrors, batchErrors, wasTerminated, failedParamsMap);
         return Stream.of(result);
     }
 
@@ -410,10 +419,11 @@ public class Periodic {
         public final Map<String,Object> batch;
         public final Map<String,Object> operations;
         public final boolean wasTerminated;
+        public final Map<String, List<Map<String,Object>>> failedParams;
 
         public BatchAndTotalResult(long batches, long total, long timeTaken, long committedOperations,
                                    long failedOperations, long failedBatches, long retries,
-                                   Map<String, Long> operationErrors, Map<String, Long> batchErrors, boolean wasTerminated) {
+                                   Map<String, Long> operationErrors, Map<String, Long> batchErrors, boolean wasTerminated, Map<String, List<Map<String, Object>>> failedParams) {
             this.batches = batches;
             this.total = total;
             this.timeTaken = timeTaken;
@@ -423,6 +433,7 @@ public class Periodic {
             this.retries = retries;
             this.errorMessages = operationErrors;
             this.wasTerminated = wasTerminated;
+            this.failedParams = failedParams;
             this.batch = Util.map("total",batches,"failed",failedBatches,"committed",batches-failedBatches,"errors",batchErrors);
             this.operations = Util.map("total",total,"failed",failedOperations,"committed", committedOperations,"errors",operationErrors);
         }

--- a/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/src/test/java/apoc/periodic/PeriodicTest.java
@@ -15,11 +15,17 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.sql.SQLException;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
 import static apoc.util.Util.map;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.StreamSupport.stream;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.*;
 import static org.neo4j.graphdb.DependencyResolver.SelectionStrategy.FIRST;
@@ -100,7 +106,6 @@ System.out.println("call list" + db.execute(callList).resultAsString());
 
         // when&then
 
-        // TODO: remove forcing rule based in the 2nd kernelTransaction next line when 3.0.2 is released, due to https://github.com/neo4j/neo4j/pull/7152
         testResult(db, "CALL apoc.periodic.rock_n_roll('match (p:Person) return p', 'WITH {p} as p SET p.lastname =p.name REMOVE p.name', 10)", result -> {
             Map<String, Object> row = Iterators.single(result);
             assertEquals(10L, row.get("batches"));
@@ -288,6 +293,23 @@ System.out.println("call list" + db.execute(callList).resultAsString());
     }
 
     @Test
+    public void testIterateWithReportingFailed() throws Exception {
+        testResult(db, "CALL apoc.periodic.iterate('UNWIND range(-5, 5) AS x RETURN x', 'return sum(1000/x)', {batchSize:3, failedParams:9999})", result -> {
+            Map<String, Object> row = Iterators.single(result);
+            assertEquals(4L, row.get("batches"));
+            assertEquals(1L, row.get("failedBatches"));
+            assertEquals(11L, row.get("total"));
+            Map<String, List<Map<String, Object>>> failedParams = (Map<String, List<Map<String, Object>>>) row.get("failedParams");
+            assertEquals(1, failedParams.size());
+            List<Map<String, Object>> failedParamsForBatch = failedParams.get("1");
+            assertEquals( 3, failedParamsForBatch.size());
+
+            List<Object> values = stream(failedParamsForBatch.spliterator(),false).map(map -> map.get("x")).collect(toList());
+            assertEquals(values, Stream.of(-2l, -1l, 0l).collect(toList()));
+        });
+    }
+
+    @Test
     public void testIterateRetries() throws Exception {
         testResult(db, "CALL apoc.periodic.iterate('return 1', 'CREATE (n {prop: 1/{_retry}})', {retries:1})", result -> {
             Map<String, Object> row = Iterators.single(result);
@@ -306,6 +328,8 @@ System.out.println("call list" + db.execute(callList).resultAsString());
             assertEquals(100L, row.get("total"));
             assertEquals(100L, row.get("failedOperations"));
             assertEquals(0L, row.get("committedOperations"));
+            List<Map<String,Object>> failedParams = (List<Map<String, Object>>) row.get("failedParams");
+            assertTrue(failedParams.isEmpty());
         });
 
         testCall(db,


### PR DESCRIPTION
adding a new optional parameter to apoc.periodic.iterate.

If `includeFailedBatches:true` is set, the data of all failed batches is included in the result being passed back to the caller. 

Since it defaults to false I don't expect any compatibility issues.