### PR TITLE
#1177 keep the mongodb connection open until stream is closed

### DIFF
--- a/src/main/java/apoc/mongodb/MongoDB.java
+++ b/src/main/java/apoc/mongodb/MongoDB.java
@@ -55,7 +55,8 @@ public class MongoDB {
                                  @Name("db") String db,
                                  @Name("collection") String collection,
                                  @Name("query") Map<String, Object> query,
-                                 @Name(value = "compatibleValues", defaultValue = "false") boolean compatibleValues, @Name(value = "skip", defaultValue = "0") Long skip,
+                                 @Name(value = "compatibleValues", defaultValue = "false") boolean compatibleValues, 
+                                 @Name(value = "skip", defaultValue = "0") Long skip,
                                  @Name(value = "limit", defaultValue = "0") Long limit) {
         try (Coll coll = getMongoColl(hostOrKey, db, collection, compatibleValues)) {
             return coll.all(query, skip, limit).map(MapResult::new); // .onClose(coll::safeClose);


### PR DESCRIPTION
In apoc/mongodb/MongoDB.java ...
```
 try (Coll coll = getMongoColl(hostOrKey, db, collection, compatibleValues)) {
            return coll.all(query, skip, limit).map(MapResult::new); // .onClose(coll::safeClose);
        } catch (Exception e) {
            log.error("...");
            throw new RuntimeException(e);
        }
```
When leaving the try block the `coll` goes out of scope and its `close()` is called.
apoc.mongodb.MongoDBColl
```
   @Override
    public void close() throws IOException { 
        mongoClient.close();
    }
```
However, the returned stream (let's call it `res_stream`) needs for 
the mongo connection associated with `coll`  to remain open.

The closing of `res_stream` is handled by the .onClose() stream modifier
apoc.mongodb.MongoDBColl
```
 private Stream<Map<String, Object>> asStream(FindIterable<Document> result) {
        logger.info("making a result stream");
        Iterable<Document> it = () -> result.iterator();
        return StreamSupport
                .stream(it.spliterator(), false)
                .map(doc -> this.documentToPackableMap(doc))
                .onClose( () -> {
                        result.iterator().close();
                    } );
    }
```
The closing of the `mongoClient.close()` needs to be contingent 
upon the closing of `res_stream` and not the `coll` going out of scope.

Of course in those situations where a stream is not returned the `mongoClient.close()` 
may need to be called when `coll` goes out of scope.
I suppose a `door_stop` flag could be used to hold the `mongoClient` open
in those cases where things like stream are returned.
Seems kind of a hack (I generally feel that way about flags). 