### PR TITLE
fixes #1073: Add "description" to custom procedures/functions

### DIFF
--- a/docs/asciidoc/custom.adoc
+++ b/docs/asciidoc/custom.adoc
@@ -44,6 +44,7 @@ Given statement will be registered as a procedure, the results will be turned in
 | mode | read | execution mode of the procedure: read, write, or schema
 | outputs | [["row","MAP"]] | List of pairs of name-type to be used as output columns, need to be in-order with the cypher statement, the default is a special case, that will collect all columns of the statement result into a map
 | inputs | [["params","MAP","{}"]] | Pairs or triples of name-type-default, to be used as input parameters. The default just takes an optional map, otherwise they will become proper paramters in order
+| description | "" | A general description about the business rules implemented into the procedure
 |===
 
 The type names are what you would expect and see in outputs of `dbms.procedures` or `apoc.help` just without the `?`.
@@ -65,7 +66,7 @@ The default values are parsed as JSON.
 ----
 CALL apoc.custom.asProcedure('neighbours',
   'MATCH (n:Person {name:$name})-->(nb) RETURN nb as neighbour','read',
-  [['neighbour','NODE']],[['name','STRING']]);
+  [['neighbour','NODE']],[['name','STRING'], 'get neighbours of a person']);
 
 CALL custom.neighbours('Keanu Reeves') YIELD neighbour;
 ----
@@ -90,6 +91,7 @@ The statement needs to return a single column, otherwise an error is thrown.
 If your single row result is a list you can force a single row by setting the last parameter to `true`
 | inputs | [["params","MAP","{}"]] | Pairs or triples of name-type-default, to be used as input parameters. The default just takes an optional map, otherwise they will become proper paramters in order
 | singleRow | false | If set to true, the statement is treated as single row even with the list result type, then your statement has to return a list.
+| description | "" | A general description about the business rules implemented into the function
 |===
 
 The type names are what you would expect and see in outputs of `dbms.procedures` or `apoc.help` just without the `?`.

--- a/src/main/java/apoc/custom/CypherProcedures.java
+++ b/src/main/java/apoc/custom/CypherProcedures.java
@@ -54,24 +54,25 @@ public class CypherProcedures {
     public Log log;
 
     /*
-    * store in graph properties, load at startup
-    * allow to register proper params as procedure-params
-    * allow to register proper return columns
-    * allow to register mode
+     * store in graph properties, load at startup
+     * allow to register proper params as procedure-params
+     * allow to register proper return columns
+     * allow to register mode
      */
     @Procedure(value = "apoc.custom.asProcedure",mode = Mode.WRITE)
     public void asProcedure(@Name("name") String name, @Name("statement") String statement,
-                         @Name(value = "mode",defaultValue = "read") String mode,
-                         @Name(value= "outputs", defaultValue = "null") List<List<String>> outputs,
-                         @Name(value= "inputs", defaultValue = "null") List<List<String>> inputs
-                         ) throws ProcedureException {
+                            @Name(value = "mode",defaultValue = "read") String mode,
+                            @Name(value= "outputs", defaultValue = "null") List<List<String>> outputs,
+                            @Name(value= "inputs", defaultValue = "null") List<List<String>> inputs,
+                            @Name(value= "description", defaultValue = "null") String description
+    ) throws ProcedureException {
         debug(name,"before", ktx);
 
         CustomStatementRegistry registry = new CustomStatementRegistry(api, log);
-        if (!registry.registerProcedure(name, statement, mode, outputs, inputs)) {
+        if (!registry.registerProcedure(name, statement, mode, outputs, inputs, description)) {
             throw new IllegalStateException("Error registering procedure "+name+", see log.");
         }
-        CustomProcedureStorage.storeProcedure(api, name, statement, mode, outputs, inputs);
+        CustomProcedureStorage.storeProcedure(api, name, statement, mode, outputs, inputs, description);
         debug(name, "after", ktx);
     }
 
@@ -88,12 +89,13 @@ public class CypherProcedures {
     public void asFunction(@Name("name") String name, @Name("statement") String statement,
                            @Name(value= "outputs", defaultValue = "") String output,
                            @Name(value= "inputs", defaultValue = "null") List<List<String>> inputs,
-                           @Name(value = "forceSingle",defaultValue = "false") boolean forceSingle) throws ProcedureException {
+                           @Name(value = "forceSingle", defaultValue = "false") boolean forceSingle,
+                           @Name(value = "description", defaultValue = "null") String description) throws ProcedureException {
         CustomStatementRegistry registry = new CustomStatementRegistry(api, log);
-        if (!registry.registerFunction(name, statement, output, inputs, forceSingle)) {
+        if (!registry.registerFunction(name, statement, output, inputs, forceSingle, description)) {
             throw new IllegalStateException("Error registering function "+name+", see log.");
         }
-        CustomProcedureStorage.storeFunction(api, name, statement, output, inputs, forceSingle);
+        CustomProcedureStorage.storeFunction(api, name, statement, output, inputs, forceSingle, description);
     }
 
     static class CustomStatementRegistry {
@@ -107,12 +109,12 @@ public class CypherProcedures {
             this.log = log;
         }
 
-        public boolean registerProcedure(@Name("name") String name, @Name("statement") String statement, @Name(value = "mode", defaultValue = "read") String mode, @Name(value = "outputs", defaultValue = "null") List<List<String>> outputs, @Name(value = "inputs", defaultValue = "null") List<List<String>> inputs) {
+        public boolean registerProcedure(@Name("name") String name, @Name("statement") String statement, @Name(value = "mode", defaultValue = "read") String mode, @Name(value = "outputs", defaultValue = "null") List<List<String>> outputs, @Name(value = "inputs", defaultValue = "null") List<List<String>> inputs, @Name(value= "description", defaultValue = "") String description) {
             try {
                 Procedures procedures = api.getDependencyResolver().resolveDependency(Procedures.class);
                 boolean admin = false; // TODO
                 ProcedureSignature signature = new ProcedureSignature(qualifiedName(name), inputSignatures(inputs), outputSignatures(outputs),
-                        Mode.valueOf(mode.toUpperCase()), admin, null, new String[0], null, null, false, true
+                        Mode.valueOf(mode.toUpperCase()), admin, null, new String[0], description, null, false, true
                 );
                 procedures.register(new CallableProcedure.BasicProcedure(signature) {
                     @Override
@@ -141,11 +143,11 @@ public class CypherProcedures {
 
         }
 
-        public boolean registerFunction(String name, String statement, String output, List<List<String>> inputs, boolean forceSingle)  {
+        public boolean registerFunction(String name, String statement, String output, List<List<String>> inputs, boolean forceSingle, String description)  {
             try {
                 AnyType outType = typeof(output.isEmpty() ? "LIST OF MAP" : output);
                 UserFunctionSignature signature = new UserFunctionSignature(qualifiedName(name), inputSignatures(inputs), outType,
-                        null, new String[0], null, false);
+                        null, new String[0], description, false);
 
                 DefaultValueMapper defaultValueMapper = new DefaultValueMapper(api.getDependencyResolver().resolveDependency(GraphDatabaseFacade.class));
 
@@ -333,11 +335,11 @@ public class CypherProcedures {
             Map<String, Map<String,Map<String, Object>>> stored = readData(properties);
             stored.get(FUNCTIONS).forEach((name, data) -> {
                 registry.registerFunction(name, (String) data.get("statement"), (String) data.get("output"),
-                        (List<List<String>>) data.get("inputs"), (Boolean)data.get("forceSingle"));
+                        (List<List<String>>) data.get("inputs"), (Boolean)data.get("forceSingle"), (String) data.get("description"));
             });
             stored.get(PROCEDURES).forEach((name, data) -> {
                 registry.registerProcedure(name, (String) data.get("statement"), (String) data.get("mode"),
-                        (List<List<String>>) data.get("outputs"), (List<List<String>>) data.get("inputs"));
+                        (List<List<String>>) data.get("outputs"), (List<List<String>>) data.get("inputs"), (String) data.get("description"));
             });
         }
 
@@ -346,13 +348,13 @@ public class CypherProcedures {
             properties = null;
         }
 
-        public static Map<String, Object> storeProcedure(GraphDatabaseAPI api, String name, String statement, String mode, List<List<String>> outputs, List<List<String>> inputs) {
+        public static Map<String, Object> storeProcedure(GraphDatabaseAPI api, String name, String statement, String mode, List<List<String>> outputs, List<List<String>> inputs, String description) {
 
-            Map<String, Object> data = map("statement", statement, "mode", mode, "inputs", inputs, "outputs", outputs);
+            Map<String, Object> data = map("statement", statement, "mode", mode, "inputs", inputs, "outputs", outputs, "description", description);
             return updateCustomData(getProperties(api), name, PROCEDURES, data);
         }
-        public static Map<String, Object> storeFunction(GraphDatabaseAPI api, String name, String statement, String output, List<List<String>> inputs, boolean forceSingle) {
-            Map<String, Object> data = map("statement", statement, "forceSingle", forceSingle, "inputs", inputs, "output", output);
+        public static Map<String, Object> storeFunction(GraphDatabaseAPI api, String name, String statement, String output, List<List<String>> inputs, boolean forceSingle, String description) {
+            Map<String, Object> data = map("statement", statement, "forceSingle", forceSingle, "inputs", inputs, "output", output, "description", description);
             return updateCustomData(getProperties(api), name, FUNCTIONS, data);
         }
 
@@ -384,9 +386,7 @@ public class CypherProcedures {
         }
 
         public Map<String, Map<String, Map<String, Object>>> list() {
-            try (Transaction tx = properties.getGraphDatabase().beginTx()) {
-                return readData(properties);
-            }
+            return readData(properties);
         }
     }
 }


### PR DESCRIPTION
Fixes #1073

Add "description" to custom procedures/functions.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:
- Added the `description` field as the last field in `apoc.custom.asProcedure` and `apoc.custom. asFunction`
- Added test
- Updated the documentation