### PR TITLE
fixes #1142: switch import directory mode to honor neo4j import directory setting

### DIFF
--- a/docs/asciidoc/_export_import.adoc
+++ b/docs/asciidoc/_export_import.adoc
@@ -8,8 +8,9 @@ Supported protocols are `file`, `http`, `https`, `s3`, `hdfs` with redirect allo
 In case no protocol is passed, this procedure set will try to check whether the url is actually a file.
 
 [NOTE]
-If 'apoc.import.file.use_neo4j_config' is enabled, the procedures check whether file system access is allowed and possibly constrained to a specific directory by
+As `apoc.import.file.use_neo4j_config` is enabled, the procedures check whether file system access is allowed and possibly constrained to a specific directory by
 reading the two configuration parameters `dbms.security.allow_csv_import_from_file_urls` and `dbms.directories.import` respectively.
+If you want to remove these constraints please set `apoc.import.file.use_neo4j_config=false`
 
 [cols="1m,5"]
 |===

--- a/docs/asciidoc/config.adoc
+++ b/docs/asciidoc/config.adoc
@@ -3,20 +3,25 @@
 
 Set these config options in `$NEO4J_HOME/neo4j.conf`
 
-All boolean options default to **false**, i.e. they are disabled, unless mentioned otherwise.
+All boolean options have default value set to **false**. This means that they are *disabled*, unless mentioned otherwise.
 
 [cols="1m,5"]
 |===
 | apoc.trigger.enabled=false/true | Enable triggers
 | apoc.ttl.enabled=false/true | Enable time to live background task
-| apoc.ttl.schedule=5 | Set frequency in seconds to run ttl background task (default 60)
-| apoc.import.file.use_neo4j_config=true | Enable reading properties: `dbms.directories.import`,`dbms.security.allow_csv_import_from_file_urls`
-| apoc.import.file.enabled=true | Enable reading local files from disk
-| apoc.export.file.enabled=true | Enable writing local files to disk
+| apoc.ttl.schedule=5 (default `60`) | Set frequency in seconds to run ttl background task
+| apoc.import.file.use_neo4j_config=true/false (default `true`) | the procedures check whether file system access is
+allowed and possibly constrained to a specific directory by reading the two configuration parameters
+`dbms.security.allow_csv_import_from_file_urls` and `dbms.directories.import` respectively
+| apoc.import.file.enabled=false/true | Enable reading local files from disk
+| apoc.export.file.enabled=false/true | Enable writing local files to disk
 | apoc.jdbc.<key>.uri=jdbc-url-with-credentials | store jdbc-urls under a key to be used by apoc.load.jdbc
 | apoc.es.<key>.uri=es-url-with-credentials | store es-urls under a key to be used by elasticsearch procedures
 | apoc.mongodb.<key>.uri=mongodb-url-with-credentials | store mongodb-urls under a key to be used by mongodb procedures
-| apoc.couchbase.<key>.uri=couchbase-url-with-credentials | store couchbase-urls under a key to be used by couchbase procedures
-| apoc.jobs.scheduled.num_threads=number-of-threads | Many periodic procedures rely on a scheduled executor that has a pool of threads with a default fixed size. You can configure the pool size using this configuration property
-| apoc.jobs.pool.num_threads=number-of-threads | Number of threads in the default APOC thread pool used for background executions.
+| apoc.couchbase.<key>.uri=couchbase-url-with-credentials | store couchbase-urls under a key to be used by couchbase
+procedures
+| apoc.jobs.scheduled.num_threads=number-of-threads | Many periodic procedures rely on a scheduled executor that has
+a pool of threads with a default fixed size. You can configure the pool size using this configuration property
+| apoc.jobs.pool.num_threads=number-of-threads | Number of threads in the default APOC thread pool used for background
+executions.
 |===

--- a/src/main/java/apoc/ApocConfiguration.java
+++ b/src/main/java/apoc/ApocConfiguration.java
@@ -1,7 +1,6 @@
 package apoc;
 
 import apoc.cache.Static;
-import apoc.metrics.Metrics;
 import apoc.util.FileUtils;
 import apoc.util.Util;
 import org.neo4j.kernel.configuration.Config;
@@ -24,6 +23,8 @@ public class ApocConfiguration {
     private static Map<String, Object> config = new HashMap<>(32);
     private static final Map<String, String> PARAM_WHITELIST = new HashMap<>(2);
 
+    private static final Map<String, Object> DEFAULTS = Util.map("import.file.use_neo4j_config", true);
+
     static {
         PARAM_WHITELIST.put("dbms.security.allow_csv_import_from_file_urls", "import.file.allow_read_from_filesystem");
 
@@ -39,6 +40,7 @@ public class ApocConfiguration {
         Map<String, String> params = neo4jConfig.getRaw();
         apocConfig.clear();
         apocConfig.putAll(Util.subMap(params, PREFIX));
+        mergeDefaults();
         PARAM_WHITELIST.forEach((k, v) -> {
             Optional<Object> configValue = neo4jConfig.getValue(k);
             if (configValue.isPresent()) {
@@ -47,6 +49,10 @@ public class ApocConfiguration {
         });
         config.clear();
         params.forEach((k, v) -> { if (!SKIP.matcher(k).find()) {config.put(k, v);} });
+    }
+
+    private static void mergeDefaults() {
+        DEFAULTS.forEach((key, value) -> apocConfig.computeIfAbsent(key, (k) -> value));
     }
 
     public static Map<String, Object> get(String prefix) {

--- a/src/test/java/apoc/cypher/CypherTest.java
+++ b/src/test/java/apoc/cypher/CypherTest.java
@@ -2,7 +2,6 @@ package apoc.cypher;
 
 import apoc.util.TestUtil;
 import apoc.util.Util;
-import static apoc.util.Util.*;
 import apoc.util.Utils;
 import org.hamcrest.Matchers;
 import org.junit.*;
@@ -15,10 +14,14 @@ import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.io.File;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
+import static apoc.util.Util.map;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.*;
@@ -39,6 +42,7 @@ public class CypherTest {
         db = new TestGraphDatabaseFactory()
                 .newImpermanentDatabaseBuilder()
                 .setConfig("apoc.import.file.enabled", "true")
+                .setConfig("apoc.import.file.use_neo4j_config", "false")
                 .setConfig(GraphDatabaseSettings.load_csv_file_url_root,new File("src/test/resources").getAbsolutePath())
                 .newGraphDatabase();
         TestUtil.registerProcedure(db, Cypher.class);

--- a/src/test/java/apoc/export/csv/ImportCsvLdbcTest.java
+++ b/src/test/java/apoc/export/csv/ImportCsvLdbcTest.java
@@ -131,7 +131,6 @@ public class ImportCsvLdbcTest {
                 .newImpermanentDatabaseBuilder()
                 .setConfig("apoc.import.file.enabled", "true")
                 .setConfig("apoc.export.file.enabled", "true")
-                .setConfig("apoc.import.file.use_neo4j_config", "true")
                 .setConfig("dbms.security.allow_csv_import_from_file_urls","true")
                 .setConfig("dbms.directories.import",
                         new File("src/test/resources/csv-inputs").getAbsolutePath())

--- a/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -98,7 +98,6 @@ public class ImportCsvTest {
                 .newImpermanentDatabaseBuilder()
                 .setConfig("apoc.import.file.enabled", "true")
                 .setConfig("apoc.export.file.enabled", "true")
-                .setConfig("apoc.import.file.use_neo4j_config", "true")
                 .setConfig("dbms.security.allow_csv_import_from_file_urls","true")
                 .setConfig("dbms.directories.import",
                         new File("src/test/resources/csv-inputs").getAbsolutePath())

--- a/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -128,6 +128,7 @@ public class ExportGraphMLTest {
     public void setUp() throws Exception {
         GraphDatabaseBuilder builder  = new TestGraphDatabaseFactory()
                 .newImpermanentDatabaseBuilder()
+                .setConfig("apoc.import.file.use_neo4j_config", "false")
                 .setConfig(GraphDatabaseSettings.load_csv_file_url_root, directory.getAbsolutePath());
         if (!testName.getMethodName().endsWith(TEST_WITH_NO_EXPORT)) {
             builder.setConfig("apoc.export.file.enabled", "true");

--- a/src/test/java/apoc/load/LoadJsonTest.java
+++ b/src/test/java/apoc/load/LoadJsonTest.java
@@ -1,6 +1,5 @@
 package apoc.load;
 
-import apoc.ApocConfiguration;
 import apoc.util.TestUtil;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.junit.After;
@@ -9,7 +8,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.QueryExecutionException;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.net.URL;
@@ -31,6 +29,7 @@ public class LoadJsonTest {
         URL url = ClassLoader.getSystemResource("map.json");
         db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
                 .setConfig("apoc.import.file.enabled","true")
+                .setConfig("apoc.import.file.use_neo4j_config", "false")
                 .setConfig("apoc.json.zip.url","https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/3.4/src/test/resources/testload.zip?raw=true!person.json")
                 .setConfig("apoc.json.simpleJson.url", url.toString())
                 .newGraphDatabase();

--- a/src/test/java/apoc/load/LoadS3Test.java
+++ b/src/test/java/apoc/load/LoadS3Test.java
@@ -31,7 +31,10 @@ public class LoadS3Test {
     }
 
     @Before public void setUp() throws Exception {
-        db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder().setConfig("apoc.import.file.enabled","true").newGraphDatabase();
+        db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
+                .setConfig("apoc.import.file.use_neo4j_config", "false")
+                .setConfig("apoc.import.file.enabled","true")
+                .newGraphDatabase();
         TestUtil.registerProcedure(db, LoadCsv.class, LoadJson.class, Xml.class);
         minio = new MinioSetUp("dddbucketddd");
     }

--- a/src/test/java/apoc/load/XmlTest.java
+++ b/src/test/java/apoc/load/XmlTest.java
@@ -17,13 +17,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static apoc.util.TestUtil.testCall;
-import static apoc.util.TestUtil.testCallEmpty;
-import static apoc.util.TestUtil.testResult;
-import static apoc.util.Util.map;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static apoc.util.TestUtil.*;
+import static org.junit.Assert.*;
 
 public class XmlTest {
 
@@ -56,7 +51,10 @@ public class XmlTest {
 
     @Before
     public void setUp() throws Exception {
-        db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder().setConfig("apoc.import.file.enabled", "true").newGraphDatabase();
+        db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
+                .setConfig("apoc.import.file.use_neo4j_config", "false")
+                .setConfig("apoc.import.file.enabled", "true")
+                .newGraphDatabase();
         TestUtil.registerProcedure(db, Xml.class);
     }
 

--- a/src/test/java/apoc/load/relative/LoadRelativePathTest.java
+++ b/src/test/java/apoc/load/relative/LoadRelativePathTest.java
@@ -35,7 +35,6 @@ public class LoadRelativePathTest {
         db = new TestGraphDatabaseFactory()
                 .newImpermanentDatabaseBuilder()
                 .setConfig("apoc.import.file.enabled","true")
-                .setConfig("apoc.import.file.use_neo4j_config", "true")
                 .setConfig("dbms.directories.import", PATH)
                 .setConfig("dbms.security.allow_csv_import_from_file_urls","true")
                 .newGraphDatabase();

--- a/src/test/java/apoc/util/FileUtilsTest.java
+++ b/src/test/java/apoc/util/FileUtilsTest.java
@@ -31,8 +31,7 @@ public class FileUtilsTest {
     public void setUp() throws Exception {
         GraphDatabaseBuilder builder = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder(new File(PATH,"impermanent-db"))
                 .setConfig("dbms.security.allow_csv_import_from_file_urls", "true")
-                .setConfig("foo", "BAR")
-                .setConfig("apoc.import.file.use_neo4j_config", "true");
+                .setConfig("foo", "BAR");
         if (testName.getMethodName().endsWith(TEST_WITH_DIRECTORY_IMPORT)) {
             builder.setConfig("dbms.directories.import", "import");
         }


### PR DESCRIPTION
Fixes #1142

Switch import directory mode to honor neo4j import directory setting

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - created a `DEFAULTS` map into `ApocConfiguration.java` which contains the <k,v> pairs of default configuration values
  - improved the documentation
  - fixed broken tests configuring `apoc.import.file.use_neo4j_config=false` into them.
