### PR TITLE
fixes #1203 - Added RFC date support and date string converter function 

### DIFF
--- a/src/main/java/apoc/date/Date.java
+++ b/src/main/java/apoc/date/Date.java
@@ -1,5 +1,6 @@
 package apoc.date;
 
+import apoc.util.DateFormatUtil;
 import apoc.util.Util;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -189,6 +190,21 @@ public class Date {
 	@Description("apoc.date.convert(12345, 'ms', 'd') convert a timestamp in one time unit into one of a different time unit")
 	public Long convert(@Name("time") long time, @Name(value = "unit") String unit, @Name(value = "toUnit") String toUnit) {
 		return unit(toUnit).convert(time, unit(unit));
+	}
+
+	@UserFunction
+	@Description("apoc.date.convertFormat('Tue, 14 May 2019 14:52:06 -0400', 'rfc_1123_date_time', 'iso_date_time') convert a String of one date format into a String of another date format.")
+	public String convertFormat( @Name( "temporal" ) String input, @Name( value = "currentFormat" ) String currentFormat, @Name( value = "convertTo" , defaultValue = "yyyy-MM-dd" ) String convertTo )
+	{
+		if (input == null || input.isEmpty())
+		{
+			return null;
+		}
+
+		DateTimeFormatter currentFormatter = DateFormatUtil.getOrCreate( currentFormat );
+		DateTimeFormatter convertToFormatter = DateFormatUtil.getOrCreate( convertTo );
+
+		return convertToFormatter.format(  currentFormatter.parse( input ) );
 	}
 
 	@UserFunction

--- a/src/main/java/apoc/util/DateFormatUtil.java
+++ b/src/main/java/apoc/util/DateFormatUtil.java
@@ -69,6 +69,7 @@ public class DateFormatUtil {
         map.put("year", DateTimeFormatter.ofPattern("yyyy"));
         map.put("year_month", DateTimeFormatter.ofPattern("yyyy-MM"));
         map.put("year_month_day", DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+        map.put( "rfc_1123_date_time", DateTimeFormatter.RFC_1123_DATE_TIME );
         ISO_DATE_FORMAT = Collections.unmodifiableMap(map);
     }
 

--- a/src/test/java/apoc/date/DateTest.java
+++ b/src/test/java/apoc/date/DateTest.java
@@ -401,6 +401,15 @@ public class DateTest {
 		testCall(db, "RETURN apoc.date.add($firstOf2017ms, 'ms', -5, 'd') as firstOf2017Minus5days", params, row -> assertEquals(firstOf2017Minus5Daysms, row.get("firstOf2017Minus5days")));
 	}
 
+	@Test
+	public void testConvertFormats() throws Exception {
+		String rfcDateTime = "Tue, 14 May 2019 14:52:06 -0400";
+		String isoDateTime = "2019-05-14T14:52:06-04:00";
+		Map<String, Object> params = new HashMap<>();
+		params.put("rfcDateTime", rfcDateTime);
+		testCall(db, "RETURN apoc.date.convertFormats($rfcDateTime, 'rfc_1123_date_time', 'iso_date_time') as convertedTime", params, row -> assertEquals(isoDateTime, row.get("convertedTime")));
+	}
+
 	private SimpleDateFormat formatInUtcZone(final String pattern) {
 		SimpleDateFormat customFormat = new SimpleDateFormat(pattern);
 		customFormat.setTimeZone(TimeZone.getTimeZone("UTC"));


### PR DESCRIPTION
Fixes #1203

Adds support for the date format `RFC_1123_DATE_TIME`.

Adds a method to convert a String of one date format into a String of another date format.

The function header has an input, a string currentFormat, and a string convertToFormat parameter. 
``` 
apoc.date.convertFormat('Tue, 14 May 2019 14:52:06 -0400', 'rfc_1123_date_time', 'iso_date_time')
```

