### PR TITLE
fixes #1141: add config option to "garble" log messages

### DIFF
--- a/docs/asciidoc/_utilities.adoc
+++ b/docs/asciidoc/_utilities.adoc
@@ -24,6 +24,7 @@ Cypher brings along some basic functions for math, text, collections and maps.
 * <<utility-functions>>
 * <<bitwise-operations>>
 * <<atomic-updates>>
+* <<log>>
 
 [[conversion-functions]]
 === Conversion Functions
@@ -223,3 +224,8 @@ examples
 === Atomic
 
 include::atomic.adoc[leveloffset=1]
+=== Log
+
+include::log.adoc[leveloffset=1]
+
+

--- a/docs/asciidoc/log.adoc
+++ b/docs/asciidoc/log.adoc
@@ -1,0 +1,44 @@
+[[log]]
+=== Log Procedures
+
+APOC provide a set of store procedures in order to add log functionality:
+
+* `apoc.log.info`: logs info message
+* `apoc.log.error`: logs error message
+* `apoc.log.warn`: logs warn message
+* `apoc.log.debug`: logs debug message
+
+Every log procedure has the following signature:
+
+`apoc.log.<name>(message, params)`
+
+Available configuration:
+
+[opts=header,cols="m,m,a"]
+|===
+| property | type | description
+| `apoc.user.log.type` | enum[none, safe, raw] (default value `safe`) | type of logging:
+
+ * `node`: disable the procedures
+ * `safe`: replace all `.` and whitespace (space and tab) with underscore and lowercase all characters
+ * `raw`: left the messages as-is
+
+| `apoc.user.log.window.ops` | int (default value `10`) | num of logs permitted in a time-window, exceeded this quota every log message will be skip
+| `apoc.user.log.window.time` | long (default value `10000`) | the length (in milliseconds) of the time-window (default 10 seconds)
+|===
+
+Example:
+
+The following call (with the default configuration):
+
+[source,cypher]
+----
+call apoc.log.info('Hello %s', ['World'])
+----
+
+produces the following output into the log:
+
+[source,cypher]
+----
+hello_world
+----

--- a/src/main/java/apoc/log/Logging.java
+++ b/src/main/java/apoc/log/Logging.java
@@ -1,52 +1,96 @@
 package apoc.log;
 
+import apoc.ApocConfiguration;
+import apoc.util.SimpleRateLimiter;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
-import java.util.Map;
+
+import java.util.List;
+import java.util.function.Consumer;
 
 /**
  * @author bradnussbaum
  * @since 2017.07.28
  */
-public class Logging
-{
+public class Logging {
+
+    enum LoggingType {none, safe, raw}
+
+    private static LoggingType LOGGING_TYPE;
+
+    private static SimpleRateLimiter RATE_LIMITER;
+
+    public Logging() {}
+
+    public Logging(LoggingType loggingType, long timeWindow, int maxOpsPerWindow) { // for testing purpose only
+        LOGGING_TYPE = loggingType;
+        RATE_LIMITER = new SimpleRateLimiter(timeWindow, maxOpsPerWindow);
+
+    }
+
+    static {
+        LOGGING_TYPE = LoggingType.valueOf(ApocConfiguration.get("user.log.type", "safe").trim());
+        RATE_LIMITER = new SimpleRateLimiter(Long.valueOf(ApocConfiguration.get("user.log.window.time", "10000")),
+                Integer.valueOf(ApocConfiguration.get("user.log.window.ops", "10")));
+    }
 
     @Context
     public Log log;
 
     @Procedure
-    @Description( "apoc.log.error(message, params) - logs error message" )
-    public void error( @Name( "message" ) String message,
-            @Name( value = "params", defaultValue = "{}" ) Map<String,Object> params )
-    {
-        log.error( message, params );
+    @Description("apoc.log.error(message, params) - logs error message")
+    public void error(@Name("message") String message,
+                      @Name(value = "params", defaultValue = "[]") List<Object> params) {
+        log((logMessage) -> log.error(logMessage), message, params);
     }
 
     @Procedure
-    @Description( "apoc.log.warn(message, params) - logs warn message" )
-    public void warn( @Name( "message" ) String message,
-            @Name( value = "params", defaultValue = "{}" ) Map<String,Object> params )
-    {
-        log.warn( message, params );
+    @Description("apoc.log.warn(message, params) - logs warn message")
+    public void warn(@Name("message") String message,
+                     @Name(value = "params", defaultValue = "[]") List<Object> params) {
+        log((logMessage) -> log.warn(logMessage), message, params);
     }
 
     @Procedure
-    @Description( "apoc.log.info(message, params) - logs info message" )
-    public void info( @Name( "message" ) String message,
-            @Name( value = "params", defaultValue = "{}" ) Map<String,Object> params )
-    {
-        log.info( message, params );
+    @Description("apoc.log.info(message, params) - logs info message")
+    public void info(@Name("message") String message,
+                     @Name(value = "params", defaultValue = "[]") List<Object> params) {
+        log((logMessage) -> log.info(logMessage), message, params);
     }
 
     @Procedure
-    @Description( "apoc.log.debug(message, params) - logs debug message" )
-    public void debug( @Name( "message" ) String message,
-            @Name( value = "params", defaultValue = "{}" ) Map<String,Object> params )
-    {
-        log.debug( message, params );
+    @Description("apoc.log.debug(message, params) - logs debug message")
+    public void debug(@Name("message") String message,
+                      @Name(value = "params", defaultValue = "[]") List<Object> params) {
+        log((logMessage) -> log.debug(logMessage), message, params);
+    }
+
+    public String format(String message, List<Object> params) { // visible for testing
+        if (canLog()) {
+            String formattedMessage = String.format(message, params.isEmpty() ? new Object[0] : params.toArray(new Object[params.size()]));
+            if (LoggingType.safe == LOGGING_TYPE) {
+                return formattedMessage.replaceAll("\\.| |\\t", "_").toLowerCase();
+            }
+            return formattedMessage;
+        }
+        return null;
+    }
+
+    private void log(Consumer<String> consumer, String message, List<Object> params) {
+        String format = format(message, params);
+        if (format != null) {
+            consumer.accept(format);
+        }
+    }
+
+    private boolean canLog() {
+        if (LoggingType.none == LOGGING_TYPE) {
+            return false;
+        }
+        return RATE_LIMITER.canExecute();
     }
 
 }

--- a/src/main/java/apoc/util/SimpleRateLimiter.java
+++ b/src/main/java/apoc/util/SimpleRateLimiter.java
@@ -1,0 +1,27 @@
+package apoc.util;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class SimpleRateLimiter {
+
+    private final AtomicInteger countDownLatch = new AtomicInteger(0);
+    private final AtomicLong lastUpdate = new AtomicLong(0);
+
+    private final long timeWindow;
+    private final int operationPerWindow;
+
+    public SimpleRateLimiter(long timeWindow, int operationPerWindow) {
+        this.timeWindow = timeWindow;
+        this.operationPerWindow = operationPerWindow;
+    }
+
+    public boolean canExecute() {
+        long now = System.currentTimeMillis();
+        if ((now - lastUpdate.get()) > timeWindow) {
+            lastUpdate.set(now);
+            countDownLatch.set(operationPerWindow);
+        }
+        return countDownLatch.decrementAndGet() >= 0;
+    }
+}

--- a/src/test/java/apoc/log/LoggingTest.java
+++ b/src/test/java/apoc/log/LoggingTest.java
@@ -1,0 +1,195 @@
+package apoc.log;
+
+import apoc.util.TestUtil;
+import org.junit.Test;
+import org.neo4j.internal.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
+
+public class LoggingTest {
+
+    @Test
+    public void shouldWriteSafeStrings() {
+        // given
+        Logging logging = new Logging(Logging.LoggingType.safe, 10000L, 10);
+
+        // when
+        String stringWithWhitespaces = logging.format("Test %s ", asList(1));
+        String stringWithWhitespacesAndTabs = logging.format("Test %s \t", asList(1));
+        String stringWithWhitespacesAndTabsAndNewLine = logging.format("Test %s \t\nNewLine", asList(1));
+
+        // then
+        assertEquals("test_1_", stringWithWhitespaces);
+        assertEquals("test_1__", stringWithWhitespacesAndTabs);
+        assertEquals("test_1__\nnewline", stringWithWhitespacesAndTabsAndNewLine);
+    }
+
+    @Test
+    public void shouldWriteRawStrings() {
+        // given
+        Logging logging = new Logging(Logging.LoggingType.raw, 10000L, 10);
+
+        // when
+        String stringWithWhitespaces = logging.format("Test %s ", asList(1));
+        String stringWithWhitespacesAndTabs = logging.format("Test %s \t", asList(1));
+        String stringWithWhitespacesAndTabsAndNewLine = logging.format("Test %s \t\nNewLine", asList(1));
+
+        // then
+        assertEquals("Test 1 ", stringWithWhitespaces);
+        assertEquals("Test 1 \t", stringWithWhitespacesAndTabs);
+        assertEquals("Test 1 \t\nNewLine", stringWithWhitespacesAndTabsAndNewLine);
+    }
+
+    @Test
+    public void shouldNotLog() {
+        // given
+        Logging logging = new Logging(Logging.LoggingType.none, 10000L, 10);
+
+        // when
+        String stringWithWhitespaces = logging.format("Test %s ", asList(1));
+        String stringWithWhitespacesAndTabs = logging.format("Test %s \t", asList(1));
+        String stringWithWhitespacesAndTabsAndNewLine = logging.format("Test %s \t\nNewLine", asList(1));
+
+        // then
+        assertNull(stringWithWhitespaces);
+        assertNull(stringWithWhitespacesAndTabs);
+        assertNull(stringWithWhitespacesAndTabsAndNewLine);
+    }
+
+    @Test
+    public void shouldSkipMessagesFor10Seconds() {
+        // given
+        Logging logging = new Logging(Logging.LoggingType.safe, 10000L, 10);
+
+        List<String> all = IntStream.range(0, 10).mapToObj(i -> "test_" + i + "_")
+                .collect(Collectors.toList());
+
+        all.addAll(IntStream.range(50, 60).mapToObj(i -> "test_" + i + "_")
+                .collect(Collectors.toList()));
+
+        // when
+        IntStream.range(0, 100).forEach(i -> {
+            if (i < 10) {
+                // when
+                String msg = logging.format("Test %s ", asList(i));
+
+                // then
+                assertEquals("test_" + i + "_", msg);
+                all.remove(msg);
+                return;
+            }
+            if (i >= 10 && i < 50) {
+                // when
+                String msg = logging.format("Test %s ", asList(i));
+
+                // then
+                assertNull(msg);
+                return;
+            }
+            if (i == 50) {
+                try {
+                    Thread.sleep(11_000L); // wait for a new time window
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+            if (i >= 50 && i < 60) {
+                // when
+                String msg = logging.format("Test %s ", asList(i));
+
+                // then
+                assertEquals("test_" + i + "_", msg);
+                all.remove(msg);
+                return;
+            }
+            if (i >= 60) {
+                // when
+                String msg = logging.format("Test %s ", asList(i));
+
+                // then
+                assertNull(msg);
+            }
+        });
+
+        // then
+        assertTrue(all.isEmpty());
+    }
+
+    @Test
+    public void shouldWrite20MessagesIn1Second() {
+        // given
+        Logging logging = new Logging(Logging.LoggingType.safe, 1000L, 20);
+
+        List<String> all = IntStream.range(0, 20).mapToObj(i -> "test_" + i + "_")
+                .collect(Collectors.toList());
+
+        all.addAll(IntStream.range(50, 70).mapToObj(i -> "test_" + i + "_")
+                .collect(Collectors.toList()));
+
+        // when
+        IntStream.range(0, 100).forEach(i -> {
+            if (i < 20) {
+                // when
+                String msg = logging.format("Test %s ", asList(i));
+
+                // then
+                assertEquals("test_" + i + "_", msg);
+                all.remove(msg);
+                return;
+            }
+            if (i >= 20 && i < 50) {
+                // when
+                String msg = logging.format("Test %s ", asList(i));
+
+                // then
+                assertNull(msg); // then
+                return;
+            }
+            if (i == 50) {
+                try {
+                    Thread.sleep(2_000L); // wait for a new time window
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+            if (i >= 50 && i < 70) {
+                // when
+                String msg = logging.format("Test %s ", asList(i));
+
+                // then
+                assertEquals("test_" + i + "_", msg);
+                all.remove(msg);
+                return;
+            }
+            if (i >= 70) {
+                // when
+                String msg = logging.format("Test %s ", asList(i));
+
+                // then
+                assertNull(msg);
+            }
+        });
+
+        // then
+        assertTrue(all.isEmpty());
+    }
+
+    @Test
+    public void shouldCallTheProcedure() throws KernelException {
+        // given
+        GraphDatabaseAPI db = (GraphDatabaseAPI) TestUtil.apocGraphDatabaseBuilder().newGraphDatabase();
+        TestUtil.registerProcedure(db, Logging.class);
+
+        // when
+        db.execute("CALL apoc.log.warn('Prova %s', [1])");
+
+        // then
+        db.shutdown();
+    }
+}

--- a/src/test/java/apoc/util/SimpleRateLimiterTest.java
+++ b/src/test/java/apoc/util/SimpleRateLimiterTest.java
@@ -1,0 +1,70 @@
+package apoc.util;
+
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.*;
+
+public class SimpleRateLimiterTest {
+
+   @Test
+   public void shouldTestTheRateLimiter() throws InterruptedException {
+       // given
+       SimpleRateLimiter srl = new SimpleRateLimiter(1000, 1);
+
+       // when
+       boolean canExecute = srl.canExecute();
+       boolean cantExecute = srl.canExecute();
+       Thread.sleep(2000);
+       boolean nowCanExecute = srl.canExecute();
+
+       // then
+       assertTrue(canExecute);
+       assertFalse(cantExecute);
+       assertTrue(nowCanExecute);
+   }
+
+    @Test
+    public void shouldTestTheRateLimiterInExecutors() throws InterruptedException {
+        // given
+        SimpleRateLimiter srl = new SimpleRateLimiter(1000, 10);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        Map<String, AtomicInteger> map = new ConcurrentHashMap<>();
+
+        // when
+        execRunnable(srl, executor, map, 50);
+        execRunnable(srl, executor, map, 50);
+        executor.awaitTermination(5, TimeUnit.SECONDS);
+
+        // then
+        int count = map
+                .entrySet()
+                .stream()
+                .map(Map.Entry::getValue)
+                .map(AtomicInteger::get)
+                .reduce(0, (x, y) -> x + y);
+        assertEquals(10, count);
+    }
+
+    private void execRunnable(SimpleRateLimiter srl,
+                              ExecutorService executor,
+                              Map<String, AtomicInteger> map,
+                              int operations) {
+        executor.execute(() -> {
+            AtomicInteger ai = map.computeIfAbsent(Thread.currentThread().getName(), k -> new AtomicInteger(0));
+            IntStream.range(0, operations).forEach(i -> {
+                if (srl.canExecute()) {
+                    ai.incrementAndGet();
+                }
+            });
+        });
+    }
+
+}


### PR DESCRIPTION
Fixes #1141

add config option to "garble" log messages

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:
* Added three properties:
  * `apoc.user.log.type` | enum[none, safe, raw] (default value `safe`) | type of logging:
    * `node`: disable the procedures
    * `safe`: replace all `.` and whitespace (space and tab) with underscore and lowercase all characters
    * `raw`: left the messages as-is
  * `apoc.user.log.window.ops` | int (default value `10`) | num of logs permitted in a time-window, exceeded this quota every log message will be skip
  * `apoc.user.log.window.time` | long (default value `10000`) | the length (in milliseconds) of the time-window (default 10 seconds)
* Added documentation
* Added tests
