### PR TITLE
fixes #1188: headers incorrect order after apoc csv export in enterprise edition 3.5.4, 3.5.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -158,6 +158,9 @@ dependencies {
     testCompile group: 'org.testcontainers', name: 'postgresql', version: testContainersVersion
     testCompile group: 'org.testcontainers', name: 'cassandra', version: testContainersVersion
 
+    testCompile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: '2.9.7'
+
+
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'
     }

--- a/docs/asciidoc/_export_import.adoc
+++ b/docs/asciidoc/_export_import.adoc
@@ -88,6 +88,12 @@ If the file name is passed as `null` and the config `stream:true` the results ar
 
 ==== Note:
 
+For `apoc.export.csv.all/data/graph` nodes and relationships properties are ordered alphabetically, following this general structure:
+
+`_id,_labels,<list_nodes_properties_naturally_sorted>,_start,_end,_type,<list_rel_properties_naturally_sorted>`, so for instance:
+
+`_id,_labels,age,city,kids,male,name,street,_start,_end,_type,bar,foo`
+
 The labels exported are ordered alphabetically.
 The output of `labels()` function is not sorted, use it in combination with `apoc.coll.sort()`.
 

--- a/src/test/java/apoc/export/csv/CsvTestUtil.java
+++ b/src/test/java/apoc/export/csv/CsvTestUtil.java
@@ -1,13 +1,37 @@
 package apoc.export.csv;
 
+import com.fasterxml.jackson.databind.MappingIterator;
+import com.fasterxml.jackson.dataformat.csv.CsvMapper;
+import com.fasterxml.jackson.dataformat.csv.CsvParser;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.List;
 
 public class CsvTestUtil {
 
+    public static final CsvMapper CSV_MAPPER;
+
+    static {
+        CSV_MAPPER = new CsvMapper();
+        CSV_MAPPER.enable(CsvParser.Feature.WRAP_AS_ARRAY);
+    }
+
     public static void saveCsvFile(String fileName, String content) throws IOException {
         Files.write(Paths.get("src/test/resources/csv-inputs/" + fileName + ".csv"), content.getBytes());
+    }
+
+    public static List<String[]> toCollection(String csv) {
+
+        try {
+            MappingIterator<String[]> it = CSV_MAPPER.readerFor(String[].class)
+//                    .with(CsvSchema.emptySchema().withHeader())
+                    .<String[]>readValues(csv.getBytes());
+            return it.readAll();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/src/test/java/apoc/export/csv/ExportCsvIT.java
+++ b/src/test/java/apoc/export/csv/ExportCsvIT.java
@@ -1,0 +1,67 @@
+package apoc.export.csv;
+
+import apoc.util.Neo4jContainerExtension;
+import apoc.util.TestUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.driver.v1.Session;
+
+import java.util.List;
+
+import static apoc.util.MapUtil.map;
+import static apoc.util.TestContainerUtil.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeNotNull;
+
+/**
+ * @author as
+ * @since 13.02.19
+ */
+public class ExportCsvIT {
+
+    private static Neo4jContainerExtension neo4jContainer;
+    private static Session session;
+
+    @BeforeClass
+    public static void beforeAll() {
+        TestUtil.ignoreException(() -> {
+            neo4jContainer = createEnterpriseDB(true);
+            neo4jContainer.start();
+        }, Exception.class);
+        assumeNotNull(neo4jContainer);
+        session = neo4jContainer.getSession();
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        if (neo4jContainer != null) {
+            neo4jContainer.close();
+        }
+        cleanBuild();
+    }
+
+    @Test
+    public void testExportQueryCsvIssue1188() throws Exception {
+        String copyright = "\n" +
+                "(c) 2018 Hovsepian, Albanese, et al. \"\"ASCB(r),\"\" \"\"The American Society for Cell Biology(r),\"\" and \"\"Molecular Biology of the Cell(r)\"\" are registered trademarks of The American Society for Cell Biology.\n" +
+                "2018\n" +
+                "\n" +
+                "This article is distributed by The American Society for Cell Biology under license from the author(s). Two months after publication it is available to the public under an Attribution-Noncommercial-Share Alike 3.0 Unported Creative Commons License.\n" +
+                "\n";
+        String pk = "5921569";
+        session.writeTransaction(tx -> tx.run("CREATE (n:Document{pk:{pk}, copyright: {copyright}})", map("copyright", copyright, "pk", pk)));
+        String query = "MATCH (n:Document{pk:'5921569'}) return n.pk as pk, n.copyright as copyright";
+        testCall(session, "CALL apoc.export.csv.query({query}, null, {config})", map("query", query,
+                "config", map("stream", true)),
+                (r) -> {
+                    List<String[]> csv = CsvTestUtil.toCollection(r.get("data").toString());
+                    assertEquals(2, csv.size());
+                    assertArrayEquals(new String[]{"pk","copyright"}, csv.get(0));
+                    assertArrayEquals(new String[]{"5921569",copyright}, csv.get(1));
+                });
+        session.writeTransaction(tx -> tx.run("MATCH (d:Document) DETACH DELETE d"));
+    }
+
+}

--- a/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -19,6 +19,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import java.io.File;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -36,27 +37,27 @@ public class ExportCsvTest {
             "\"{\"\"id\"\":0,\"\"labels\"\":[\"\"User\"\",\"\"User1\"\"],\"\"properties\"\":{\"\"name\"\":\"\"foo\"\",\"\"age\"\":42,\"\"male\"\":true,\"\"kids\"\":[\"\"a\"\",\"\"b\"\",\"\"c\"\"]}}\"%n" +
             "\"{\"\"id\"\":1,\"\"labels\"\":[\"\"User\"\"],\"\"properties\"\":{\"\"name\"\":\"\"bar\"\",\"\"age\"\":42}}\"%n" +
             "\"{\"\"id\"\":2,\"\"labels\"\":[\"\"User\"\"],\"\"properties\"\":{\"\"age\"\":12}}\"%n");
-    private static final String EXPECTED_QUERY = String.format("\"labels(u)\",\"u.age\",\"u.kids\",\"u.male\",\"u.name\"%n" +
-            "\"[\"\"User1\"\",\"\"User\"\"]\",\"42\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"true\",\"foo\"%n" +
-            "\"[\"\"User\"\"]\",\"42\",\"\",\"\",\"bar\"%n" +
-            "\"[\"\"User\"\"]\",\"12\",\"\",\"\",\"\"%n");
-    private static final String EXPECTED_QUERY_WITHOUT_QUOTES = String.format("labels(u),u.age,u.kids,u.male,u.name%n" +
-            "[\"User1\",\"User\"],42,[\"a\",\"b\",\"c\"],true,foo%n" +
-            "[\"User\"],42,,,bar%n" +
-            "[\"User\"],12,,,%n");
-    private static final String EXPECTED_QUERY_QUOTES_NONE = String.format("a.city,a.name,a.street,labels(a)%n" +
-            "Milano,Andrea,Via Garibaldi, 7,[\"Address1\",\"Address\"]%n" +
-            ",Bar Sport,,[\"Address\"]%n" +
+    private static final String EXPECTED_QUERY = String.format("\"u.age\",\"u.name\",\"u.male\",\"u.kids\",\"labels(u)\"%n" +
+            "\"42\",\"foo\",\"true\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"[\"\"User1\"\",\"\"User\"\"]\"%n" +
+            "\"42\",\"bar\",\"\",\"\",\"[\"\"User\"\"]\"%n" +
+            "\"12\",\"\",\"\",\"\",\"[\"\"User\"\"]\"%n");
+    private static final String EXPECTED_QUERY_WITHOUT_QUOTES = String.format("u.age,u.name,u.male,u.kids,labels(u)%n" +
+            "42,foo,true,[\"a\",\"b\",\"c\"],[\"User1\",\"User\"]%n" +
+            "42,bar,,,[\"User\"]%n" +
+            "12,,,,[\"User\"]%n");
+    private static final String EXPECTED_QUERY_QUOTES_NONE = String.format("a.name,a.city,a.street,labels(a)%n" +
+            "Andrea,Milano,Via Garibaldi, 7,[\"Address1\",\"Address\"]%n" +
+            "Bar Sport,,,[\"Address\"]%n" +
             ",,via Benni,[\"Address\"]%n");
-    private static final String EXPECTED_QUERY_QUOTES_ALWAYS = String.format("\"a.city\",\"a.name\",\"a.street\",\"labels(a)\"%n" +
-            "\"Milano\",\"Andrea\",\"Via Garibaldi, 7\",\"[\"\"Address1\"\",\"\"Address\"\"]\"%n" +
-            "\"\",\"Bar Sport\",\"\",\"[\"\"Address\"\"]\"%n" +
+    private static final String EXPECTED_QUERY_QUOTES_ALWAYS = String.format("\"a.name\",\"a.city\",\"a.street\",\"labels(a)\"%n" +
+            "\"Andrea\",\"Milano\",\"Via Garibaldi, 7\",\"[\"\"Address1\"\",\"\"Address\"\"]\"%n" +
+            "\"Bar Sport\",\"\",\"\",\"[\"\"Address\"\"]\"%n" +
             "\"\",\"\",\"via Benni\",\"[\"\"Address\"\"]\"%n");
-    private static final String EXPECTED_QUERY_QUOTES_NEEDED = String.format( "a.city,a.name,a.street,labels(a)%n" +
-            "Milano,Andrea,\"Via Garibaldi, 7\",\"[\"Address1\",\"Address\"]\"%n" +
-            ",Bar Sport,,\"[\"Address\"]\"%n" +
+    private static final String EXPECTED_QUERY_QUOTES_NEEDED = String.format("a.name,a.city,a.street,labels(a)%n" +
+            "Andrea,Milano,\"Via Garibaldi, 7\",\"[\"Address1\",\"Address\"]\"%n" +
+            "Bar Sport,,,\"[\"Address\"]\"%n" +
             ",,via Benni,\"[\"Address\"]\"%n");
-    private static final String EXPECTED = String.format("\"_id\",\"_labels\",\"name\",\"age\",\"male\",\"kids\",\"street\",\"city\",\"_start\",\"_end\",\"_type\"%n" +
+    private static final String EXPECTED = String.format("\"_id\",\"_labels\",\"age\",\"city\",\"kids\",\"male\",\"name\",\"street\",\"_start\",\"_end\",\"_type\"%n" +
             "\"0\",\":User:User1\",\"foo\",\"42\",\"true\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"\",\"\",,,%n" +
             "\"1\",\":User\",\"bar\",\"42\",\"\",\"\",\"\",\"\",,,%n" +
             "\"2\",\":User\",\"\",\"12\",\"\",\"\",\"\",\"\",,,%n" +
@@ -65,7 +66,7 @@ public class ExportCsvTest {
             "\"22\",\":Address\",\"\",\"\",\"\",\"\",\"via Benni\",\"\",,,%n" +
             ",,,,,,,,\"0\",\"1\",\"KNOWS\"%n" +
             ",,,,,,,,\"20\",\"21\",\"NEXT_DELIVERY\"%n");
-    private static final String EXPECTED_NONE_QUOTES = String.format("_id,_labels,name,age,male,kids,street,city,_start,_end,_type%n" +
+    private static final String EXPECTED_NONE_QUOTES = String.format("_id,_labels,age,city,kids,male,name,street,_start,_end,_type%n" +
             "0,:User:User1,foo,42,true,[\"a\",\"b\",\"c\"],,,,,%n" +
             "1,:User,bar,42,,,,,,,%n" +
             "2,:User,,12,,,,,,,%n" +
@@ -74,7 +75,7 @@ public class ExportCsvTest {
             "22,:Address,,,,,via Benni,,,,%n" +
             ",,,,,,,,0,1,KNOWS%n" +
             ",,,,,,,,20,21,NEXT_DELIVERY%n");
-    private static final String EXPECTED_NEEDED_QUOTES = String.format("_id,_labels,name,age,male,kids,street,city,_start,_end,_type%n" +
+    private static final String EXPECTED_NEEDED_QUOTES = String.format("_id,_labels,age,city,kids,male,name,street,_start,_end,_type%n" +
             "0,:User:User1,foo,42,true,\"[\"a\",\"b\",\"c\"]\",,,,,%n" +
             "1,:User,bar,42,,,,,,,%n" +
             "2,:User,,12,,,,,,,%n" +
@@ -381,6 +382,29 @@ public class ExportCsvTest {
                 getAndCheckStreamingMetadataQueryMatchAddress(sb));
 
         assertEquals(EXPECTED_QUERY_QUOTES_NONE, sb.toString());
+    }
+
+    @Test
+    public void testExportQueryCsvIssue1188() throws Exception {
+        String copyright = "\n" +
+                "(c) 2018 Hovsepian, Albanese, et al. \"\"ASCB(r),\"\" \"\"The American Society for Cell Biology(r),\"\" and \"\"Molecular Biology of the Cell(r)\"\" are registered trademarks of The American Society for Cell Biology.\n" +
+                "2018\n" +
+                "\n" +
+                "This article is distributed by The American Society for Cell Biology under license from the author(s). Two months after publication it is available to the public under an Attribution-Noncommercial-Share Alike 3.0 Unported Creative Commons License.\n" +
+                "\n";
+        String pk = "5921569";
+        db.execute("CREATE (n:Document{pk:{pk}, copyright: {copyright}})", map("copyright", copyright, "pk", pk)).close();
+        String query = "MATCH (n:Document{pk:'5921569'}) return n.pk as pk, n.copyright as copyright";
+        TestUtil.testCall(db, "CALL apoc.export.csv.query({query}, null, {config})", map("query", query,
+                "config", map("stream", true)),
+                (r) -> {
+                    List<String[]> csv = CsvTestUtil.toCollection(r.get("data").toString());
+                    assertEquals(2, csv.size());
+                    assertArrayEquals(new String[]{"pk","copyright"}, csv.get(0));
+                    assertArrayEquals(new String[]{"5921569",copyright}, csv.get(1));
+                });
+        db.execute("MATCH (d:Document) DETACH DELETE d").close();
+
     }
 
     private Consumer<Result> getAndCheckStreamingMetadataQueryMatchAddress(StringBuilder sb)


### PR DESCRIPTION
Fixes #1188 

Removed sorting for `apoc.export.csv.query` and added for `apoc.export.csv.all/data/graph`

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added sorting in exporting a subgraph. As described here:

https://github.com/conker84/neo4j-apoc-procedures/blob/fb316cce65daab4198a1d348fa9f39f08138f849/src/main/java/apoc/export/csv/CsvFormat.java#L245-L261

In particular, now we have this general structure for the headers:

`_id,_labels,<list_nodes_properties_naturally_sorted>,_start,_end,_type,<list_rel_properties_naturally_sorted>`

So for instance:

`_id,_labels,age,city,kids,male,name,street,_start,_end,_type,bar,foo`

  - Fixed tests related to `apoc.export.csv.query`
  - Updated the documentation
