### PR TITLE
fixes #1243: Improving apoc.graph.fromDocument: manage missing id and label

### DIFF
--- a/docs/asciidoc/virtual/virtual-graph.adoc
+++ b/docs/asciidoc/virtual/virtual-graph.adoc
@@ -67,7 +67,7 @@ It takes two arguments:
 The value can be a String, or Cypher Map or List of Maps.
 * *config*, _type Map_: the configuration params
 
-Currently spatial and datetime properties are not handled yet. 
+Currently spatial and datetime properties are not handled yet.
 More advanced configuration for mapping the document is coming in future versions.
 
 The config is composed by the following parameters:

--- a/src/main/java/apoc/graph/Graphs.java
+++ b/src/main/java/apoc/graph/Graphs.java
@@ -5,8 +5,8 @@ import apoc.graph.document.builder.DocumentToGraph;
 import apoc.graph.util.GraphsConfig;
 import apoc.result.RowResult;
 import apoc.result.VirtualGraph;
-import apoc.util.JsonUtil;
 import apoc.util.Util;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
@@ -15,7 +15,6 @@ import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.procedure.*;
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
 /**
@@ -117,39 +116,20 @@ public class Graphs {
     @Description("apoc.graph.fromDocument({json}, {config}) yield graph - transform JSON documents into graph structures")
     @Procedure(mode = Mode.WRITE)
     public Stream<VirtualGraph> fromDocument(@Name("json") Object document, @Name(value = "config", defaultValue = "{}") Map<String,Object> config) throws Exception {
-        Collection<Map> coll = getDocumentCollection(document);
         DocumentToGraph documentToGraph = new DocumentToGraph(db, new GraphsConfig(config));
-        return Stream.of(documentToGraph.create(coll));
-    }
-
-    public Collection<Map> getDocumentCollection(@Name("json") Object document) {
-        Collection<Map> coll;
-        if (document instanceof String) {
-            document  = JsonUtil.parse((String) document, null, Object.class);
-        }
-        if (document instanceof Collection) {
-            coll = (Collection) document;
-        } else {
-            coll = Collections.singleton((Map) document);
-        }
-        return coll;
+        return Stream.of(documentToGraph.create(document));
     }
 
     @Description("apoc.graph.validateDocument({json}, {config}) yield row - validates the json, return the result of the validation")
     @Procedure(mode = Mode.READ)
     public Stream<RowResult> validateDocument(@Name("json") Object document, @Name(value = "config", defaultValue = "{}") Map<String,Object> config) {
-        DocumentToGraph documentToGraph = new DocumentToGraph(db, new GraphsConfig(config));
-        AtomicLong index = new AtomicLong(-1);
-        return getDocumentCollection(document).stream()
-                .map(elem -> {
-                    long line = index.incrementAndGet();
-                    try {
-                        documentToGraph.validate(elem);
-                        return null;
-                    } catch (Exception e) {
-                        return new RowResult(Util.map("index", line, "message", e.getMessage()));
-                    }
-                })
-                .filter(elem -> elem != null);
+        GraphsConfig graphConfig = new GraphsConfig(config);
+        DocumentToGraph documentToGraph = new DocumentToGraph(db, graphConfig);
+        Map<Long, List<String>> dups = documentToGraph.validateDocument(document);
+
+        return dups.entrySet().stream()
+                .map(e -> new RowResult(Util.map("index", e.getKey(), "message", String.join(StringUtils.LF, e.getValue()))));
     }
+
+
 }

--- a/src/main/java/apoc/graph/document/builder/LabelBuilder.java
+++ b/src/main/java/apoc/graph/document/builder/LabelBuilder.java
@@ -16,7 +16,7 @@ public class LabelBuilder {
     }
 
     public Label buildLabel(Map<String, Object> obj) {
-        String label = "DocNode"; // Default label
+        String label = "";
 
         Object type = obj.get(config.getLabelField());
         if (type != null) {

--- a/src/main/java/apoc/graph/util/GraphsConfig.java
+++ b/src/main/java/apoc/graph/util/GraphsConfig.java
@@ -10,14 +10,18 @@ public class GraphsConfig {
     private boolean write;
     private String labelField;
     private String idField;
+    private boolean generateId;
+    private String defaultLabel;
 
     public GraphsConfig(Map<String, Object> config) {
         if (config == null) {
             config = Collections.emptyMap();
         }
         write = toBoolean(config.getOrDefault("write", false));
+        generateId = toBoolean(config.getOrDefault("generateId", true));
         idField = config.getOrDefault("idField", "id").toString();
         labelField = config.getOrDefault("labelField", "type").toString();
+        defaultLabel = config.getOrDefault("defaultLabel", "DocNode").toString();
     }
 
     public boolean isWrite() {
@@ -32,4 +36,11 @@ public class GraphsConfig {
         return idField;
     }
 
+    public boolean isGenerateId() {
+        return generateId;
+    }
+
+    public String getDefaultLabel() {
+        return defaultLabel;
+    }
 }

--- a/src/test/java/apoc/graph/GraphsTest.java
+++ b/src/test/java/apoc/graph/GraphsTest.java
@@ -12,6 +12,8 @@ import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static apoc.util.MapUtil.map;
 import static java.util.Arrays.asList;
@@ -375,7 +377,9 @@ public class GraphsTest {
     public void testCreateVirtualSimpleNodeWithErrorId() throws Exception{
         Map<String, Object> genesisMap = Util.map("type", "artist", "name", "Genesis");
         try {
-            TestUtil.testCall(db, "CALL apoc.graph.fromDocument({json}) yield graph", Util.map("json", JsonUtil.OBJECT_MAPPER.writeValueAsString(genesisMap)), stringObjectMap -> { });
+            TestUtil.testCall(db, "CALL apoc.graph.fromDocument({json}, {config}) yield graph",
+                    Util.map("json", JsonUtil.OBJECT_MAPPER.writeValueAsString(genesisMap),
+                            "config", Util.map("generateId", false)), stringObjectMap -> { });
         } catch (QueryExecutionException e) {
             Throwable except = ExceptionUtils.getRootCause(e);
             assertTrue(except instanceof RuntimeException);
@@ -391,8 +395,8 @@ public class GraphsTest {
                 Util.map("id", 1, "name", "Daft Punk"),
                 Util.map("name", "Daft Punk"));
 
-        TestUtil.testResult(db, "CALL apoc.graph.validateDocument({json}) yield row",
-                Util.map("json", JsonUtil.OBJECT_MAPPER.writeValueAsString(list)), result -> {
+        TestUtil.testResult(db, "CALL apoc.graph.validateDocument({json}, {config}) yield row",
+                Util.map("json", JsonUtil.OBJECT_MAPPER.writeValueAsString(list), "config", Util.map("generateId", false, "defaultLabel", "")), result -> {
                     Map<String, Object> row = (Map<String, Object>) result.next().get("row");
                     assertEquals(0L, row.get("index"));
                     assertEquals("The object `{\"type\":\"artist\",\"name\":\"Daft Punk\"}` must have `id` as id-field name", row.get("message"));
@@ -409,14 +413,27 @@ public class GraphsTest {
     @Test
     public void testValidateDocumentWithCutErrorFormatter() throws Exception {
         String json = "{\"quiz\":{\"sport\":{\"q1\":{\"question\":\"Which one is correct team name in NBA?\",\"options\":[\"New York Bulls\",\"Los Angeles Kings\",\"Golden State Warriros\",\"Huston Rocket\"],\"answer\":\"Huston Rocket\"}},\"maths\":{\"q1\":{\"question\":\"5 + 7 = ?\",\"options\":[\"10\",\"11\",\"12\",\"13\"],\"answer\":\"12\"},\"q2\":{\"question\":\"12 - 8 = ?\",\"options\":[\"1\",\"2\",\"3\",\"4\"],\"answer\":\"4\"}}}}";
-
-        TestUtil.testResult(db, "CALL apoc.graph.validateDocument({json}) yield row",
-                Util.map("json", json), result -> {
+        Set<String> errors = new HashSet<>();
+        errors.add("The object `{\"quiz\":{\"sport\":{\"q1\":{\"question\":\"Which one is correct team name in NBA?\",\"options\":[\"New York Bul...}` must have `id` as id-field name and `type` as label-field name");
+        errors.add("The object `{\"sport\":{\"q1\":{\"question\":\"Which one is correct team name in NBA?\",\"options\":[\"New York Bulls\",\"Los...}` must have `id` as id-field name and `type` as label-field name");
+        errors.add("The object `{\"q1\":{\"question\":\"Which one is correct team name in NBA?\",\"options\":[\"New York Bulls\",\"Los Angeles ...}` must have `id` as id-field name and `type` as label-field name");
+        errors.add("The object `{\"question\":\"Which one is correct team name in NBA?\",\"options\":[\"New York Bulls\",\"Los Angeles Kings\"...}` must have `id` as id-field name and `type` as label-field name");
+        errors.add("The object `{\"q1\":{\"question\":\"5 + 7 = ?\",\"options\":[\"10\",\"11\",\"12\",\"13\"],\"answer\":\"12\"},\"q2\":{\"question\":\"12 - ...}` must have `id` as id-field name and `type` as label-field name");
+        errors.add("The object `{\"question\":\"5 + 7 = ?\",\"options\":[\"10\",\"11\",\"12\",\"13\"],\"answer\":\"12\"}` must have `id` as id-field name and `type` as label-field name");
+        errors.add("The object `{\"question\":\"12 - 8 = ?\",\"options\":[\"1\",\"2\",\"3\",\"4\"],\"answer\":\"4\"}` must have `id` as id-field name and `type` as label-field name");
+        TestUtil.testResult(db, "CALL apoc.graph.validateDocument({json}, {config}) yield row",
+                Util.map("json", json, "config", Util.map("generateId", false, "defaultLabel", "")), result -> {
                     Map<String, Object> row = (Map<String, Object>) result.next().get("row");
                     assertEquals(0L, row.get("index"));
-                    assertEquals("The object `{\"quiz\":{\"sport\":{\"q1\":{\"question\":\"Which one is correct team name in NBA?\",\"options\":[\"New York Bul...}` must have `id` as id-field name and `type` as label-field name", row.get("message"));
+                    Set<String> message = messageToSet(row);
+                    assertEquals(errors, message);
                     assertFalse("should not have next", result.hasNext());
                 });
+    }
+
+    private Set<String> messageToSet(Map<String, Object> row) {
+        return Stream.of(row.get("message").toString().split("\n"))
+                .collect(Collectors.toSet());
     }
 
     @Test
@@ -561,7 +578,10 @@ public class GraphsTest {
     public void testCreateVirtualSimpleNodeWithErrorType() throws Exception{
         Map<String, Object> genesisMap = Util.map("id", 1L, "name", "Genesis");
         try {
-            TestUtil.testCall(db, "CALL apoc.graph.fromDocument({json}) yield graph", Util.map("json", JsonUtil.OBJECT_MAPPER.writeValueAsString(genesisMap)), result -> { });
+            TestUtil.testCall(db, "CALL apoc.graph.fromDocument({json}, {config}) yield graph",
+                    Util.map("json", JsonUtil.OBJECT_MAPPER.writeValueAsString(genesisMap),
+                            "config", map("defaultLabel", "")),
+                    result -> { });
         } catch (QueryExecutionException e) {
             Throwable except = ExceptionUtils.getRootCause(e);
             assertTrue(except instanceof RuntimeException);
@@ -687,6 +707,67 @@ public class GraphsTest {
                     assertEquals(genesisMap.get("id"), artist.getProperty("id"));
                     Arrays.equals((Long[]) genesisMap.get("years"), (Long[]) artist.getProperty("years"));
                     Arrays.equals((String[]) genesisMap.get("members"), (String[]) artist.getProperty("members"));
+                });
+    }
+
+
+    @Test
+    public void shouldFindDuplicatesWithValidation() {
+        Map<String, Object> child = Util.map("key", "childKey");
+        List<Map<String, Object>> data = Arrays.asList(
+                Util.map("key", "value", "key1", "Foo"), // index 0
+                Util.map("key", "value", "key1", "Foo"), // index 1 -> dup of index 0
+                Util.map("key", "value1", "key1", "Foo", "child", child), // index 2
+                Util.map("key", "value1", "key1", "Foo"), // index 3
+                Util.map("key", "value2", "key1", "Foo", "childA", child), // index 4 -> dup of "child" field at index 1
+                Util.map("key", "value2", "key1", "Foo", "childA", Util.map("child", child)) // index 5 -> dup of "child" field at index 1
+        );
+
+        TestUtil.testResult(db, "CALL apoc.graph.validateDocument({json}, {config})",
+                Util.map("json", data, "config", Util.map("generateId", false, "defaultLabel", "")), result -> {
+                    Map<String, Object> row = (Map<String, Object>) result.next().get("row");
+                    assertEquals(0L, row.get("index"));
+                    Set<String> errors = new HashSet<>();
+                    Set<String> messages = messageToSet(row);
+                    errors.add("The object `{\"key1\":\"Foo\",\"key\":\"value\"}` has duplicate at lines [1]");
+                    errors.add("The object `{\"key1\":\"Foo\",\"key\":\"value\"}` must have `id` as id-field name and `type` as label-field name");
+                    assertEquals(errors, messages);
+
+                    row = (Map<String, Object>) result.next().get("row");
+                    assertEquals(1L, row.get("index"));
+                    assertEquals("The object `{\"key1\":\"Foo\",\"key\":\"value\"}` must have `id` as id-field name and `type` as label-field name", row.get("message"));
+
+                    row = (Map<String, Object>) result.next().get("row");
+                    assertEquals(2L, row.get("index"));
+                    errors = new HashSet<>();
+                    messages = messageToSet(row);
+                    errors.add("The object `{\"key\":\"childKey\"}` has duplicate at lines [4,5]");
+                    errors.add("The object `{\"key1\":\"Foo\",\"key\":\"value1\",\"child\":{\"key\":\"childKey\"}}` must have `id` as id-field name and `type` as label-field name");
+                    errors.add("The object `{\"key\":\"childKey\"}` must have `id` as id-field name and `type` as label-field name");
+                    assertEquals(errors, messages);
+
+                    row = (Map<String, Object>) result.next().get("row");
+                    assertEquals(3L, row.get("index"));
+                    assertEquals("The object `{\"key1\":\"Foo\",\"key\":\"value1\"}` must have `id` as id-field name and `type` as label-field name", row.get("message"));
+
+                    row = (Map<String, Object>) result.next().get("row");
+                    assertEquals(4L, row.get("index"));
+                    errors = new HashSet<>();
+                    messages = messageToSet(row);
+                    errors.add("The object `{\"key1\":\"Foo\",\"key\":\"value2\",\"childA\":{\"key\":\"childKey\"}}` must have `id` as id-field name and `type` as label-field name");
+                    errors.add("The object `{\"key\":\"childKey\"}` must have `id` as id-field name and `type` as label-field name");
+                    assertEquals(errors, messages);
+
+                    row = (Map<String, Object>) result.next().get("row");
+                    assertEquals(5L, row.get("index"));
+                    errors = new HashSet<>();
+                    messages = messageToSet(row);
+                    errors.add("The object `{\"key1\":\"Foo\",\"key\":\"value2\",\"childA\":{\"child\":{\"key\":\"childKey\"}}}` must have `id` as id-field name and `type` as label-field name");
+                    errors.add("The object `{\"child\":{\"key\":\"childKey\"}}` must have `id` as id-field name and `type` as label-field name");
+                    errors.add("The object `{\"key\":\"childKey\"}` must have `id` as id-field name and `type` as label-field name");
+                    assertEquals(errors, messages);
+
+                    assertFalse("should not have next", result.hasNext());
                 });
     }
 


### PR DESCRIPTION
Fixes #1243 

Added new config params in order to manage auto-generated ids and the default label

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:
- [x] be smarter about missing id's assign a UUID
- [x] Validate unique ids (we only check duplicates on ids, not labels)
- [x] provide a default label from config in case is missing in the data