### PR TITLE
fixes #1072: Make sure custom procedures are also recreated on other cluster members

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
     testCompile group: 'com.sun.mail', name: 'javax.mail', version: '1.6.0'
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.2.0'
     compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
-    compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '1.6.3'
+    compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '1.7.3'
 
     compile group: 'com.novell.ldap', name: 'jldap', version: '2009-10-07'
 

--- a/docs/asciidoc/custom.adoc
+++ b/docs/asciidoc/custom.adoc
@@ -118,3 +118,15 @@ The the output will look like the following table:
 | "function"  | "answer" | <null> | <null> | "RETURN $input as answer" | [["input","number"]] | "long" | false
 | "procedure" | "answer" | "Procedure that answer to the Ultimate Question of Life, the Universe, and Everything" | "read" | "RETURN $input as answer" | [["input","int","42"]] | [["answer","number"]] | <null>
 |===
+
+
+=== How to manage procedure/function replication in a Causal Cluster
+
+In order to replicate the procedure/function in a cluster environment you can tune the following parameters:
+
+[%autowidth,opts=header]
+|===
+| name | type | description
+| `apoc.custom.procedures.refresh` | long (default `60000`) | the refresh time that allows replicating the procedure/function
+changes to each cluster member
+|===

--- a/src/main/java/apoc/custom/CypherProcedures.java
+++ b/src/main/java/apoc/custom/CypherProcedures.java
@@ -1,5 +1,6 @@
 package apoc.custom;
 
+import apoc.ApocConfiguration;
 import apoc.util.JsonUtil;
 import apoc.util.Util;
 import org.neo4j.collection.PrefetchingRawIterator;
@@ -28,6 +29,7 @@ import org.neo4j.values.AnyValue;
 import org.neo4j.values.virtual.MapValue;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -327,10 +329,12 @@ public class CypherProcedures {
         public List<List<String>>inputs;
         public Object outputs;
         public Boolean forceSingle;
+        public long lastUpdate;
 
         public CustomProcedureInfo(String type, String name, String description, String mode,
                                    String statement, List<List<String>> inputs, Object outputs,
-                                   Boolean forceSingle){
+                                   Boolean forceSingle,
+                                   long lastUpdate){
             this.type = type;
             this.name = name;
             this.description = description;
@@ -339,6 +343,7 @@ public class CypherProcedures {
             this.inputs = inputs;
             this.forceSingle = forceSingle;
             this.mode = mode;
+            this.lastUpdate = lastUpdate;
         }
     }
 
@@ -347,6 +352,7 @@ public class CypherProcedures {
         private GraphProperties properties;
         private final GraphDatabaseAPI api;
         private final Log log;
+        private Timer timer;
 
         public CustomProcedureStorage(GraphDatabaseAPI api, Log log) {
             this.api = api;
@@ -364,30 +370,76 @@ public class CypherProcedures {
         }
 
         private void restoreProcedures() {
+            timer = new Timer(this.getClass().getSimpleName());
             CustomStatementRegistry registry = new CustomStatementRegistry(api, log);
-            Map<String, Map<String,Map<String, Object>>> stored = readData(properties);
-            stored.get(FUNCTIONS).forEach((name, data) -> {
-                registry.registerFunction(name, (String) data.get("statement"), (String) data.get("output"),
-                        (List<List<String>>) data.get("inputs"), (Boolean)data.get("forceSingle"), (String) data.get("description"));
-            });
-            stored.get(PROCEDURES).forEach((name, data) -> {
-                registry.registerProcedure(name, (String) data.get("statement"), (String) data.get("mode"),
-                        (List<List<String>>) data.get("outputs"), (List<List<String>>) data.get("inputs"), (String) data.get("description"));
-            });
+            timer.scheduleAtFixedRate(new TimerTask() {
+                private AtomicLong highWaterMark = new AtomicLong(0);
+                private static final String LAST_UPDATE_KEY = "lastUpdate";
+                @Override
+                public void run() {
+                    Map<String, Map<String, Map<String, Object>>> storage = readData(properties);
+                    int updated = storage.entrySet().stream()
+                            .filter(entry -> CypherProcedures.PROCEDURES.equals(entry.getKey()) || CypherProcedures.FUNCTIONS.equals(entry.getKey()))
+                            .flatMap(storageEntry -> {
+                                String type = storageEntry.getKey();
+                                Map<String, Map<String, Object>> map = storageEntry.getValue();
+                                boolean isProcedure = CypherProcedures.PROCEDURES.equals(type);
+                                return map.entrySet().stream()
+                                        // `!e.getValue().containsKey("lastUpdate")` is for backwards compatibility for already present procedures/functions
+                                        .filter(e -> !e.getValue().containsKey(LAST_UPDATE_KEY) || (long) e.getValue().get(LAST_UPDATE_KEY) > highWaterMark.get())
+                                        .map(e -> {
+                                            e.getValue().computeIfAbsent(LAST_UPDATE_KEY, (k) -> System.currentTimeMillis());
+                                            return e;
+                                        })
+                                        .map(entry -> {
+                                            String name = entry.getKey();
+                                            Map<String, Object> data = entry.getValue();
+                                            if (log.isDebugEnabled()) {
+                                                log.debug("Updating procedure `%s`", name);
+                                            }
+                                            String statement = (String) data.get("statement");
+                                            List<List<String>> inputs = (List<List<String>>) data.get("inputs");
+                                            String description = (String) data.get("description");
+
+                                            if (isProcedure) {
+                                                registry.registerProcedure(name, statement, (String) data.get("mode"),
+                                                        (List<List<String>>) data.get("outputs"), inputs, description);
+                                            } else {
+                                                registry.registerFunction(name, statement, (String) data.get("output"),
+                                                        inputs, (Boolean) data.get("forceSingle"), description);
+                                            }
+                                            long lastUpdate = (long) data.get(LAST_UPDATE_KEY);
+                                            if (lastUpdate > highWaterMark.get()) {
+                                                highWaterMark.set(lastUpdate);
+                                            }
+                                            return 1;
+                                        });
+                            })
+                            .reduce(0, Math::addExact);
+                    if (updated > 0 && log.isDebugEnabled()) {
+                        log.debug("Restored %d custom procedures/functions", updated);
+                    }
+                }
+            }, 0, Long.valueOf(ApocConfiguration.get("custom.procedures.refresh", "60000")));
         }
 
         @Override
         public void unavailable() {
             properties = null;
+            if (timer != null)  {
+                timer.cancel();
+            }
         }
 
         public static Map<String, Object> storeProcedure(GraphDatabaseAPI api, String name, String statement, String mode, List<List<String>> outputs, List<List<String>> inputs, String description) {
 
-            Map<String, Object> data = map("statement", statement, "mode", mode, "inputs", inputs, "outputs", outputs, "description", description);
+            Map<String, Object> data = map("statement", statement, "mode", mode, "inputs", inputs, "outputs",
+                    outputs, "description", description, "lastUpdate", System.currentTimeMillis());
             return updateCustomData(getProperties(api), name, PROCEDURES, data);
         }
         public static Map<String, Object> storeFunction(GraphDatabaseAPI api, String name, String statement, String output, List<List<String>> inputs, boolean forceSingle, String description) {
-            Map<String, Object> data = map("statement", statement, "forceSingle", forceSingle, "inputs", inputs, "output", output, "description", description);
+            Map<String, Object> data = map("statement", statement, "forceSingle", forceSingle, "inputs",
+                    inputs, "output", output, "description", description, "lastUpdate", System.currentTimeMillis());
             return updateCustomData(getProperties(api), name, FUNCTIONS, data);
         }
 
@@ -437,7 +489,8 @@ public class CypherProcedures {
                                     String.valueOf(procedureParams.get("statement")),
                                     (List<List<String>>) procedureParams.get("inputs"),
                                     procedureParams.get(outputs),
-                                    (Boolean) procedureParams.get("forceSingle"));
+                                    (Boolean) procedureParams.get("forceSingle"),
+                                    (long) procedureParams.getOrDefault("lastUpdate", 0L)); // for already present procedures/functions
                         });
                     })
                     .collect(Collectors.toList());

--- a/src/test/java/apoc/custom/CypherProceduresClusterTest.java
+++ b/src/test/java/apoc/custom/CypherProceduresClusterTest.java
@@ -1,0 +1,97 @@
+package apoc.custom;
+
+
+import apoc.util.TestContainerUtil;
+import apoc.util.TestUtil;
+import apoc.util.TestcontainersCausalCluster;
+import apoc.util.Util;
+import org.junit.*;
+
+import java.util.List;
+import java.util.Map;
+
+import static apoc.util.TestContainerUtil.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeNotNull;
+
+
+public class CypherProceduresClusterTest {
+
+    private static TestcontainersCausalCluster cluster;
+
+    @BeforeClass
+    public static void setupCluster() {
+        executeGradleTasks("clean", "shadow");
+        TestUtil.ignoreException(() ->  cluster = TestContainerUtil
+                .createEnterpriseCluster(3, 1, Util.map("apoc.custom.procedures.refresh", 100)),
+                Exception.class);
+        assumeNotNull(cluster);
+    }
+
+    @AfterClass
+    public static void bringDownCluster() {
+        if (cluster != null) {
+            cluster.close();
+        }
+        cleanBuild();
+    }
+
+    @Before
+    public void clearCache() {
+        cluster.getSession().writeTransaction(tx -> tx.run("call dbms.clearQueryCaches()")); // we update the function
+    }
+
+    @Test
+    public void shouldRecreateCustomFunctionsOnOtherClusterMembers() {
+        // given
+        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asFunction('answer1', 'RETURN 42 as answer')")); // we create a function
+
+        // when
+        testCall(cluster.getSession(), "return custom.answer1() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+
+        // then
+        // we use the readTransaction in order to route the execution to the READ_REPLICA
+        testCallInReadTransaction(cluster.getSession(), "return custom.answer1() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+    }
+
+    @Test
+    public void shouldUpdateCustomFunctionsOnOtherClusterMembers() {
+        // given
+        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asFunction('answer2', 'RETURN 42 as answer')")); // we create a function
+        testCall(cluster.getSession(), "return custom.answer2() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+
+        // when
+        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asFunction('answer2', 'RETURN 52 as answer')")); // we update the function
+        clearCache();
+
+        // then
+        // we use the readTransaction in order to route the execution to the READ_REPLICA
+        testCallInReadTransaction(cluster.getSession(), "return custom.answer2() as row", (row) -> assertEquals(52L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+    }
+
+    @Test
+    public void shouldRegisterSimpleStatementOnOtherClusterMembers() {
+        // given
+        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asProcedure('answerProcedure1', 'RETURN 33 as answer', 'read', [['answer','long']])")); // we create a procedure
+
+        // when
+        testCall(cluster.getSession(), "call custom.answerProcedure1()", (row) -> assertEquals(33L, row.get("answer")));
+
+        // then
+        testCallInReadTransaction(cluster.getSession(), "call custom.answerProcedure1()", (row) -> assertEquals(33L, row.get("answer")));
+    }
+
+    @Test
+    public void shouldUpdateSimpleStatementOnOtherClusterMembers() {
+        // given
+        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asProcedure('answerProcedure2', 'RETURN 33 as answer', 'read', [['answer','long']])")); // we create a procedure
+        testCall(cluster.getSession(), "call custom.answerProcedure2()", (row) -> assertEquals(33L, row.get("answer")));
+
+        // when
+        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asProcedure('answerProcedure2', 'RETURN 55 as answer', 'read', [['answer','long']])")); // we create a procedure
+        clearCache();
+
+        // then
+        testCallInReadTransaction(cluster.getSession(), "call custom.answerProcedure2()", (row) -> assertEquals(55L, row.get("answer")));
+    }
+}

--- a/src/test/java/apoc/custom/CypherProceduresClusterTest.java
+++ b/src/test/java/apoc/custom/CypherProceduresClusterTest.java
@@ -36,18 +36,14 @@ public class CypherProceduresClusterTest {
         cleanBuild();
     }
 
-    @Before
-    public void clearCache() {
-        cluster.getSession().writeTransaction(tx -> tx.run("call dbms.clearQueryCaches()")); // we update the function
-    }
-
     @Test
-    public void shouldRecreateCustomFunctionsOnOtherClusterMembers() {
+    public void shouldRecreateCustomFunctionsOnOtherClusterMembers() throws InterruptedException {
         // given
         cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asFunction('answer1', 'RETURN 42 as answer')")); // we create a function
 
         // when
         testCall(cluster.getSession(), "return custom.answer1() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        Thread.sleep(1000);
 
         // then
         // we use the readTransaction in order to route the execution to the READ_REPLICA
@@ -55,14 +51,14 @@ public class CypherProceduresClusterTest {
     }
 
     @Test
-    public void shouldUpdateCustomFunctionsOnOtherClusterMembers() {
+    public void shouldUpdateCustomFunctionsOnOtherClusterMembers() throws InterruptedException {
         // given
         cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asFunction('answer2', 'RETURN 42 as answer')")); // we create a function
         testCall(cluster.getSession(), "return custom.answer2() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
 
         // when
         cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asFunction('answer2', 'RETURN 52 as answer')")); // we update the function
-        clearCache();
+        Thread.sleep(1000);
 
         // then
         // we use the readTransaction in order to route the execution to the READ_REPLICA
@@ -70,27 +66,27 @@ public class CypherProceduresClusterTest {
     }
 
     @Test
-    public void shouldRegisterSimpleStatementOnOtherClusterMembers() {
+    public void shouldRegisterSimpleStatementOnOtherClusterMembers() throws InterruptedException {
         // given
         cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asProcedure('answerProcedure1', 'RETURN 33 as answer', 'read', [['answer','long']])")); // we create a procedure
 
         // when
         testCall(cluster.getSession(), "call custom.answerProcedure1()", (row) -> assertEquals(33L, row.get("answer")));
-
+        Thread.sleep(1000);
         // then
         testCallInReadTransaction(cluster.getSession(), "call custom.answerProcedure1()", (row) -> assertEquals(33L, row.get("answer")));
     }
 
     @Test
-    public void shouldUpdateSimpleStatementOnOtherClusterMembers() {
+    public void shouldUpdateSimpleStatementOnOtherClusterMembers() throws InterruptedException {
         // given
         cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asProcedure('answerProcedure2', 'RETURN 33 as answer', 'read', [['answer','long']])")); // we create a procedure
         testCall(cluster.getSession(), "call custom.answerProcedure2()", (row) -> assertEquals(33L, row.get("answer")));
 
         // when
         cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asProcedure('answerProcedure2', 'RETURN 55 as answer', 'read', [['answer','long']])")); // we create a procedure
-        clearCache();
 
+        Thread.sleep(1000);
         // then
         testCallInReadTransaction(cluster.getSession(), "call custom.answerProcedure2()", (row) -> assertEquals(55L, row.get("answer")));
     }

--- a/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -1,6 +1,7 @@
 package apoc.custom;
 
 import apoc.util.TestUtil;
+import apoc.util.Util;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -44,7 +45,6 @@ public class CypherProceduresTest {
     }
 
     @Test
-    @Ignore
     public void overrideSingleCallStatement() throws Exception {
         db.execute("call apoc.custom.asProcedure('answer','RETURN 42 as answer')");
         TestUtil.testCall(db, "call custom.answer() yield row return row", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
@@ -54,8 +54,8 @@ public class CypherProceduresTest {
         db.execute("call apoc.custom.asProcedure('answer','RETURN 43 as answer')");
         TestUtil.testCall(db, "call custom.answer() yield row return row", (row) -> assertEquals(43L, ((Map)row.get("row")).get("answer")));
     }
+
     @Test
-    @Ignore
     public void overrideCypherCallStatement() throws Exception {
         db.execute("call apoc.custom.asProcedure('answer','RETURN 42 as answer')");
         TestUtil.testCall(db, "with 1 as foo call custom.answer() yield row return row", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));

--- a/src/test/java/apoc/export/cypher/ExportCypherEnterpriseFeaturesTest.java
+++ b/src/test/java/apoc/export/cypher/ExportCypherEnterpriseFeaturesTest.java
@@ -35,7 +35,9 @@ public class ExportCypherEnterpriseFeaturesTest {
     @BeforeClass
     public static void beforeAll() {
         TestUtil.ignoreException(() -> {
-            neo4jContainer = createEnterpriseDB(true)
+            // We build the project, the artifact will be placed into ./build/libs
+            executeGradleTasks("clean", "shadow");
+            neo4jContainer = createEnterpriseDB(!TestUtil.isTravis())
                     .withInitScript("init_neo4j_export_csv.cypher");
             neo4jContainer.start();
         }, Exception.class);

--- a/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
+++ b/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
@@ -1,12 +1,13 @@
 package apoc.schema;
 
+import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.neo4j.driver.v1.*;
-import org.testcontainers.containers.Neo4jContainer;
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.Session;
 
 import java.util.List;
 import java.util.Map;
@@ -22,26 +23,25 @@ import static org.junit.Assume.assumeNotNull;
  */
 public class SchemasEnterpriseFeaturesTest {
 
-    private static Neo4jContainer neo4jContainer;
+    private static Neo4jContainerExtension neo4jContainer;
     private static Session session;
-    private static Driver driver;
 
     @BeforeClass
     public static void beforeAll() {
+        executeGradleTasks("clean", "shadow");
         TestUtil.ignoreException(() -> {
-            neo4jContainer = createEnterpriseDB(true);
+            // We build the project, the artifact will be placed into ./build/libs
+            neo4jContainer = createEnterpriseDB(!TestUtil.isTravis());
             neo4jContainer.start();
         }, Exception.class);
         assumeNotNull(neo4jContainer);
-        driver = GraphDatabase.driver(neo4jContainer.getBoltUrl(), AuthTokens.none());
-        session = driver.session();
+        session = neo4jContainer.getSession();
     }
 
     @AfterClass
     public static void afterAll() {
         if (neo4jContainer != null) {
             session.close();
-            driver.close();
             neo4jContainer.close();
         }
         cleanBuild();

--- a/src/test/java/apoc/util/Neo4jContainerExtension.java
+++ b/src/test/java/apoc/util/Neo4jContainerExtension.java
@@ -24,18 +24,33 @@ public class Neo4jContainerExtension extends Neo4jContainer<Neo4jContainerExtens
 
     private String filePath;
 
+    private boolean withDriver = true;
+
+    public Neo4jContainerExtension() {}
+
+    public Neo4jContainerExtension(String dockerImage) {
+        setDockerImageName(dockerImage);
+    }
+
     public Neo4jContainerExtension withInitScript(String filePath) {
         this.filePath = filePath;
+        return this;
+    }
+
+    public Neo4jContainerExtension withoutDriver() {
+        this.withDriver = false;
         return this;
     }
 
     @Override
     public void start() {
         super.start();
-        driver = GraphDatabase.driver(getBoltUrl(), getAuth());
-        session = driver.session();
-        if (filePath != null && !filePath.isEmpty()) {
-            executeScript(filePath);
+        if (withDriver) {
+            driver = GraphDatabase.driver(getBoltUrl(), getAuth());
+            session = driver.session();
+            if (filePath != null && !filePath.isEmpty()) {
+                executeScript(filePath);
+            }
         }
     }
 
@@ -78,8 +93,10 @@ public class Neo4jContainerExtension extends Neo4jContainer<Neo4jContainerExtens
 
     @Override
     public void stop() {
-        session.close();
-        driver.close();
+        if (withDriver) {
+            session.close();
+            driver.close();
+        }
         super.stop();
     }
 }

--- a/src/test/java/apoc/util/TestContainerUtil.java
+++ b/src/test/java/apoc/util/TestContainerUtil.java
@@ -8,6 +8,7 @@ import org.testcontainers.utility.MountableFile;
 
 import java.io.File;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
@@ -23,28 +24,27 @@ public class TestContainerUtil {
 
     private static File baseDir = Paths.get(".").toFile();
 
-
+    public static TestcontainersCausalCluster createEnterpriseCluster(int numOfCoreInstances, int numberOfReadReplica, Map<String, Object> neo4jConfig) {
+        return TestcontainersCausalCluster.create(numOfCoreInstances, numberOfReadReplica, Duration.ofMinutes(4), neo4jConfig);
+    }
 
     public static Neo4jContainerExtension createEnterpriseDB(boolean withLogging) {
-        // We build the project, the artifact will be placed into ./build/libs
-        executeGradleTasks("clean", "shadow");
         // We define the container with external volumes
-        Neo4jContainerExtension neo4jContainer = new Neo4jContainerExtension()
+        Neo4jContainerExtension neo4jContainer = new Neo4jContainerExtension("neo4j:3.5.3-enterprise")
                 .withPlugins(MountableFile.forHostPath("./target/tests/gradle-build/libs")) // map the apoc's artifact dir as the Neo4j's plugin dir
-                .withoutAuthentication()
-                .withEnv("NEO4J_apoc_export_file_enabled", "true")
-                .withEnv("NEO4J_dbms_security_procedures_unrestricted", "apoc.*")
+                .withAdminPassword("apoc")
+                .withNeo4jConfig("apoc.export.file.enabled", "true")
+                .withNeo4jConfig("dbms.security.procedures.unrestricted", "apoc.*")
 //                .withEnv("NEO4J_wrapper_java_additional","-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005 -Xdebug-Xnoagent-Djava.compiler=NONE-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005")
                 .withFileSystemBind("./target/import", "/import") // map the "target/import" dir as the Neo4j's import dir
                 .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes");
         if (withLogging) {
             neo4jContainer.withLogging();
         }
-        neo4jContainer.setDockerImageName("neo4j:3.5.3-enterprise");
         return neo4jContainer;
     }
 
-    private static void executeGradleTasks(String... tasks) {
+    public static void executeGradleTasks(String... tasks) {
         ProjectConnection connection = GradleConnector.newConnector()
                 .forProjectDirectory(baseDir)
                 .useBuildDistribution()
@@ -88,6 +88,38 @@ public class TestContainerUtil {
 
     public static void testResult(Session session, String call, Map<String,Object> params, Consumer<Iterator<Map<String, Object>>> resultConsumer) {
         session.writeTransaction(tx -> {
+            Map<String, Object> p = (params == null) ? Collections.<String, Object>emptyMap() : params;
+            resultConsumer.accept(tx.run(call, p).list().stream().map(Record::asMap).collect(Collectors.toList()).iterator());
+            tx.success();
+            return null;
+        });
+    }
+
+    public static void testCallInReadTransaction(Session session, String call, Consumer<Map<String, Object>> consumer) {
+        testCallInReadTransaction(session, call, null, consumer);
+    }
+
+    public static void testCallInReadTransaction(Session session, String call, Map<String,Object> params, Consumer<Map<String, Object>> consumer) {
+        testResultInReadTransaction(session, call, params, (res) -> {
+            try {
+                assertNotNull("result should be not null", res);
+                assertTrue("result should be not empty", res.hasNext());
+                Map<String, Object> row = res.next();
+                consumer.accept(row);
+                assertFalse("result should not have next", res.hasNext());
+            } catch(Throwable t) {
+                printFullStackTrace(t);
+                throw t;
+            }
+        });
+    }
+
+    public static void testResultInReadTransaction(Session session, String call, Consumer<Iterator<Map<String, Object>>> resultConsumer) {
+        testResultInReadTransaction(session, call, null, resultConsumer);
+    }
+
+    public static void testResultInReadTransaction(Session session, String call, Map<String,Object> params, Consumer<Iterator<Map<String, Object>>> resultConsumer) {
+        session.readTransaction(tx -> {
             Map<String, Object> p = (params == null) ? Collections.<String, Object>emptyMap() : params;
             resultConsumer.accept(tx.run(call, p).list().stream().map(Record::asMap).collect(Collectors.toList()).iterator());
             tx.success();

--- a/src/test/java/apoc/util/TestcontainersCausalCluster.java
+++ b/src/test/java/apoc/util/TestcontainersCausalCluster.java
@@ -1,0 +1,187 @@
+package apoc.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.neo4j.driver.v1.AuthTokens;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Session;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitStrategy;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.*;
+
+/*
+ * Thanks to Michael Simons that inspired this.
+ *
+ * https://github.com/michael-simons/junit-jupiter-causal-cluster-testcontainer-extension/blob/master/src/main/java/org/neo4j/junit/jupiter/causal_cluster/CausalCluster.java
+ */
+
+public class TestcontainersCausalCluster {
+    private static final int DEFAULT_BOLT_PORT = 7687;
+
+    public enum ClusterInstanceType {CORE, READ_REPLICA}
+
+    private static Stream<String> iterateMembers(int numOfMembers, ClusterInstanceType instanceType) {
+        final IntFunction<String> generateInstanceName = i -> String.format("neo4j-%s-%d", instanceType.toString(), i);
+
+        return IntStream.rangeClosed(1, numOfMembers).mapToObj(generateInstanceName);
+    }
+
+    public static TestcontainersCausalCluster create(int numberOfCoreMembers, int numberOfReadReplica, Duration timeout, Map<String, Object> neo4jConfig) {
+        if (numberOfCoreMembers < 3) {
+            throw new IllegalArgumentException("numberOfCoreMembers must be >= 3");
+        }
+        if (numberOfReadReplica < 0) {
+            throw new IllegalArgumentException("numberOfReadReplica must be >= 0");
+        }
+
+        // Setup a naming strategy and the initial discovery members
+        final String initialDiscoveryMembers = iterateMembers(numberOfCoreMembers, ClusterInstanceType.CORE)
+                .map(n -> String.format("%s:5000", n))
+                .collect(joining(","));
+
+        // Prepare one shared network for those containers
+        Network network = Network.newNetwork();
+
+        // Prepare proxys as sidecars
+        Map<String, GenericContainer> sidecars = createSidecars(numberOfCoreMembers, network, ClusterInstanceType.CORE);
+        sidecars.putAll(createSidecars(numberOfReadReplica, network, ClusterInstanceType.READ_REPLICA));
+
+        // Start the sidecars so that the exposed ports are available
+        sidecars.values().forEach(GenericContainer::start);
+
+        // Build the core/read_replica
+        List<Neo4jContainerExtension> members = getClusterMembers(numberOfCoreMembers, ClusterInstanceType.CORE, sidecars, network, initialDiscoveryMembers, neo4jConfig, timeout);
+        members.addAll(getClusterMembers(numberOfReadReplica, ClusterInstanceType.READ_REPLICA, sidecars, network, initialDiscoveryMembers, neo4jConfig, timeout));
+
+        // Start all of them in parallel
+        final CountDownLatch latch = new CountDownLatch(numberOfCoreMembers);
+        members.forEach(instance -> CompletableFuture.runAsync(() -> {
+            instance.start();
+            latch.countDown();
+        }));
+
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        return new TestcontainersCausalCluster(members, sidecars.values().stream().collect(toList()));
+    }
+
+    @NotNull
+    private static List<Neo4jContainerExtension> getClusterMembers(int numberOfCoreMembers,
+                                                                   ClusterInstanceType instanceType,
+                                                                   Map<String, GenericContainer> sidecars,
+                                                                   Network network,
+                                                                   String initialDiscoveryMembers,
+                                                                   Map<String, Object> neo4jConfig,
+                                                                   Duration timeout) {
+        // Currently needed as a whole new waiting strategy due to a bug in test containers
+        WaitStrategy waitForBolt = new LogMessageWaitStrategy()
+                .withRegEx(String.format(".*Bolt enabled on 0\\.0\\.0\\.0:%d\\.\n", DEFAULT_BOLT_PORT))
+                .withStartupTimeout(timeout);
+        Function<GenericContainer, String> getProxyUrl = instance ->
+                String.format("%s:%d", instance.getContainerIpAddress(), instance.getMappedPort(DEFAULT_BOLT_PORT));
+        return iterateMembers(numberOfCoreMembers, instanceType)
+                .map(name -> getNeo4jContainerExtension(waitForBolt, network, initialDiscoveryMembers, sidecars, getProxyUrl, instanceType, neo4jConfig, name))
+                .collect(toList());
+    }
+
+    @NotNull
+    private static Map<String, GenericContainer> createSidecars(int numOfMembers, Network network, ClusterInstanceType instanceType) {
+        return iterateMembers(numOfMembers, instanceType)
+                .collect(toMap(
+                        Function.identity(),
+                        name -> new GenericContainer("alpine/socat")
+                                .withNetwork(network)
+                                .withLabel("memberType", instanceType.toString())
+                                // Expose the default bolt port on the sidecar
+                                .withExposedPorts(DEFAULT_BOLT_PORT)
+                                // And redirect that port to the corresponding Neo4j instance
+                                .withCommand(String
+                                        .format("tcp-listen:%d,fork,reuseaddr tcp-connect:%s:%1$d", DEFAULT_BOLT_PORT, name))
+                ));
+    }
+
+    private static Neo4jContainerExtension getNeo4jContainerExtension(WaitStrategy waitForBolt,
+                                                                      Network network,
+                                                                      String initialDiscoveryMembers,
+                                                                      Map<String, GenericContainer> sidecars,
+                                                                      Function<GenericContainer, String> getProxyUrl,
+                                                                      ClusterInstanceType instanceType,
+                                                                      Map<String, Object> neo4jConfig,
+                                                                      String name) {
+        Neo4jContainerExtension container =  TestContainerUtil.createEnterpriseDB(!TestUtil.isTravis())
+                .withLabel("memberType", instanceType.toString())
+                .withNetwork(network)
+                .withNetworkAliases(name)
+                .withoutDriver()
+                .withNeo4jConfig("dbms.mode", instanceType.toString())
+                .withNeo4jConfig("dbms.connectors.default_listen_address", "0.0.0.0")
+                .withNeo4jConfig("dbms.connectors.default_advertised_address", name)
+                .withNeo4jConfig("dbms.connector.bolt.advertised_address", getProxyUrl.apply(sidecars.get(name)))
+                .withNeo4jConfig("causal_clustering.initial_discovery_members", initialDiscoveryMembers)
+                .waitingFor(waitForBolt);
+        neo4jConfig.forEach((conf, value) -> container.withNeo4jConfig(conf, String.valueOf(value)));
+        return container;
+    }
+
+    private final List<Neo4jContainerExtension> clusterMembers;
+    private final List<GenericContainer> sidecars;
+
+    private Driver driver;
+    private Session session;
+
+    public TestcontainersCausalCluster(List<Neo4jContainerExtension> clusterMembers,
+                                       List<GenericContainer> sidecars) {
+        this.clusterMembers = clusterMembers;
+        this.sidecars = sidecars;
+        this.driver = GraphDatabase.driver(getURI(), AuthTokens.basic("neo4j", "apoc"));
+        this.session = driver.session();
+    }
+
+    public Driver getDriver() {
+        return driver;
+    }
+
+    public Session getSession() {
+        return session;
+    }
+
+    public URI getURI() {
+        return this.sidecars.stream().findAny()
+                .map(instance -> String.format("bolt+routing://%s:%d", instance.getContainerIpAddress(),
+                        instance.getMappedPort(DEFAULT_BOLT_PORT)))
+                .map(uri -> {
+                    try {
+                        return new URI(uri);
+                    } catch (URISyntaxException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .orElseThrow(() -> new IllegalStateException("No sidecar as entrypoint into the cluster available."));
+    }
+
+    public void close() {
+        getSession().close();
+        getDriver().close();
+        sidecars.forEach(GenericContainer::stop);
+        clusterMembers.forEach(Neo4jContainerExtension::stop);
+    }
+}


### PR DESCRIPTION
Fixes #1072

Make sure custom procedures are also recreated on other cluster members

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - added "lastUpdate" to the procedure/function structure
  - added timer that checks every `x` (default 60000) milliseconds if the graph property got updated and register the updated procedure/function version
  - added integration test in Causal Cluster environment (3 core + 1 read replica)
  - updated the documentation
