### PR TITLE
fix #1231 single and multi initializers

### DIFF
--- a/src/main/java/apoc/cypher/CypherInitializer.java
+++ b/src/main/java/apoc/cypher/CypherInitializer.java
@@ -5,10 +5,14 @@ import org.neo4j.kernel.availability.AvailabilityListener;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.Log;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
 public class CypherInitializer implements AvailabilityListener {
+    public static final String INITIALIZER_CYPHER = "initializer.cypher";
+
     private final GraphDatabaseAPI db;
     private final Log userLog;
 
@@ -19,7 +23,16 @@ public class CypherInitializer implements AvailabilityListener {
 
     @Override
     public void available() {
-        SortedMap<String, Object> initializers = new TreeMap<>(ApocConfiguration.get("initializer.cypher"));
+        Map<String, Object> stringObjectMap;
+
+        String singleInitializer = ApocConfiguration.get(INITIALIZER_CYPHER, null);
+        if (singleInitializer != null) {
+            stringObjectMap = Collections.singletonMap("1", singleInitializer);
+        } else {
+            stringObjectMap = ApocConfiguration.get(INITIALIZER_CYPHER);
+        }
+
+        SortedMap<String, Object> initializers = new TreeMap<>(stringObjectMap);
         for (Object initializer: initializers.values()) {
             String query = initializer.toString();
             try {

--- a/src/test/java/apoc/cypher/CypherInitializerTest.java
+++ b/src/test/java/apoc/cypher/CypherInitializerTest.java
@@ -17,16 +17,27 @@ public class CypherInitializerTest {
     public void init(String... initializers) {
         GraphDatabaseBuilder graphDatabaseBuilder = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder();
 
-        int index = 1;
-        for (String initializer: initializers) {
-            graphDatabaseBuilder.setConfig("apoc.initializer.cypher." + index++, initializer);
+        if (initializers.length == 1) {
+            graphDatabaseBuilder.setConfig("apoc.initializer.cypher", initializers[0]);
+        } else {
+            int index = 1;
+            for (String initializer: initializers) {
+                graphDatabaseBuilder.setConfig("apoc.initializer.cypher." + index++, initializer);
+            }
         }
+
         db = graphDatabaseBuilder.newGraphDatabase();
     }
 
     @After
     public void teardown() {
         db.shutdown();
+    }
+
+    @Test
+    public void noInitializerWorks() {
+        init();
+        expectNodeCount(0);
     }
 
     @Test


### PR DESCRIPTION
support single initializers via `apoc.initializer.cypher=<command>` and multiple initializers
```
apoc.initializer.cypher.1=<first command>
apoc.initializer.cypher.2=<second command>
...
```