### PR TITLE
Move deprecation warning to correct headline

### DIFF
--- a/docs/asciidoc/_indexes.adoc
+++ b/docs/asciidoc/_indexes.adoc
@@ -1,9 +1,5 @@
 [[indexes]]
-== Deprecated: Text and Lookup Indexes
-
-[WARNING]
-These Index procedures are deprecated and will be removed from APOC soon.
-From version 3.5 Neo4j provides built-in, case-insensitive, configurable fulltext indices.
+== Text and Lookup Indexes
 
 [[schema-index-operations]]
 === Schema Index Procedures
@@ -21,6 +17,10 @@ include::schema-index.adoc[leveloffset=4]
 
 [[manual-indexes]]
 === Manual Indexes
+
+[WARNING]
+These Index procedures in the namespaces `apoc.index.*` are deprecated and will be removed from APOC soon.
+From version 3.5 Neo4j provides built-in, case-insensitive, configurable fulltext indices.
 
 ==== Index Queries
 

--- a/docs/asciidoc/_indexes.adoc
+++ b/docs/asciidoc/_indexes.adoc
@@ -16,7 +16,7 @@
 include::schema-index.adoc[leveloffset=4]
 
 [[manual-indexes]]
-=== Manual Indexes
+=== Deprecated: Manual Indexes
 
 [WARNING]
 These Index procedures in the namespaces `apoc.index.*` are deprecated and will be removed from APOC soon.


### PR DESCRIPTION
Fixes #1137 

Moves deprecation warning to correct headline to clarify, which namespace specifically will be deprecated and removed in the future.

## Proposed Changes (Mandatory)

properly scope and move the deprecation warning.