### PR TITLE
fixes #1159 - Adds apoc.coll.extract function and unit tests.

### DIFF
--- a/src/main/java/apoc/coll/Coll.java
+++ b/src/main/java/apoc/coll/Coll.java
@@ -1,6 +1,7 @@
 package apoc.coll;
 
 import org.apache.commons.math3.util.Combinations;
+import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Path;
 import org.neo4j.helpers.collection.Pair;
 import org.neo4j.kernel.impl.util.statistics.IntCounter;
@@ -873,5 +874,28 @@ public class Coll {
         }
 
         return newList;
+    }
+
+    @UserFunction
+    @Description("apoc.coll.extract(coll, property) - extracts the property from each element in the coll and returns a list of the values ")
+    public List<Object> extract(@Name("coll") List<Object> coll, @Name( "property" ) String property) {
+        if (coll == null || coll.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return coll.stream().map( o -> {
+            if ( o instanceof Map )
+            {
+                return ((Map) o).getOrDefault( property, null );
+            }
+            else if ( o instanceof Entity )
+            {
+                return ((Entity) o).getProperty( property, null );
+            }
+            else
+            {
+                return null;
+            }
+        } ).collect( Collectors.toList() );
     }
 }

--- a/src/test/java/apoc/coll/CollTest.java
+++ b/src/test/java/apoc/coll/CollTest.java
@@ -841,5 +841,38 @@ public class CollTest {
                 });
     }
 
+    @Test
+    public void testExtractMap() throws Exception {
+        testCall(db, "WITH [{a: 1},{b: 2},{a: 3}] AS coll" +
+                        " RETURN apoc.coll.extract(coll, 'a') AS ext",
+                (row) -> {
+                    assertEquals(asList(1L, null, 3L), (List<Long>) row.get( "ext" ));
+                });
+    }
+
+    @Test
+    public void testExtractNode() throws Exception {
+        testCall(db, "CREATE (n1:Node {prop: 1}) CREATE (n2:Node) CREATE (n3:Node {prop: 3}) WITH [n1,n2,n3] AS coll RETURN apoc.coll.extract(coll, 'prop') AS ext",
+                (row) -> {
+                    assertEquals(asList(1L, null, 3L), (List<Long>) row.get( "ext" ));
+                });
+    }
+
+    @Test
+    public void testExtractRelationship() throws Exception {
+        testCall(db, "CREATE (n1:Node) CREATE (n2:Node) CREATE (n1)-[r1:Rel {prop: 1}]->(n2) CREATE (n1)-[r2:Rel]->(n2) CREATE (n1)-[r3:Rel {prop: 3}]->(n2) WITH [r1,r2,r3] AS coll RETURN apoc.coll.extract(coll, 'prop') AS ext",
+                (row) -> {
+                    assertEquals(asList(1L, null, 3L), (List<Long>) row.get( "ext" ));
+                });
+    }
+
+    @Test
+    public void testExtractMixed() throws Exception {
+        testCall(db, "CREATE (n1:Node {prop: 0}) CREATE (n2:Node) CREATE (n1)-[r1:Rel {prop: 1}]->(n2) WITH [n1,r1,{prop: 2},'test'] AS coll RETURN apoc.coll.extract(coll, 'prop') AS ext",
+                (row) -> {
+                    assertEquals(asList(0L, 1L, 2L, null), (List<Long>) row.get( "ext" ));
+                });
+    }
+
 }
 


### PR DESCRIPTION
Fixes #1159 

Adds apoc.coll.extract function and unit tests.

Can only extract from collections of Maps, Nodes, and Relationships. If one of the objects in the collection is missing the property then a null value is used.