### PR TITLE
fixes #1194 - Adds ignoreQuotations configuration to apoc.load.csv  - Branch 3.5

### DIFF
--- a/src/main/java/apoc/load/LoadCsv.java
+++ b/src/main/java/apoc/load/LoadCsv.java
@@ -47,6 +47,7 @@ public class LoadCsv {
                     .withCSVParser(new CSVParserBuilder()
                             .withQuoteChar(config.getQuoteChar())
                             .withSeparator(config.getSeparator())
+                            .withIgnoreQuotations( config.isIgnoreQuotations() )
                             .build())
                     .build();
 

--- a/src/main/java/apoc/load/util/LoadCsvConfig.java
+++ b/src/main/java/apoc/load/util/LoadCsvConfig.java
@@ -24,6 +24,7 @@ public class LoadCsvConfig {
     private long limit;
 
     private boolean failOnError;
+    private boolean ignoreQuotations;
 
     private EnumSet<Results> results;
 
@@ -48,6 +49,7 @@ public class LoadCsvConfig {
         hasHeader = (boolean) config.getOrDefault("header", true);
         limit = (long) config.getOrDefault("limit", Long.MAX_VALUE);
         failOnError = (boolean) config.getOrDefault("failOnError", true);
+        ignoreQuotations = (boolean) config.getOrDefault("ignoreQuotations", false);
 
         results = EnumSet.noneOf(Results.class);
         List<String> resultList = (List<String>) config.getOrDefault("results", asList("map","list"));
@@ -121,5 +123,9 @@ public class LoadCsvConfig {
 
     public boolean getIgnoreErrors() {
         return ignoreErrors;
+    }
+
+    public boolean isIgnoreQuotations() {
+        return ignoreQuotations;
     }
 }


### PR DESCRIPTION
Fixes #1194

Adds ignoreQuotations to the apoc.load.csv configuration. This will allow the load csv operation to treat quote characters as regular characters, preventing issues if a quote is unclosed. When the row is loaded quote characters are NOT included. You can include quote characters by placing an escape character in front of them.