### PR TITLE
fixes #1121: eo.ClientError.Procedure.ProcedureCallFailed: Failed to invoke procedure `apoc.periodic.iterate`: Caused by: java.lang.ArrayIndexOutOfBoundsException: 131

### DIFF
--- a/docs/asciidoc/loadcsv.adoc
+++ b/docs/asciidoc/loadcsv.adoc
@@ -72,6 +72,7 @@ Besides the file you can pass in a config map:
 | limit | none | limit result rows
 | header | true | indicates if file has a header
 | sep | ',' | separator character or 'TAB'
+| quoteChar | '"' | the char to use for quoted elements
 | arraySep | ';' | array separator
 | ignore | [] | which columns to ignore
 | nullValues | [] | which values to treat as null, e.g. `['na',false]`

--- a/src/main/java/apoc/export/csv/CsvEntityLoader.java
+++ b/src/main/java/apoc/export/csv/CsvEntityLoader.java
@@ -4,6 +4,7 @@ import apoc.export.util.BatchTransaction;
 import apoc.export.util.CountingReader;
 import apoc.export.util.ProgressReporter;
 import apoc.load.LoadCsv;
+import apoc.load.util.LoadCsvConfig;
 import apoc.util.FileUtils;
 import com.opencsv.CSVReader;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -88,7 +89,7 @@ public class CsvEntityLoader {
             for (String[] line : csv.readAll()) {
                 lineNo++;
 
-                final EnumSet<LoadCsv.Results> results = EnumSet.of(LoadCsv.Results.map);
+                final EnumSet<LoadCsvConfig.Results> results = EnumSet.of(LoadCsvConfig.Results.map);
                 final LoadCsv.CSVResult result = new LoadCsv.CSVResult(
                         loadCsvCompatibleHeader, line, lineNo, false, mapping, Collections.emptyList(), results
                 );
@@ -201,7 +202,7 @@ public class CsvEntityLoader {
             for (String[] line : csv.readAll()) {
                 lineNo++;
 
-                final EnumSet<LoadCsv.Results> results = EnumSet.of(LoadCsv.Results.map);
+                final EnumSet<LoadCsvConfig.Results> results = EnumSet.of(LoadCsvConfig.Results.map);
                 final LoadCsv.CSVResult result = new LoadCsv.CSVResult(
                         loadCsvCompatibleHeader, line, lineNo, false, mapping, Collections.emptyList(), results
                 );

--- a/src/main/java/apoc/load/LoadCsv.java
+++ b/src/main/java/apoc/load/LoadCsv.java
@@ -1,10 +1,13 @@
 package apoc.load;
 
 import apoc.export.util.CountingReader;
+import apoc.load.util.LoadCsvConfig;
 import apoc.meta.Meta;
 import apoc.util.FileUtils;
 import apoc.util.Util;
+import com.opencsv.CSVParserBuilder;
 import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
@@ -12,17 +15,7 @@ import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Spliterator;
-import java.util.Spliterators;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -30,65 +23,44 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static apoc.util.Util.cleanUrl;
+import static apoc.util.Util.parseCharFromConfig;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static apoc.load.util.LoadCsvConfig.*;
 
 public class LoadCsv {
 
-    public static final char DEFAULT_ARRAY_SEP = ';';
-    public static final char DEFAULT_SEP = ',';
+
     @Context
     public GraphDatabaseService db;
 
-    public enum Results {
-        map, list, strings, stringMap
-    }
-
     @Procedure
     @Description("apoc.load.csv('url',{config}) YIELD lineNo, list, map - load CSV fom URL as stream of values,\n config contains any of: {skip:1,limit:5,header:false,sep:'TAB',ignore:['tmp'],nullValues:['na'],arraySep:';',mapping:{years:{type:'int',arraySep:'-',array:false,name:'age',ignore:false}}")
-    public Stream<CSVResult> csv(@Name("url") String url, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
-        boolean failOnError = booleanValue(config, "failOnError", true);
+    public Stream<CSVResult> csv(@Name("url") String url, @Name(value = "config",defaultValue = "{}") Map<String, Object> configMap) {
+        LoadCsvConfig config = new LoadCsvConfig(configMap);
         try {
             CountingReader reader = FileUtils.readerFor(url);
 
-            char separator = separator(config, "sep", DEFAULT_SEP);
-            char arraySep = separator(config, "arraySep", DEFAULT_ARRAY_SEP);
-            long skip = longValue(config, "skip", 0L);
-            boolean hasHeader = booleanValue(config, "header", true);
-            long limit = longValue(config, "limit", Long.MAX_VALUE);
+            // new CSVReader(...) is deprecated, moved to the new builder
+            CSVReader csv = new CSVReaderBuilder(reader)
+                    .withCSVParser(new CSVParserBuilder()
+                            .withQuoteChar(config.getQuoteChar())
+                            .withSeparator(config.getSeparator())
+                            .build())
+                    .build();
 
-            EnumSet<Results> results = EnumSet.noneOf(Results.class);
-            for (String result : value(config, "results", asList("map","list"))) {
-                results.add(Results.valueOf(result));
-            }
-
-            List<String> ignore = value(config, "ignore", emptyList());
-            List<String> nullValues = value(config, "nullValues", emptyList());
-            Map<String, Map<String, Object>> mapping = value(config, "mapping", Collections.emptyMap());
-            Map<String, Mapping> mappings = createMapping(mapping, arraySep, ignore);
-
-            CSVReader csv = new CSVReader(reader, separator);
-            String[] header = getHeader(hasHeader, csv, ignore, mappings);
-            boolean checkIgnore = !ignore.isEmpty() || mappings.values().stream().anyMatch( m -> m.ignore);
-            return StreamSupport.stream(new CSVSpliterator(csv, header, url, skip, limit, checkIgnore,mappings, nullValues,results), false);
+            String[] header = getHeader(csv, config);
+            boolean checkIgnore = !config.getIgnore().isEmpty() || config.getMappings().values().stream().anyMatch( m -> m.ignore);
+            return StreamSupport.stream(new CSVSpliterator(csv, header, url, config.getSkip(), config.getLimit(),
+                    checkIgnore, config.getMappings(), config.getNullValues(), config.getResults()), false);
         } catch (IOException e) {
 
-            if(!failOnError)
+            if(!config.isFailOnError())
                 return Stream.of(new  CSVResult(new String[0], new String[0], 0, true, Collections.emptyMap(), emptyList(), EnumSet.noneOf(Results.class)));
             else
                 throw new RuntimeException("Can't read CSV from URL " + cleanUrl(url), e);
         }
-    }
-
-    private Map<String, Mapping> createMapping(Map<String, Map<String, Object>> mapping, char arraySep, List<String> ignore) {
-        if (mapping.isEmpty()) return Collections.emptyMap();
-        HashMap<String, Mapping> result = new HashMap<>(mapping.size());
-        for (Map.Entry<String, Map<String, Object>> entry : mapping.entrySet()) {
-            String name = entry.getKey();
-            result.put(name, new Mapping(name, entry.getValue(), arraySep, ignore.contains(name)));
-        }
-        return result;
     }
 
     public static class Mapping {
@@ -106,7 +78,7 @@ public class LoadCsv {
             this.array = (Boolean) mapping.getOrDefault("array", false);
             this.ignore = (Boolean) mapping.getOrDefault("ignore", ignore);
             this.nullValues = (Collection<String>) mapping.getOrDefault("nullValues", emptyList());
-            this.arraySep = separator(mapping.getOrDefault("arraySep", arraySep).toString(),DEFAULT_ARRAY_SEP);
+            this.arraySep = parseCharFromConfig(mapping, "arraySep", arraySep);
             this.type = Meta.Types.from(mapping.getOrDefault("type", "STRING").toString());
             this.arrayPattern = Pattern.compile(String.valueOf(this.arraySep), Pattern.LITERAL);
 
@@ -145,49 +117,20 @@ public class LoadCsv {
         }
     }
 
-    private String[] getHeader(boolean hasHeader, CSVReader csv, List<String> ignore, Map<String, Mapping> mapping) throws IOException {
-        if (!hasHeader) return null;
-        String[] header = csv.readNext();
-        if (ignore.isEmpty()) return header;
+    private String[] getHeader(CSVReader csv, LoadCsvConfig config) throws IOException {
+        if (!config.isHasHeader()) return null;
+        String[] headers = csv.readNext();
+        List<String> ignore = config.getIgnore();
+        if (ignore.isEmpty()) return headers;
 
-        for (int i = 0; i < header.length; i++) {
-            if (ignore.contains(header[i]) || mapping.getOrDefault(header[i], Mapping.EMPTY).ignore) {
-                header[i] = null;
+        Map<String, Mapping> mappings = config.getMappings();
+        for (int i = 0; i < headers.length; i++) {
+            String header = headers[i];
+            if (ignore.contains(header) || mappings.getOrDefault(header, Mapping.EMPTY).ignore) {
+                headers[i] = null;
             }
         }
-        return header;
-    }
-
-    private boolean booleanValue(Map<String, Object> config, String key, boolean defaultValue) {
-        if (config == null || !config.containsKey(key)) return defaultValue;
-        Object value = config.get(key);
-        if (value instanceof Boolean) return ((Boolean) value);
-        return Boolean.parseBoolean(value.toString());
-    }
-
-    private long longValue(Map<String, Object> config, String key, long defaultValue) {
-        if (config == null || !config.containsKey(key)) return defaultValue;
-        Object value = config.get(key);
-        if (value instanceof Number) return ((Number) value).longValue();
-        return Long.parseLong(value.toString());
-    }
-
-    private <T> T value(Map<String, Object> config, String key, T defaultValue) {
-        if (config == null || !config.containsKey(key)) return defaultValue;
-        return (T) config.get(key);
-    }
-
-    private char separator(Map<String, Object> config, String key, char defaultValue) {
-        if (config == null) return defaultValue;
-        Object value = config.get(key);
-        if (value == null) return defaultValue;
-        return separator(value.toString(), defaultValue);
-    }
-
-    private static char separator(String separator, char defaultSep) {
-        if (separator==null) return defaultSep;
-        if ("TAB".equalsIgnoreCase(separator)) return '\t';
-        return separator.charAt(0);
+        return headers;
     }
 
     public static class CSVResult {

--- a/src/main/java/apoc/load/util/LoadCsvConfig.java
+++ b/src/main/java/apoc/load/util/LoadCsvConfig.java
@@ -1,0 +1,118 @@
+package apoc.load.util;
+
+import apoc.load.LoadCsv;
+
+import java.util.*;
+
+import static apoc.util.Util.parseCharFromConfig;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+
+public class LoadCsvConfig {
+
+    public static final char DEFAULT_ARRAY_SEP = ';';
+    public static final char DEFAULT_SEP = ',';
+    public static final char DEFAULT_QUOTE_CHAR = '"';
+
+    private char separator;
+    private char arraySep;
+    private char quoteChar;
+    private long skip;
+    private boolean hasHeader;
+    private long limit;
+
+    private boolean failOnError;
+
+    private EnumSet<Results> results;
+
+    public enum Results {
+        map, list, strings, stringMap
+    }
+
+    private List<String> ignore;
+    private List<String> nullValues;
+    private Map<String, Map<String, Object>> mapping;
+    private Map<String, LoadCsv.Mapping> mappings;
+
+    public LoadCsvConfig(Map<String, Object> config) {
+        if (config == null) {
+            config = Collections.emptyMap();
+        }
+        separator = parseCharFromConfig(config, "sep", DEFAULT_SEP);
+        arraySep = parseCharFromConfig(config, "arraySep", DEFAULT_ARRAY_SEP);
+        quoteChar = parseCharFromConfig(config,"quoteChar", DEFAULT_QUOTE_CHAR);
+        skip = (long) config.getOrDefault("skip", 0L);
+        hasHeader = (boolean) config.getOrDefault("header", true);
+        limit = (long) config.getOrDefault("limit", Long.MAX_VALUE);
+        failOnError = (boolean) config.getOrDefault("failOnError", true);
+
+        results = EnumSet.noneOf(Results.class);
+        List<String> resultList = (List<String>) config.getOrDefault("results", asList("map","list"));
+        for (String result : resultList) {
+            results.add(Results.valueOf(result));
+        }
+
+        ignore = (List<String>) config.getOrDefault("ignore", emptyList());
+        nullValues = (List<String>) config.getOrDefault("nullValues", emptyList());
+        mapping = (Map<String, Map<String, Object>>) config.getOrDefault("mapping", Collections.emptyMap());
+        mappings = createMapping(mapping, arraySep, ignore);
+    }
+
+    private Map<String, LoadCsv.Mapping> createMapping(Map<String, Map<String, Object>> mapping, char arraySep, List<String> ignore) {
+        if (mapping.isEmpty()) return Collections.emptyMap();
+        HashMap<String, LoadCsv.Mapping> result = new HashMap<>(mapping.size());
+        for (Map.Entry<String, Map<String, Object>> entry : mapping.entrySet()) {
+            String name = entry.getKey();
+            result.put(name, new LoadCsv.Mapping(name, entry.getValue(), arraySep, ignore.contains(name)));
+        }
+        return result;
+    }
+
+    public char getSeparator() {
+        return separator;
+    }
+
+    public char getArraySep() {
+        return arraySep;
+    }
+
+    public long getSkip() {
+        return skip;
+    }
+
+    public boolean isHasHeader() {
+        return hasHeader;
+    }
+
+    public long getLimit() {
+        return limit;
+    }
+
+    public boolean isFailOnError() {
+        return failOnError;
+    }
+
+    public EnumSet<Results> getResults() {
+        return results;
+    }
+
+    public List<String> getIgnore() {
+        return ignore;
+    }
+
+    public List<String> getNullValues() {
+        return nullValues;
+    }
+
+    public Map<String, Map<String, Object>> getMapping() {
+        return mapping;
+    }
+
+    public Map<String, LoadCsv.Mapping> getMappings() {
+        return mappings;
+    }
+
+    public char getQuoteChar() {
+        return quoteChar;
+    }
+}

--- a/src/main/java/apoc/util/Util.java
+++ b/src/main/java/apoc/util/Util.java
@@ -726,4 +726,15 @@ public class Util {
     public static DateTimeFormatter getFormat(String format) {
         return getOrCreate(format);
     }
+
+    public static char parseCharFromConfig(Map<String, Object> config, String key, char defaultValue) {
+        String separator = (String) config.getOrDefault(key, "");
+        if (separator == null || separator.isEmpty()) {
+            return defaultValue;
+        }
+        if ("TAB".equals(separator)) {
+            return '\t';
+        }
+        return separator.charAt(0);
+    }
 }

--- a/src/test/java/apoc/load/LoadCsvTest.java
+++ b/src/test/java/apoc/load/LoadCsvTest.java
@@ -330,4 +330,11 @@ RETURN m.col_1,m.col_2,m.col_3
         }
         httpServer.stop();
     }
+
+    @Test public void testWithEmptyQuoteChar() throws Exception {
+        Assume.assumeFalse("skip this on travis it downloads 7.3 MB of data", TestUtil.isTravis());
+        URL url = new URL("https://www.fhwa.dot.gov/bridge/nbi/2010/delimited/AL10.txt");
+        testResult(db, "CALL apoc.load.csv({url}, {quoteChar: '\0'})", map("url",url.toString()),
+                (r) -> assertEquals(16018L, r.stream().count()));
+    }
 }


### PR DESCRIPTION
Fixes #1121

Added a configuration property that allows providing a custom quote char.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:
 - moved into the new `LoadCsvConfig` class all the configuration about the `LoadCsv`
 - added a new configuration parameter `quoteChar` which is `the char to use for quoted elements`
 - updated the documentation
 - added the test case `testWithEmptyQuoteChar` which is skipped on Travis as it downloads 7.3 MB of data