### PR TITLE
fixes #1127

### DIFF
--- a/src/main/java/apoc/meta/Meta.java
+++ b/src/main/java/apoc/meta/Meta.java
@@ -479,7 +479,8 @@ public class Meta {
             if (min >= max) {
                 return -1L;
             }
-            return ThreadLocalRandom.current().nextLong(min, max);
+            long randomValue = ThreadLocalRandom.current().nextLong(min, max);
+            return randomValue == 0L ? -1L : randomValue; // it can't return zero as it's used in % ops
         } else {
             return sample;
         }


### PR DESCRIPTION
Fixes #1127 

The bug was caused by the method `Meta#getSampleForLabelCount` that sometimes returns 0, that value is then used in a `%` operation causing the `ArithmeticException`

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:
  - in case `ThreadLocalRandom.current().nextLong` returns 0 (zero) we change that value to -1 (with the same strategy adopted for the if `min >= max`)
