### PR TITLE
fixes #1219: change dbms.export.cypher.query default format, or document

### DIFF
--- a/docs/asciidoc/exportCypher.adoc
+++ b/docs/asciidoc/exportCypher.adoc
@@ -19,10 +19,10 @@ apoc.import.file.enabled=true
 
 Data is exported as Cypher statements to the given file.
 
-It is possible to choose between three export formats:
+It is possible to choose between three export formats (`cypher-shell` is the default value):
 
-* `neo4j-shell`: for Neo4j Shell and partly `apoc.cypher.runFile`
 * `cypher-shell`: for Cypher shell
+* `neo4j-shell`: for Neo4j Shell and partly `apoc.cypher.runFile`
 * `plain`: doesn't output begin / commit / await just plain Cypher
 
 You can also use the Optimizations like: `useOptimizations: {config}`

--- a/src/main/java/apoc/export/util/ExportConfig.java
+++ b/src/main/java/apoc/export/util/ExportConfig.java
@@ -87,7 +87,7 @@ public class ExportConfig {
         this.nodesOfRelationships = toBoolean(config.get("nodesOfRelationships"));
         this.bulkImport = toBoolean(config.get("bulkImport"));
         this.separateHeader = toBoolean(config.get("separateHeader"));
-        this.format = ExportFormat.fromString((String) config.getOrDefault("format", "neo4j-shell"));
+        this.format = ExportFormat.fromString((String) config.getOrDefault("format", "cypher-shell"));
         this.cypherFormat = CypherFormat.fromString((String) config.getOrDefault("cypherFormat", "create"));
         this.config = config;
         this.streamStatements = toBoolean(config.get("streamStatements")) || toBoolean(config.get("stream"));


### PR DESCRIPTION
Fixes #1219

Changed the default format as suggested into the issue (new default is `cypher-shell`) and updated the related documentation

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - changed default export type to `cypher-shell`
  - updated the documentation
