### PR TITLE
 fixes #1211: Create a function apoc.xml.parse and apoc.xml.format

### DIFF
--- a/docs/asciidoc/functions.adoc
+++ b/docs/asciidoc/functions.adoc
@@ -98,6 +98,11 @@ In our APOC procedure library we already converted about https://github.com/neo4
 | 2
 | apoc.util.md5(value)
 
+| XML parse function
+| 1
+| RETURN apoc.xml.parse('<?xml version="1.0"?><table><tr><td><img src="pix/logo-tl.gif"></img></td></tr></table>') AS value
+
+
 |===
 
 You can list user defined functions with `call dbms.functions()`

--- a/docs/asciidoc/import/loadxml.adoc
+++ b/docs/asciidoc/import/loadxml.adoc
@@ -349,3 +349,15 @@ CALL apoc.xml.import('https://seafile.rlp.net/f/6282a26504cc4f079ab9/?dl=1', {co
 return node;
 
 ----
+
+=== Helper Function `apoc.xml.parse`
+
+In case you have in your dataset nodes with property values XML string you can parse them into Maps
+with the `apoc.xml.parse` function.
+
+Following an example of how to use it:
+
+```
+WITH '<?xml version="1.0"?><table><tr><td><img src="pix/logo-tl.gif"></img></td></tr></table>' AS xmlString
+RETURN apoc.xml.parse(xmlString) AS value
+```

--- a/src/main/java/apoc/load/Xml.java
+++ b/src/main/java/apoc/load/Xml.java
@@ -1,5 +1,6 @@
 package apoc.load;
 
+import apoc.export.util.CountingInputStream;
 import apoc.result.MapResult;
 import apoc.result.NodeResult;
 import apoc.util.FileUtils;
@@ -26,12 +27,10 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathFactory;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringReader;
+import java.io.*;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.charset.Charset;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -56,6 +55,15 @@ public class Xml {
         return xmlXpathToMapResult(url, simpleMode, path ,config);
     }
 
+    @UserFunction("apoc.xml.parse")
+    @Description("RETURN apoc.xml.parse(<xml string>, <xPath string>, config, false) AS value")
+    public Map<String, Object> parse(@Name("data") String data, @Name(value = "path", defaultValue = "/") String path, @Name(value = "config",defaultValue = "{}") Map<String, Object> config, @Name(value = "simple", defaultValue = "false") boolean simpleMode) throws Exception {
+        if (config == null) config = Collections.emptyMap();
+        boolean failOnError = (boolean) config.getOrDefault("failOnError", true);
+        return parse(new ByteArrayInputStream(data.getBytes(Charset.forName("UTF-8"))), simpleMode, path, failOnError)
+                .map(mr -> mr.value).findFirst().orElse(null);
+    }
+
     @Procedure(deprecatedBy = "apoc.load.xml")
     @Deprecated
     @Description("apoc.load.xmlSimple('http://example.com/test.xml') YIELD value as doc CREATE (p:Person) SET p.name = doc.name load from XML URL (e.g. web-api) to import XML as single nested map with attributes and _type, _text and _children fields. This method does intentionally not work with XML mixed content.")
@@ -66,6 +74,21 @@ public class Xml {
     private Stream<MapResult> xmlXpathToMapResult(@Name("url") String url, boolean simpleMode, String path, Map<String, Object> config) throws Exception {
         if (config == null) config = Collections.emptyMap();
         boolean failOnError = (boolean) config.getOrDefault("failOnError", true);
+        try {
+            FileUtils.checkReadAllowed(url);
+            url = FileUtils.changeFileUrlIfImportDirectoryConstrained(url);
+            Map<String, Object> headers = (Map) config.getOrDefault( "headers", Collections.emptyMap() );
+            CountingInputStream is = Util.openInputStream(url, headers, null);
+            return parse(is, simpleMode, path, failOnError);
+        } catch (Exception e){
+            if(!failOnError)
+                return Stream.of(new MapResult(Collections.emptyMap()));
+            else
+                throw e;
+        }
+    }
+
+    private Stream<MapResult> parse(InputStream data, boolean simpleMode, String path, boolean failOnError) throws Exception {
         List<MapResult> result = new ArrayList<>();
         try {
             DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
@@ -74,12 +97,7 @@ public class Xml {
             DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
             documentBuilder.setEntityResolver((publicId, systemId) -> new InputSource(new StringReader("")));
 
-            FileUtils.checkReadAllowed(url);
-            url = FileUtils.changeFileUrlIfImportDirectoryConstrained(url);
-
-            Map<String, Object> headers = (Map) config.getOrDefault( "headers", Collections.emptyMap() );
-
-            Document doc = documentBuilder.parse(Util.openInputStream(url, headers, null));
+            Document doc = documentBuilder.parse(data);
             XPathFactory xPathFactory = XPathFactory.newInstance();
 
             XPath xPath = xPathFactory.newXPath();
@@ -101,13 +119,13 @@ public class Xml {
             if(!failOnError)
                 return Stream.of(new MapResult(Collections.emptyMap()));
             else
-                throw new FileNotFoundException(e.getMessage());
+                throw e;
         }
         catch (Exception e){
             if(!failOnError)
                 return Stream.of(new MapResult(Collections.emptyMap()));
             else
-                throw new Exception(e);
+                throw e;
         }
         return result.stream();
     }

--- a/src/test/java/apoc/load/LoadS3Test.java
+++ b/src/test/java/apoc/load/LoadS3Test.java
@@ -74,8 +74,7 @@ public class LoadS3Test {
         String url = minio.putFile("src/test/resources/xml/books.xml");
 
         testCall(db, "CALL apoc.load.xml({url},'/catalog/book[title=\"Maeve Ascendant\"]/.',{failOnError:false}) yield value as result", Util.map("url", url), (r) -> {
-            Object value = r.values();
-            assertEquals(XML_XPATH_AS_NESTED_MAP, value.toString());
+            assertEquals(XML_XPATH_AS_NESTED_MAP, r.get("result"));
         });
     }
 

--- a/src/test/java/apoc/load/XmlTest.java
+++ b/src/test/java/apoc/load/XmlTest.java
@@ -1,6 +1,7 @@
 package apoc.load;
 
 import apoc.util.TestUtil;
+import org.apache.commons.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -8,41 +9,52 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static apoc.util.TestUtil.*;
+import static apoc.util.Util.map;
 import static org.junit.Assert.*;
 
 public class XmlTest {
 
-    private static final String XML_AS_NESTED_MAP =
-            "{_type=parent, name=databases, " +
-                    "_children=[" +
-                    "{_type=child, name=Neo4j, _text=Neo4j is a graph database}, " +
-                    "{_type=child, name=relational, _children=[" +
-                    "{_type=grandchild, name=MySQL, _text=MySQL is a database & relational}, " +
-                    "{_type=grandchild, name=Postgres, _text=Postgres is a relational database}]}]}";
-    private static final String XML_AS_NESTED_SIMPLE_MAP =
-            "{_type=parent, name=databases, " +
-                    "_child=[" +
-                    "{_type=child, name=Neo4j, _text=Neo4j is a graph database}, " +
-                    "{_type=child, name=relational, _grandchild=[" +
-                    "{_type=grandchild, name=MySQL, _text=MySQL is a database & relational}, " +
-                    "{_type=grandchild, name=Postgres, _text=Postgres is a relational database}]}]}";
-    static final String XML_XPATH_AS_NESTED_MAP =
-            "[{_type=book, id=bk103, _children=[{_type=author, _text=Corets, Eva}, {_type=title, _text=Maeve Ascendant}, {_type=genre, _text=Fantasy}, {_type=price, _text=5.95}, {_type=publish_date, _text=2000-11-17}, {_type=description, _text=After the collapse of a nanotechnology " +
-                    "society in England, the young survivors lay the " +
-                    "foundation for a new society.}]}]";
+    private static List<Map<String, Object>> DBS_CHILDREN = Arrays.asList(
+            map("_type", "grandchild", "name", "MySQL", "_text", "MySQL is a database & relational"),
+            map("_type", "grandchild", "name", "Postgres", "_text", "Postgres is a relational database"));
+    private static List<Map<String, Object>> DBS = Arrays.asList(map("_type", "child", "name", "Neo4j", "_text", "Neo4j is a graph database"),
+        map("_type", "child", "name", "relational", "_children", DBS_CHILDREN));
+    private static final Map<String, Object> XML_AS_NESTED_MAP = map("_type", "parent", "name", "databases", "_children", DBS);
 
-    private static final String XML_AS_SINGLE_LINE =
-            "{_type=table, _children=[{_type=tr, _children=[{_type=td, _children=[{_type=img, src=pix/logo-tl.gif}]}]}]}";
+    private static List<Map<String, Object>> DBS_NESTED = Arrays.asList(map("_type", "child", "name", "Neo4j", "_text", "Neo4j is a graph database"),
+            map("_type", "child", "name", "relational", "_grandchild", DBS_CHILDREN));
 
-    private static final String XML_AS_SINGLE_LINE_SIMPLE =
-            "{_type=table, _table=[{_type=tr, _tr=[{_type=td, _td=[{_type=img, src=pix/logo-tl.gif}]}]}]}";
+    private static final Map<String, Object> XML_AS_NESTED_SIMPLE_MAP = map("_type", "parent", "name", "databases", "_child", DBS_NESTED);
+
+    public static final Map<String, Object> XML_XPATH_AS_NESTED_MAP = map("_type", "book", "id", "bk103", "_children",
+            Arrays.asList(map("_type", "author", "_text", "Corets, Eva"),
+                    map("_type", "title", "_text", "Maeve Ascendant"),
+                    map("_type", "genre", "_text", "Fantasy"),
+                    map("_type", "price", "_text", "5.95"),
+                    map("_type", "publish_date", "_text", "2000-11-17"),
+                    map("_type", "description", "_text", "After the collapse of a nanotechnology society in England, the young survivors lay the foundation for a new society.")
+            ));
+
+
+    private static final Map<String, Object> XML_AS_SINGLE_LINE = map("_type", "table",
+            "_children", Arrays.asList(
+                    map("_type", "tr", "_children",
+                            Arrays.asList(map("_type", "td", "_children",
+                                    Arrays.asList(map("_type", "img", "src", "pix/logo-tl.gif")))))));
+
+    private static final Map<String, Object> XML_AS_SINGLE_LINE_SIMPLE = map("_type", "table",
+            "_table", Arrays.asList(
+                    map("_type", "tr", "_tr", Arrays.asList(map("_type", "td", "_td", Arrays.asList(map("_type", "img", "src", "pix/logo-tl.gif")))))));
+
+    private static final Map<String, Object> MIXED_CONTENT = map("_type", "root", "_children",
+            Arrays.asList(map("_type", "text", "_children", Arrays.asList(map("_type", "mixed"), "text0", "text1")), map("_type", "text", "_text", "text as cdata")));
 
     private GraphDatabaseService db;
 
@@ -65,7 +77,7 @@ public class XmlTest {
         testCall(db, "CALL apoc.load.xml('file:databases.xml')", //  YIELD value RETURN value
                 (row) -> {
                     Object value = row.get("value");
-                    assertEquals(XML_AS_NESTED_MAP, value.toString());
+                    assertEquals(XML_AS_NESTED_MAP, value);
                 });
     }
 
@@ -74,7 +86,7 @@ public class XmlTest {
         testCall(db, "CALL apoc.load.xmlSimple('file:databases.xml')", //  YIELD value RETURN value
                 (row) -> {
                     Object value = row.get("value");
-                    assertEquals(XML_AS_NESTED_SIMPLE_MAP, value.toString());
+                    assertEquals(XML_AS_NESTED_SIMPLE_MAP, value);
                 });
     }
 
@@ -84,7 +96,7 @@ public class XmlTest {
                 (row) -> {
                     Object value = row.get("value");
                     //assertEquals("{_type=root, _children=[{_type=text, _children=[text0, {_type=mixed}, text1]}, {_type=text, _text=text as cdata}]}", value.toString());
-                    assertEquals("{_type=root, _children=[{_type=text, _children=[{_type=mixed}, text0, text1]}, {_type=text, _text=text as cdata}]}", value.toString());
+                    assertEquals(MIXED_CONTENT, value);
 
                 });
     }
@@ -174,8 +186,7 @@ public class XmlTest {
     public void testLoadXmlXpathReturnBookFromBookTitle () {
         testCall(db, "CALL apoc.load.xml('file:src/test/resources/xml/books.xml', '/catalog/book[title=\"Maeve Ascendant\"]/.') yield value as result",
                 (r) -> {
-                    Object value = r.values();
-                    assertEquals(XML_XPATH_AS_NESTED_MAP, value.toString());
+                    assertEquals(XML_XPATH_AS_NESTED_MAP, r.get("result"));
                 });
     }
 
@@ -377,10 +388,11 @@ public class XmlTest {
 
     @Test
     public void testExternalDTDschouldNotBeLoaded() {
+        Map<String, Object> expected = map("_type", "document", "_document", Arrays.asList(null, map("_type", "title", "_text", "dtd 404")));
         testCall(db, "CALL apoc.load.xml('file:src/test/resources/xml/missingExternalDTD.xml', '/', null, true)",
                 (row) -> {
                     Object value = row.get("value");
-                    assertEquals("{_type=document, _document=[null, {_type=title, _text=dtd 404}]}", value.toString());
+                    assertEquals(expected, value);
                 });
     }
 
@@ -389,7 +401,7 @@ public class XmlTest {
         testCall(db, "CALL apoc.load.xml('file:src/test/resources/xml/singleLine.xml', '/', null, true)", //  YIELD value RETURN value
                 (row) -> {
                     Object value = row.get("value");
-                    assertEquals(XML_AS_SINGLE_LINE_SIMPLE, value.toString());
+                    assertEquals(XML_AS_SINGLE_LINE_SIMPLE, value);
                 });
     }
 
@@ -398,7 +410,7 @@ public class XmlTest {
         testCall(db, "CALL apoc.load.xml('file:src/test/resources/xml/singleLine.xml')", //  YIELD value RETURN value
                 (row) -> {
                     Object value = row.get("value");
-                    assertEquals(XML_AS_SINGLE_LINE, value.toString());
+                    assertEquals(XML_AS_SINGLE_LINE, value);
                 });
     }
 }

--- a/src/test/java/apoc/load/XmlTest.java
+++ b/src/test/java/apoc/load/XmlTest.java
@@ -413,4 +413,18 @@ public class XmlTest {
                     assertEquals(XML_AS_SINGLE_LINE, value);
                 });
     }
+
+    @Test
+    public void testParse() {
+        testCall(db, "WITH '<?xml version=\"1.0\"?><table><tr><td><img src=\"pix/logo-tl.gif\"></img></td></tr></table>' AS xmlString RETURN apoc.xml.parse(xmlString) AS value",
+                (row) -> assertEquals(XML_AS_SINGLE_LINE, row.get("value")));
+    }
+
+    @Test
+    public void testParseWithXPath() throws Exception {
+        String xmlString = FileUtils.readFileToString(new File("src/test/resources/xml/books.xml"), Charset.forName("UTF-8"));
+        testCall(db, "RETURN apoc.xml.parse({xmlString}, '/catalog/book[title=\"Maeve Ascendant\"]/.') AS result",
+                map("xmlString", xmlString),
+                (r) -> assertEquals(XML_XPATH_AS_NESTED_MAP, r.get("result")));
+    }
 }


### PR DESCRIPTION
Fixes #1211

In this PR is provided only the `apoc.xml.parse` function.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - moved tests to string comparison into objects because I had problems with property order
  - implemented the `apoc.xml.parse` function
  - updated the documentation
