### PR TITLE
 fixes rounding issues in min, max calculations of statistics aggrega…

### DIFF
--- a/src/main/java/apoc/agg/Statistics.java
+++ b/src/main/java/apoc/agg/Statistics.java
@@ -5,7 +5,6 @@ import org.HdrHistogram.Histogram;
 import org.HdrHistogram.HistogramUtil;
 import org.neo4j.procedure.*;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,12 +27,14 @@ public class Statistics {
 
         private Histogram values = new Histogram(3);
         private DoubleHistogram doubles;
-        private List<Double> percentiles = asList(0.5D,0.75D,0.9D,0.95D,0.9D,0.99D);
+        private List<Double> percentiles = asList(0.5D, 0.75D, 0.9D, 0.95D, 0.9D, 0.99D);
+        private Number minValue;
+        private Number maxValue;
 
         @UserAggregationUpdate
         public void aggregate(@Name("value") Number value, @Name(value = "percentiles", defaultValue = "[0.5,0.75,0.9,0.95,0.99]") List<Double> percentiles) {
             if (value != null) {
-                if (doubles!=null) {
+                if (doubles != null) {
                     doubles.recordValue(value.doubleValue());
                 } else if (value instanceof Double || value instanceof Float) {
                     this.doubles = HistogramUtil.toDoubleHistogram(values, 5);
@@ -42,21 +43,27 @@ public class Statistics {
                 } else {
                     values.recordValue(value.longValue());
                 }
+                if (minValue == null || minValue.doubleValue() > value.doubleValue()) {
+                    minValue = value;
+                }
+                if (maxValue == null || maxValue.doubleValue() < value.doubleValue()) {
+                    maxValue = value;
+                }
             }
             this.percentiles = percentiles;
         }
 
         @UserAggregationResult
-        public Map<String,Number> result() {
+        public Map<String, Number> result() {
             long totalCount = values != null ? values.getTotalCount() : doubles.getTotalCount();
             boolean empty = totalCount == 0;
-            Map<String,Number> result = new LinkedHashMap<>(percentiles.size()+6);
-            result.put("min",values != null ? (Number)values.getMinValue() : (Number)doubles.getMinValue());
-            result.put("minNonZero",values != null ? (Number)values.getMinNonZeroValue() : (Number)doubles.getMinNonZeroValue());
-            result.put("max",values != null ? (Number)values.getMaxValue() : (Number)doubles.getMaxValue());
-            result.put("total",totalCount);
-            result.put("mean",values != null ? values.getMean() : doubles.getMean());
-            result.put("stdev",values != null ? values.getStdDeviation() : doubles.getStdDeviation());
+            Map<String, Number> result = new LinkedHashMap<>(percentiles.size() + 6);
+            result.put("min", minValue != null ? minValue : 0L);
+            result.put("minNonZero", values != null ? values.getMinNonZeroValue() : doubles.getMinNonZeroValue());
+            result.put("max", maxValue != null ? maxValue : 0L);
+            result.put("total", totalCount);
+            result.put("mean", values != null ? values.getMean() : doubles.getMean());
+            result.put("stdev", values != null ? values.getStdDeviation() : doubles.getStdDeviation());
 
             for (Double percentile : percentiles) {
                 if (percentile != null && !empty) {

--- a/src/main/java/apoc/agg/Statistics.java
+++ b/src/main/java/apoc/agg/Statistics.java
@@ -58,9 +58,9 @@ public class Statistics {
             long totalCount = values != null ? values.getTotalCount() : doubles.getTotalCount();
             boolean empty = totalCount == 0;
             Map<String, Number> result = new LinkedHashMap<>(percentiles.size() + 6);
-            result.put("min", minValue != null ? minValue : 0L);
+            result.put("min", minValue);
             result.put("minNonZero", values != null ? values.getMinNonZeroValue() : doubles.getMinNonZeroValue());
-            result.put("max", maxValue != null ? maxValue : 0L);
+            result.put("max", maxValue);
             result.put("total", totalCount);
             result.put("mean", values != null ? values.getMean() : doubles.getMean());
             result.put("stdev", values != null ? values.getStdDeviation() : doubles.getStdDeviation());

--- a/src/test/java/apoc/agg/StatisticsTest.java
+++ b/src/test/java/apoc/agg/StatisticsTest.java
@@ -2,29 +2,29 @@ package apoc.agg;
 
 import apoc.util.TestUtil;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-import java.util.List;
+import java.util.Map;
 
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.Util.map;
-import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
 public class StatisticsTest {
 
     private static GraphDatabaseService db;
 
-    @BeforeClass public static void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         db = new TestGraphDatabaseFactory().newImpermanentDatabase();
         TestUtil.registerProcedure(db, Statistics.class);
     }
 
-    @AfterClass public static void tearDown() {
+    @AfterClass
+    public static void tearDown() {
         db.shutdown();
     }
 
@@ -36,21 +36,25 @@ public class StatisticsTest {
                 });
         testCall(db, "UNWIND [0,1,1,2,2,2,3] as value RETURN apoc.agg.statistics(value,[0.5,0.95]) as p",
                 (row) -> {
-                    assertEquals(map("total",7L, "min",0L, "minNonZero",1L, "max",3L, "mean",1.5714285714285714D, "0.5",2L, "0.95",3L, "stdev",0.9035079029052512), row.get("p"));
+                    assertEquals(map("total", 7L, "min", 0L, "minNonZero", 1L, "max", 3L, "mean", 1.5714285714285714D, "0.5", 2L, "0.95", 3L, "stdev", 0.9035079029052512), row.get("p"));
                 });
     }
+
     @Test
     public void testStatisticsDouble() throws Exception {
         testCall(db, "UNWIND [0,1,1,2.0,2,2,3] as value RETURN apoc.agg.statistics(value,[0.5,0.95]) as p",
                 (row) -> {
-                    assertEquals(map("total",7L, "min",0D, "minNonZero",1D, "max",3.0000076293945312D, "mean",1.5714329310825892D, "0.5",2.0000076293945312D, "0.95",3.0000076293945312D, "stdev",0.9035111771858774), row.get("p"));
+                    assertEquals(map("total", 7L, "min", 0L, "minNonZero", 1D, "max", 3L, "mean", 1.5714329310825892D, "0.5", 2.0000076293945312D, "0.95", 3.0000076293945312D, "stdev", 0.9035111771858774), row.get("p"));
                 });
     }
 
-    private static void assertSameValues(List<Double> expected, Object values) {
-        List<Double> doubleValues = (List<Double>) values;
-        for (int i = 0; i < expected.size(); i++) {
-            Assert.assertEquals(expected.get(i), doubleValues.get(i),0.0001);
-        }
+    @Test
+    public void testStatisticsDoubleMinMax() throws Exception {
+        testCall(db, "UNWIND [0.123,0.234] as value RETURN apoc.agg.statistics(value,[0.05,0.5,0.95]) as p",
+                (row) -> {
+                    Map<String, Number> stats = (Map<String, Number>) row.get("p");
+                    assertEquals(0.234D, stats.get("max"));
+                    assertEquals(0.123D, stats.get("min"));
+                });
     }
 }


### PR DESCRIPTION
Fixes #788

Compute Min/Max properties of the apoc.agg.statistics aggregation using standard comparison instead of the HdrHistogram

## Proposed Changes 

HdrHistogram is used to compute statistics but it introduces some differences on min/max properties when it uses double computations. HdrHistogram use is replaced by keeping a reference to the actual min and max values.

The minNonZero calculation is still coming from HdrHistogram, as I am not sure if we should also handle it outside of the histogram.
