### PR TITLE
fixes #1206 alias sql statements in conf for apoc.load.jdbc

### DIFF
--- a/src/main/java/apoc/load/Jdbc.java
+++ b/src/main/java/apoc/load/Jdbc.java
@@ -20,8 +20,7 @@ import java.util.*;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static apoc.load.util.JdbcUtil.getConnection;
-import static apoc.load.util.JdbcUtil.getUrlOrKey;
+import static apoc.load.util.JdbcUtil.*;
 
 /**
  * @author mh
@@ -72,7 +71,7 @@ public class Jdbc {
     private Stream<RowResult> executeQuery(String urlOrKey, String tableOrSelect, Map<String, Object> config, Object... params) {
         LoadJdbcConfig loadJdbcConfig = new LoadJdbcConfig(config);
         String url = getUrlOrKey(urlOrKey);
-        String query = tableOrSelect.indexOf(' ') == -1 ? "SELECT * FROM " + tableOrSelect : tableOrSelect;
+        String query = getSqlOrKey(tableOrSelect);
         try {
             Connection connection = getConnection(url,loadJdbcConfig);
             try {

--- a/src/main/java/apoc/load/util/JdbcUtil.java
+++ b/src/main/java/apoc/load/util/JdbcUtil.java
@@ -59,4 +59,8 @@ public class JdbcUtil {
     public static String getUrlOrKey(String urlOrKey) {
         return urlOrKey.contains(":") ? urlOrKey : Util.getLoadUrlByConfigFile(LOAD_TYPE, urlOrKey, "url").orElseThrow(() -> new RuntimeException(String.format(KEY_NOT_FOUND_MESSAGE, urlOrKey)));
     }
+
+    public static String getSqlOrKey(String sqlOrKey) {
+        return sqlOrKey.contains(" ") ? sqlOrKey : Util.getLoadUrlByConfigFile(LOAD_TYPE, sqlOrKey, "sql").orElse("SELECT * FROM " + sqlOrKey);
+    }
 }

--- a/src/test/java/apoc/load/JdbcTest.java
+++ b/src/test/java/apoc/load/JdbcTest.java
@@ -42,6 +42,8 @@ public class JdbcTest extends AbstractJdbcTest {
         db = TestUtil.apocGraphDatabaseBuilder().newGraphDatabase();
         ApocConfiguration.initialize((GraphDatabaseAPI)db);
         ApocConfiguration.addToConfig(map("jdbc.derby.url","jdbc:derby:derbyDB"));
+        ApocConfiguration.addToConfig(map("jdbc.test.sql","SELECT * FROM PERSON"));
+        ApocConfiguration.addToConfig(map("jdbc.testparams.sql","SELECT * FROM PERSON WHERE NAME = ?"));
         TestUtil.registerProcedure(db,Jdbc.class);
         createPersonTableAndData();
     }
@@ -120,6 +122,18 @@ public class JdbcTest extends AbstractJdbcTest {
     @Test
     public void testLoadJdbcKey() throws Exception {
         testCall(db, "CALL apoc.load.jdbc('derby','PERSON')",
+                (row) -> assertResult(row));
+    }
+
+    @Test
+    public void testLoadJdbcSqlAlias() throws Exception {
+        testCall(db, "CALL apoc.load.jdbc('derby','test')",
+                (row) -> assertResult(row));
+    }
+
+    @Test
+    public void testLoadJdbcSqlAliasParams() throws Exception {
+        testCall(db, "CALL apoc.load.jdbc('jdbc:derby:derbyDB','testparams',['John'])", //  YIELD row RETURN row
                 (row) -> assertResult(row));
     }
 


### PR DESCRIPTION
Fixes #1206 

Allow for SQL called by apoc.load.jdbc to be aliased under the conf file in the same way as connection strings currently are.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Moved logic for `executeQuery`'s query generation to new method `JdbcUtil.getSqlOrKey()`, using existing `Util.loadUrlByConfigFile()` to access conf value.
  - Created two new unit tests for use of aliased sql statements.
  - Existing unit tests were unaffected.
