### PR TITLE
Added apoc.agg.maxItems() and apoc.agg.minItems()

### DIFF
--- a/docs/asciidoc/aggregation.adoc
+++ b/docs/asciidoc/aggregation.adoc
@@ -10,4 +10,6 @@
 | apoc.agg.median(number) | returns median for non-null numeric values
 | apoc.agg.percentiles(value,[percentiles = 0.5,0.75,0.9,0.95,0.99]) | returns given percentiles for integer values
 | apoc.agg.statistics(value,[percentiles = 0.5,0.75,0.9,0.95,0.99]) | returns numeric statistics (percentiles, min,minNonZero,max,total,mean,stdev) for values
+| apoc.agg.maxItems(item, value, groupLimit: -1) | for collecting only items with the maximal value. Returns a map {items:[], value:n} where `value` is the maximum value, and `items` are all items with the same maximal value. The number of items can be optionally limited
+| apoc.agg.minItems(item, value, groupLimit: -1) | for collecting only items with the minimal value. Returns a map {items:[], value:n} where `value` is the minimum value, and `items` are all items with the same minimal value. The number of items can be optionally limited.
 |===

--- a/src/main/java/apoc/agg/MaxAndMinItems.java
+++ b/src/main/java/apoc/agg/MaxAndMinItems.java
@@ -1,0 +1,80 @@
+package apoc.agg;
+
+import apoc.util.Util;
+import org.neo4j.procedure.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Aggregation functions for collecting items with only the minimal or maximal values.
+ * This is meant to replace queries like this:
+
+ MATCH (p:Person)
+ WHERE p.born >= 1930
+ WITH p.born as born, collect(p.name) as persons
+ WITH min(born) as minBorn, collect({born:born, persons:persons}) as bornInfoList
+ UNWIND [info in bornInfoList WHERE info.born = minBorn] as bornInfo
+ RETURN bornInfo.born as born, [person in bornInfo.persons | person.name] as persons
+
+ * with an aggregation like this:
+
+ MATCH (p:Person)
+ WHERE p.born >= 1930
+ WITH apoc.agg.minItems(p, p.born) as minResult
+ RETURN minResult.value as born, [person in minResult.items | person.name] as persons
+
+ * returns {born:1930, persons:["Gene Hackman", "Richard Harris", "Clint Eastwood"]}
+
+ */
+public class MaxAndMinItems {
+
+    @UserAggregationFunction("apoc.agg.maxItems")
+    @Description("apoc.agg.maxItems(item, value, groupLimit: -1) - returns a map {items:[], value:n} where `value` is the maximum value present, and `items` are all items with the same value. The number of items can be optionally limited.")
+    public MaxOrMinItemsFunction maxItems() {
+        return new MaxOrMinItemsFunction(true);
+    }
+
+    @UserAggregationFunction("apoc.agg.minItems")
+    @Description("apoc.agg.minItems(item, value, groupLimit: -1) - returns a map {items:[], value:n} where `value` is the minimum value present, and `items` are all items with the same value. The number of items can be optionally limited.")
+    public MaxOrMinItemsFunction minItems() {
+        return new MaxOrMinItemsFunction(false);
+    }
+
+
+    public static class MaxOrMinItemsFunction {
+        private final List<Object> items = new ArrayList<>();
+        private final boolean isMax;
+        private Comparable value;
+
+        private MaxOrMinItemsFunction(boolean isMax) {
+            this.isMax = isMax;
+        }
+
+        @UserAggregationUpdate
+        public void maxOrMinItems(@Name("item") final Object item, @Name("value") final Object inputValue,
+                                  @Name(value = "groupLimit", defaultValue = "-1") final Long groupLimitParam) {
+            int groupLimit = groupLimitParam.intValue();
+            boolean noGroupLimit = groupLimit < 0;
+
+            if (item != null && inputValue != null) {
+                int result = value == null ? (isMax ? -1 : 1) : value.compareTo(inputValue);
+                if (result == 0) {
+                    if (noGroupLimit || items.size() < groupLimit) {
+                        items.add(item);
+                    }
+                } else if (result < 0 == isMax) {
+                    // xnor logic, interested value should replace current value
+                    items.clear();
+                    items.add(item);
+                    value = (Comparable) inputValue;
+                }
+            }
+        }
+
+        @UserAggregationResult
+        public Object result() {
+            return Util.map("items", items, "value", value);
+        }
+    }
+}

--- a/src/test/java/apoc/agg/MaxAndMinItemsAggregationTest.java
+++ b/src/test/java/apoc/agg/MaxAndMinItemsAggregationTest.java
@@ -1,0 +1,212 @@
+package apoc.agg;
+
+import apoc.util.TestUtil;
+import apoc.util.Util;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.*;
+
+
+public class MaxAndMinItemsAggregationTest {
+    private static GraphDatabaseService db;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        TestUtil.registerProcedure(db, MaxAndMinItems.class);
+
+        String movies = Util.readResourceFile("movies.cypher");
+        String bigbrother = "MATCH (per:Person) MERGE (bb:BigBrother {name : 'Big Brother' })  MERGE (bb)-[:FOLLOWS]->(per)";
+        try (Transaction tx = db.beginTx()) {
+            db.execute(movies);
+            db.execute(bigbrother);
+            tx.success();
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
+    }
+
+    @Test
+    public void testBasicMax() throws Exception {
+        testCall(db, "UNWIND RANGE(0,10) as value " +
+                        "WITH apoc.agg.maxItems(value, value) as maxResult " +
+                        "RETURN maxResult.value as value, maxResult.items as items",
+                (row) -> {
+                    assertEquals(10L, row.get("value"));
+                    assertThat((List<Object>) row.get("items"), iterableWithSize(1));
+                    assertThat((List<Object>) row.get("items"), contains(10L));
+                });
+
+
+        testCall(db, "UNWIND RANGE(0,10) as value " +
+                        "WITH apoc.agg.maxItems(value, value) as maxResult " +
+                        "ORDER BY maxResult.value DESC " +
+                        "RETURN maxResult.value as value, maxResult.items as items",
+                (row) -> {
+                    assertEquals(10L, row.get("value"));
+                    assertThat((List<Object>) row.get("items"), iterableWithSize(1));
+                    assertThat((List<Object>) row.get("items"), contains(10L));
+                });
+    }
+
+    @Test
+    public void testBasicMin() throws Exception {
+        testCall(db, "UNWIND RANGE(0,10) as value " +
+                        "WITH apoc.agg.minItems(value, value) as minResult " +
+                        "RETURN minResult.value as value, minResult.items as items",
+                (row) -> {
+                    assertEquals(0L, row.get("value"));
+                    assertThat((List<Object>) row.get("items"), iterableWithSize(1));
+                    assertThat((List<Object>) row.get("items"), contains(0L));
+                });
+
+
+        testCall(db, "UNWIND RANGE(0,10) as value " +
+                        "WITH apoc.agg.minItems(value, value) as minResult " +
+                        "ORDER BY minResult.value DESC " +
+                        "RETURN minResult.value as value, minResult.items as items",
+                (row) -> {
+                    assertEquals(0L, row.get("value"));
+                    assertThat((List<Object>) row.get("items"), iterableWithSize(1));
+                    assertThat((List<Object>) row.get("items"), contains(0L));
+                });
+    }
+
+    @Test
+    public void testMaxWithGrouping() throws Exception {
+        /** comparing to:
+          MATCH (p:Person)
+          WHERE p.born <= 1974
+          WITH p.born as born, collect(p.name) as persons
+          ORDER BY born DESC
+          LIMIT 1
+          RETURN born, persons
+
+          * returns {born:1974, persons:["Jerry O'Connell", "Christian Bale"]}
+         */
+
+        testCall(db, "MATCH (p:Person) " +
+                        "WHERE p.born <= 1974 " +
+                        "WITH apoc.agg.maxItems(p, p.born) as maxResult " +
+                        "RETURN maxResult.value as born, [person in maxResult.items | person.name] as persons",
+                (row) -> {
+                    assertEquals(1974L, row.get("born"));
+                    assertThat((List<Object>)row.get("persons"), iterableWithSize(2));
+                    assertThat((List<Object>)row.get("persons"), containsInAnyOrder("Jerry O'Connell", "Christian Bale"));
+                });
+    }
+
+    @Test
+    public void testMinWithGrouping() throws Exception {
+        /** comparing to:
+         MATCH (p:Person)
+         WHERE p.born >= 1930
+         WITH p.born as born, collect(p.name) as persons
+         ORDER BY born ASC
+         LIMIT 1
+         RETURN born, persons
+
+         * returns {born:1930, persons:["Gene Hackman", "Richard Harris", "Clint Eastwood"]}
+         * with limited grouping will return a limited subset of the results
+         */
+
+        testCall(db, "MATCH (p:Person) " +
+                        "WHERE p.born >= 1930 " +
+                        "WITH apoc.agg.minItems(p, p.born) as minResult " +
+                        "RETURN minResult.value as born, [person in minResult.items | person.name] as persons",
+                (row) -> {
+                    assertEquals(1930L, row.get("born"));
+                    assertThat((List<Object>)row.get("persons"), iterableWithSize(3));
+                    assertThat((List<Object>)row.get("persons"), containsInAnyOrder("Gene Hackman", "Richard Harris", "Clint Eastwood"));
+                });
+    }
+
+    @Test
+    public void testMaxWithLimitedGrouping() throws Exception {
+        /** comparing to:
+         MATCH (p:Person)
+         WHERE p.born <= 1974
+         WITH p.born as born, collect(p.name) as persons
+         ORDER BY born DESC
+         LIMIT 1
+         RETURN born, persons
+
+         * returns {born:1974, persons:["Jerry O'Connell", "Christian Bale"]}
+         * with limited grouping will return a limited subset of the results
+         */
+
+        testCall(db, "MATCH (p:Person) " +
+                        "WHERE p.born <= 1974 " +
+                        "WITH apoc.agg.maxItems(p, p.born, 1) as maxResult " +
+                        "RETURN maxResult.value as born, [person in maxResult.items | person.name] as persons",
+                (row) -> {
+                    assertEquals(1974L, row.get("born"));
+                    List<String> persons = (List<String>)row.get("persons");
+                    assertThat(persons.size(), equalTo(1));
+                    assertTrue(Arrays.asList("Jerry O'Connell", "Christian Bale").containsAll(persons));
+                });
+    }
+
+    @Test
+    public void testMinWithLimitedGrouping() throws Exception {
+        /** comparing to:
+         MATCH (p:Person)
+         WHERE p.born >= 1930
+         WITH p.born as born, collect(p.name) as persons
+         ORDER BY born ASC
+         LIMIT 1
+         RETURN born, persons
+
+         * returns {born:1930, persons:["Gene Hackman", "Richard Harris", "Clint Eastwood"]}
+         * with limited grouping will return a limited subset of the results
+         */
+
+        testCall(db, "MATCH (p:Person) " +
+                        "WHERE p.born >= 1930 " +
+                        "WITH apoc.agg.minItems(p, p.born, 2) as minResult " +
+                        "RETURN minResult.value as born, [person in minResult.items | person.name] as persons",
+                (row) -> {
+                    assertEquals(1930L, row.get("born"));
+                    List<String> persons = (List<String>)row.get("persons");
+                    assertThat(persons.size(), equalTo(2));
+                    assertTrue(Arrays.asList("Gene Hackman", "Richard Harris", "Clint Eastwood").containsAll(persons));
+                });
+    }
+
+    @Test
+    public void testMaxWithNullValuesProducesNoResults() throws Exception {
+        testCall(db,  "MATCH (p:Person) " +
+                        "WITH apoc.agg.maxItems(p, p.doesNotExist) as maxResult " +
+                        "RETURN maxResult.value as value, [person in maxResult.items | person.name] as persons",
+                (row) -> {
+                    assertEquals(null, row.get("value"));
+                    assertThat((List<Object>)row.get("persons"), iterableWithSize(0));
+                });
+    }
+
+    @Test
+    public void testMinWithNullValuesProducesNoResults() throws Exception {
+        testCall(db,  "MATCH (p:Person) " +
+                        "WITH apoc.agg.minItems(p, p.doesNotExist) as minResult " +
+                        "RETURN minResult.value as value, [person in minResult.items | person.name] as persons",
+                (row) -> {
+                    assertEquals(null, row.get("value"));
+                    assertThat((List<Object>)row.get("persons"), iterableWithSize(0));
+                });
+    }
+}
+


### PR DESCRIPTION
Implements #1229 

Adds aggregation functions for collecting items associated with a minimal or maximal value.

## Proposed Changes (Mandatory)

Adds aggregation functions for collecting items associated with a minimal or maximal value. Includes the ability to optionally limit the results per value.