### PR TITLE
fixes #1161 - Adds apoc.util.compress and apoc.util.decompress functions

### DIFF
--- a/src/main/java/apoc/util/CompressionUtils.java
+++ b/src/main/java/apoc/util/CompressionUtils.java
@@ -1,0 +1,63 @@
+package apoc.util;
+
+import org.apache.commons.lang.ArrayUtils;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CompressionUtils
+{
+
+    public static List<Long> bytesWithCharSet( String text, String charSetString )
+    {
+        if ( Charset.isSupported( charSetString ) )
+        {
+
+            try
+            {
+                byte[] bytes = text.getBytes( charSetString );
+                List<Long> result = new ArrayList<>( bytes.length );
+                for ( byte b : bytes )
+                {
+                    result.add( (long) b & 0xFFL );
+                }
+                return result;
+            }
+            catch ( UnsupportedEncodingException e )
+            {
+                throw new RuntimeException( "Encoding problem. ", e );
+            }
+        }
+        throw new RuntimeException( "CharSet '" + charSetString + "' is not supported." );
+    }
+
+    public static String decompressWithCharSet( List<Long> longBytes, String charSetString )
+    {
+        if ( Charset.isSupported( charSetString ) )
+        {
+
+            try
+            {
+                // Turn long bytes into their real bytes
+                List<Byte> bytes = new ArrayList<>( longBytes.size() );
+                for ( long b : longBytes )
+                {
+                    bytes.add( (byte) (b & 0xFF) );
+                }
+
+                byte[] byteArray = ArrayUtils.toPrimitive( bytes.toArray( new Byte[bytes.size()] ) );
+
+                return Charset.forName( charSetString ).newDecoder().decode( ByteBuffer.wrap( byteArray ) ).toString();
+            }
+            catch ( CharacterCodingException e )
+            {
+                throw new RuntimeException( "Decoding problem. ", e );
+            }
+        }
+        throw new RuntimeException( "CharSet '" + charSetString + "' is not supported." );
+    }
+}

--- a/src/main/java/apoc/util/Utils.java
+++ b/src/main/java/apoc/util/Utils.java
@@ -6,6 +6,7 @@ import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.procedure.*;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -75,5 +76,25 @@ public class Utils {
             if (params!=null && !params.isEmpty()) message = String.format(message,params.toArray(new Object[params.size()]));
             throw new RuntimeException(message);
         }
+    }
+
+    @UserFunction
+    @Description("apoc.util.compress(string, {config}) | compresses the string value into binary value. Optional configuration map with charSet parameter")
+    public List<Long> compress(@Name("string") String string, @Name( value = "config", defaultValue = "{}") Map<String,Object> config) {
+        if ( config.containsKey( "charSet" ) )
+        {
+            return CompressionUtils.bytesWithCharSet( string, (String) config.get( "charSet" ) );
+        }
+        return CompressionUtils.bytesWithCharSet( string, "UTF-8" );
+    }
+
+    @UserFunction
+    @Description("apoc.util.decompress(byteArray, {config}) | compresses the string value into binary value. Optional configuration map with charSet parameter")
+    public String decompress(@Name("byteArray") List<Long> bytes, @Name( value = "config", defaultValue = "{}") Map<String,Object> config) {
+        if ( config.containsKey( "charSet" ) )
+        {
+            return CompressionUtils.decompressWithCharSet( bytes, (String) config.get( "charSet" ) );
+        }
+        return CompressionUtils.decompressWithCharSet( bytes, "UTF-8" );
     }
 }


### PR DESCRIPTION
Fixes #1161 

Adds apoc.util.compress and apoc.util.decompress functions.

Uses a `{config}` map for configuration so function header does not have to change incase we want to add more options at a later time.