### PR TITLE
fixes #1173: Fix ExportCsv ordering tests

### DIFF
--- a/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/src/main/java/apoc/export/csv/CsvFormat.java
@@ -110,6 +110,7 @@ public class CsvFormat implements Format {
 
     public String[] writeResultHeader(Result result, CSVWriter out) {
         List<String> columns = result.columns();
+        columns.sort(Comparator.naturalOrder());
         int cols = columns.size();
         String[] header = columns.toArray(new String[cols]);
         out.writeNext(header, applyQuotesToAll);

--- a/src/test/java/apoc/export/csv/ExportCsvNeo4jAdmin.java
+++ b/src/test/java/apoc/export/csv/ExportCsvNeo4jAdmin.java
@@ -1,0 +1,177 @@
+package apoc.export.csv;
+
+import apoc.graph.Graphs;
+import apoc.util.TestUtil;
+import apoc.util.Util;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+import static apoc.util.MapUtil.map;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+public class ExportCsvNeo4jAdmin {
+
+    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_TYPES_NODE = String
+            .format("id:ID;born_2D:point;born_3D:point;localtime:localtime;time:time;dateTime:datetime;localDateTime:localdatetime;date:date;duration:duration;:LABEL%n");
+
+    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_TYPES_NODE = String
+            .format("3;{crs:cartesian,x:2.3,y:4.5};{crs:wgs-84-3d,latitude:56.7,longitude:12.78,height:100.0};12:50:35.556;12:50:35.556+01:00;2018-10-30T12:50:35.556+01:00;2018-10-30T19:32:24;2018-10-30;P5M1DT12H;Types%n");
+
+    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS = String
+            .format("id:ID;name;street;:LABEL%n");
+
+    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS1 = String
+            .format("id:ID;street;name;city;:LABEL%n");
+
+    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER = String
+            .format("id:ID;name;age:long;:LABEL%n");
+
+    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER1 = String
+            .format("id:ID;name;age:long;male:boolean;kids;:LABEL%n");
+
+    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_KNOWS = String
+            .format(":START_ID;:END_ID;:TYPE%n");
+
+    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_NEXT_DELIVERY = String
+            .format(":START_ID;:END_ID;:TYPE%n");
+
+    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS = String
+            .format("21;Bar Sport;;Address%n" +
+                    "22;;via Benni;Address%n");
+
+    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS1 = String
+            .format("20;Via Garibaldi, 7;Andrea;Milano;\"Address1;Address\"%n");
+
+    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER = String
+            .format("1;bar;42;User%n" +
+                    "2;;12;User%n");
+
+    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER1 = String
+            .format("0;foo;42;true;[a,b,c];\"User1;User\"%n");
+
+    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_KNOWS = String
+            .format("0;1;KNOWS%n");
+
+    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_NEXT_DELIVERY = String
+            .format("20;21;NEXT_DELIVERY%n");
+
+    private static GraphDatabaseService db;
+    private static File directory = new File("target/import");
+
+    static { //noinspection ResultOfMethodCallIgnored
+        directory.mkdirs();
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        db = new TestGraphDatabaseFactory()
+                .newImpermanentDatabaseBuilder()
+                .setConfig(GraphDatabaseSettings.load_csv_file_url_root, directory.getAbsolutePath())
+                .setConfig("apoc.export.file.enabled", "true")
+                .newGraphDatabase();
+        TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class);
+        db.execute("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})").close();
+        db.execute("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})").close();
+        db.execute("CREATE (a:Types {date: date('2018-10-30'), localDateTime: localdatetime('20181030T19:32:24'), dateTime: datetime('2018-10-30T12:50:35.556+0100'), localtime: localtime('12:50:35.556'), duration: duration('P5M1DT12H'), time: time('125035.556+0100'), born_2D: point({ x: 2.3, y: 4.5 }), born_3D:point({ longitude: 56.7, latitude: 12.78, height: 100 })})").close();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
+    }
+
+    @Test
+    public void testCypherExportCsvForAdminNeo4jImportWithConfig() throws Exception {
+
+        File dir = new File(directory, "query_nodes.csv");
+
+        TestUtil.testCall(db, "CALL apoc.export.csv.all({directory},{bulkImport: true, separateHeader: true, delim: ';'})",
+                map("directory", dir.getAbsolutePath()), r -> {
+                    assertEquals(20000L, r.get("batchSize"));
+                    assertEquals(1L, r.get("batches"));
+                    assertEquals(7L, r.get("nodes"));
+                    assertEquals(9L, r.get("rows"));
+                    assertEquals(2L, r.get("relationships"));
+                    assertEquals(20L, r.get("properties"));
+                    assertTrue("Should get time greater than 0",
+                            ((long) r.get("time")) >= 0);
+                }
+        );
+
+        String file = dir.getParent() + File.separator;
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS, "query_nodes.header.nodes.Address.csv");
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS1, "query_nodes.header.nodes.Address1.Address.csv");
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER, "query_nodes.header.nodes.User.csv");
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER1, "query_nodes.header.nodes.User1.User.csv");
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_TYPES_NODE, "query_nodes.header.nodes.Types.csv");
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_KNOWS, "query_nodes.header.relationships.KNOWS.csv");
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_NEXT_DELIVERY, "query_nodes.header.relationships.NEXT_DELIVERY.csv");
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS, "query_nodes.nodes.Address.csv");
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS1, "query_nodes.nodes.Address1.Address.csv");
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER, "query_nodes.nodes.User.csv");
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER1, "query_nodes.nodes.User1.User.csv");
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_TYPES_NODE, "query_nodes.nodes.Types.csv");
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_KNOWS, "query_nodes.relationships.KNOWS.csv");
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_NEXT_DELIVERY, "query_nodes.relationships.NEXT_DELIVERY.csv");
+    }
+
+    @Test
+    public void testExportGraphNeo4jAdminCsv() throws Exception {
+        File output = new File(directory, "graph.csv");
+        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.csv.graph(graph, {file},{bulkImport: true, delim: ';'}) " +
+                        "YIELD nodes, relationships, properties, file, source,format, time " +
+                        "RETURN *", map("file", output.getAbsolutePath()),
+                (r) -> assertResults(output, r, "graph"));
+
+        String file = output.getParent() + File.separator;
+        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS + EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS, "graph.nodes.Address.csv");
+        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS1 + EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS1, "graph.nodes.Address1.Address.csv");
+        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER + EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER, "graph.nodes.User.csv");
+        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER1 + EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER1, "graph.nodes.User1.User.csv");
+        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_TYPES_NODE + EXPECTED_NEO4J_ADMIN_IMPORT_TYPES_NODE, "graph.nodes.Types.csv");
+        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_KNOWS + EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_KNOWS, "graph.relationships.KNOWS.csv");
+        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_NEXT_DELIVERY + EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_NEXT_DELIVERY, "graph.relationships.NEXT_DELIVERY.csv");
+    }
+
+    private void assertFileEquals(String file, String expectedNeo4jAdminImportNodeProduct, String s) throws IOException {
+        assertEquals(expectedNeo4jAdminImportNodeProduct, FileUtils.readFileToString(new File(file + s), Charset.forName("UTF-8")));
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testCypherExportCsvForAdminNeo4jImportExceptionBulk() throws Exception {
+        File dir = new File(directory, "query_nodes.csv");
+        try {
+            TestUtil.testCall(db, "CALL apoc.export.csv.query('MATCH (n) return (n)',{directory},{bulkImport: true})", Util.map("directory", dir.getAbsolutePath()), (r) -> {
+            });
+        } catch (Exception e) {
+            Throwable except = ExceptionUtils.getRootCause(e);
+            assertTrue(except instanceof RuntimeException);
+            assertEquals("You can use the `bulkImport` only with apoc.export.all and apoc.export.csv.graph", except.getMessage());
+            throw e;
+        }
+    }
+
+    private void assertResults(File output, Map<String, Object> r, final String source) {
+        assertEquals(7L, r.get("nodes"));
+        assertEquals(2L, r.get("relationships"));
+        assertEquals(20L, r.get("properties"));
+        assertEquals(source + ": nodes(7), rels(2)", r.get("source"));
+        assertEquals(output.getAbsolutePath(), r.get("file"));
+        assertEquals("csv", r.get("format"));
+        assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
+    }
+}
+

--- a/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -3,9 +3,7 @@ package apoc.export.csv;
 import apoc.graph.Graphs;
 import apoc.util.HdfsTestUtils;
 import apoc.util.TestUtil;
-import apoc.util.Util;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -19,10 +17,9 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.io.File;
-import java.io.FileNotFoundException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.Map;
-import java.util.Scanner;
 import java.util.function.Consumer;
 
 import static apoc.util.MapUtil.map;
@@ -38,27 +35,27 @@ public class ExportCsvTest {
     private static final String EXPECTED_QUERY_NODES = String.format("\"u\"%n" +
             "\"{\"\"id\"\":0,\"\"labels\"\":[\"\"User\"\",\"\"User1\"\"],\"\"properties\"\":{\"\"name\"\":\"\"foo\"\",\"\"age\"\":42,\"\"male\"\":true,\"\"kids\"\":[\"\"a\"\",\"\"b\"\",\"\"c\"\"]}}\"%n" +
             "\"{\"\"id\"\":1,\"\"labels\"\":[\"\"User\"\"],\"\"properties\"\":{\"\"name\"\":\"\"bar\"\",\"\"age\"\":42}}\"%n" +
-            "\"{\"\"id\"\":2,\"\"labels\"\":[\"\"User\"\"],\"\"properties\"\":{\"\"age\"\":12}}\"");
-    private static final String EXPECTED_QUERY = String.format("\"u.age\",\"u.name\",\"u.male\",\"u.kids\",\"labels(u)\"%n" +
-            "\"42\",\"foo\",\"true\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"[\"\"User1\"\",\"\"User\"\"]\"%n" +
-            "\"42\",\"bar\",\"\",\"\",\"[\"\"User\"\"]\"%n" +
-            "\"12\",\"\",\"\",\"\",\"[\"\"User\"\"]\"");
-    private static final String EXPECTED_QUERY_WITHOUT_QUOTES = String.format("u.age,u.name,u.male,u.kids,labels(u)%n" +
-            "42,foo,true,[\"a\",\"b\",\"c\"],[\"User1\",\"User\"]%n" +
-            "42,bar,,,[\"User\"]%n" +
-            "12,,,,[\"User\"]");
-    private static final String EXPECTED_QUERY_QUOTES_NONE= String.format( "a.name,a.city,a.street,labels(a)%n" +
-            "Andrea,Milano,Via Garibaldi, 7,[\"Address1\",\"Address\"]%n" +
-            "Bar Sport,,,[\"Address\"]%n" +
-            ",,via Benni,[\"Address\"]" );
-    private static final String EXPECTED_QUERY_QUOTES_ALWAYS= String.format( "\"a.name\",\"a.city\",\"a.street\",\"labels(a)\"%n" +
-            "\"Andrea\",\"Milano\",\"Via Garibaldi, 7\",\"[\"\"Address1\"\",\"\"Address\"\"]\"%n" +
-            "\"Bar Sport\",\"\",\"\",\"[\"\"Address\"\"]\"%n" +
-            "\"\",\"\",\"via Benni\",\"[\"\"Address\"\"]\"");
-    private static final String EXPECTED_QUERY_QUOTES_NEEDED= String.format( "a.name,a.city,a.street,labels(a)%n" +
-            "Andrea,Milano,\"Via Garibaldi, 7\",\"[\"Address1\",\"Address\"]\"%n" +
-            "Bar Sport,,,\"[\"Address\"]\"%n" +
-            ",,via Benni,\"[\"Address\"]\"");
+            "\"{\"\"id\"\":2,\"\"labels\"\":[\"\"User\"\"],\"\"properties\"\":{\"\"age\"\":12}}\"%n");
+    private static final String EXPECTED_QUERY = String.format("\"labels(u)\",\"u.age\",\"u.kids\",\"u.male\",\"u.name\"%n" +
+            "\"[\"\"User1\"\",\"\"User\"\"]\",\"42\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"true\",\"foo\"%n" +
+            "\"[\"\"User\"\"]\",\"42\",\"\",\"\",\"bar\"%n" +
+            "\"[\"\"User\"\"]\",\"12\",\"\",\"\",\"\"%n");
+    private static final String EXPECTED_QUERY_WITHOUT_QUOTES = String.format("labels(u),u.age,u.kids,u.male,u.name%n" +
+            "[\"User1\",\"User\"],42,[\"a\",\"b\",\"c\"],true,foo%n" +
+            "[\"User\"],42,,,bar%n" +
+            "[\"User\"],12,,,%n");
+    private static final String EXPECTED_QUERY_QUOTES_NONE = String.format("a.city,a.name,a.street,labels(a)%n" +
+            "Milano,Andrea,Via Garibaldi, 7,[\"Address1\",\"Address\"]%n" +
+            ",Bar Sport,,[\"Address\"]%n" +
+            ",,via Benni,[\"Address\"]%n");
+    private static final String EXPECTED_QUERY_QUOTES_ALWAYS = String.format("\"a.city\",\"a.name\",\"a.street\",\"labels(a)\"%n" +
+            "\"Milano\",\"Andrea\",\"Via Garibaldi, 7\",\"[\"\"Address1\"\",\"\"Address\"\"]\"%n" +
+            "\"\",\"Bar Sport\",\"\",\"[\"\"Address\"\"]\"%n" +
+            "\"\",\"\",\"via Benni\",\"[\"\"Address\"\"]\"%n");
+    private static final String EXPECTED_QUERY_QUOTES_NEEDED = String.format( "a.city,a.name,a.street,labels(a)%n" +
+            "Milano,Andrea,\"Via Garibaldi, 7\",\"[\"Address1\",\"Address\"]\"%n" +
+            ",Bar Sport,,\"[\"Address\"]\"%n" +
+            ",,via Benni,\"[\"Address\"]\"%n");
     private static final String EXPECTED = String.format("\"_id\",\"_labels\",\"name\",\"age\",\"male\",\"kids\",\"street\",\"city\",\"_start\",\"_end\",\"_type\"%n" +
             "\"0\",\":User:User1\",\"foo\",\"42\",\"true\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"\",\"\",,,%n" +
             "\"1\",\":User\",\"bar\",\"42\",\"\",\"\",\"\",\"\",,,%n" +
@@ -67,7 +64,7 @@ public class ExportCsvTest {
             "\"21\",\":Address\",\"Bar Sport\",\"\",\"\",\"\",\"\",\"\",,,%n" +
             "\"22\",\":Address\",\"\",\"\",\"\",\"\",\"via Benni\",\"\",,,%n" +
             ",,,,,,,,\"0\",\"1\",\"KNOWS\"%n" +
-            ",,,,,,,,\"20\",\"21\",\"NEXT_DELIVERY\"");
+            ",,,,,,,,\"20\",\"21\",\"NEXT_DELIVERY\"%n");
     private static final String EXPECTED_NONE_QUOTES = String.format("_id,_labels,name,age,male,kids,street,city,_start,_end,_type%n" +
             "0,:User:User1,foo,42,true,[\"a\",\"b\",\"c\"],,,,,%n" +
             "1,:User,bar,42,,,,,,,%n" +
@@ -76,7 +73,7 @@ public class ExportCsvTest {
             "21,:Address,Bar Sport,,,,,,,,%n" +
             "22,:Address,,,,,via Benni,,,,%n" +
             ",,,,,,,,0,1,KNOWS%n" +
-            ",,,,,,,,20,21,NEXT_DELIVERY");
+            ",,,,,,,,20,21,NEXT_DELIVERY%n");
     private static final String EXPECTED_NEEDED_QUOTES = String.format("_id,_labels,name,age,male,kids,street,city,_start,_end,_type%n" +
             "0,:User:User1,foo,42,true,\"[\"a\",\"b\",\"c\"]\",,,,,%n" +
             "1,:User,bar,42,,,,,,,%n" +
@@ -85,92 +82,7 @@ public class ExportCsvTest {
             "21,:Address,Bar Sport,,,,,,,,%n" +
             "22,:Address,,,,,via Benni,,,,%n" +
             ",,,,,,,,0,1,KNOWS%n" +
-            ",,,,,,,,20,21,NEXT_DELIVERY");
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_MOVIE = String.format(
-            "id:ID,year:long,movieId,title,:LABEL%n" +
-                    "3,1999,tt0133093,The Matrix,Movie");
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_TEST_NODE = String.format(
-            "id:ID,born_2D:point,time:time,localtime:localtime,dateTime:datetime,localDateTime:localdatetime,date:date,born_3D:point,duration:duration,:LABEL%n" +
-                    "10,\"{crs:cartesian,x:2.3,y:4.5}\",12:50:35.556+01:00,12:50:35.556,2018-10-30T12:50:35.556+01:00,2018-10-30T19:32:24,2018-10-30,\"{crs:wgs-84-3d,latitude:56.7,longitude:12.78,height:100.0}\",P5M1DT12H,Test");
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_PRODUCT = String.format(
-            "id:ID,reorderLevel:long,unitsOnOrder:long,quantityPerUnit,unitPrice:double,categoryID:long,discontinued:boolean,productName,supplierID:long,productID:long,unitsInStock:long,:LABEL%n" +
-                    "9,10,0,10 boxes x 20 bags,18,1,false,Chai,1,1,39,Product");
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_MOVIE_SEQUEL = String.format(
-            "id:ID,title,movieId,year:long,:LABEL%n" +
-                    "4,The Matrix Reloaded,tt0234215,2003,Movie;Sequel%n" +
-                    "5,The Matrix Revolutions,tt0242653,2003,Movie;Sequel");
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ACTOR = String.format(
-            "id:ID,personId,name,age,:LABEL%n" +
-                    "6,keanu,Keanu Reeves,45.1,Actor%n" +
-                    "7,laurence,Laurence Fishburne,50,Actor%n" +
-                    "8,carrieanne,Carrie-Anne Moss,40.9,Actor");
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP = String.format(
-            "role,:START_ID,:END_ID,:TYPE%n" +
-                    "Neo,6,3,ACTED_IN%n" +
-                    "Neo,6,4,ACTED_IN%n" +
-                    "Neo,6,5,ACTED_IN%n" +
-                    "Morpheus,7,3,ACTED_IN%n" +
-                    "Morpheus,7,4,ACTED_IN%n" +
-                    "Morpheus,7,5,ACTED_IN%n" +
-                    "Trinity,8,3,ACTED_IN%n" +
-                    "Trinity,8,4,ACTED_IN%n" +
-                    "Trinity,8,5,ACTED_IN");
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS = String.format(
-            "id:ID;name;street;:LABEL"
-    );
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS1 = String.format(
-            "id:ID;street;name;city;:LABEL"
-    );
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER = String.format(
-            "id:ID;name;age:long;:LABEL"
-    );
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER1 = String.format(
-            "id:ID;name;age:long;male:boolean;kids;:LABEL"
-    );
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_KNOWS = String.format(
-            ":START_ID;:END_ID;:TYPE"
-    );
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_NEXT_DELIVERY = String.format(
-            ":START_ID;:END_ID;:TYPE"
-    );
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS = String.format(
-            "21;Bar Sport;;Address%n" +
-            "22;;via Benni;Address"
-    );
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS1 = String.format(
-            "20;Via Garibaldi, 7;Andrea;Milano;\"Address1;Address\""
-    );
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER = String.format(
-            "1;bar;42;User%n" +
-            "2;;12;User"
-    );
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER1 = String.format(
-            "0;foo;42;true;[a,b,c];\"User1;User\""
-    );
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_KNOWS = String.format(
-            "0;1;KNOWS"
-    );
-
-    private static final String EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_NEXT_DELIVERY = String.format(
-            "20;21;NEXT_DELIVERY"
-    );
+            ",,,,,,,,20,21,NEXT_DELIVERY%n");
 
     private static GraphDatabaseService db;
     private static File directory = new File("target/import");
@@ -188,7 +100,8 @@ public class ExportCsvTest {
                 .setConfig("apoc.export.file.enabled", "true")
                 .newGraphDatabase();
         TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class);
-        cleanAndCreate();
+        db.execute("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})").close();
+        db.execute("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})").close();
         miniDFSCluster = HdfsTestUtils.getLocalHDFSCluster();
     }
 
@@ -215,7 +128,7 @@ public class ExportCsvTest {
         File output = new File(directory, "all.csv");
         TestUtil.testCall(db, "CALL apoc.export.csv.all({file},null)", map("file", output.getAbsolutePath()),
                 (r) -> assertResults(output, r, "database"));
-        assertEquals(EXPECTED, new Scanner(output).useDelimiter("\\Z").next());
+        assertEquals(EXPECTED, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
     }
 
     @Test
@@ -223,7 +136,7 @@ public class ExportCsvTest {
         File output = new File(directory, "all.csv");
         TestUtil.testCall(db, "CALL apoc.export.csv.all({file},{quotes: true})", map("file", output.getAbsolutePath()),
                 (r) -> assertResults(output, r, "database"));
-        assertEquals(EXPECTED, new Scanner(output).useDelimiter("\\Z").next());
+        assertEquals(EXPECTED, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
     }
 
     @Test
@@ -231,7 +144,7 @@ public class ExportCsvTest {
         File output = new File(directory, "all.csv");
         TestUtil.testCall(db, "CALL apoc.export.csv.all({file},{quotes: 'none'})", map("file", output.getAbsolutePath()),
                 (r) -> assertResults(output, r, "database"));
-        assertEquals(EXPECTED_NONE_QUOTES, new Scanner(output).useDelimiter("\\Z").next());
+        assertEquals(EXPECTED_NONE_QUOTES, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
     }
 
     @Test
@@ -239,7 +152,7 @@ public class ExportCsvTest {
         File output = new File(directory, "all.csv");
         TestUtil.testCall(db, "CALL apoc.export.csv.all({file},{quotes: 'ifNeeded'})", map("file", output.getAbsolutePath()),
                 (r) -> assertResults(output, r, "database"));
-        assertEquals(EXPECTED_NEEDED_QUOTES, new Scanner(output).useDelimiter("\\Z").next());
+        assertEquals(EXPECTED_NEEDED_QUOTES, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
     }
 
     @Test
@@ -258,7 +171,7 @@ public class ExportCsvTest {
                         assertEquals("database: nodes(6), rels(2)", r.get("source"));
                         assertEquals("csv", r.get("format"));
                         assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
-                        assertEquals(EXPECTED, new Scanner(output).useDelimiter("\\Z").next());
+                        assertEquals(EXPECTED, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
                     } catch (Exception e) {
                         e.printStackTrace();
                     }
@@ -273,7 +186,7 @@ public class ExportCsvTest {
                         "YIELD nodes, relationships, properties, file, source,format, time " +
                         "RETURN *", map("file", output.getAbsolutePath()),
                 (r) -> assertResults(output, r, "graph"));
-        assertEquals(EXPECTED_NONE_QUOTES, new Scanner(output).useDelimiter("\\Z").next());
+        assertEquals(EXPECTED_NONE_QUOTES, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
     }
 
     @Test
@@ -284,7 +197,7 @@ public class ExportCsvTest {
                         "YIELD nodes, relationships, properties, file, source,format, time " +
                         "RETURN *", map("file", output.getAbsolutePath()),
                 (r) -> assertResults(output, r, "graph"));
-        assertEquals(EXPECTED, new Scanner(output).useDelimiter("\\Z").next());
+        assertEquals(EXPECTED, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
     }
 
     @Test
@@ -298,7 +211,7 @@ public class ExportCsvTest {
                     assertEquals("csv", r.get("format"));
 
                 });
-        assertEquals(EXPECTED_QUERY, new Scanner(output).useDelimiter("\\Z").next());
+        assertEquals(EXPECTED_QUERY, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
     }
 
     @Test
@@ -312,7 +225,7 @@ public class ExportCsvTest {
                     assertEquals("csv", r.get("format"));
 
                 });
-        assertEquals(EXPECTED_QUERY_WITHOUT_QUOTES, new Scanner(output).useDelimiter("\\Z").next());
+        assertEquals(EXPECTED_QUERY_WITHOUT_QUOTES, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
     }
 
     @Test
@@ -326,7 +239,7 @@ public class ExportCsvTest {
                     assertEquals("csv", r.get("format"));
 
                 });
-        assertEquals(EXPECTED_QUERY_NODES, new Scanner(output).useDelimiter("\\Z").next());
+        assertEquals(EXPECTED_QUERY_NODES, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
     }
 
     @Test
@@ -340,7 +253,7 @@ public class ExportCsvTest {
                     assertEquals("csv", r.get("format"));
 
                 });
-        assertEquals(EXPECTED_QUERY_NODES, new Scanner(output).useDelimiter("\\Z").next());
+        assertEquals(EXPECTED_QUERY_NODES, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
     }
 
     private void assertResults(File output, Map<String, Object> r, final String source) {
@@ -396,7 +309,7 @@ public class ExportCsvTest {
             assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
             sb.append(r.get("data"));
         });
-        assertEquals(EXPECTED+"\n",sb.toString());
+        assertEquals(EXPECTED, sb.toString());
     }
 
     @Test public void testCypherCsvStreaming() throws Exception {
@@ -404,7 +317,7 @@ public class ExportCsvTest {
         StringBuilder sb = new StringBuilder();
         TestUtil.testResult(db, "CALL apoc.export.csv.query({query},null,{stream:true,batchSize:2})", map("query",query),
                 getAndCheckStreamingMetadataQueryMatchUsers(sb));
-        assertEquals(EXPECTED_QUERY+"\n",sb.toString());
+        assertEquals(EXPECTED_QUERY, sb.toString());
     }
 
     @Test public void testCypherCsvStreamingWithoutQuotes() throws Exception {
@@ -413,7 +326,7 @@ public class ExportCsvTest {
         TestUtil.testResult(db, "CALL apoc.export.csv.query({query},null,{quotes: false, stream:true,batchSize:2})", map("query",query),
                 getAndCheckStreamingMetadataQueryMatchUsers(sb));
 
-        assertEquals(EXPECTED_QUERY_WITHOUT_QUOTES+"\n",sb.toString());
+        assertEquals(EXPECTED_QUERY_WITHOUT_QUOTES, sb.toString());
     }
 
     private Consumer<Result> getAndCheckStreamingMetadataQueryMatchUsers(StringBuilder sb)
@@ -449,7 +362,7 @@ public class ExportCsvTest {
         TestUtil.testResult(db, "CALL apoc.export.csv.query({query},null,{quotes: 'always', stream:true,batchSize:2})", map("query",query),
                 getAndCheckStreamingMetadataQueryMatchAddress(sb));
 
-        assertEquals(EXPECTED_QUERY_QUOTES_ALWAYS+"\n",sb.toString());
+        assertEquals(EXPECTED_QUERY_QUOTES_ALWAYS, sb.toString());
     }
 
     @Test public void testCypherCsvStreamingWithNeededQuotes() throws Exception {
@@ -458,7 +371,7 @@ public class ExportCsvTest {
         TestUtil.testResult(db, "CALL apoc.export.csv.query({query},null,{quotes: 'ifNeeded', stream:true,batchSize:2})", map("query",query),
                 getAndCheckStreamingMetadataQueryMatchAddress(sb));
 
-        assertEquals(EXPECTED_QUERY_QUOTES_NEEDED + "\n",sb.toString());
+        assertEquals(EXPECTED_QUERY_QUOTES_NEEDED, sb.toString());
     }
 
     @Test public void testCypherCsvStreamingWithNoneQuotes() throws Exception {
@@ -467,144 +380,7 @@ public class ExportCsvTest {
         TestUtil.testResult(db, "CALL apoc.export.csv.query({query},null,{quotes: 'none', stream:true,batchSize:2})", map("query",query),
                 getAndCheckStreamingMetadataQueryMatchAddress(sb));
 
-        assertEquals(EXPECTED_QUERY_QUOTES_NONE + "\n",sb.toString());
-    }
-
-    @Test
-    public void testCypherExportCsvForAdminNeo4jImportWithConfig() throws Exception {
-
-        File dir = new File(directory, "query_nodes.csv");
-
-        TestUtil.testCall(db, "CALL apoc.export.csv.all({directory},{bulkImport: true, separateHeader: true, delim: ';'})",
-                map("directory", dir.getAbsolutePath()), r -> {
-                    assertEquals(20000L, r.get("batchSize"));
-                    assertEquals(1L, r.get("batches"));
-                    assertEquals(6L, r.get("nodes"));
-                    assertEquals(8L, r.get("rows"));
-                    assertEquals(2L, r.get("relationships"));
-                    assertEquals(12L, r.get("properties"));
-                    assertTrue("Should get time greater than 0",
-                            ((long) r.get("time")) >= 0);
-                }
-        );
-
-        String file = dir.getParent() + File.separator;
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS, "query_nodes.header.nodes.Address.csv");
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS1, "query_nodes.header.nodes.Address1.Address.csv");
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER, "query_nodes.header.nodes.User.csv");
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER1, "query_nodes.header.nodes.User1.User.csv");
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_KNOWS, "query_nodes.header.relationships.KNOWS.csv");
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_NEXT_DELIVERY, "query_nodes.header.relationships.NEXT_DELIVERY.csv");
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS, "query_nodes.nodes.Address.csv");
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS1, "query_nodes.nodes.Address1.Address.csv");
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER, "query_nodes.nodes.User.csv");
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER1, "query_nodes.nodes.User1.User.csv");
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_KNOWS, "query_nodes.relationships.KNOWS.csv");
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_NEXT_DELIVERY, "query_nodes.relationships.NEXT_DELIVERY.csv");
-    }
-
-    @Test
-    public void testCypherExportCsvForAdminNeo4jImport() throws Exception {
-
-        File dir = new File(directory, "query_nodes.csv");
-
-        db.execute("MATCH (n) detach delete (n)").close();
-
-        String movieDb = "CREATE (m1:`Movie` {`movieId`:\"tt0133093\", `title`:\"The Matrix\", `year`:1999}),\n" +
-                "(m2:`Movie`:`Sequel` {`movieId`:\"tt0234215\", `title`:\"The Matrix Reloaded\", `year`:2003}),\n" +
-                "(m3:`Movie`:`Sequel` {`movieId`:\"tt0242653\", `title`:\"The Matrix Revolutions\", `year`:2003}),\n" +
-                "(a1:`Actor` {`name`:\"Keanu Reeves\", `personId`:\"keanu\", `age`: 45.1}),\n" +
-                "(a2:`Actor` {`name`:\"Laurence Fishburne\", `personId`:\"laurence\", `age`: 50}),\n" +
-                "(a3:`Actor` {`name`:\"Carrie-Anne Moss\", `personId`:\"carrieanne\", `age`: 40.9}),\n" +
-                "(a1)-[r1:`ACTED_IN` {`role`:\"Neo\"}]->(m1),\n" +
-                "(a1)-[r2:`ACTED_IN` {`role`:\"Neo\"}]->(m2), \n" +
-                "(a1)-[r3:`ACTED_IN` {`role`:\"Neo\"}]->(m3), \n" +
-                "(a2)-[r4:`ACTED_IN` {`role`:\"Morpheus\"}]->(m1),\n" +
-                "(a2)-[r5:`ACTED_IN` {`role`:\"Morpheus\"}]->(m2), \n" +
-                "(a2)-[r6:`ACTED_IN` {`role`:\"Morpheus\"}]->(m3), \n" +
-                "(a3)-[r7:`ACTED_IN` {`role`:\"Trinity\"}]->(m1),\n" +
-                "(a3)-[r8:`ACTED_IN` {`role`:\"Trinity\"}]->(m2), \n" +
-                "(a3)-[r9:`ACTED_IN` {`role`:\"Trinity\"}]->(m3), \n" +
-                "(p:Product {categoryID: 1, discontinued: false, productID: 1, productName: 'Chai', quantityPerUnit: '10 boxes x 20 bags', reorderLevel: 10, supplierID: 1, unitPrice: 18.0, unitsInStock: 39, unitsOnOrder: 0}), \n" +
-                "(a:Test {date: date('2018-10-30'), localDateTime: localdatetime('20181030T19:32:24'), dateTime: datetime('2018-10-30T12:50:35.556+0100'), localtime: localtime('12:50:35.556'), duration: duration('P5M1DT12H'), time: time('125035.556+0100'), born_2D: point({ x: 2.3, y: 4.5 }), born_3D:point({ longitude: 56.7, latitude: 12.78, height: 100 })})";
-        db.execute(movieDb).close();
-        TestUtil.testCall(db, "CALL apoc.export.csv.all({directory},{bulkImport: true})",
-                map("directory", dir.getAbsolutePath()), r -> {
-                    assertEquals(20000L, r.get("batchSize"));
-                    assertEquals(1L, r.get("batches"));
-                    assertEquals(8L, r.get("nodes"));
-                    assertEquals(17L, r.get("rows"));
-                    assertEquals(9L, r.get("relationships"));
-                    assertEquals(45L, r.get("properties"));
-                    assertTrue("Should get time greater than 0",
-                            ((long) r.get("time")) >= 0);
-                }
-        );
-        String file = dir.getParent() + File.separator;
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_PRODUCT, "query_nodes.nodes.Product.csv");
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_MOVIE, "query_nodes.nodes.Movie.csv");
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ACTOR, "query_nodes.nodes.Actor.csv");
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_MOVIE_SEQUEL, "query_nodes.nodes.Movie.Sequel.csv");
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP, "query_nodes.relationships.ACTED_IN.csv");
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_TEST_NODE, "query_nodes.nodes.Test.csv");
-        cleanAndCreate();
-    }
-
-    @Test
-    public void testExportGraphNeo4jAdminCsv() throws Exception {
-        File output = new File(directory, "graph.csv");
-        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
-                        "CALL apoc.export.csv.graph(graph, {file},{bulkImport: true, delim: ';'}) " +
-                        "YIELD nodes, relationships, properties, file, source,format, time " +
-                        "RETURN *", map("file", output.getAbsolutePath()),
-                (r) -> assertResults(output, r, "graph"));
-
-        String file = output.getParent() + File.separator;
-        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS +"\n"+ EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS, "graph.nodes.Address.csv");
-        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS1 +"\n"+ EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS1, "graph.nodes.Address1.Address.csv");
-        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER +"\n"+ EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER, "graph.nodes.User.csv");
-        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER1 +"\n"+ EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER1, "graph.nodes.User1.User.csv");
-        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_KNOWS +"\n"+ EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_KNOWS, "graph.relationships.KNOWS.csv");
-        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_NEXT_DELIVERY +"\n"+ EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_NEXT_DELIVERY, "graph.relationships.NEXT_DELIVERY.csv");
-    }
-
-    private static void cleanAndCreate() {
-        db.execute("MATCH (n) detach delete (n)").close();
-        db.execute("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})").close();
-        db.execute("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})").close();
-    }
-
-    private void assertFileEquals(String file, String expectedNeo4jAdminImportNodeProduct, String s) throws FileNotFoundException {
-        assertEquals(expectedNeo4jAdminImportNodeProduct, new Scanner(new File(file + s)).useDelimiter("\\Z").next());
-    }
-
-    @Test(expected = RuntimeException.class)
-    public void testCypherExportCsvForAdminNeo4jImportException() throws Exception {
-        File dir = new File(directory, "query_nodes.csv");
-        try {
-            TestUtil.testCall(db, "CALL apoc.export.csv.query('MATCH (n) return (n)',{directory},{bulkImport: true})", Util.map("directory", dir.getAbsolutePath()), (r) -> {});
-        } catch (Exception e) {
-            Throwable except = ExceptionUtils.getRootCause(e);
-            assertTrue(except instanceof RuntimeException);
-            assertEquals("You can use the `bulkImport` only with apoc.export.all and apoc.export.csv.graph", except.getMessage());
-            throw e;
-        }
-        try {
-            TestUtil.testCall(db, "CALL apoc.export.csv.data('MATCH (n) return (n)',{directory},{bulkImport: true})", Util.map("directory", dir.getAbsolutePath()), (r) -> {});
-        } catch (Exception e) {
-            Throwable except = ExceptionUtils.getRootCause(e);
-            assertTrue(except instanceof RuntimeException);
-            assertEquals("Only apoc.export.all can have the `neo4jAdmin` config", except.getMessage());
-            throw e;
-        }
-        try {
-            TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph CALL apoc.export.csv.graph(graph,{directory},{bulkImport: true})", Util.map("directory", dir.getAbsolutePath()), (r) -> {});
-        } catch (Exception e) {
-            Throwable except = ExceptionUtils.getRootCause(e);
-            assertTrue(except instanceof RuntimeException);
-            assertEquals("Only apoc.export.all can have the `neo4jAdmin` config", except.getMessage());
-            throw e;
-        }
+        assertEquals(EXPECTED_QUERY_QUOTES_NONE, sb.toString());
     }
 
     private Consumer<Result> getAndCheckStreamingMetadataQueryMatchAddress(StringBuilder sb)


### PR DESCRIPTION
Fixes #1173

Fix ExportCsv ordering tests

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Provided a natural sorting for the headers in order to have a deterministic, test prone, result
  - Moved tests of Neo4j Admin Import to a separate class in order to simplify the dataset management
  - Clean some code test