### PR TITLE
fixes #1140: Prevent unsafe redirect

### DIFF
--- a/src/test/java/apoc/load/LoadCsvTest.java
+++ b/src/test/java/apoc/load/LoadCsvTest.java
@@ -3,11 +3,14 @@ package apoc.load;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.test.TestGraphDatabaseFactory;
+import org.testcontainers.containers.GenericContainer;
 
 import java.net.URL;
 import java.util.ArrayList;
@@ -18,12 +21,13 @@ import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.getUrlFileName;
 import static apoc.util.TestUtil.testResult;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 
 public class LoadCsvTest {
 
     private GraphDatabaseService db;
+
+    private GenericContainer httpServer;
 
     @Before public void setUp() throws Exception {
         db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder().setConfig("apoc.import.file.enabled","true").newGraphDatabase();
@@ -306,5 +310,24 @@ RETURN m.col_1,m.col_2,m.col_3
                     assertRow(r,2L,"name","Selina","age","18");
                     assertEquals(false, r.hasNext());
                 });
+    }
+
+    @Test(expected = QueryExecutionException.class)
+    public void testLoadRedirectWithProtocolChange() {
+        TestUtil.ignoreException(() -> {
+            httpServer = new GenericContainer("alpine")
+                    .withCommand("/bin/sh", "-c", "while true; do { echo -e 'HTTP/1.1 301 Moved Permanently\\r\\nLocation: file:/etc/passwd'; echo ; } | nc -l -p 8000; done")
+                    .withExposedPorts(8000);
+            httpServer.start();
+        }, Exception.class);
+        Assume.assumeNotNull(httpServer);
+        try {
+            testResult(db, "CALL apoc.load.csv({url})", map("url", "http://localhost:" + httpServer.getMappedPort(8000)),
+                    (r) -> {});
+        } catch (QueryExecutionException e) {
+            assertTrue(e.getMessage().contains("The redirect URI has a different protocol: file:/etc/passwd"));
+            throw e;
+        }
+        httpServer.stop();
     }
 }

--- a/src/test/java/apoc/util/UtilIT.java
+++ b/src/test/java/apoc/util/UtilIT.java
@@ -1,0 +1,75 @@
+package apoc.util;
+
+import org.apache.commons.io.IOUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.*;
+import org.junit.rules.TestName;
+import org.testcontainers.containers.GenericContainer;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class UtilIT {
+
+    @Rule
+    public TestName testName = new TestName();
+
+    private GenericContainer httpServer;
+
+    private static final String WITH_URL_LOCATION = "WithUrlLocation";
+    private static final String WITH_FILE_LOCATION = "WithFileLocation";
+
+    @Before
+    public void setUp() throws Exception {
+        TestUtil.ignoreException(() -> {
+            httpServer = new GenericContainer("alpine")
+                    .withCommand("/bin/sh", "-c", String.format("while true; do { echo -e 'HTTP/1.1 301 Moved Permanently\\r\\nLocation: %s'; echo ; } | nc -l -p 8000; done",
+                            testName.getMethodName().endsWith(WITH_URL_LOCATION) ? "http://www.google.com" : "file:/etc/passwd"))
+                    .withExposedPorts(8000);
+            httpServer.start();
+        }, Exception.class);
+        Assume.assumeNotNull(httpServer);
+    }
+
+    @After
+    public void tearDown() {
+        if (httpServer != null) {
+            httpServer.stop();
+        }
+    }
+
+    @Test
+    public void redirectShouldWorkWhenProtocolNotChangesWithUrlLocation() throws IOException {
+        // given
+        String url = getServerUrl();
+
+        // when
+        String page = IOUtils.toString(Util.openInputStream(url, null, null), Charset.forName("UTF-8"));
+
+        // then
+        assertTrue(page.contains("<title>Google</title>"));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void redirectShouldThrowExceptionWhenProtocolChangesWithFileLocation() throws IOException {
+        try {
+            // given
+            String url = getServerUrl();
+
+            // when
+            Util.openInputStream(url, null, null);
+        } catch (RuntimeException e) {
+            // then
+            assertEquals("The redirect URI has a different protocol: file:/etc/passwd", e.getMessage());
+            throw e;
+        }
+    }
+
+    @NotNull
+    private String getServerUrl() {
+        return "http://localhost:" + httpServer.getMappedPort(8000);
+    }
+}


### PR DESCRIPTION
Fixes #1140 

In case of the HTTP response code is 3XX and the `Location` header provides a different protocol we throw an Exception with the value of the `Location` in the message

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - changed the `Util#isRedirect` method in order to implement that logic
  - provided a simple test for `CALL apoc.load.csv({url})` in order to highlight the new behaviour
  - added the `UtilIT` class that tests the method `Util#openInputStream` for two call, one that has as redirect location `http://www.google.com` and the other one has `file:/etc/passwd`
