### PR TITLE
fixes #1178: Make the `dbms.directories.import` dir root dir for exports

### DIFF
--- a/docs/asciidoc/_export_import.adoc
+++ b/docs/asciidoc/_export_import.adoc
@@ -1,6 +1,9 @@
 [[export-import]]
 == Export / Import
 
+[NOTE]
+In case you have the default configuration with `apoc.import.file.use_neo4j_config=true` the export consider as root the directory defined into the `dbms.directories.import` property
+
 === Loading Data from Web-APIs
 
 Supported protocols are `file`, `http`, `https`, `s3`, `hdfs` with redirect allowed. 

--- a/src/main/java/apoc/ApocConfiguration.java
+++ b/src/main/java/apoc/ApocConfiguration.java
@@ -73,4 +73,5 @@ public class ApocConfiguration {
     public static Map<String,Object> list() {
         return config;
     }
+
 }

--- a/src/main/java/apoc/util/FileUtils.java
+++ b/src/main/java/apoc/util/FileUtils.java
@@ -8,6 +8,7 @@ import apoc.util.s3.S3URLConnection;
 import org.apache.commons.io.output.WriterOutputStream;
 
 import java.io.*;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.util.Arrays;
@@ -86,7 +87,7 @@ public class FileUtils {
     }
 
     public static String changeFileUrlIfImportDirectoryConstrained(String url) throws IOException {
-        if (isFile(url) && ApocConfiguration.isEnabled("import.file.use_neo4j_config")) {
+        if (isFile(url) && isImportUsingNeo4jConfig()) {
             if (!ApocConfiguration.isEnabled("import.file.allow_read_from_filesystem"))
                 throw new RuntimeException("Import file "+url+" not enabled, please set dbms.security.allow_csv_import_from_file_urls=true in your neo4j.conf");
 
@@ -138,9 +139,36 @@ public class FileUtils {
                 throw new RuntimeException(e);
             }
         } else {
-            outputStream = fileName.equals("-") ? out : new FileOutputStream(fileName);
+            outputStream = getOrCreateOutputStream(fileName, out);
+//            outputStream = fileName.equals("-") ? out : new FileOutputStream(fileName);
         }
         return new BufferedOutputStream(outputStream);
+    }
+
+    private static OutputStream getOrCreateOutputStream(String fileName, OutputStream out) throws FileNotFoundException, MalformedURLException {
+        OutputStream outputStream;
+        if (fileName.equals("-")) {
+            outputStream = out;
+        } else {
+            boolean enabled = isImportUsingNeo4jConfig();
+            if (enabled) {
+                String importDir = getConfiguredImportDirectory();
+                File file = new File(importDir, fileName);
+                outputStream = new FileOutputStream(file);
+            } else {
+                URI uri = URI.create(fileName);
+                outputStream = new FileOutputStream(uri.isAbsolute() ? uri.toURL().getFile() : fileName);
+            }
+        }
+        return outputStream;
+    }
+
+    private static boolean isImportUsingNeo4jConfig() {
+        return ApocConfiguration.isEnabled("import.file.use_neo4j_config");
+    }
+
+    public static String getConfiguredImportDirectory() {
+        return ApocConfiguration.get("dbms.directories.import", "import");
     }
 
     public static void checkReadAllowed(String url) {

--- a/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -17,7 +17,6 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.io.File;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -111,12 +110,17 @@ public class ExportCsvTest {
         miniDFSCluster.shutdown();
     }
 
+    private String readFile(String fileName) {
+        return TestUtil.readFileToString(new File(directory, fileName));
+    }
+
     @Test
     public void testExportInvalidQuoteValue() throws Exception {
         try {
-            File output = new File(directory, "all.csv");
-            TestUtil.testCall(db, "CALL apoc.export.csv.all({file},{quote: 'Invalid'}, null)", map("file", output.getAbsolutePath()),
-                    (r) -> assertResults(output, r, "database"));
+            String fileName = "all.csv";
+            TestUtil.testCall(db, "CALL apoc.export.csv.all({file},{quote: 'Invalid'}, null)",
+                    map("file", fileName),
+                    (r) -> assertResults(fileName, r, "database"));
             fail();
         } catch (RuntimeException e) {
             assertTrue(true);
@@ -125,34 +129,37 @@ public class ExportCsvTest {
 
     @Test
     public void testExportAllCsv() throws Exception {
-        File output = new File(directory, "all.csv");
-        TestUtil.testCall(db, "CALL apoc.export.csv.all({file},null)", map("file", output.getAbsolutePath()),
-                (r) -> assertResults(output, r, "database"));
-        assertEquals(EXPECTED, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
+        String fileName = "all.csv";
+        TestUtil.testCall(db, "CALL apoc.export.csv.all({file},null)", map("file", fileName),
+                (r) -> assertResults(fileName, r, "database"));
+        assertEquals(EXPECTED, readFile(fileName));
     }
 
     @Test
     public void testExportAllCsvWithQuotes() throws Exception {
-        File output = new File(directory, "all.csv");
-        TestUtil.testCall(db, "CALL apoc.export.csv.all({file},{quotes: true})", map("file", output.getAbsolutePath()),
-                (r) -> assertResults(output, r, "database"));
-        assertEquals(EXPECTED, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
+        String fileName = "all.csv";
+        TestUtil.testCall(db, "CALL apoc.export.csv.all({file},{quotes: true})",
+                map("file", fileName),
+                (r) -> assertResults(fileName, r, "database"));
+        assertEquals(EXPECTED, readFile(fileName));
     }
 
     @Test
     public void testExportAllCsvWithoutQuotes() throws Exception {
-        File output = new File(directory, "all.csv");
-        TestUtil.testCall(db, "CALL apoc.export.csv.all({file},{quotes: 'none'})", map("file", output.getAbsolutePath()),
-                (r) -> assertResults(output, r, "database"));
-        assertEquals(EXPECTED_NONE_QUOTES, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
+        String fileName = "all.csv";
+        TestUtil.testCall(db, "CALL apoc.export.csv.all({file},{quotes: 'none'})",
+                map("file", fileName),
+                (r) -> assertResults(fileName, r, "database"));
+        assertEquals(EXPECTED_NONE_QUOTES, readFile(fileName));
     }
 
     @Test
     public void testExportAllCsvNeededQuotes() throws Exception {
-        File output = new File(directory, "all.csv");
-        TestUtil.testCall(db, "CALL apoc.export.csv.all({file},{quotes: 'ifNeeded'})", map("file", output.getAbsolutePath()),
-                (r) -> assertResults(output, r, "database"));
-        assertEquals(EXPECTED_NEEDED_QUOTES, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
+        String fileName = "all.csv";
+        TestUtil.testCall(db, "CALL apoc.export.csv.all({file},{quotes: 'ifNeeded'})",
+                map("file", fileName),
+                (r) -> assertResults(fileName, r, "database"));
+        assertEquals(EXPECTED_NEEDED_QUOTES, readFile(fileName));
     }
 
     @Test
@@ -171,7 +178,7 @@ public class ExportCsvTest {
                         assertEquals("database: nodes(6), rels(2)", r.get("source"));
                         assertEquals("csv", r.get("format"));
                         assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
-                        assertEquals(EXPECTED, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
+                        assertEquals(EXPECTED, TestUtil.readFileToString(output));
                     } catch (Exception e) {
                         e.printStackTrace();
                     }
@@ -180,88 +187,91 @@ public class ExportCsvTest {
 
     @Test
     public void testExportGraphCsv() throws Exception {
-        File output = new File(directory, "graph.csv");
+        String fileName = "graph.csv";
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
                         "CALL apoc.export.csv.graph(graph, {file},{quotes: 'none'}) " +
                         "YIELD nodes, relationships, properties, file, source,format, time " +
-                        "RETURN *", map("file", output.getAbsolutePath()),
-                (r) -> assertResults(output, r, "graph"));
-        assertEquals(EXPECTED_NONE_QUOTES, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
+                        "RETURN *", map("file", fileName),
+                (r) -> assertResults(fileName, r, "graph"));
+        assertEquals(EXPECTED_NONE_QUOTES, readFile(fileName));
     }
 
     @Test
     public void testExportGraphCsvWithoutQuotes() throws Exception {
-        File output = new File(directory, "graph.csv");
+        String fileName = "graph.csv";
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
                         "CALL apoc.export.csv.graph(graph, {file},null) " +
                         "YIELD nodes, relationships, properties, file, source,format, time " +
-                        "RETURN *", map("file", output.getAbsolutePath()),
-                (r) -> assertResults(output, r, "graph"));
-        assertEquals(EXPECTED, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
+                        "RETURN *", map("file", fileName),
+                (r) -> assertResults(fileName, r, "graph"));
+        assertEquals(EXPECTED, readFile(fileName));
     }
 
     @Test
     public void testExportQueryCsv() throws Exception {
-        File output = new File(directory, "query.csv");
+        String fileName = "query.csv";
         String query = "MATCH (u:User) return u.age, u.name, u.male, u.kids, labels(u)";
-        TestUtil.testCall(db, "CALL apoc.export.csv.query({query},{file},null)", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.csv.query({query},{file},null)",
+                map("file", fileName, "query", query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(5)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(fileName, r.get("file"));
                     assertEquals("csv", r.get("format"));
 
                 });
-        assertEquals(EXPECTED_QUERY, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
+        assertEquals(EXPECTED_QUERY, readFile(fileName));
     }
 
     @Test
     public void testExportQueryCsvWithoutQuotes() throws Exception {
-        File output = new File(directory, "query.csv");
+        String fileName = "query.csv";
         String query = "MATCH (u:User) return u.age, u.name, u.male, u.kids, labels(u)";
-        TestUtil.testCall(db, "CALL apoc.export.csv.query({query},{file},{quotes: false})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.csv.query({query},{file},{quotes: false})",
+                map("file", fileName, "query", query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(5)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(fileName, r.get("file"));
                     assertEquals("csv", r.get("format"));
 
                 });
-        assertEquals(EXPECTED_QUERY_WITHOUT_QUOTES, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
+        assertEquals(EXPECTED_QUERY_WITHOUT_QUOTES, readFile(fileName));
     }
 
     @Test
     public void testExportQueryNodesCsv() throws Exception {
-        File output = new File(directory, "query_nodes.csv");
+        String fileName = "query_nodes.csv";
         String query = "MATCH (u:User) return u";
-        TestUtil.testCall(db, "CALL apoc.export.csv.query({query},{file},null)", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.csv.query({query},{file},null)",
+                map("file", fileName, "query", query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(fileName, r.get("file"));
                     assertEquals("csv", r.get("format"));
 
                 });
-        assertEquals(EXPECTED_QUERY_NODES, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
+        assertEquals(EXPECTED_QUERY_NODES, readFile(fileName));
     }
 
     @Test
     public void testExportQueryNodesCsvParams() throws Exception {
-        File output = new File(directory, "query_nodes.csv");
+        String fileName = "query_nodes.csv";
         String query = "MATCH (u:User) WHERE u.age > {age} return u";
-        TestUtil.testCall(db, "CALL apoc.export.csv.query({query},{file},{params:{age:10}})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.csv.query({query},{file},{params:{age:10}})", map("file", fileName,"query",query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(fileName, r.get("file"));
                     assertEquals("csv", r.get("format"));
 
                 });
-        assertEquals(EXPECTED_QUERY_NODES, FileUtils.readFileToString(output, Charset.forName("UTF-8")));
+        assertEquals(EXPECTED_QUERY_NODES, readFile(fileName));
     }
 
-    private void assertResults(File output, Map<String, Object> r, final String source) {
+    private void assertResults(String fileName, Map<String, Object> r, final String source) {
         assertEquals(6L, r.get("nodes"));
         assertEquals(2L, r.get("relationships"));
         assertEquals(12L, r.get("properties"));
         assertEquals(source + ": nodes(6), rels(2)", r.get("source"));
-        assertEquals(output.getAbsolutePath(), r.get("file"));
+        assertEquals(fileName, r.get("file"));
         assertEquals("csv", r.get("format"));
         assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
     }

--- a/src/test/java/apoc/export/cypher/ExportCypherEnterpriseFeaturesTest.java
+++ b/src/test/java/apoc/export/cypher/ExportCypherEnterpriseFeaturesTest.java
@@ -12,7 +12,6 @@ import org.neo4j.driver.v1.Session;
 import java.io.File;
 import java.util.Map;
 
-import static apoc.export.cypher.ExportCypherTest.ExportCypherResults.*;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestContainerUtil.*;
 import static apoc.util.TestUtil.isTravis;

--- a/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -2,7 +2,6 @@ package apoc.export.cypher;
 
 import apoc.graph.Graphs;
 import apoc.util.TestUtil;
-import apoc.util.Util;
 import org.junit.*;
 import org.junit.rules.TestName;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -12,11 +11,10 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Map;
-import java.util.Scanner;
 
 import static apoc.export.cypher.ExportCypherTest.ExportCypherResults.*;
 import static apoc.export.util.ExportFormat.*;
-import static apoc.util.MapUtil.map;
+import static apoc.util.Util.map;
 import static org.junit.Assert.*;
 
 /**
@@ -25,7 +23,7 @@ import static org.junit.Assert.*;
  */
 public class ExportCypherTest {
 
-    private static final Map<String, Object> exportConfig = Util.map("useOptimizations", Util.map("type", "none"),"separateFiles", true);
+    private static final Map<String, Object> exportConfig = map("useOptimizations", map("type", "none"),"separateFiles", true);
     private static GraphDatabaseService db;
     private static File directory = new File("target/import");
 
@@ -41,8 +39,10 @@ public class ExportCypherTest {
 
     @Before
     public void setUp() throws Exception {
-        db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder().setConfig(GraphDatabaseSettings.load_csv_file_url_root, directory.getAbsolutePath())
-                .setConfig("apoc.export.file.enabled", "true").newGraphDatabase();
+        db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder()
+                .setConfig(GraphDatabaseSettings.load_csv_file_url_root, directory.getAbsolutePath())
+                .setConfig("apoc.export.file.enabled", "true")
+                .newGraphDatabase();
         TestUtil.registerProcedure(db, ExportCypher.class, Graphs.class);
         if (testName.getMethodName().endsWith(OPTIMIZED)) {
             db.execute("CREATE INDEX ON :Foo(name)").close();
@@ -115,124 +115,127 @@ public class ExportCypherTest {
     // -- Whole file test -- //
     @Test
     public void testExportAllCypherDefault() throws Exception {
-        File output = new File(directory, "all.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{useOptimizations: { type: 'none'}})", map("file", output.getAbsolutePath()), (r) -> assertResults(output, r, "database"));
-        assertEquals(EXPECTED_NEO4J_SHELL, readFile(output));
+        String fileName = "all.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({fileName},{useOptimizations: { type: 'none'}})",
+                map("fileName", fileName),
+                (r) -> assertResults(fileName, r, "database"));
+        assertEquals(EXPECTED_NEO4J_SHELL, readFile(fileName));
     }
 
     @Test
     public void testExportAllCypherForCypherShell() throws Exception {
-        File output = new File(directory, "all.cypher");
+        String fileName = "all.cypher";
         TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{config})",
-                map("file", output.getAbsolutePath(), "config", Util.map("useOptimizations", Util.map("type", "none"), "format", "cypher-shell")), (r) -> assertResults(output, r, "database"));
-        assertEquals(EXPECTED_CYPHER_SHELL, readFile(output));
+                map("file", fileName, "config", map("useOptimizations", map("type", "none"), "format", "cypher-shell")),
+                (r) -> assertResults(fileName, r, "database"));
+        assertEquals(EXPECTED_CYPHER_SHELL, readFile(fileName));
     }
 
     @Test
     public void testExportQueryCypherForNeo4j() throws Exception {
-        File output = new File(directory, "all.cypher");
+        String fileName = "all.cypher";
         String query = "MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"), "format", "neo4j-shell")), (r) -> {
+                map("file", fileName, "query", query, "config", map("useOptimizations", map("type", "none"), "format", "neo4j-shell")), (r) -> {
                 });
-        assertEquals(EXPECTED_NEO4J_SHELL, readFile(output));
+        assertEquals(EXPECTED_NEO4J_SHELL, readFile(fileName));
     }
 
-    private static String readFile(File output) throws FileNotFoundException {
-        return new Scanner(output).useDelimiter("\\Z").next() + String.format("%n");
+    private static String readFile(String fileName) throws FileNotFoundException {
+        return TestUtil.readFileToString(new File(directory, fileName));
     }
 
     @Test
     public void testExportGraphCypher() throws Exception {
-        File output = new File(directory, "graph.cypher");
+        String fileName = "graph.cypher";
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
                 "CALL apoc.export.cypher.graph(graph, {file},{useOptimizations: { type: 'none'}}) " +
                 "YIELD nodes, relationships, properties, file, source,format, time " +
-                "RETURN *", map("file", output.getAbsolutePath()), (r) -> assertResults(output, r, "graph"));
-        assertEquals(EXPECTED_NEO4J_SHELL, readFile(output));
+                "RETURN *", map("file", fileName), (r) -> assertResults(fileName, r, "graph"));
+        assertEquals(EXPECTED_NEO4J_SHELL, readFile(fileName));
     }
 
     // -- Separate files tests -- //
     @Test
     public void testExportAllCypherNodes() throws Exception {
-        File output = new File(directory, "all.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{exportConfig})", map("file", output.getAbsolutePath(), "exportConfig", exportConfig),
-                (r) -> assertResults(output, r, "database"));
-        assertEquals(EXPECTED_NODES, readFile(new File(directory, "all.nodes.cypher")));
+        String fileName = "all.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{exportConfig})", map("file", fileName, "exportConfig", exportConfig),
+                (r) -> assertResults(fileName, r, "database"));
+        assertEquals(EXPECTED_NODES, readFile("all.nodes.cypher"));
     }
 
     @Test
     public void testExportAllCypherRelationships() throws Exception {
-        File output = new File(directory, "all.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{exportConfig})", map("file", output.getAbsolutePath(), "exportConfig", exportConfig),
-                (r) -> assertResults(output, r, "database"));
-        assertEquals(EXPECTED_RELATIONSHIPS, readFile(new File(directory, "all.relationships.cypher")));
+        String fileName = "all.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{exportConfig})", map("file", fileName, "exportConfig", exportConfig),
+                (r) -> assertResults(fileName, r, "database"));
+        assertEquals(EXPECTED_RELATIONSHIPS, readFile("all.relationships.cypher"));
     }
 
     @Test
     public void testExportAllCypherSchema() throws Exception {
-        File output = new File(directory, "all.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{exportConfig})", map("file", output.getAbsolutePath(), "exportConfig", exportConfig),
-                (r) -> assertResults(output, r, "database"));
-        assertEquals(EXPECTED_SCHEMA, readFile(new File(directory, "all.schema.cypher")));
+        String fileName = "all.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{exportConfig})", map("file", fileName, "exportConfig", exportConfig),
+                (r) -> assertResults(fileName, r, "database"));
+        assertEquals(EXPECTED_SCHEMA, readFile("all.schema.cypher"));
     }
 
     @Test
     public void testExportAllCypherCleanUp() throws Exception {
-        File output = new File(directory, "all.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{exportConfig})", map("file", output.getAbsolutePath(), "exportConfig", exportConfig),
-                (r) -> assertResults(output, r, "database"));
-        assertEquals(EXPECTED_CLEAN_UP, readFile(new File(directory, "all.cleanup.cypher")));
+        String fileName = "all.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{exportConfig})", map("file", fileName, "exportConfig", exportConfig),
+                (r) -> assertResults(fileName, r, "database"));
+        assertEquals(EXPECTED_CLEAN_UP, readFile("all.cleanup.cypher"));
     }
 
     @Test
     public void testExportGraphCypherNodes() throws Exception {
-        File output = new File(directory, "graph.cypher");
+        String fileName = "graph.cypher";
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
                 "CALL apoc.export.cypher.graph(graph, {file},{exportConfig}) " +
                 "YIELD nodes, relationships, properties, file, source,format, time " +
-                "RETURN *", map("file", output.getAbsolutePath(), "exportConfig", exportConfig), (r) -> assertResults(output, r, "graph"));
-        assertEquals(EXPECTED_NODES, readFile(new File(directory, "graph.nodes.cypher")));
+                "RETURN *", map("file", fileName, "exportConfig", exportConfig), (r) -> assertResults(fileName, r, "graph"));
+        assertEquals(EXPECTED_NODES, readFile("graph.nodes.cypher"));
     }
 
     @Test
     public void testExportGraphCypherRelationships() throws Exception {
-        File output = new File(directory, "graph.cypher");
+        String fileName = "graph.cypher";
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
                         "CALL apoc.export.cypher.graph(graph, {file},{exportConfig}) " +
                         "YIELD nodes, relationships, properties, file, source,format, time " +
-                        "RETURN *", map("file", output.getAbsolutePath(), "exportConfig", exportConfig),
-                (r) -> assertResults(output, r, "graph"));
-        assertEquals(EXPECTED_RELATIONSHIPS, readFile(new File(directory, "graph.relationships.cypher")));
+                        "RETURN *", map("file", fileName, "exportConfig", exportConfig),
+                (r) -> assertResults(fileName, r, "graph"));
+        assertEquals(EXPECTED_RELATIONSHIPS, readFile("graph.relationships.cypher"));
     }
 
     @Test
     public void testExportGraphCypherSchema() throws Exception {
-        File output = new File(directory, "graph.cypher");
+        String fileName = "graph.cypher";
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
                         "CALL apoc.export.cypher.graph(graph, {file},{exportConfig}) " +
                         "YIELD nodes, relationships, properties, file, source,format, time " +
-                        "RETURN *", map("file", output.getAbsolutePath(), "exportConfig", exportConfig),
-                (r) -> assertResults(output, r, "graph"));
-        assertEquals(EXPECTED_SCHEMA, readFile(new File(directory, "graph.schema.cypher")));
+                        "RETURN *", map("file", fileName, "exportConfig", exportConfig),
+                (r) -> assertResults(fileName, r, "graph"));
+        assertEquals(EXPECTED_SCHEMA, readFile("graph.schema.cypher"));
     }
 
     @Test
     public void testExportGraphCypherCleanUp() throws Exception {
-        File output = new File(directory, "graph.cypher");
+        String fileName = "graph.cypher";
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
                         "CALL apoc.export.cypher.graph(graph, {file},{exportConfig}) " +
                         "YIELD nodes, relationships, properties, file, source,format, time " +
-                        "RETURN *", map("file", output.getAbsolutePath(), "exportConfig", exportConfig),
-                (r) -> assertResults(output, r, "graph"));
-        assertEquals(EXPECTED_CLEAN_UP, readFile(new File(directory, "graph.cleanup.cypher")));
+                        "RETURN *", map("file", fileName, "exportConfig", exportConfig),
+                (r) -> assertResults(fileName, r, "graph"));
+        assertEquals(EXPECTED_CLEAN_UP, readFile("graph.cleanup.cypher"));
     }
 
-    private void assertResults(File output, Map<String, Object> r, final String source) {
+    private void assertResults(String fileName, Map<String, Object> r, final String source) {
         assertEquals(3L, r.get("nodes"));
         assertEquals(1L, r.get("relationships"));
         assertEquals(6L, r.get("properties"));
-        assertEquals(output == null ? null : output.getAbsolutePath(), r.get("file"));
+        assertEquals(fileName, r.get("file"));
         assertEquals(source + ": nodes(3), rels(1)", r.get("source"));
         assertEquals("cypher", r.get("format"));
         assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
@@ -240,58 +243,59 @@ public class ExportCypherTest {
 
     @Test
     public void testExportQueryCypherPlainFormat() throws Exception {
-        File output = new File(directory, "all.cypher");
+        String fileName = "all.cypher";
         String query = "MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"), "format", "plain")), (r) -> {
+                map("file", fileName, "query", query, "config", map("useOptimizations", map("type", "none"), "format", "plain")), (r) -> {
                 });
-        assertEquals(EXPECTED_PLAIN, readFile(output));
+        assertEquals(EXPECTED_PLAIN, readFile(fileName));
     }
 
     @Test
     public void testExportQueryCypherFormatUpdateAll() throws Exception {
-        File output = new File(directory, "all.cypher");
+        String fileName = "all.cypher";
         String query = "MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"), "format", "neo4j-shell", "cypherFormat", "updateAll")), (r) -> {
+                map("file", fileName, "query", query, "config", map("useOptimizations", map("type", "none"), "format", "neo4j-shell", "cypherFormat", "updateAll")), (r) -> {
                 });
-        assertEquals(EXPECTED_NEO4J_MERGE, readFile(output));
+        assertEquals(EXPECTED_NEO4J_MERGE, readFile(fileName));
     }
 
     @Test
     public void testExportQueryCypherFormatAddStructure() throws Exception {
-        File output = new File(directory, "all.cypher");
+        String fileName = "all.cypher";
         String query = "MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"), "format", "neo4j-shell", "cypherFormat", "addStructure")), (r) -> {
+                map("file", fileName, "query", query, "config", map("useOptimizations", map("type", "none"), "format", "neo4j-shell", "cypherFormat", "addStructure")), (r) -> {
                 });
-        assertEquals(EXPECTED_NODES_MERGE_ON_CREATE_SET + EXPECTED_SCHEMA_EMPTY + EXPECTED_RELATIONSHIPS + EXPECTED_CLEAN_UP_EMPTY, readFile(output));
+        assertEquals(EXPECTED_NODES_MERGE_ON_CREATE_SET + EXPECTED_SCHEMA_EMPTY + EXPECTED_RELATIONSHIPS + EXPECTED_CLEAN_UP_EMPTY, readFile(fileName));
     }
 
     @Test
     public void testExportQueryCypherFormatUpdateStructure() throws Exception {
-        File output = new File(directory, "all.cypher");
+        String fileName = "all.cypher";
         String query = "MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"), "format", "neo4j-shell", "cypherFormat", "updateStructure")), (r) -> {
+                map("file", fileName, "query", query, "config", map("useOptimizations", map("type", "none"), "format", "neo4j-shell", "cypherFormat", "updateStructure")), (r) -> {
                 });
-        assertEquals(EXPECTED_NODES_EMPTY + EXPECTED_SCHEMA_EMPTY + EXPECTED_RELATIONSHIPS_MERGE_ON_CREATE_SET + EXPECTED_CLEAN_UP_EMPTY, readFile(output));
+        assertEquals(EXPECTED_NODES_EMPTY + EXPECTED_SCHEMA_EMPTY + EXPECTED_RELATIONSHIPS_MERGE_ON_CREATE_SET + EXPECTED_CLEAN_UP_EMPTY, readFile(fileName));
     }
 
     @Test
     public void testExportSchemaCypher() throws Exception {
-        File output = new File(directory, "onlySchema.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.schema({file},{exportConfig})", map("file", output.getAbsolutePath(), "exportConfig", exportConfig), (r) -> {
+        String fileName = "onlySchema.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.schema({file},{exportConfig})", map("file", fileName, "exportConfig", exportConfig), (r) -> {
         });
-        assertEquals(EXPECTED_ONLY_SCHEMA_NEO4J_SHELL, readFile(new File(directory, "onlySchema.cypher")));
+        assertEquals(EXPECTED_ONLY_SCHEMA_NEO4J_SHELL, readFile(fileName));
     }
 
     @Test
     public void testExportSchemaCypherShell() throws Exception {
-        File output = new File(directory, "onlySchema.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.schema({file},{exportConfig})", map("file", output.getAbsolutePath(), "exportConfig", Util.map("useOptimizations", Util.map("type", "none"), "format", "cypher-shell")), (r) -> {
-        });
-        assertEquals(EXPECTED_ONLY_SCHEMA_CYPHER_SHELL, readFile(new File(directory, "onlySchema.cypher")));
+        String fileName = "onlySchema.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.schema({file},{exportConfig})",
+                map("file", fileName, "exportConfig", map("useOptimizations", map("type", "none"), "format", "cypher-shell")),
+                (r) -> {});
+        assertEquals(EXPECTED_ONLY_SCHEMA_CYPHER_SHELL, readFile(fileName));
     }
 
     @Test
@@ -301,12 +305,12 @@ public class ExportCypherTest {
                 "place3d1:point({ x: 2.3, y: 4.5 , z: 1.2})})" +
                 "-[:FRIEND_OF {place2d:point({ longitude: 56.7, latitude: 12.78 })}]->" +
                 "(:Bar {place3d:point({ longitude: 12.78, latitude: 56.7, height: 100 })})").close();
-        File output = new File(directory, "temporalPoint.cypher");
+        String fileName = "temporalPoint.cypher";
         String query = "MATCH (n:Test)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"),"format", "neo4j-shell")), (r) -> {
-                });
-        assertEquals(EXPECTED_CYPHER_POINT, readFile(output));
+                map("file", fileName, "query", query, "config", map("useOptimizations", map("type", "none"),"format", "neo4j-shell")),
+                (r) -> {});
+        assertEquals(EXPECTED_CYPHER_POINT, readFile(fileName));
     }
 
     @Test
@@ -317,12 +321,12 @@ public class ExportCypherTest {
                 "localTime:localdatetime('20181030T19:32:24')})" +
                 "-[:FRIEND_OF {date:date('2018-10-30')}]->" +
                 "(:Bar {datetime:datetime('2018-10-30T12:50:35.556')})").close();
-        File output = new File(directory, "temporalDate.cypher");
+        String fileName = "temporalDate.cypher";
         String query = "MATCH (n:Test)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"),"format", "neo4j-shell")), (r) -> {
-                });
-        assertEquals(EXPECTED_CYPHER_DATE, readFile(output));
+                map("file", fileName, "query", query, "config", map("useOptimizations", map("type", "none"),"format", "neo4j-shell")),
+                (r) -> {});
+        assertEquals(EXPECTED_CYPHER_DATE, readFile(fileName));
     }
 
     @Test
@@ -332,12 +336,12 @@ public class ExportCypherTest {
                 "t:time('125035.556+0100')})" +
                 "-[:FRIEND_OF {t:time('125035.556+0100')}]->" +
                 "(:Bar {datetime:datetime('2018-10-30T12:50:35.556+0100')})").close();
-        File output = new File(directory, "temporalTime.cypher");
+        String fileName = "temporalTime.cypher";
         String query = "MATCH (n:Test)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"),"format", "neo4j-shell")), (r) -> {
-                });
-        assertEquals(EXPECTED_CYPHER_TIME, readFile(output));
+                map("file", fileName, "query", query, "config", map("useOptimizations", map("type", "none"),"format", "neo4j-shell")),
+                (r) -> {});
+        assertEquals(EXPECTED_CYPHER_TIME, readFile(fileName));
     }
 
     @Test
@@ -346,157 +350,173 @@ public class ExportCypherTest {
                 "duration:duration('P5M1.5D')})" +
                 "-[:FRIEND_OF {duration:duration('P5M1.5D')}]->" +
                 "(:Bar {duration:duration('P5M1.5D')})").close();
-        File output = new File(directory, "temporalDuration.cypher");
+        String fileName = "temporalDuration.cypher";
         String query = "MATCH (n:Test)-[r]-(m) RETURN n,r,m";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"),"format", "neo4j-shell")), (r) -> {
-                });
-        assertEquals(EXPECTED_CYPHER_DURATION, readFile(output));
+                map("file", fileName, "query", query, "config", map("useOptimizations", map("type", "none"),"format", "neo4j-shell")),
+                (r) -> {});
+        assertEquals(EXPECTED_CYPHER_DURATION, readFile(fileName));
     }
 
     @Test
     public void testExportWithAscendingLabels() throws FileNotFoundException {
         db.execute("CREATE (f:User:User1:User0:User12 {name:'Alan'})").close();
-        File output = new File(directory, "ascendingLabels.cypher");
+        String fileName = "ascendingLabels.cypher";
         String query = "MATCH (f:User) WHERE f.name='Alan' RETURN f";
         TestUtil.testCall(db, "CALL apoc.export.cypher.query({query},{file},{config})",
-                map("file", output.getAbsolutePath(), "query", query, "config", Util.map("useOptimizations", Util.map("type", "none"),"format", "neo4j-shell")), (r) -> {
-                });
-        assertEquals(EXPECTED_CYPHER_LABELS_ASCENDEND, readFile(output));
+                map("file", fileName, "query", query, "config", map("useOptimizations", map("type", "none"),"format", "neo4j-shell")),
+                (r) -> {});
+        assertEquals(EXPECTED_CYPHER_LABELS_ASCENDEND, readFile(fileName));
     }
 
     @Test
     public void testExportAllCypherDefaultWithUnwindBatchSizeOptimized() throws Exception {
-        File output = new File(directory, "allDefaultOptimized.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}})", map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r));
-        assertEquals(EXPECTED_NEO4J_OPTIMIZED_BATCH_SIZE, readFile(output));
+        String fileName = "allDefaultOptimized.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}})", map("file", fileName),
+                (r) -> assertResultsOptimized(fileName, r));
+        assertEquals(EXPECTED_NEO4J_OPTIMIZED_BATCH_SIZE, readFile(fileName));
     }
 
     @Test
     public void testExportAllCypherDefaultOptimized() throws Exception {
-        File output = new File(directory, "allDefaultOptimized.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file})", map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r));
-        assertEquals(EXPECTED_NEO4J_OPTIMIZED, readFile(output));
+        String fileName = "allDefaultOptimized.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file})", map("file", fileName),
+                (r) -> assertResultsOptimized(fileName, r));
+        assertEquals(EXPECTED_NEO4J_OPTIMIZED, readFile(fileName));
     }
 
     @Test
     public void testExportAllCypherDefaultSeparatedFilesOptimized() throws Exception {
-        File output = new File(directory, "allDefaultOptimized.cypher");
+        String fileName = "allDefaultOptimized.cypher";
         TestUtil.testCall(db, "CALL apoc.export.cypher.all({file}, {exportConfig})",
-                map("file", output.getAbsolutePath(), "exportConfig", Util.map("separateFiles", true)),
-                (r) -> assertResultsOptimized(output, r));
-        assertEquals(EXPECTED_NODES_OPTIMIZED, readFile(new File(directory, "allDefaultOptimized.nodes.cypher")));
-        assertEquals(EXPECTED_RELATIONSHIPS_OPTIMIZED, readFile(new File(directory, "allDefaultOptimized.relationships.cypher")));
-        assertEquals(EXPECTED_SCHEMA_OPTIMIZED, readFile(new File(directory, "allDefaultOptimized.schema.cypher")));
-        assertEquals(EXPECTED_CLEAN_UP, readFile(new File(directory, "allDefaultOptimized.cleanup.cypher")));
+                map("file", fileName, "exportConfig", map("separateFiles", true)),
+                (r) -> assertResultsOptimized(fileName, r));
+        assertEquals(EXPECTED_NODES_OPTIMIZED, readFile("allDefaultOptimized.nodes.cypher"));
+        assertEquals(EXPECTED_RELATIONSHIPS_OPTIMIZED, readFile("allDefaultOptimized.relationships.cypher"));
+        assertEquals(EXPECTED_SCHEMA_OPTIMIZED, readFile("allDefaultOptimized.schema.cypher"));
+        assertEquals(EXPECTED_CLEAN_UP, readFile("allDefaultOptimized.cleanup.cypher"));
     }
 
     @Test
     public void testExportAllCypherCypherShellWithUnwindBatchSizeOptimized() throws Exception {
-        File output = new File(directory, "allCypherShellOptimized.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'cypher-shell', useOptimizations: {type: 'unwind_batch'}})", map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r));
-        assertEquals(EXPECTED_CYPHER_SHELL_OPTIMIZED_BATCH_SIZE, readFile(output));
+        String fileName = "allCypherShellOptimized.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'cypher-shell', useOptimizations: {type: 'unwind_batch'}})",
+                map("file", fileName),
+                (r) -> assertResultsOptimized(fileName, r));
+        assertEquals(EXPECTED_CYPHER_SHELL_OPTIMIZED_BATCH_SIZE, readFile(fileName));
     }
 
     @Test
     public void testExportAllCypherCypherShellOptimized() throws Exception {
-        File output = new File(directory, "allCypherShellOptimized.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'cypher-shell'})", map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r));
-        assertEquals(EXPECTED_CYPHER_SHELL_OPTIMIZED, readFile(output));
+        String fileName = "allCypherShellOptimized.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'cypher-shell'})",
+                map("file", fileName),
+                (r) -> assertResultsOptimized(fileName, r));
+        assertEquals(EXPECTED_CYPHER_SHELL_OPTIMIZED, readFile(fileName));
     }
 
     @Test
     public void testExportAllCypherPlainWithUnwindBatchSizeOptimized() throws Exception {
-        File output = new File(directory, "allPlainOptimized.cypher");
+        String fileName = "allPlainOptimized.cypher";
         TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'plain', useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}})",
-                map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r));
-        assertEquals(EXPECTED_PLAIN_OPTIMIZED_BATCH_SIZE, readFile(output));
+                map("file", fileName),
+                (r) -> assertResultsOptimized(fileName, r));
+        assertEquals(EXPECTED_PLAIN_OPTIMIZED_BATCH_SIZE, readFile(fileName));
     }
 
     @Test
     public void testExportAllCypherPlainAddStructureWithUnwindBatchSizeOptimized() throws Exception {
-        File output = new File(directory, "allPlainAddStructureOptimized.cypher");
+        String fileName = "allPlainAddStructureOptimized.cypher";
         TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'plain', cypherFormat: 'addStructure', useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}})",
-                map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r));
-        assertEquals(EXPECTED_PLAIN_ADD_STRUCTURE_UNWIND, readFile(output));
+                map("file", fileName), (r) -> assertResultsOptimized(fileName, r));
+        assertEquals(EXPECTED_PLAIN_ADD_STRUCTURE_UNWIND, readFile(fileName));
     }
 
     @Test
     public void testExportAllCypherPlainUpdateStructureWithUnwindBatchSizeOptimized() throws Exception {
-        File output = new File(directory, "allPlainUpdateStructureOptimized.cypher");
+        String fileName = "allPlainUpdateStructureOptimized.cypher";
         TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'plain', cypherFormat: 'updateStructure', useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}})",
-                map("file", output.getAbsolutePath()), (r) -> {
+                map("file", fileName), (r) -> {
                     assertEquals(0L, r.get("nodes"));
                     assertEquals(2L, r.get("relationships"));
                     assertEquals(2L, r.get("properties"));
-                    assertEquals(output == null ? null : output.getAbsolutePath(), r.get("file"));
+                    assertEquals(fileName, r.get("file"));
                     assertEquals("cypher", r.get("format"));
                     assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
                 });
-        assertEquals(EXPECTED_PLAIN_UPDATE_STRUCTURE_UNWIND, readFile(output));
+        assertEquals(EXPECTED_PLAIN_UPDATE_STRUCTURE_UNWIND, readFile(fileName));
     }
 
     @Test
     public void testExportAllCypherPlainUpdateAllWithUnwindBatchSizeOptimized() throws Exception {
-        File output = new File(directory, "allPlainUpdateAllOptimized.cypher");
+        String fileName = "allPlainUpdateAllOptimized.cypher";
+        File output = new File(directory, fileName);
         TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'plain', cypherFormat: 'updateAll', useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}})",
-                map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r));
-        assertEquals(EXPECTED_UPDATE_ALL_UNWIND, readFile(output));
+                map("file", fileName), (r) -> assertResultsOptimized(fileName, r));
+        assertEquals(EXPECTED_UPDATE_ALL_UNWIND, readFile(fileName));
     }
 
     @Test
     public void testExportQueryCypherShellWithUnwindBatchSizeWithBatchSizeOptimized() throws Exception {
-        File output = new File(directory, "allPlainOptimized.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'cypher-shell', useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}, batchSize: 2})", map("file", output.getAbsolutePath()), (r) -> assertResultsOptimized(output, r));
-        assertEquals(EXPECTED_QUERY_CYPHER_SHELL_OPTIMIZED_UNWIND, readFile(output));
+        String fileName = "allPlainOptimized.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'cypher-shell', useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}, batchSize: 2})",
+                map("file", fileName),
+                (r) -> assertResultsOptimized(fileName, r));
+        assertEquals(EXPECTED_QUERY_CYPHER_SHELL_OPTIMIZED_UNWIND, readFile(fileName));
     }
 
     @Test
     public void testExportQueryCypherShellWithUnwindBatchSizeWithBatchSizeOdd() throws Exception {
-        File output = new File(directory, "allPlainOdd.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'cypher-shell', useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}, batchSize: 2})", map("file", output.getAbsolutePath()), (r) -> assertResultsOdd(output, r));
-        assertEquals(EXPECTED_QUERY_CYPHER_SHELL_OPTIMIZED_ODD, readFile(output));
+        String fileName = "allPlainOdd.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'cypher-shell', useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}, batchSize: 2})",
+                map("file", fileName), (r) -> assertResultsOdd(fileName, r));
+        assertEquals(EXPECTED_QUERY_CYPHER_SHELL_OPTIMIZED_ODD, readFile(fileName));
     }
 
     @Test
     public void testExportQueryCypherShellWithUnwindBatchSizeWithBatchSizeParamsOdd() throws Exception {
-        File output = new File(directory, "allPlainOdd.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'cypher-shell', useOptimizations: { type: 'unwind_batch_params', unwindBatchSize: 2}, batchSize:2})", map("file", output.getAbsolutePath()), (r) -> assertResultsOdd(output, r));
-        assertEquals(EXPECTED_QUERY_CYPHER_SHELL_PARAMS_OPTIMIZED_ODD, readFile(output));
+        String fileName = "allPlainOdd.cypher";
+        File output = new File(directory, fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all({file},{format:'cypher-shell', useOptimizations: { type: 'unwind_batch_params', unwindBatchSize: 2}, batchSize:2})",
+                map("file", fileName),
+                (r) -> assertResultsOdd(fileName, r));
+        assertEquals(EXPECTED_QUERY_CYPHER_SHELL_PARAMS_OPTIMIZED_ODD, readFile(fileName));
     }
 
     @Test
     @Ignore("non-deterministic index order")
     public void testExportAllCypherPlainOptimized() throws Exception {
-        File output = new File(directory, "queryPlainOptimized.cypher");
-        TestUtil.testCall(db, "CALL apoc.export.cypher.query('MATCH (f:Foo)-[r:KNOWS]->(b:Bar) return f,r,b', {file},{format:'cypher-shell', useOptimizations: {type: 'unwind_batch'}})", map("file", output.getAbsolutePath()), (r) -> {
-            assertEquals(4L, r.get("nodes"));
-            assertEquals(2L, r.get("relationships"));
-            assertEquals(10L, r.get("properties"));
-            assertEquals(output.getAbsolutePath(), r.get("file"));
-            assertEquals("statement: nodes(4), rels(2)", r.get("source"));
-            assertEquals("cypher", r.get("format"));
-            assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
-        });
-        String actual = readFile(output);
+        String fileName = "queryPlainOptimized.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.query('MATCH (f:Foo)-[r:KNOWS]->(b:Bar) return f,r,b', {file},{format:'cypher-shell', useOptimizations: {type: 'unwind_batch'}})",
+                map("file", fileName),
+                (r) -> {
+                    assertEquals(4L, r.get("nodes"));
+                    assertEquals(2L, r.get("relationships"));
+                    assertEquals(10L, r.get("properties"));
+                    assertEquals(fileName, r.get("file"));
+                    assertEquals("statement: nodes(4), rels(2)", r.get("source"));
+                    assertEquals("cypher", r.get("format"));
+                    assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
+                });
+        String actual = readFile(fileName);
         assertTrue("expected generated output",EXPECTED_QUERY_CYPHER_SHELL_OPTIMIZED.equals(actual) || EXPECTED_QUERY_CYPHER_SHELL_OPTIMIZED2.equals(actual));
     }
 
-    private void assertResultsOptimized(File output, Map<String, Object> r) {
+    private void assertResultsOptimized(String fileName, Map<String, Object> r) {
         assertEquals(7L, r.get("nodes"));
         assertEquals(2L, r.get("relationships"));
         assertEquals(13L, r.get("properties"));
-        assertEquals(output == null ? null : output.getAbsolutePath(), r.get("file"));
+        assertEquals(fileName, r.get("file"));
         assertEquals("database" + ": nodes(7), rels(2)", r.get("source"));
         assertEquals("cypher", r.get("format"));
         assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
     }
 
-    private void assertResultsOdd(File output, Map<String, Object> r) {
+    private void assertResultsOdd(String fileName, Map<String, Object> r) {
         assertEquals(7L, r.get("nodes"));
         assertEquals(1L, r.get("relationships"));
         assertEquals(13L, r.get("properties"));
-        assertEquals(output == null ? null : output.getAbsolutePath(), r.get("file"));
+        assertEquals(fileName, r.get("file"));
         assertEquals("database" + ": nodes(7), rels(1)", r.get("source"));
         assertEquals("cypher", r.get("format"));
         assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);

--- a/src/test/java/apoc/export/json/ExportJsonTest.java
+++ b/src/test/java/apoc/export/json/ExportJsonTest.java
@@ -3,8 +3,6 @@ package apoc.export.json;
 import apoc.graph.Graphs;
 import apoc.util.JsonUtil;
 import apoc.util.TestUtil;
-import apoc.util.Util;
-import net.minidev.json.JSONUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -13,9 +11,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.util.Map;
-import java.util.Scanner;
 
 import static apoc.util.MapUtil.map;
 import static org.junit.Assert.assertEquals;
@@ -50,19 +46,18 @@ public class ExportJsonTest {
     @Test
     public void testExportAllJson() throws Exception {
         String filename = "all.json";
-        File output = new File(directory, filename);
-        TestUtil.testCall(db, "CALL apoc.export.json.all({file},null)", map("file", output.getAbsolutePath()),
+        TestUtil.testCall(db, "CALL apoc.export.json.all({file},null)",
+                map("file", filename),
                 (r) -> {
-                    assertResults(output, r, "database");
+                    assertResults(filename, r, "database");
                 }
         );
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportPointMapDatetimeJson() throws Exception {
         String filename = "mapPointDatetime.json";
-        File output = new File(directory, filename);
         String query = "return {data: 1, value: {age: 12, name:'Mike', data: {number: [1,3,5], born: date('2018-10-29'), place: point({latitude: 13.1, longitude: 33.46789})}}} as map, " +
                 "datetime('2015-06-24T12:50:35.556+0100') AS theDateTime, " +
                 "localdatetime('2015185T19:32:24') AS theLocalDateTime," +
@@ -70,288 +65,281 @@ public class ExportJsonTest {
                 "date('+2015-W13-4') as date," +
                 "time('125035.556+0100') as time," +
                 "localTime('12:50:35.556') as localTime";
-        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})",
+                map("file", filename, "query", query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(7)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportListNode() throws Exception {
         String filename = "listNode.json";
-        File output = new File(directory, filename);
 
         String query = "MATCH (u:User) RETURN COLLECT(u) as list";
 
-        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})",
+                map("file", filename, "query", query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportListRel() throws Exception {
         String filename = "listRel.json";
-        File output = new File(directory, filename);
 
         String query = "MATCH (u:User)-[rel:KNOWS]->(u2:User) RETURN COLLECT(rel) as list";
 
-        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", filename,"query",query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportListPath() throws Exception {
         String filename = "listPath.json";
-        File output = new File(directory, filename);
 
         String query = "MATCH p = (u:User)-[rel]->(u2:User) RETURN COLLECT(p) as list";
 
-        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})",
+                map("file", filename, "query", query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportMap() throws Exception {
         String filename = "MapNode.json";
-        File output = new File(directory, filename);
 
         String query = "MATCH (u:User)-[r:KNOWS]->(d:User) RETURN u {.*}, d {.*}, r {.*}";
 
-        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", filename, "query", query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(3)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportMapPath() throws Exception {
         db.execute("CREATE (f:User {name:'Mike',age:78,male:true})-[:KNOWS {since: 1850}]->(b:User {name:'John',age:18}),(c:User {age:39})").close();
         String filename = "MapPath.json";
-        File output = new File(directory, filename);
 
         String query = "MATCH path = (u:User)-[rel:KNOWS]->(u2:User) RETURN {key:path} as map, 'Kate' as name";
 
-        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})",
+                map("file", filename, "query", query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(2)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportMapRel() throws Exception {
         String filename = "MapRel.json";
-        File output = new File(directory, filename);
 
         String query = "MATCH p = (u:User)-[rel:KNOWS]->(u2:User) RETURN rel {.*}";
 
-        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})",
+                map("file", filename,"query",query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportMapComplex() throws Exception {
         String filename = "MapComplex.json";
-        File output = new File(directory, filename);
 
         String query = "RETURN {value:1, data:[10,'car',null, point({ longitude: 56.7, latitude: 12.78 }), point({ longitude: 56.7, latitude: 12.78, height: 8 }), point({ x: 2.3, y: 4.5 }), point({ x: 2.3, y: 4.5, z: 2 }),date('2018-10-10'), datetime('2018-10-18T14:21:40.004Z'), localdatetime({ year:1984, week:10, dayOfWeek:3, hour:12, minute:31, second:14, millisecond: 645 }), {x:1, y:[1,2,3,{age:10}]}]} as key";
 
-        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})",
+                map("file", filename, "query", query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportGraphJson() throws Exception {
         String filename = "graph.json";
-        File output = new File(directory, filename);
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
                         "CALL apoc.export.json.graph(graph, {file}) " +
                         "YIELD nodes, relationships, properties, file, source,format, time " +
-                        "RETURN *", map("file", output.getAbsolutePath()),
-                (r) -> assertResults(output, r, "graph"));
-        assertFileEquals(filename, output);
+                        "RETURN *", map("file", filename),
+                (r) -> assertResults(filename, r, "graph"));
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportQueryJson() throws Exception {
         String filename = "query.json";
-        File output = new File(directory, filename);
         String query = "MATCH (u:User) return u.age, u.name, u.male, u.kids, labels(u)";
-        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})",
+                map("file", filename, "query", query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(5)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportQueryNodesJson() throws Exception {
         String filename = "query_nodes.json";
-        File output = new File(directory, filename);
         String query = "MATCH (u:User) return u";
-        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})",
+                map("file", filename,"query",query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportQueryTwoNodesJson() throws Exception {
         String filename = "query_two_nodes.json";
-        File output = new File(directory, filename);
         String query = "MATCH (u:User{name:'Adam'}), (l:User{name:'Jim'}) return u, l";
-        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", filename, "query", query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(2)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
 
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportQueryNodesJsonParams() throws Exception {
         String filename = "query_nodes_param.json";
-        File output = new File(directory, filename);
         String query = "MATCH (u:User) WHERE u.age > {age} return u";
-        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file},{params:{age:10}})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file},{params:{age:10}})",
+                map("file", filename, "query", query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportQueryNodesJsonCount() throws Exception {
         String filename = "query_nodes_count.json";
-        File output = new File(directory, filename);
         String query = "MATCH (n) return count(n)";
-        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})",
+                map("file", filename, "query", query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportData() throws Exception {
         String filename = "data.json";
-        File output = new File(directory, filename);
         TestUtil.testCall(db, "MATCH (nod:User) " +
                         "MATCH ()-[reels:KNOWS]->() " +
                         "WITH collect(nod) as node, collect(reels) as rels "+
                         "CALL apoc.export.json.data(node, rels, {file}, null) " +
                         "YIELD nodes, relationships, properties, file, source,format, time " +
-                        "RETURN *", map("file", output.getAbsolutePath()),
+                        "RETURN *",
+                map("file", filename),
                 (r) -> {
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportDataPath() throws Exception {
         String filename = "query_nodes_path.json";
-        File output = new File(directory, filename);
         String query = "MATCH p = (u:User)-[rel]->(u2:User) return u, rel, u2, p, u.name";
-        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})",
+                map("file", filename, "query", query),
                 (r) -> {
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportAllWithWriteNodePropertiesJson() throws Exception {
         String filename = "writeNodeProperties.json";
-        File output = new File(directory, filename);
         String query = "MATCH p = (u:User)-[rel:KNOWS]->(u2:User) RETURN rel";
 
-        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file},{writeNodeProperties:true})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file},{writeNodeProperties:true})",
+                map("file", filename,"query", query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
     @Test
     public void testExportQueryOrderJson() throws Exception {
         db.execute("CREATE (f:User12:User1:User0:User {name:'Alan'})").close();
         String filename = "query_node_labels.json";
-        File output = new File(directory, filename);
         String query = "MATCH (u:User) WHERE u.name='Alan' RETURN u";
 
-        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", output.getAbsolutePath(),"query",query),
+        TestUtil.testCall(db, "CALL apoc.export.json.query({query},{file})", map("file", filename,"query",query),
                 (r) -> {
                     assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
-                    assertEquals(output.getAbsolutePath(), r.get("file"));
+                    assertEquals(filename, r.get("file"));
                     assertEquals("json", r.get("format"));
                 });
-        assertFileEquals(filename, output);
+        assertFileEquals(filename);
     }
 
-    private void assertResults(File output, Map<String, Object> r, final String source) {
+    private void assertResults(String filename, Map<String, Object> r, final String source) {
         assertEquals(3L, r.get("nodes"));
         assertEquals(1L, r.get("relationships"));
         assertEquals(10L, r.get("properties"));
         assertEquals(source + ": nodes(3), rels(1)", r.get("source"));
-        assertEquals(output.getAbsolutePath(), r.get("file"));
+        assertEquals(filename, r.get("file"));
         assertEquals("json", r.get("format"));
         assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
     }
 
-    private void assertFileEquals(String filename, File output) throws FileNotFoundException {
-
-        File expexted = new File(directoryExpected, filename);
-
-        String expectedText = new Scanner(expexted).useDelimiter("\\Z").next();
-        String actualText = new Scanner(output).useDelimiter("\\Z").next();
+    private void assertFileEquals(String fileName) {
+        String expectedText = TestUtil.readFileToString(new File(directoryExpected, fileName));
+        String actualText = TestUtil.readFileToString(new File(directory, fileName));
         assertEquals(JsonUtil.parse(expectedText,null,Object.class), JsonUtil.parse(actualText,null,Object.class));
     }
 }


### PR DESCRIPTION
Fixes #1178 

Make the `dbms.directories.import` dir root dir for exports 

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - changed the behaviour of `FileUtils#getOutputStream` method in order to manage the property `apoc.import.file.use_neo4j_config`, in case it's `true` it takes the value `dbms.directories.import` as root dir
  - fixed all the test
  - updated the documentation
