### PR TITLE
Added apoc.merge.node.eager() and apoc.merge.relationship.eager()

### DIFF
--- a/src/main/java/apoc/merge/Merge.java
+++ b/src/main/java/apoc/merge/Merge.java
@@ -1,7 +1,7 @@
 package apoc.merge;
 
 import apoc.result.*;
-import apoc.util.Util;
+import com.google.common.collect.Lists;
 import org.neo4j.graphdb.*;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.procedure.*;
@@ -25,7 +25,8 @@ public class Merge {
         String labels = labelNames.stream().map(s -> wrapInBacktics(s)).collect(Collectors.joining(":"));
 
         Map<String, Object> params = new HashMap<>();
-        params.put("props", Util.merge(identProps, props));
+        params.put("identProps", identProps);
+        params.put("props", props);
         String identPropsString = buildIdentPropsString(identProps);
 
         final String cypher = "MERGE (n:" + labels + "{" + identPropsString + "}) ON CREATE SET n += $props RETURN n";
@@ -33,18 +34,40 @@ public class Merge {
         return Stream.of(new NodeResult(node));
     }
 
-    private String wrapInBacktics(String s) {
-        return "`" + s + "`";
+    @Procedure(value="apoc.merge.node.eager", mode = Mode.WRITE, eager = true)
+    @Description("apoc.merge.node.eager(['Label'], identProps:{key:value, ...}, config:{onCreateProps:{key:value,...}, onMatchProps:{key:value,...}}) - merge node with dynamic labels, with support for setting properties ON CREATE or ON MATCH")
+    public Stream<NodeResult> nodeEager(@Name("label") List<String> labelNames, @Name("identProps") Map<String, Object> identProps, @Name(value="config", defaultValue = "{}") Map<String, Object> config) {
+        if ((identProps==null) || (identProps.isEmpty())) {
+            throw new IllegalArgumentException("you need to supply at least one identifying property for a merge");
+        }
+
+        validateKeys(config.keySet(), Lists.newArrayList("onCreateProps", "onMatchProps"));
+
+        String labels = labelNames.stream().map(s -> wrapInBacktics(s)).collect(Collectors.joining(":"));
+
+        Map<String, Object> params = new HashMap<>();
+
+        Map<String, Object> onCreateProps = (Map<String, Object>) config.getOrDefault("onCreateProps", Collections.emptyMap());
+        Map<String, Object> onMatchProps = (Map<String, Object>) config.getOrDefault("onMatchProps", Collections.emptyMap());
+
+        params.put("identProps", identProps);
+        params.put("onCreateProps", onCreateProps);
+        params.put("onMatchProps", onMatchProps);
+        String identPropsString = buildIdentPropsString(identProps);
+
+        final String cypher = "MERGE (n:" + labels + "{" + identPropsString + "}) ON CREATE SET n += $onCreateProps ON MATCH SET n += $onMatchProps RETURN n";
+        return db.execute(cypher, params ).columnAs("n").stream().map(node -> new NodeResult((Node) node));
     }
 
     @Procedure(mode = Mode.WRITE)
-    @Description("apoc.merge.relationship(startNode, relType,  {key:value, ...}, {key:value, ...}, endNode) - merge relationship with dynamic type")
+    @Description("apoc.merge.relationship(startNode, relType,  identProps:{key:value, ...}, {key:value, ...}, endNode) - merge relationship with dynamic type")
     public Stream<RelationshipResult> relationship(@Name("startNode") Node startNode, @Name("relationshipType") String relType,
                                                    @Name("identProps") Map<String, Object> identProps, @Name("props") Map<String, Object> props, @Name("endNode") Node endNode) {
         String identPropsString = buildIdentPropsString(identProps);
 
         Map<String, Object> params = new HashMap<>();
-        params.put("props", Util.merge(identProps, props));
+        params.put("identProps", identProps);
+        params.put("props", props != null ? props : Collections.emptyMap());
         params.put("startNode", startNode);
         params.put("endNode", endNode);
 
@@ -53,18 +76,47 @@ public class Merge {
         return Stream.of(new RelationshipResult(rel));
     }
 
+    @Procedure(value = "apoc.merge.relationship.eager", mode = Mode.WRITE, eager = true)
+    @Description("apoc.merge.relationship.eager(startNode, relType,  identProps:{key:value, ...}, config:{onCreateProps:{key:value, ...}, onMatchProps:{key:value, ...}}, endNode) - merge relationship with dynamic type, with support for setting properties ON CREATE or ON MATCH")
+    public Stream<RelationshipResult> relationshipEager(@Name("startNode") Node startNode, @Name("relationshipType") String relType,
+                                                   @Name("identProps") Map<String, Object> identProps, @Name("config") Map<String, Object> config, @Name("endNode") Node endNode) {
+        validateKeys(config.keySet(), Lists.newArrayList("onCreateProps", "onMatchProps"));
+
+        String identPropsString = buildIdentPropsString(identProps);
+
+        Map<String, Object> params = new HashMap<>();
+
+        Map<String, Object> onCreateProps = (Map<String, Object>) config.getOrDefault("onCreateProps", Collections.emptyMap());
+        Map<String, Object> onMatchProps = (Map<String, Object>) config.getOrDefault("onMatchProps", Collections.emptyMap());
+
+        params.put("identProps", identProps);
+        params.put("onCreateProps", onCreateProps);
+        params.put("onMatchProps", onMatchProps);
+        params.put("startNode", startNode);
+        params.put("endNode", endNode);
+
+        final String cypher = "WITH $startNode as startNode, $endNode as endNode MERGE (startNode)-[r:"+ wrapInBacktics(relType) +"{"+identPropsString+"}]->(endNode) ON CREATE SET r+= $onCreateProps ON MATCH SET r+= $onMatchProps RETURN r";
+        return db.execute(cypher, params ).columnAs("r").stream().map(rel -> new RelationshipResult((Relationship) rel));
+    }
+
+    private void validateKeys(Set<String> mapKeys, List<String> allowedKeys) {
+        Set<String> copy = new HashSet<>(mapKeys);
+        copy.removeAll(allowedKeys);
+
+        if (!copy.isEmpty()) {
+            throw new IllegalArgumentException("Config map may only take the following: " + allowedKeys.toString() + ". Unknown keys found: " + copy.toString());
+        }
+    }
+
+    private String wrapInBacktics(String s) {
+        return "`" + s + "`";
+    }
+
     private String buildIdentPropsString(Map<String, Object> identProps) {
         if (identProps==null) {
             return "";
         } else {
-            return identProps.keySet().stream().map(s -> "`"+s+"`:$props.`" + s+"`").collect(Collectors.joining(","));
+            return identProps.keySet().stream().map(s -> "`"+s+"`:$identProps.`" + s+"`").collect(Collectors.joining(","));
         }
     }
-
-    private Map<String, Object> buildParams(Map<String, Object> identProps, Map<String, Object> props) {
-        Map<String, Object> map = identProps == null ? new HashMap<>() : new HashMap<>(identProps);
-        map.put("props", props == null ? Collections.EMPTY_MAP : props);
-        return map;
-    }
-
 }

--- a/src/test/java/apoc/merge/MergeTest.java
+++ b/src/test/java/apoc/merge/MergeTest.java
@@ -161,15 +161,15 @@ public class MergeTest {
 
     @Test
     public void testMergeEagerNodesWithOnMatchCanMergeOnMultipleMatches() throws Exception {
-        db.execute("UNWIND range(1,5) as index MERGE (:Person:Bastard {ssid:'123', index:index})");
+        db.execute("UNWIND range(1,5) as index MERGE (:Person:`Bastard Man`{ssid:'123', index:index})");
 
         try (Transaction tx = db.beginTx()) {
-            Result result = db.execute("CALL apoc.merge.node.eager(['Person','Bastard'],{ssid:'123'}, {onCreateProps:{name:'John'}, onMatchProps:{occupation:'juggler'}}) YIELD node RETURN node");
+            Result result = db.execute("CALL apoc.merge.node.eager(['Person','Bastard Man'],{ssid:'123'}, {onCreateProps:{name:'John'}, onMatchProps:{occupation:'juggler'}}) YIELD node RETURN node");
 
             for (long index = 1; index <= 5; index++) {
                 Node node = (Node) result.next().get("node");
                 assertEquals(true, node.hasLabel(Label.label("Person")));
-                assertEquals(true, node.hasLabel(Label.label("Bastard")));
+                assertEquals(true, node.hasLabel(Label.label("Bastard Man")));
                 assertEquals("123", node.getProperty("ssid"));
                 assertEquals(index, node.getProperty("index"));
                 assertEquals("juggler", node.getProperty("occupation"));

--- a/src/test/java/apoc/merge/MergeTest.java
+++ b/src/test/java/apoc/merge/MergeTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.*;
 public class MergeTest {
 
     private GraphDatabaseService db;
-    public static final Label PERSON = Label.label("Person");
 
     @Before
     public void setUp() throws Exception {
@@ -117,4 +116,147 @@ public class MergeTest {
         }
     }
 
+
+    // MERGE EAGER TESTS
+
+
+    @Test
+    public void testMergeEagerNode() throws Exception {
+        testCall(db, "CALL apoc.merge.node.eager(['Person','Bastard'],{ssid:'123'}, {onCreateProps:{name:'John'}}) YIELD node RETURN node",
+                (row) -> {
+                    Node node = (Node) row.get("node");
+                    assertEquals(true, node.hasLabel(Label.label("Person")));
+                    assertEquals(true, node.hasLabel(Label.label("Bastard")));
+                    assertEquals("John", node.getProperty("name"));
+                    assertEquals("123", node.getProperty("ssid"));
+                });
+    }
+
+    @Test
+    public void testMergeEagerNodeWithOnCreate() throws Exception {
+        testCall(db, "CALL apoc.merge.node.eager(['Person','Bastard'],{ssid:'123'}, {onCreateProps:{name:'John'}, onMatchProps:{occupation:'juggler'}}) YIELD node RETURN node",
+                (row) -> {
+                    Node node = (Node) row.get("node");
+                    assertEquals(true, node.hasLabel(Label.label("Person")));
+                    assertEquals(true, node.hasLabel(Label.label("Bastard")));
+                    assertEquals("John", node.getProperty("name"));
+                    assertEquals("123", node.getProperty("ssid"));
+                    assertFalse(node.hasProperty("occupation"));
+                });
+    }
+
+    @Test
+    public void testMergeEagerNodeWithOnMatch() throws Exception {
+        db.execute("CREATE (p:Person:Bastard {ssid:'123'})");
+        testCall(db, "CALL apoc.merge.node.eager(['Person','Bastard'],{ssid:'123'}, {onCreateProps:{name:'John'}, onMatchProps:{occupation:'juggler'}}) YIELD node RETURN node",
+                (row) -> {
+                    Node node = (Node) row.get("node");
+                    assertEquals(true, node.hasLabel(Label.label("Person")));
+                    assertEquals(true, node.hasLabel(Label.label("Bastard")));
+                    assertEquals("juggler", node.getProperty("occupation"));
+                    assertEquals("123", node.getProperty("ssid"));
+                    assertFalse(node.hasProperty("name"));
+                });
+    }
+
+    @Test
+    public void testMergeEagerNodesWithOnMatchCanMergeOnMultipleMatches() throws Exception {
+        db.execute("UNWIND range(1,5) as index MERGE (:Person:Bastard {ssid:'123', index:index})");
+
+        try (Transaction tx = db.beginTx()) {
+            Result result = db.execute("CALL apoc.merge.node.eager(['Person','Bastard'],{ssid:'123'}, {onCreateProps:{name:'John'}, onMatchProps:{occupation:'juggler'}}) YIELD node RETURN node");
+
+            for (long index = 1; index <= 5; index++) {
+                Node node = (Node) result.next().get("node");
+                assertEquals(true, node.hasLabel(Label.label("Person")));
+                assertEquals(true, node.hasLabel(Label.label("Bastard")));
+                assertEquals("123", node.getProperty("ssid"));
+                assertEquals(index, node.getProperty("index"));
+                assertEquals("juggler", node.getProperty("occupation"));
+                assertFalse(node.hasProperty("name"));
+            }
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testMergeEagerRelationships() throws Exception {
+        db.execute("create (:Person{name:'Foo'}), (:Person{name:'Bar'})");
+
+        testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship.eager(s, 'KNOWS', {rid:123}, {onCreateProps:{since:'Thu'}}, e) YIELD rel RETURN rel",
+                (row) -> {
+                    Relationship rel = (Relationship) row.get("rel");
+                    assertEquals("KNOWS", rel.getType().name());
+                    assertEquals(123l, rel.getProperty("rid"));
+                    assertEquals("Thu", rel.getProperty("since"));
+                });
+
+        testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship.eager(s, 'KNOWS', {rid:123}, {onCreateProps:{since:'Fri'}}, e) YIELD rel RETURN rel",
+                (row) -> {
+                    Relationship rel = (Relationship) row.get("rel");
+                    assertEquals("KNOWS", rel.getType().name());
+                    assertEquals(123l, rel.getProperty("rid"));
+                    assertEquals("Thu", rel.getProperty("since"));
+                });
+        testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship(s, 'OTHER', null, null, e) YIELD rel RETURN rel",
+                (row) -> {
+                    Relationship rel = (Relationship) row.get("rel");
+                    assertEquals("OTHER", rel.getType().name());
+                    assertTrue(rel.getAllProperties().isEmpty());
+                });
+    }
+
+    @Test
+    public void testMergeEagerRelationshipsWithOnMatch() throws Exception {
+        db.execute("create (:Person{name:'Foo'}), (:Person{name:'Bar'})");
+
+        testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship.eager(s, 'KNOWS', {rid:123}, {onCreateProps:{since:'Thu'}, onMatchProps:{until:'Saturday'}}, e) YIELD rel RETURN rel",
+                (row) -> {
+                    Relationship rel = (Relationship) row.get("rel");
+                    assertEquals("KNOWS", rel.getType().name());
+                    assertEquals(123l, rel.getProperty("rid"));
+                    assertEquals("Thu", rel.getProperty("since"));
+                    assertFalse(rel.hasProperty("until"));
+                });
+
+        testCall(db, "MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship.eager(s, 'KNOWS', {rid:123}, {onMatchProps:{since:'Fri'}}, e) YIELD rel RETURN rel",
+                (row) -> {
+                    Relationship rel = (Relationship) row.get("rel");
+                    assertEquals("KNOWS", rel.getType().name());
+                    assertEquals(123l, rel.getProperty("rid"));
+                    assertEquals("Fri", rel.getProperty("since"));
+                });
+    }
+
+    @Test
+    public void testMergeEagerRelationshipsWithOnMatchCanMergeOnMultipleMatches() throws Exception {
+        db.execute("CREATE (foo:Person{name:'Foo'}), (bar:Person{name:'Bar'}) WITH foo, bar UNWIND range(1,3) as index CREATE (foo)-[:KNOWS {rid:123}]->(bar)");
+
+        try (Transaction tx = db.beginTx()) {
+            Result result = db.execute("MERGE (s:Person{name:'Foo'}) MERGE (e:Person{name:'Bar'}) WITH s,e CALL apoc.merge.relationship.eager(s, 'KNOWS', {rid:123}, {onMatchProps:{since:'Fri'}}, e) YIELD rel RETURN rel");
+
+            for (long index = 1; index <= 3; index++) {
+                Relationship rel = (Relationship) result.next().get("rel");
+                assertEquals("KNOWS", rel.getType().name());
+                assertEquals(123l, rel.getProperty("rid"));
+                assertEquals("Fri", rel.getProperty("since"));
+            }
+        } catch (Exception e) {
+            fail();
+        }
+    }
+
+    @Test
+    public void testMergeEagerWithEmptyIdentityPropertiesShouldFail() {
+        for (String idProps: new String[]{"null", "{}"}) {
+            try {
+                testCall(db, "CALL apoc.merge.node(['Person']," + idProps +", {name:'John'}) YIELD node RETURN node",
+                        row -> assertTrue(row.get("node") instanceof Node));
+                fail();
+            } catch (QueryExecutionException e) {
+                assertTrue(e.getMessage().contains("you need to supply at least one identifying property for a merge"));
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes #1182 
New procedures added, old procedures unchanged (some refactoring, but no changes to behavior)

These both accept a config map that can take 'onMatchProps' and 'onCreateProps' map properties.

These procs can also match to multiple existing nodes unlike apoc.merge.node() and apoc.merge.relationship().

Documentation to be checked in separately.