### PR TITLE
Creates a VirtualNode from an existing node, filtering its properties

### DIFF
--- a/docs/asciidoc/create-virtual-nodes-rels.adoc
+++ b/docs/asciidoc/create-virtual-nodes-rels.adoc
@@ -11,6 +11,7 @@ Please note that they have negative id's.
 |===
 | CALL apoc.create.vNode(['Label'], {key:value,...}) YIELD node | returns a virtual node
 | apoc.create.vNode(['Label'], {key:value,...}) | function returns a virtual node
+| apoc.create.virtual.fromNode(node, [propertyNames]) | function returns a virtual node  built from an existing node with only the requested properties
 | CALL apoc.create.vNodes(['Label'], [{key:value,...}]) | returns virtual nodes
 | CALL apoc.create.vRelationship(nodeFrom,'KNOWS',{key:value,...}, nodeTo) YIELD rel | returns a virtual relationship
 | apoc.create.vRelationship(nodeFrom,'KNOWS',{key:value,...}, nodeTo) | function returns a virtual relationship
@@ -70,6 +71,15 @@ image::{img}/apoc.create.vRelationshipAndvNode.png[width=800]
 Virtual nodes and virtual relationships have always a negative id
 
 image::{img}/vNodeId.png[width=200]
+
+Virtual nodes can also be built from existing nodes, filtering the properties in order to get a subset of them.
+In this case, the Virtual node keeps the id of the original node.
+
+[source,cypher]
+----
+MATCH (node:Person {name:'neo', age:'42'})
+return apoc.create.virtual.fromNode(node, ['name']) as person
+----
 
 .Virtual pattern `vPattern`
 

--- a/src/main/java/apoc/create/Create.java
+++ b/src/main/java/apoc/create/Create.java
@@ -1,16 +1,13 @@
 package apoc.create;
 
-import org.neo4j.procedure.*;
 import apoc.get.Get;
 import apoc.result.*;
 import apoc.util.Util;
 import org.neo4j.graphdb.*;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.procedure.*;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
@@ -25,7 +22,7 @@ public class Create {
     @Procedure(mode = Mode.WRITE)
     @Description("apoc.create.node(['Label'], {key:value,...}) - create node with dynamic labels")
     public Stream<NodeResult> node(@Name("label") List<String> labelNames, @Name("props") Map<String, Object> props) {
-        return Stream.of(new NodeResult(setProperties(db.createNode(Util.labels(labelNames)),props)));
+        return Stream.of(new NodeResult(setProperties(db.createNode(Util.labels(labelNames)), props)));
     }
 
 
@@ -46,7 +43,7 @@ public class Create {
     @Description("apoc.create.setProperty( [node,id,ids,nodes], key, value) - sets the given property on the node(s)")
     public Stream<NodeResult> setProperty(@Name("nodes") Object nodes, @Name("key") String key, @Name("value") Object value) {
         return new Get(db).nodes(nodes).map((r) -> {
-            setProperty(r.node, key,toPropertyValue(value));
+            setProperty(r.node, key, toPropertyValue(value));
             return r;
         });
     }
@@ -55,7 +52,7 @@ public class Create {
     @Description("apoc.create.setRelProperty( [rel,id,ids,rels], key, value) - sets the given property on the relationship(s)")
     public Stream<RelationshipResult> setRelProperty(@Name("relationships") Object rels, @Name("key") String key, @Name("value") Object value) {
         return new Get(db).rels(rels).map((r) -> {
-            setProperty(r.rel,key,toPropertyValue(value));
+            setProperty(r.rel, key, toPropertyValue(value));
             return r;
         });
     }
@@ -64,15 +61,16 @@ public class Create {
     @Description("apoc.create.setProperties( [node,id,ids,nodes], [keys], [values]) - sets the given property on the nodes(s)")
     public Stream<NodeResult> setProperties(@Name("nodes") Object nodes, @Name("keys") List<String> keys, @Name("values") List<Object> values) {
         return new Get(db).nodes(nodes).map((r) -> {
-            setProperties(r.node, Util.mapFromLists(keys,values));
+            setProperties(r.node, Util.mapFromLists(keys, values));
             return r;
         });
     }
+
     @Procedure(mode = Mode.WRITE)
     @Description("apoc.create.removeProperties( [node,id,ids,nodes], [keys]) - removes the given property from the nodes(s)")
     public Stream<NodeResult> removeProperties(@Name("nodes") Object nodes, @Name("keys") List<String> keys) {
         return new Get(db).nodes(nodes).map((r) -> {
-            keys.forEach( r.node::removeProperty );
+            keys.forEach(r.node::removeProperty);
             return r;
         });
     }
@@ -81,7 +79,7 @@ public class Create {
     @Description("apoc.create.setRelProperties( [rel,id,ids,rels], [keys], [values]) - sets the given property on the relationship(s)")
     public Stream<RelationshipResult> setRelProperties(@Name("rels") Object rels, @Name("keys") List<String> keys, @Name("values") List<Object> values) {
         return new Get(db).rels(rels).map((r) -> {
-            setProperties(r.rel, Util.mapFromLists(keys,values));
+            setProperties(r.rel, Util.mapFromLists(keys, values));
             return r;
         });
     }
@@ -90,7 +88,7 @@ public class Create {
     @Description("apoc.create.removeRelProperties( [rel,id,ids,rels], [keys], [values]) - removes the given property from the relationship(s)")
     public Stream<RelationshipResult> removeRelProperties(@Name("rels") Object rels, @Name("keys") List<String> keys) {
         return new Get(db).rels(rels).map((r) -> {
-            keys.forEach( r.rel::removeProperty);
+            keys.forEach(r.rel::removeProperty);
             return r;
         });
     }
@@ -125,6 +123,7 @@ public class Create {
             return r;
         });
     }
+
     @Procedure(mode = Mode.WRITE)
     @Description("apoc.create.nodes(['Label'], [{key:value,...}]) create multiple nodes with dynamic labels")
     public Stream<NodeResult> nodes(@Name("label") List<String> labelNames, @Name("props") List<Map<String, Object>> props) {
@@ -137,19 +136,25 @@ public class Create {
     public Stream<RelationshipResult> relationship(@Name("from") Node from,
                                                    @Name("relType") String relType, @Name("props") Map<String, Object> props,
                                                    @Name("to") Node to) {
-        return Stream.of(new RelationshipResult(setProperties(from.createRelationshipTo(to, withName(relType)),props)));
+        return Stream.of(new RelationshipResult(setProperties(from.createRelationshipTo(to, withName(relType)), props)));
     }
 
     @Procedure
     @Description("apoc.create.vNode(['Label'], {key:value,...}) returns a virtual node")
     public Stream<NodeResult> vNode(@Name("label") List<String> labelNames, @Name("props") Map<String, Object> props) {
-        return Stream.of(new NodeResult(vNodeFunction(labelNames,props)));
+        return Stream.of(new NodeResult(vNodeFunction(labelNames, props)));
     }
 
     @UserFunction("apoc.create.vNode")
     @Description("apoc.create.vNode(['Label'], {key:value,...}) returns a virtual node")
-    public Node vNodeFunction(@Name("label") List<String> labelNames, @Name(value = "props",defaultValue = "{}") Map<String, Object> props) {
+    public Node vNodeFunction(@Name("label") List<String> labelNames, @Name(value = "props", defaultValue = "{}") Map<String, Object> props) {
         return new VirtualNode(Util.labels(labelNames), props, db);
+    }
+
+    @UserFunction("apoc.create.virtual.fromNode")
+    @Description("apoc.create.virtual.fromNode(node, [propertyNames]) returns a virtual node built from an existing node with only the requested properties")
+    public Node virtualFromNodeFunction(@Name("node") Node node, @Name("propertyNames") List<String> propertyNames) {
+        return new VirtualNode(node, propertyNames);
     }
 
     @Procedure
@@ -162,21 +167,22 @@ public class Create {
     @Procedure
     @Description("apoc.create.vRelationship(nodeFrom,'KNOWS',{key:value,...}, nodeTo) returns a virtual relationship")
     public Stream<RelationshipResult> vRelationship(@Name("from") Node from, @Name("relType") String relType, @Name("props") Map<String, Object> props, @Name("to") Node to) {
-        return Stream.of(new RelationshipResult(vRelationshipFunction(from,relType,props,to)));
+        return Stream.of(new RelationshipResult(vRelationshipFunction(from, relType, props, to)));
     }
 
     @UserFunction("apoc.create.vRelationship")
     @Description("apoc.create.vRelationship(nodeFrom,'KNOWS',{key:value,...}, nodeTo) returns a virtual relationship")
     public Relationship vRelationshipFunction(@Name("from") Node from, @Name("relType") String relType, @Name("props") Map<String, Object> props, @Name("to") Node to) {
-        return new VirtualRelationship(from,to, withName(relType)).withProperties(props);
+        return new VirtualRelationship(from, to, withName(relType)).withProperties(props);
     }
 
     @Procedure
     @Description("apoc.create.vPattern({_labels:['LabelA'],key:value},'KNOWS',{key:value,...}, {_labels:['LabelB'],key:value}) returns a virtual pattern")
-    public Stream<VirtualPathResult> vPattern(@Name("from") Map<String,Object> n,
+    public Stream<VirtualPathResult> vPattern(@Name("from") Map<String, Object> n,
                                               @Name("relType") String relType, @Name("props") Map<String, Object> props,
-                                              @Name("to") Map<String,Object> m) {
-        n = new LinkedHashMap<>(n); m=new LinkedHashMap<>(m);
+                                              @Name("to") Map<String, Object> m) {
+        n = new LinkedHashMap<>(n);
+        m = new LinkedHashMap<>(m);
         RelationshipType type = withName(relType);
         VirtualNode from = new VirtualNode(Util.labels(n.remove("_labels")), n, db);
         VirtualNode to = new VirtualNode(Util.labels(m.remove("_labels")), m, db);
@@ -186,14 +192,14 @@ public class Create {
 
     @Procedure
     @Description("apoc.create.vPatternFull(['LabelA'],{key:value},'KNOWS',{key:value,...},['LabelB'],{key:value}) returns a virtual pattern")
-    public Stream<VirtualPathResult> vPatternFull(@Name("labelsN") List<String> labelsN, @Name("n") Map<String,Object> n,
+    public Stream<VirtualPathResult> vPatternFull(@Name("labelsN") List<String> labelsN, @Name("n") Map<String, Object> n,
                                                   @Name("relType") String relType, @Name("props") Map<String, Object> props,
-                                                  @Name("labelsM") List<String> labelsM, @Name("m") Map<String,Object> m) {
+                                                  @Name("labelsM") List<String> labelsM, @Name("m") Map<String, Object> m) {
         RelationshipType type = withName(relType);
         VirtualNode from = new VirtualNode(Util.labels(labelsN), n, db);
         VirtualNode to = new VirtualNode(Util.labels(labelsM), m, db);
         Relationship rel = new VirtualRelationship(from, to, type).withProperties(props);
-        return Stream.of(new VirtualPathResult(from,rel,to));
+        return Stream.of(new VirtualPathResult(from, rel, to));
     }
 
     private <T extends PropertyContainer> T setProperties(T pc, Map<String, Object> p) {
@@ -219,7 +225,7 @@ public class Create {
         if (value instanceof Iterable) {
             Iterable it = (Iterable) value;
             Object first = Iterables.firstOrNull(it);
-            if (first==null) return EMPTY_ARRAY;
+            if (first == null) return EMPTY_ARRAY;
             return Iterables.asArray(first.getClass(), it);
         }
         return value;
@@ -228,7 +234,7 @@ public class Create {
     @Procedure
     @Description("apoc.create.uuids(count) yield uuid - creates 'count' UUIDs ")
     public Stream<UUIDResult> uuids(@Name("count") long count) {
-        return LongStream.range(0,count).mapToObj(UUIDResult::new);
+        return LongStream.range(0, count).mapToObj(UUIDResult::new);
     }
 
     public static class UUIDResult {
@@ -238,7 +244,7 @@ public class Create {
         public UUIDResult(long row) {
             this.row = row;
             this.uuid = UUID.randomUUID().toString();
-                    // TODO Long.toHexString(uuid.getMostSignificantBits())+Long.toHexString(uuid.getLeastSignificantBits());
+            // TODO Long.toHexString(uuid.getMostSignificantBits())+Long.toHexString(uuid.getLeastSignificantBits());
         }
     }
 

--- a/src/main/java/apoc/path/RelationshipTypeAndDirections.java
+++ b/src/main/java/apoc/path/RelationshipTypeAndDirections.java
@@ -44,13 +44,13 @@ public abstract class RelationshipTypeAndDirections {
 		return relsAndDirs;
 	}
 
-	private static Direction directionFor(String type) {
+	public static Direction directionFor(String type) {
 		if (type.contains("<")) return INCOMING;
 		if (type.contains(">")) return OUTGOING;
 		return BOTH;
 	}
 
-	private static RelationshipType relationshipTypeFor(String name) {
+	public static RelationshipType relationshipTypeFor(String name) {
 		if (name.indexOf(BACKTICK) > -1) name = name.substring(name.indexOf(BACKTICK)+1,name.lastIndexOf(BACKTICK));
 		else {
 			name = name.replaceAll("[<>:]", "");

--- a/src/main/java/apoc/result/VirtualNode.java
+++ b/src/main/java/apoc/result/VirtualNode.java
@@ -1,5 +1,6 @@
 package apoc.result;
 
+import apoc.util.Util;
 import org.neo4j.graphdb.*;
 import org.neo4j.helpers.collection.FilteringIterable;
 import org.neo4j.helpers.collection.Iterables;
@@ -39,6 +40,14 @@ public class VirtualNode implements Node {
     public VirtualNode(long nodeId, GraphDatabaseService db) {
         this.id = nodeId;
         this.db = db;
+    }
+
+    public VirtualNode(Node node, List<String> propertyNames) {
+        this.id = node.getId();
+        this.db = node.getGraphDatabase();
+        this.labels.addAll(Util.labelStrings(node));
+        String[] keys = propertyNames.toArray(new String[propertyNames.size()]);
+        this.props.putAll(node.getProperties(keys));
     }
 
     @Override
@@ -166,7 +175,7 @@ public class VirtualNode implements Node {
 
     @Override
     public int getDegree(RelationshipType relationshipType, Direction direction) {
-        return (int) Iterables.count(getRelationships(relationshipType,direction));
+        return (int) Iterables.count(getRelationships(relationshipType, direction));
     }
 
     @Override
@@ -175,7 +184,7 @@ public class VirtualNode implements Node {
     }
 
     public void addLabels(Iterable<Label> labels) {
-        for (Label label: labels) {
+        for (Label label : labels) {
             addLabel(label);
         }
     }
@@ -218,7 +227,7 @@ public class VirtualNode implements Node {
 
     @Override
     public void setProperty(String s, Object o) {
-        props.put(s,o);
+        props.put(s, o);
     }
 
     @Override
@@ -259,8 +268,7 @@ public class VirtualNode implements Node {
     }
 
     @Override
-    public String toString()
-    {
+    public String toString() {
         return "VirtualNode{" + "labels=" + labels + ", props=" + props + ", rels=" + rels + '}';
     }
 }

--- a/src/test/java/apoc/create/CreateTest.java
+++ b/src/test/java/apoc/create/CreateTest.java
@@ -11,23 +11,26 @@ import java.util.Map;
 
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class CreateTest {
 
     private GraphDatabaseService db;
     public static final Label PERSON = Label.label("Person");
 
-    @Before public void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         db = new TestGraphDatabaseFactory().newImpermanentDatabase();
-        TestUtil.registerProcedure(db,Create.class);
+        TestUtil.registerProcedure(db, Create.class);
     }
-    @After public void tearDown() {
+
+    @After
+    public void tearDown() {
         db.shutdown();
     }
 
-    @Test public void testCreateNode() throws Exception {
+    @Test
+    public void testCreateNode() throws Exception {
         testCall(db, "CALL apoc.create.node(['Person'],{name:'John'})",
                 (row) -> {
                     Node node = (Node) row.get("node");
@@ -35,41 +38,49 @@ public class CreateTest {
                     assertEquals("John", node.getProperty("name"));
                 });
     }
-    @Test public void testCreateNodeWithArrayProps() throws Exception {
+
+    @Test
+    public void testCreateNodeWithArrayProps() throws Exception {
         testCall(db, "CALL apoc.create.node(['Person'],{name:['John','Doe'],kids:[],age:[32,10]})",
                 (row) -> {
                     Node node = (Node) row.get("node");
                     assertEquals(true, node.hasLabel(Label.label("Person")));
-                    assertArrayEquals(new String[] {"John","Doe"}, (String[])node.getProperty("name"));
-                    assertArrayEquals(new String[] {}, (String[])node.getProperty("kids"));
-                    assertArrayEquals(new long[] {32,10}, (long[])node.getProperty("age"));
+                    assertArrayEquals(new String[]{"John", "Doe"}, (String[]) node.getProperty("name"));
+                    assertArrayEquals(new String[]{}, (String[]) node.getProperty("kids"));
+                    assertArrayEquals(new long[]{32, 10}, (long[]) node.getProperty("age"));
                 });
     }
 
-    @Test public void testSetProperty() throws Exception {
+    @Test
+    public void testSetProperty() throws Exception {
         testResult(db, "CREATE (n),(m) WITH n,m CALL apoc.create.setProperty([id(n),m],'name','John') YIELD node RETURN node",
                 (result) -> {
                     Map<String, Object> row = result.next();
                     assertEquals("John", ((Node) row.get("node")).getProperty("name"));
                     row = result.next();
                     assertEquals("John", ((Node) row.get("node")).getProperty("name"));
-                    assertEquals(false,result.hasNext());
+                    assertEquals(false, result.hasNext());
                 });
     }
-    @Test public void testRemoveProperty() throws Exception {
+
+    @Test
+    public void testRemoveProperty() throws Exception {
         testCall(db, "CREATE (n:Foo {name:'foo'}) WITH n CALL apoc.create.setProperty(n,'name',null) YIELD node RETURN node",
                 (row) -> assertEquals(false, ((Node) row.get("node")).hasProperty("name")));
         testCall(db, "CREATE (n:Foo {name:'foo'}) WITH n CALL apoc.create.removeProperties(n,['name']) YIELD node RETURN node",
                 (row) -> assertEquals(false, ((Node) row.get("node")).hasProperty("name")));
     }
 
-    @Test public void testRemoveRelProperty() throws Exception {
+    @Test
+    public void testRemoveRelProperty() throws Exception {
         testCall(db, "CREATE (n)-[r:TEST {name:'foo'}]->(m) WITH r CALL apoc.create.setRelProperty(r,'name',null) YIELD rel RETURN rel",
                 (row) -> assertEquals(false, ((Relationship) row.get("rel")).hasProperty("name")));
         testCall(db, "CREATE (n)-[r:TEST {name:'foo'}]->(m) WITH r CALL apoc.create.removeRelProperties(r,['name']) YIELD rel RETURN rel",
                 (row) -> assertEquals(false, ((Relationship) row.get("rel")).hasProperty("name")));
     }
-    @Test public void testSetRelProperties() throws Exception {
+
+    @Test
+    public void testSetRelProperties() throws Exception {
         testResult(db, "CREATE (n)-[r:X]->(m),(m)-[r2:Y]->(n) WITH r,r2 CALL apoc.create.setRelProperties([id(r),r2],['name','age'],['John',42]) YIELD rel RETURN rel",
                 (result) -> {
                     Map<String, Object> row = result.next();
@@ -80,20 +91,24 @@ public class CreateTest {
                     r = (Relationship) row.get("rel");
                     assertEquals("John", r.getProperty("name"));
                     assertEquals(42L, r.getProperty("age"));
-                    assertEquals(false,result.hasNext());
+                    assertEquals(false, result.hasNext());
                 });
     }
-    @Test public void testSetRelProperty() throws Exception {
+
+    @Test
+    public void testSetRelProperty() throws Exception {
         testResult(db, "CREATE (n)-[r:X]->(m),(m)-[r2:Y]->(n) WITH r,r2 CALL apoc.create.setRelProperty([id(r),r2],'name','John') YIELD rel RETURN rel",
                 (result) -> {
                     Map<String, Object> row = result.next();
                     assertEquals("John", ((Relationship) row.get("rel")).getProperty("name"));
                     row = result.next();
                     assertEquals("John", ((Relationship) row.get("rel")).getProperty("name"));
-                    assertEquals(false,result.hasNext());
+                    assertEquals(false, result.hasNext());
                 });
     }
-    @Test public void testSetProperties() throws Exception {
+
+    @Test
+    public void testSetProperties() throws Exception {
         testResult(db, "CREATE (n),(m) WITH n,m CALL apoc.create.setProperties([id(n),m],['name','age'],['John',42]) YIELD node RETURN node",
                 (result) -> {
                     Map<String, Object> row = result.next();
@@ -102,11 +117,12 @@ public class CreateTest {
                     row = result.next();
                     assertEquals("John", ((Node) row.get("node")).getProperty("name"));
                     assertEquals(42L, ((Node) row.get("node")).getProperty("age"));
-                    assertEquals(false,result.hasNext());
+                    assertEquals(false, result.hasNext());
                 });
     }
 
-    @Test public void testVirtualNode() throws Exception {
+    @Test
+    public void testVirtualNode() throws Exception {
         testCall(db, "CALL apoc.create.vNode(['Person'],{name:'John'})",
                 (row) -> {
                     Node node = (Node) row.get("node");
@@ -115,7 +131,8 @@ public class CreateTest {
                 });
     }
 
-    @Test public void testVirtualNodeFunction() throws Exception {
+    @Test
+    public void testVirtualNodeFunction() throws Exception {
         testCall(db, "RETURN apoc.create.vNode(['Person'],{name:'John'}) as node",
                 (row) -> {
                     Node node = (Node) row.get("node");
@@ -123,10 +140,12 @@ public class CreateTest {
                     assertEquals("John", node.getProperty("name"));
                 });
     }
-    @Test public void testCreateNodes() throws Exception {
+
+    @Test
+    public void testCreateNodes() throws Exception {
         testResult(db, "CALL apoc.create.nodes(['Person'],[{name:'John'},{name:'Jane'}])",
-                 (res) -> {
-                     Node node = (Node) res.next().get("node");
+                (res) -> {
+                    Node node = (Node) res.next().get("node");
                     assertEquals(true, node.hasLabel(PERSON));
                     assertEquals("John", node.getProperty("name"));
 
@@ -135,7 +154,9 @@ public class CreateTest {
                     assertEquals("Jane", node.getProperty("name"));
                 });
     }
-    @Test public void testCreateRelationship() throws Exception {
+
+    @Test
+    public void testCreateRelationship() throws Exception {
         testCall(db, "CREATE (n),(m) WITH n,m CALL apoc.create.relationship(n,'KNOWS',{since:2010}, m) YIELD rel RETURN rel",
                 (row) -> {
                     Relationship rel = (Relationship) row.get("rel");
@@ -144,7 +165,8 @@ public class CreateTest {
                 });
     }
 
-    @Test public void testCreateVirtualRelationship() throws Exception {
+    @Test
+    public void testCreateVirtualRelationship() throws Exception {
         testCall(db, "CREATE (n),(m) WITH n,m CALL apoc.create.vRelationship(n,'KNOWS',{since:2010}, m) YIELD rel RETURN rel",
                 (row) -> {
                     Relationship rel = (Relationship) row.get("rel");
@@ -152,7 +174,9 @@ public class CreateTest {
                     assertEquals(2010L, rel.getProperty("since"));
                 });
     }
-    @Test public void testCreateVirtualRelationshipFunction() throws Exception {
+
+    @Test
+    public void testCreateVirtualRelationshipFunction() throws Exception {
         testCall(db, "CREATE (n),(m) WITH n,m RETURN apoc.create.vRelationship(n,'KNOWS',{since:2010}, m) AS rel",
                 (row) -> {
                     Relationship rel = (Relationship) row.get("rel");
@@ -160,7 +184,9 @@ public class CreateTest {
                     assertEquals(2010L, rel.getProperty("since"));
                 });
     }
-    @Test public void testCreatePattern() throws Exception {
+
+    @Test
+    public void testCreatePattern() throws Exception {
         testCall(db, "CALL apoc.create.vPattern({_labels:['Person'],name:'John'},'KNOWS',{since:2010},{_labels:['Person'],name:'Jane'})",
                 (row) -> {
                     Node john = (Node) row.get("from");
@@ -174,7 +200,9 @@ public class CreateTest {
                     assertEquals("Jane", jane.getProperty("name"));
                 });
     }
-    @Test public void testCreatePatternFull() throws Exception {
+
+    @Test
+    public void testCreatePatternFull() throws Exception {
         testCall(db, "CALL apoc.create.vPatternFull(['Person'],{name:'John'},'KNOWS',{since:2010},['Person'],{name:'Jane'})",
                 (row) -> {
                     Node john = (Node) row.get("from");
@@ -188,4 +216,18 @@ public class CreateTest {
                     assertEquals("Jane", jane.getProperty("name"));
                 });
     }
+
+
+    @Test
+    public void testVirtualFromNodeFunction() throws Exception {
+        testCall(db, "CREATE (n:Person{name:'Vincent', born: 1974} )  RETURN apoc.create.virtual.fromNode(n, ['name']) as node",
+                (row) -> {
+                    Node node = (Node) row.get("node");
+
+                    assertEquals(true, node.hasLabel(Label.label("Person")));
+                    assertEquals("Vincent", node.getProperty("name"));
+                    assertNull(node.getProperty("born"));
+                });
+    }
+
 }


### PR DESCRIPTION
Fixes #148

new function that creates a VirtualNode from an existing Node, filtering the properties in order to keep only the wished ones

## Proposed Changes

new function:  `apoc.create.virtual.fromNode(node,[propertyNames])`