### PR TITLE
 fixes #1245: Improving apoc.graph.fromDocument: storing value objects

### DIFF
--- a/docs/asciidoc/virtual/virtual-graph.adoc
+++ b/docs/asciidoc/virtual/virtual-graph.adoc
@@ -75,6 +75,8 @@ The config is composed by the following parameters:
 * *write*, _type boolean_: persist the graph otherwise return a Virtual Graph, default *false*
 * *labelField*, _type String_: the field name that became the label of the node, default *type*
 * *idField*, _type String_: the document field name that will become the id field of the created nodes (used for node resolution when you create relationships between nodes), default *id*
+* *autoGenerateID*, _type boolean_: in case of missing id-field value it generates an UUID for it, default *true*
+* *defaultLabel*, _type String_: in case of missing label-field value is uses the provided default label, default is empty
 
 
 [source, json]

--- a/docs/asciidoc/virtual/virtual-graph.adoc
+++ b/docs/asciidoc/virtual/virtual-graph.adoc
@@ -199,7 +199,11 @@ RETURN graph
 
 As a result we have a virtual graph with two nodes and one relationship:
 
+<<<<<<< HEAD
 image::apoc.graph.fromDocument_1[scaledwidth="100%"]
+=======
+image::{img}/apoc.graph.fromDocument_1[width=800]
+>>>>>>> fixes #1200: better error handling for apoc.graph.fromDocument
 
 You can also do a pre-validation over the document with the `apoc.graph.validateDocument` procedure that will return the
 record with invalid data.

--- a/docs/asciidoc/virtual/virtual-graph.adoc
+++ b/docs/asciidoc/virtual/virtual-graph.adoc
@@ -199,11 +199,7 @@ RETURN graph
 
 As a result we have a virtual graph with two nodes and one relationship:
 
-<<<<<<< HEAD
 image::apoc.graph.fromDocument_1[scaledwidth="100%"]
-=======
-image::{img}/apoc.graph.fromDocument_1[width=800]
->>>>>>> fixes #1200: better error handling for apoc.graph.fromDocument
 
 You can also do a pre-validation over the document with the `apoc.graph.validateDocument` procedure that will return the
 record with invalid data.

--- a/docs/asciidoc/virtual/virtual-graph.adoc
+++ b/docs/asciidoc/virtual/virtual-graph.adoc
@@ -75,9 +75,36 @@ The config is composed by the following parameters:
 * *write*, _type boolean_: persist the graph otherwise return a Virtual Graph, default *false*
 * *labelField*, _type String_: the field name that became the label of the node, default *type*
 * *idField*, _type String_: the document field name that will become the id field of the created nodes (used for node resolution when you create relationships between nodes), default *id*
-* *autoGenerateID*, _type boolean_: in case of missing id-field value it generates an UUID for it, default *true*
+* *generateId*, _type boolean_: in case of missing id-field value it generates an UUID for it, default *true*
 * *defaultLabel*, _type String_: in case of missing label-field value is uses the provided default label, default is empty
+* *skipValidation*, _type boolean_: in case you want skip the validation process into the `apoc.graph.fromDocument` procedure *false*
+* *mappings*, _type Map<String, String>_: you can use a JSON path like syntax for:
+** include properties
+** defining document properties as value objects, by prepending the `@` to the property name
+** define custom/composite keys per Labels, by prepending the `!` to the property name
 
+Following an example of configuration with mappings:
+
+[source, cypher]
+----
+{
+    write: false,
+    idField: "id",
+    mappings: {
+      `$`: 'Person:Reader{*,@size}'
+      `$.books`: 'Book{!title, released}'
+    }
+}
+----
+
+Lets describe the mappings:
+
+* **`$`: 'Person:Reader{*,@size}'**: this means that at the root object will be applied
+two labels `Person` and `Reader`, all properties are included and the `size` property will be transformed into a value objects
+as you can see no id is specified so we will consider as id the property defined into the `idField`
+* **`$.books`: 'Book{!title, released}'**: this means that at the `books` property of the root object will transformed
+into a node with label Book composed by two properties `title` considered as id (it's marked with `!`) and `released`
+moreover the property will be connected to the parent node of type `Person:Reader` via the `BOOKS` relationship
 
 [source, json]
 ----
@@ -194,7 +221,7 @@ image::apoc.graph.png[width=800]
 
 [source,cypher]
 ----
-CALL apoc.graph.fromDocument("{'id': 1,'type': 'artist','name':'Genesis','members': ['Tony Banks','Mike Rutherford','Phil Collins'],'years': [1967, 1998, 1999, 2000, 2006],'albums': [{'type': 'album','id': 1,'producer': 'Jonathan King','title': 'From Genesis to Revelation'}]}", false)
+CALL apoc.graph.fromDocument("{'id': 1,'type': 'artist','name':'Genesis','members': ['Tony Banks','Mike Rutherford','Phil Collins'],'years': [1967, 1998, 1999, 2000, 2006],'albums': [{'type': 'album','id': 1,'producer': 'Jonathan King','title': 'From Genesis to Revelation'}]}", {write: false})
 YIELD graph
 RETURN graph
 ----
@@ -202,6 +229,55 @@ RETURN graph
 As a result we have a virtual graph with two nodes and one relationship:
 
 image::apoc.graph.fromDocument_1[scaledwidth="100%"]
+
+
+In case this json:
+[source, json]
+----
+{
+    "id": 1,
+    "type": "Person",
+    "name": "Andrea",
+    "sizes": {
+        "weight": {
+            "value": 70,
+            "um": "Kg"
+        },
+        "height": {
+            "value": 174,
+            "um": "cm"
+        }
+    }
+}
+----
+You can manage the `sizes` property as value object so you manage it as follows:
+
+
+[source,cypher]
+----
+call apoc.graph.validateDocument(<json>, {mappings: {`$`: "Person{*,@sizes}"}})
+----
+
+So the procedure will create a node with the following properties:
+[source, json]
+----
+{
+    "id": 1,
+    "type": "Person",
+    "name": "Andrea",
+    "sizes.weight.value": 70,
+    "sizes.weight.um": "Kg",
+    "sizes.height.value": 174,
+    "sizes.height.um": "cm"
+}
+----
+
+As specified you can also provide a set of value-object properties for a Label:
+
+[source,cypher]
+----
+call apoc.graph.validateDocument(<json>, {mappings: {`$`: "Person{*,@sizes}"}})
+----
 
 You can also do a pre-validation over the document with the `apoc.graph.validateDocument` procedure that will return the
 record with invalid data.

--- a/src/main/java/apoc/graph/document/builder/DocumentToGraph.java
+++ b/src/main/java/apoc/graph/document/builder/DocumentToGraph.java
@@ -5,6 +5,7 @@ import apoc.result.VirtualGraph;
 import apoc.result.VirtualNode;
 import apoc.util.FixedSizeStringWriter;
 import apoc.util.JsonUtil;
+import apoc.util.Util;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -21,6 +22,8 @@ import java.util.stream.StreamSupport;
 
 public class DocumentToGraph {
 
+    private static final String JSON_ROOT = "$";
+
     private GraphDatabaseService db;
     private RelationshipBuilder documentRelationBuilder;
     private LabelBuilder documentLabelBuilder;
@@ -33,17 +36,38 @@ public class DocumentToGraph {
         this.config = config;
     }
 
-    public Map<Map<String, Object>, List<String>> validate(Map<String, Object> map) {
-        return flatMapFields(map)
+    private boolean hasId(Map<String, Object> map, String path) {
+        List<String> ids = config.idsForPath(path);
+        if (ids.isEmpty()) {
+            return map.containsKey(config.getIdField());
+        } else {
+            return map.keySet().containsAll(ids);
+        }
+    }
+
+    private boolean hasLabel(Map<String, Object> map, String path) {
+        return !config.labelsForPath(path).isEmpty() || map.containsKey(config.getLabelField());
+    }
+
+    public Map<Map<String, Object>, List<String>> validate(Map<String, Object> map, String path) {
+        return flatMapFieldsWithPath(map, path)
+                .entrySet()
+                .stream()
+                .flatMap(elem -> elem.getValue().stream().map(data -> new AbstractMap.SimpleEntry<>(elem.getKey(), data)))
                 .map(elem -> {
+                    String subPath = elem.getKey();
+                    List<String> valueObjects = config.valueObjectForPath(subPath);
                     List<String> msgs = new ArrayList<>();
-                    if (!elem.containsKey(config.getIdField())) {
-                        msgs.add("`" + config.getIdField() + "` as id-field name");
+                    Map<String, Object> value = elem.getValue();
+                    if (valueObjects.isEmpty()) {
+                        if (!hasId(value, subPath)) {
+                            msgs.add("`" + config.getIdField() + "` as id-field name");
+                        }
+                        if (!hasLabel(value, subPath)) {
+                            msgs.add("`" + config.getLabelField() + "` as label-field name");
+                        }
                     }
-                    if (!elem.containsKey(config.getLabelField())) {
-                        msgs.add("`" + config.getLabelField() + "` as label-field name");
-                    }
-                    return new AbstractMap.SimpleEntry<>(elem, msgs);
+                    return new AbstractMap.SimpleEntry<>(value, msgs);
                 })
                 .filter(elem -> !elem.getValue().isEmpty())
                 .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
@@ -59,27 +83,47 @@ public class DocumentToGraph {
     }
 
     private void fromDocument(Map<String, Object> document, Node source, String type,
-                              Map<String, Set<Node>> nodes, Set<Relationship> relationships) {
-        boolean isRootNode = source == null;
-        prepareData(document);
-        Map<Map<String, Object>, List<String>> errors = validate(document);
-        if (!errors.isEmpty()) {
-            throwError(errors);
-        }
-        Label label = this.documentLabelBuilder.buildLabel(document);
+                              Map<Set<String>, Set<Node>> nodes, Set<Relationship> relationships,
+                              String propertyName) {
+        String path = propertyName == null ? JSON_ROOT : propertyName;
 
-        Object idValue = document.get(config.getIdField());
+        // clean the object form unwanted properties
+        if (!config.allPropertiesForPath(path)) {
+            document.keySet().retainAll(config.propertiesForPath(path));
+        }
+
+        boolean isRootNode = source == null;
+        prepareData(document, path);
+
+        // validate
+        if (!config.isSkipValidation()) {
+            Map<Map<String, Object>, List<String>> errors = validate(document, path);
+            if (!errors.isEmpty()) {
+                throwError(errors);
+            }
+        }
+
+        Label[] labels = this.documentLabelBuilder.buildLabel(document, path);
+        Map<String, Object> idValues = filterNodeIdProperties(document, path);
+
         // retrieve the current node
         final Node node;
         if (this.config.isWrite()) {
-            node = getOrCreateRealNode(label, idValue);
+            node = getOrCreateRealNode(labels, idValues);
         } else {
-            node = getOrCreateVirtualNode(nodes, label, idValue);
+            node = getOrCreateVirtualNode(nodes, labels, idValues);
         }
 
         // write node properties
         document.entrySet().stream()
-                .filter(e -> isSimpleType(e))
+                .filter(e -> isSimpleType(e, path))
+                .flatMap(e -> {
+                    if (e.getValue() instanceof Map) {
+                        return Util.flattenMap((Map<String, Object>) e.getValue(), e.getKey()).entrySet().stream();
+                    } else {
+                        return Stream.of(e);
+                    }
+                })
                 .forEach(e -> {
                     Object value = e.getValue();
                     if (value instanceof List) {
@@ -96,19 +140,21 @@ public class DocumentToGraph {
 
         // get child nodes
         document.entrySet().stream()
-                .filter(e -> !isSimpleType(e))
+                .filter(e -> !isSimpleType(e, path))
                 .forEach(e -> {
+                    String newPath = path + "."  + e.getKey();
                     if (e.getValue() instanceof Map) { // if value is a complex object (map)
                         Map inner = (Map) e.getValue();
-                        fromDocument(inner, node, e.getKey(), nodes, relationships);
+                        fromDocument(inner, node, e.getKey(), nodes, relationships, newPath);
                     } else {
                         List<Map> list = (List) e.getValue(); // if value is and array
-                        list.forEach(map -> fromDocument(map, node, e.getKey(), nodes, relationships));
+                        list.forEach(map -> fromDocument(map, node, e.getKey(), nodes, relationships, newPath));
                     }
                 });
 
-        Set<Node> nodesWithSameIds = getNodesWithSameIds(nodes, idValue);
+        Set<Node> nodesWithSameIds = getNodesWithSameLabels(nodes, labels);
         nodesWithSameIds.add(node);
+
         if (!isRootNode) {
             relationships.addAll(documentRelationBuilder.buildRelation(source, node, type));
         }
@@ -126,49 +172,79 @@ public class DocumentToGraph {
                 .collect(Collectors.joining(StringUtils.LF));
     }
 
-    public void prepareData(Map<String, Object> document) {
+    public void prepareData(Map<String, Object> document, String path) {
         if (config.isGenerateId()) {
-            document.computeIfAbsent(config.getIdField(), key -> UUID.randomUUID().toString());
-        }
-        if (!config.getDefaultLabel().isEmpty()) {
-            document.computeIfAbsent(config.getLabelField(), key -> config.getDefaultLabel());
+            List<String> ids = config.idsForPath(path);
+            String idField;
+            if (ids.isEmpty()) {
+                idField = config.getIdField();
+            } else {
+                idField = ids.get(0);
+            }
+            document.computeIfAbsent(idField, key -> UUID.randomUUID().toString());
         }
     }
 
-    private Set<Node> getNodesWithSameIds(Map<String, Set<Node>> nodes, Object idValue) {
-        return nodes.computeIfAbsent(idValue.toString(), (k) -> new LinkedHashSet<>());
+    private Map<String, Object> filterNodeIdProperties(Map<String, Object> document, String path) {
+        List<String> ids = config.idsForPath(path);
+        Map<String, Object> idMap = new HashMap<>(document);
+        if(ids.isEmpty()) {
+            idMap.keySet().retainAll(Collections.singleton(config.getIdField()));
+        } else {
+            idMap.keySet().retainAll(ids);
+        }
+        return idMap;
     }
 
-    private Node getOrCreateVirtualNode(Map<String, Set<Node>> nodes, Label label, Object idValue) {
-        Set<Node> nodesWithSameIds = getNodesWithSameIds(nodes, idValue);
+    private Map<String, Object> filterNodeIdProperties(Node n, Map<String, Object> idMap) {
+        return n.getProperties(idMap.keySet().toArray(new String[idMap.keySet().size()]));
+    }
+
+    private Set<Node> getNodesWithSameLabels(Map<Set<String>, Set<Node>> nodes, Label[] labels) {
+        Set<String> set = Stream.of(labels).map(Label::name).collect(Collectors.toSet());
+        return nodes.computeIfAbsent(set, (k) -> new LinkedHashSet<>());
+    }
+
+    private Node getOrCreateVirtualNode(Map<Set<String>, Set<Node>> nodes, Label[] labels, Map<String, Object> idValues) {
+        Set<Node> nodesWithSameIds = getNodesWithSameLabels(nodes, labels);
         return nodesWithSameIds
                 .stream()
                 .filter(n -> {
-                    if (n.hasLabel(label)) {
-                        return true;
+                    if (Stream.of(labels).anyMatch(label -> n.hasLabel(label))) {
+                        Map<String, Object> ids = filterNodeIdProperties(n, idValues);
+                        return idValues.equals(ids);
                     }
                     return StreamSupport.stream(n.getRelationships().spliterator(), false)
-                            .anyMatch(r -> r.getOtherNode(n).hasLabel(label));
+                            .anyMatch(r -> {
+                                Node otherNode = r.getOtherNode(n);
+                                Map<String, Object> ids = filterNodeIdProperties(otherNode, idValues);
+                                return Stream.of(labels).anyMatch(label -> otherNode.hasLabel(label)) && idValues.equals(ids);
+                            });
                 })
                 .findFirst()
-                .orElse(new VirtualNode(new Label[]{label}, Collections.emptyMap(), db));
+                .orElseGet(() -> new VirtualNode(labels, Collections.emptyMap(), db));
     }
 
-    private Node getOrCreateRealNode(Label label, Object idValue) {
-        Node nodeInDB = db.findNode(label, config.getIdField(), idValue);
-        return nodeInDB != null ? nodeInDB : db.createNode(label);
+    private Node getOrCreateRealNode(Label[] labels, Map<String, Object> idValues) {
+        return Stream.of(labels)
+                .map(label -> db.findNodes(label, idValues))
+                .filter(it -> it.hasNext())
+                .map(it -> it.next())
+                .findFirst()
+                .orElseGet(() -> db.createNode(labels));
     }
 
-    private boolean isSimpleType(Map.Entry<String, Object> e) {
+    private boolean isSimpleType(Map.Entry<String, Object> e, String path) {
+        List<String> valueObjects = config.valueObjectForPath(path);
         if (e.getValue() instanceof Map) {
-            return false;
+            return valueObjects.contains(e.getKey());
         }
         if (e.getValue() instanceof List) {
             List list = (List) e.getValue();
             if (!list.isEmpty()) {
                 Object object = list.get(0); // assumption: homogeneous array
                 if (object instanceof Map) { // if is an array of complex type
-                    return false;
+                    return false; // TODO add support for array of value objects
                 }
             }
         }
@@ -190,9 +266,9 @@ public class DocumentToGraph {
 
     public VirtualGraph create(Object documentObj) {
         Collection<Map<String, Object>> coll = getDocumentCollection(documentObj);
-        Map<String, Set<Node>> nodes = new LinkedHashMap<>();
+        Map<Set<String>, Set<Node>> nodes = new LinkedHashMap<>();
         Set<Relationship> relationships = new LinkedHashSet<>();
-        coll.forEach(map -> fromDocument(map, null, null, nodes, relationships));
+        coll.forEach(map -> fromDocument(map, null, null, nodes, relationships, JSON_ROOT));
         return new VirtualGraph("Graph", nodes.values().stream().flatMap(Set::stream).collect(Collectors.toCollection(LinkedHashSet::new)), relationships, Collections.emptyMap());
     }
 
@@ -233,14 +309,38 @@ public class DocumentToGraph {
                 .flatMap(e -> flatMapFields((Map<String, Object>) e)));
     }
 
+    private Map<String, List<Map<String, Object>>> flatMapFieldsWithPath(Map<String, Object> map, String path) {
+        Map<String, List<Map<String, Object>>> flatWithPath = new HashMap<>();
+        String newPath = path == null ? JSON_ROOT : path;
+        flatWithPath.computeIfAbsent(newPath, e -> new ArrayList<>()).add(map);
+        Map<String, List<Map<String, Object>>> collect = map.entrySet()
+                .stream()
+                .filter(e -> !isSimpleType(e, path))
+                .flatMap(e -> {
+                    String subPath = newPath + "." + e.getKey();
+                    if (e.getValue() instanceof Map) {
+                        return flatMapFieldsWithPath((Map<String, Object>) e.getValue(), subPath).entrySet().stream();
+                    } else {
+                        List<Map<String, Object>> list = (List<Map<String, Object>>) e.getValue();
+                        return list.stream().flatMap(le -> flatMapFieldsWithPath(le, subPath).entrySet().stream());
+                    }
+                })
+                .flatMap(e -> e.getValue().stream().map(ee -> new AbstractMap.SimpleEntry<>(e.getKey(), ee)))
+                .collect(Collectors.groupingBy(e -> e.getKey(),
+                        Collectors.mapping(e -> e.getValue(), Collectors.toList())));
+        flatWithPath.putAll(collect);
+
+        return flatWithPath;
+    }
+
     public Map<Long, String> validate(Object doc) {
         AtomicLong index = new AtomicLong(-1);
         return getDocumentCollection(doc).stream()
                 .map(elem -> {
                     long line = index.incrementAndGet();
-                    prepareData(elem);
+                    prepareData(elem, JSON_ROOT);
                     // id, label validation
-                    Map<Map<String, Object>, List<String>> errors = validate(elem);
+                    Map<Map<String, Object>, List<String>> errors = validate(elem, JSON_ROOT);
                     if (errors.isEmpty()) {
                         return null;
                     } else {

--- a/src/main/java/apoc/graph/document/builder/LabelBuilder.java
+++ b/src/main/java/apoc/graph/document/builder/LabelBuilder.java
@@ -3,6 +3,8 @@ package apoc.graph.document.builder;
 import apoc.graph.util.GraphsConfig;
 import org.neo4j.graphdb.Label;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.commons.text.WordUtils.capitalizeFully;
@@ -15,18 +17,17 @@ public class LabelBuilder {
         this.config = config;
     }
 
-    public Label buildLabel(Map<String, Object> obj) {
-        String label = "";
+    public Label[] buildLabel(Map<String, Object> obj, String path) {
+        List<String> rawLabels = new ArrayList<>();
 
-        Object type = obj.get(config.getLabelField());
-        if (type != null) {
-            label = String.valueOf(type);
-            label = capitalizeFully(label, '_', ' ')
-                    .replaceAll("_", "")
-                    .replaceAll(" ", "");
+        if (obj.containsKey(config.getLabelField())) {
+            rawLabels.add(obj.get(config.getLabelField()).toString());
         }
-
-        return Label.label(label);
+        rawLabels.addAll(config.labelsForPath(path));
+        return rawLabels.stream().map(label -> Label.label(capitalizeFully(label, '_', ' ')
+                .replaceAll("_", "")
+                .replaceAll(" ", "")))
+                .toArray(Label[]::new);
     }
 
 }

--- a/src/main/java/apoc/graph/util/GraphsConfig.java
+++ b/src/main/java/apoc/graph/util/GraphsConfig.java
@@ -1,17 +1,110 @@
 package apoc.graph.util;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static apoc.util.Util.toBoolean;
 
 public class GraphsConfig {
+
+    private static final Pattern MAPPING_PATTERN = Pattern.compile("^(\\w+\\s*(?::\\s*(?:\\w+)\\s*)*)\\s*(?:\\{\\s*(-?[\\*\\w!@\\.]+\\s*(?:,\\s*-?[!@\\w\\*\\.]+\\s*)*)\\})?$");
+
+    public static class GraphMapping {
+
+        private static final String IDS = "ids";
+        private static final String VALUE_OBJECTS = "valueObjects";
+        private static final String PROPERTIES = "properties";
+        private static final String WILDCARD = "*";
+
+        private List<String> valueObjects = new ArrayList<>();
+        private List<String> ids = new ArrayList<>();
+        private List<String> properties = new ArrayList<>();
+        private List<String> labels = new ArrayList<>();
+
+        private boolean allProps = true;
+
+        static final GraphMapping EMPTY = new GraphMapping();
+
+        GraphMapping(List<String> valueObjects, List<String> ids, List<String> properties, List<String> labels, boolean allProps) {
+            this.allProps = allProps;
+            if (valueObjects != null) this.valueObjects.addAll(valueObjects);
+            if (ids != null) this.ids.addAll(ids);
+            if (labels != null) this.labels.addAll(labels);
+            if (!this.allProps) {
+                if (properties != null) this.properties.addAll(properties);
+                this.properties.addAll(this.ids);
+                this.properties.addAll(this.valueObjects);
+            }
+        }
+
+        GraphMapping() {}
+
+        public List<String> getValueObjects() {
+            return valueObjects;
+        }
+
+        public List<String> getIds() {
+            return ids;
+        }
+
+        public List<String> getProperties() {
+            return properties;
+        }
+
+        public List<String> getLabels() {
+            return labels;
+        }
+
+        public boolean isAllProps() {
+            return allProps;
+        }
+
+        public static GraphMapping from(String pattern) {
+            Matcher matcher = MAPPING_PATTERN.matcher(pattern);
+            if (!matcher.matches()) {
+                throw new RuntimeException("The provided pattern " + pattern + " does not match the requirements");
+            }
+            List<String> labels = Arrays.asList(matcher.group(1).split(":"));
+            AtomicBoolean allProps = new AtomicBoolean(false);
+            Map<String, List<String>> map = Stream.of(matcher.group(2).split(","))
+                    .map(s -> {
+                        String value = s.trim();
+                        String key;
+                        if (value.startsWith("@")) {
+                            key = VALUE_OBJECTS;
+                            value = value.substring(1);
+                        } else if (value.startsWith("!")) {
+                            key = IDS;
+                            value = value.substring(1);
+                        } else {
+                            key = PROPERTIES;
+                        }
+                        if (WILDCARD.equals(value) && key.equals(PROPERTIES)) {
+                            allProps.set(true);
+                            return null;
+                        } else {
+                            return new AbstractMap.SimpleEntry<>(key, value);
+                        }
+                    })
+                    .filter(e -> e != null)
+                    .collect(Collectors.groupingBy(Map.Entry::getKey,
+                            Collectors.mapping(Map.Entry::getValue, Collectors.toList())));
+            return new GraphMapping(map.get(VALUE_OBJECTS), map.get(IDS), map.get(PROPERTIES), labels, allProps.get());
+        }
+    }
 
     private boolean write;
     private String labelField;
     private String idField;
     private boolean generateId;
     private String defaultLabel;
+    private Map<String, GraphMapping> mappings;
+
+    private boolean skipValidation;
 
     public GraphsConfig(Map<String, Object> config) {
         if (config == null) {
@@ -22,6 +115,14 @@ public class GraphsConfig {
         idField = config.getOrDefault("idField", "id").toString();
         labelField = config.getOrDefault("labelField", "type").toString();
         defaultLabel = config.getOrDefault("defaultLabel", "DocNode").toString();
+        mappings = toMappings((Map<String, String>) config.getOrDefault("mappings", Collections.emptyMap()));
+        skipValidation = toBoolean(config.getOrDefault("skipValidation", false));
+    }
+
+    private Map<String, GraphMapping> toMappings(Map<String, String> mappings) {
+        return mappings.entrySet().stream()
+                .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), GraphMapping.from(e.getValue())))
+                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
     }
 
     public boolean isWrite() {
@@ -42,5 +143,29 @@ public class GraphsConfig {
 
     public String getDefaultLabel() {
         return defaultLabel;
+    }
+
+    public boolean isSkipValidation() {
+        return skipValidation;
+    }
+
+    public List<String> valueObjectForPath(String path) {
+        return mappings.getOrDefault(path, GraphMapping.EMPTY).getValueObjects();
+    }
+
+    public List<String> idsForPath(String path) {
+        return mappings.getOrDefault(path, GraphMapping.EMPTY).getIds();
+    }
+
+    public List<String> labelsForPath(String path) {
+        return mappings.getOrDefault(path, GraphMapping.EMPTY).getLabels();
+    }
+
+    public List<String> propertiesForPath(String path) {
+        return mappings.getOrDefault(path, GraphMapping.EMPTY).getProperties();
+    }
+
+    public boolean allPropertiesForPath(String path) {
+        return mappings.getOrDefault(path, GraphMapping.EMPTY).isAllProps();
     }
 }

--- a/src/main/java/apoc/util/Util.java
+++ b/src/main/java/apoc/util/Util.java
@@ -748,4 +748,29 @@ public class Util {
         }
         return separator.charAt(0);
     }
+
+    public static Map<String, Object> flattenMap(Map<String, Object> map) {
+        return flattenMap(map, null);
+    }
+
+    public static Map<String, Object> flattenMap(Map<String, Object> map, String prefix) {
+        return map.entrySet().stream()
+                .flatMap(entry -> {
+                    String key;
+                    if (prefix != null && !prefix.isEmpty()) {
+                        key = prefix + "." + entry.getKey();
+                    } else {
+                        key = entry.getKey();
+                    }
+                    Object value = entry.getValue();
+                    if (value instanceof Map) {
+                        return flattenMap((Map<String, Object>) value, key).entrySet().stream();
+                    } else {
+                        Map.Entry<String, Object> newEntry = new AbstractMap.SimpleEntry(key, entry.getValue());
+                        return Stream.of(newEntry);
+                    }
+                })
+                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
+    }
+
 }

--- a/src/test/java/apoc/graph/GraphsTest.java
+++ b/src/test/java/apoc/graph/GraphsTest.java
@@ -1,5 +1,6 @@
 package apoc.graph;
 
+import apoc.graph.util.GraphsConfig;
 import apoc.util.JsonUtil;
 import apoc.util.TestUtil;
 import apoc.util.Util;
@@ -20,6 +21,7 @@ import static java.util.Arrays.asList;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertArrayEquals;
 import static org.neo4j.graphdb.Label.label;
 
 /**
@@ -137,14 +139,16 @@ public class GraphsTest {
             Iterator<Node> nodeIterator = nodes.iterator();
             Iterator<Relationship> relationshipIterator = relationships.iterator();
 
-            Node albumGenesis = nodeIterator.next();
-            assertEquals(asList(label("Album")), albumGenesis.getLabels());
-            assertTrue(albumGenesis.getId() < 0);
-            assertEquals(albumGenesisMap, albumGenesis.getAllProperties());
             Node artistGenesis = nodeIterator.next();
             assertEquals(asList(label("Artist")), artistGenesis.getLabels());
             assertTrue(artistGenesis.getId() < 0);
             assertEquals(artistGenesisMap, artistGenesis.getAllProperties());
+
+            Node albumGenesis = nodeIterator.next();
+            assertEquals(asList(label("Album")), albumGenesis.getLabels());
+            assertTrue(albumGenesis.getId() < 0);
+            assertEquals(albumGenesisMap, albumGenesis.getAllProperties());
+
             Relationship rel = relationshipIterator.next();
             assertEquals(RelationshipType.withName("ALBUMS"), rel.getType());
             assertTrue(rel.getId() < 0);
@@ -184,26 +188,30 @@ public class GraphsTest {
                     Iterator<Node> nodeIterator = nodes.iterator();
                     Iterator<Relationship> relationshipIterator = relationships.iterator();
 
-                    Node albumGenesis = nodeIterator.next();
-                    assertEquals(asList(label("Album")), albumGenesis.getLabels());
-                    assertTrue(albumGenesis.getId() < 0);
-                    assertEquals(albumGenesisMap, albumGenesis.getAllProperties());
                     Node artistGenesis = nodeIterator.next();
                     assertEquals(asList(label("Artist")), artistGenesis.getLabels());
                     assertTrue(artistGenesis.getId() < 0);
                     assertEquals(artistGenesisMap, artistGenesis.getAllProperties());
-                    Relationship rel = relationshipIterator.next();
-                    assertEquals(RelationshipType.withName("ALBUMS"), rel.getType());
-                    assertTrue(rel.getId() < 0);
+
+                    Node artistDaftPunk = nodeIterator.next();
+                    assertEquals(asList(label("Artist")), artistDaftPunk.getLabels());
+                    assertTrue(artistDaftPunk.getId() < 0);
+                    assertEquals(artistDaftPunkMap, artistDaftPunk.getAllProperties());
+
+                    Node albumGenesis = nodeIterator.next();
+                    assertEquals(asList(label("Album")), albumGenesis.getLabels());
+                    assertTrue(albumGenesis.getId() < 0);
+                    assertEquals(albumGenesisMap, albumGenesis.getAllProperties());
 
                     Node albumDaftPunk = nodeIterator.next();
                     assertEquals(asList(label("Album")), albumDaftPunk.getLabels());
                     assertTrue(albumDaftPunk.getId() < 0);
                     assertEquals(albumDaftPunkMap, albumDaftPunk.getAllProperties());
-                    Node artistDaftPunk = nodeIterator.next();
-                    assertEquals(asList(label("Artist")), artistDaftPunk.getLabels());
-                    assertTrue(artistDaftPunk.getId() < 0);
-                    assertEquals(artistDaftPunkMap, artistDaftPunk.getAllProperties());
+
+                    Relationship rel = relationshipIterator.next();
+                    assertEquals(RelationshipType.withName("ALBUMS"), rel.getType());
+                    assertTrue(rel.getId() < 0);
+
                     rel = relationshipIterator.next();
                     assertEquals(RelationshipType.withName("ALBUMS"), rel.getType());
                     assertTrue(rel.getId() < 0);
@@ -246,27 +254,32 @@ public class GraphsTest {
                     assertEquals(asList(label("Album")), albumGenesis.getLabels());
                     assertTrue(albumGenesis.getId() > 0);
                     assertEquals(albumGenesisMap, albumGenesis.getAllProperties());
-                    Node artistGenesis = nodeIterator.next();
-                    assertEquals(asList(label("Artist")), artistGenesis.getLabels());
-                    assertTrue(artistGenesis.getId() > 0);
-                    assertEquals(artistGenesisMap, artistGenesis.getAllProperties());
-                    Relationship rel = relationshipIterator.next();
-                    assertEquals("ALBUMS", rel.getType().name());
-                    assertTrue(rel.getId() > 0);
 
                     Node albumDaftPunk = nodeIterator.next();
                     assertEquals(asList(label("Album")), albumDaftPunk.getLabels());
                     assertTrue(albumDaftPunk.getId() > 0);
                     assertEquals(albumDaftPunkMap, albumDaftPunk.getAllProperties());
+
+                    Node artistGenesis = nodeIterator.next();
+                    assertEquals(asList(label("Artist")), artistGenesis.getLabels());
+                    assertTrue(artistGenesis.getId() > 0);
+                    assertEquals(artistGenesisMap, artistGenesis.getAllProperties());
+
                     Node artistDaftPunk = nodeIterator.next();
                     assertEquals(asList(label("Artist")), artistDaftPunk.getLabels());
                     assertTrue(artistDaftPunk.getId() > 0);
                     assertEquals(artistDaftPunkMap, artistDaftPunk.getAllProperties());
+
+                    Relationship rel = relationshipIterator.next();
+                    assertEquals("ALBUMS", rel.getType().name());
+                    assertTrue(rel.getId() > 0);
                     rel = relationshipIterator.next();
                     assertEquals("ALBUMS", rel.getType().name());
                     assertTrue(rel.getId() > 0);
                 });
         db.execute("MATCH p = (a:Artist)-[r:ALBUMS]->(b:Album) detach delete p").close();
+        long count = db.execute("MATCH p = (a:Artist)-[r:ALBUMS]->(b:Album) RETURN count(p) AS count").<Long>columnAs("count").next();
+        assertEquals(0L, count);
     }
 
     @Test
@@ -290,14 +303,16 @@ public class GraphsTest {
                     Iterator<Node> nodeIterator = nodes.iterator();
                     Iterator<Relationship> relationshipIterator = relationships.iterator();
 
-                    Node albumGenesis = nodeIterator.next();
-                    assertEquals(asList(label("Album")), albumGenesis.getLabels());
-                    assertTrue(albumGenesis.getId() < 0);
-                    assertEquals(albumMap, albumGenesis.getAllProperties());
                     Node artistGenesis = nodeIterator.next();
                     assertEquals(asList(label("Artist")), artistGenesis.getLabels());
                     assertTrue(artistGenesis.getId() < 0);
                     assertEquals(genesisMap, artistGenesis.getAllProperties());
+
+                    Node albumGenesis = nodeIterator.next();
+                    assertEquals(asList(label("Album")), albumGenesis.getLabels());
+                    assertTrue(albumGenesis.getId() < 0);
+                    assertEquals(albumMap, albumGenesis.getAllProperties());
+
                     Relationship rel = relationshipIterator.next();
                     assertEquals(RelationshipType.withName("ALBUMS"), rel.getType());
                     assertTrue(rel.getId() < 0);
@@ -324,14 +339,16 @@ public class GraphsTest {
                     Iterator<Node> nodeIterator = nodes.iterator();
                     Iterator<Relationship> relationshipIterator = relationships.iterator();
 
-                    Node albumGenesis = nodeIterator.next();
-                    assertEquals(asList(label("Album")), albumGenesis.getLabels());
-                    assertTrue(albumGenesis.getId() < 0);
-                    assertEquals(albumMap, albumGenesis.getAllProperties());
                     Node artistGenesis = nodeIterator.next();
                     assertEquals(asList(label("Artist")), artistGenesis.getLabels());
                     assertTrue(artistGenesis.getId() < 0);
                     assertEquals(genesisMap, artistGenesis.getAllProperties());
+
+                    Node albumGenesis = nodeIterator.next();
+                    assertEquals(asList(label("Album")), albumGenesis.getLabels());
+                    assertTrue(albumGenesis.getId() < 0);
+                    assertEquals(albumMap, albumGenesis.getAllProperties());
+
                     Relationship rel = relationshipIterator.next();
                     assertEquals(RelationshipType.withName("ALBUMS"), rel.getType());
                     assertTrue(rel.getId() < 0);
@@ -371,6 +388,8 @@ public class GraphsTest {
                     assertTrue(rel.getId() > 0);
                 });
         db.execute("MATCH p = (a:Artist)-[r:ALBUMS]->(b:Album) detach delete p").close();
+        long count = db.execute("MATCH p = (a:Artist)-[r:ALBUMS]->(b:Album) RETURN count(p) AS count").<Long>columnAs("count").next();
+        assertEquals(0L, count);
     }
 
     @Test(expected = RuntimeException.class)
@@ -461,11 +480,6 @@ public class GraphsTest {
                     Iterator<Node> nodeIterator = nodes.iterator();
                     Iterator<Relationship> relationshipIterator = relationships.iterator();
 
-                    Node product = nodeIterator.next();
-                    assertEquals(asList(label("Console")), product.getLabels());
-                    assertTrue(product.getId() < 0);
-                    assertEquals(productMap, product.getAllProperties());
-
                     Node john = nodeIterator.next();
                     assertEquals(asList(label("User")), john.getLabels());
                     assertTrue(john.getId() < 0);
@@ -475,6 +489,11 @@ public class GraphsTest {
                     assertEquals(asList(label("User")), jane.getLabels());
                     assertTrue(jane.getId() < 0);
                     assertEquals(janeMap, jane.getAllProperties());
+
+                    Node product = nodeIterator.next();
+                    assertEquals(asList(label("Console")), product.getLabels());
+                    assertTrue(product.getId() < 0);
+                    assertEquals(productMap, product.getAllProperties());
 
                     Relationship rel = relationshipIterator.next();
                     Node startJohn = rel.getStartNode();
@@ -523,20 +542,20 @@ public class GraphsTest {
                     Iterator<Node> nodeIterator = nodes.iterator();
                     Iterator<Relationship> relationshipIterator = relationships.iterator();
 
-                    Node robert = nodeIterator.next();
-                    assertEquals(asList(label("Person")), robert.getLabels());
-                    assertTrue(robert.getId() < 0);
-                    assertEquals(robertMap, robert.getAllProperties());
+                    Node john = nodeIterator.next();
+                    assertEquals(asList(label("Father")), john.getLabels());
+                    assertTrue(john.getId() < 0);
+                    assertEquals(johnMap, john.getAllProperties());
 
                     Node james = nodeIterator.next();
                     assertEquals(asList(label("Father")), james.getLabels());
                     assertTrue(james.getId() < 0);
                     assertEquals(jamesMap, james.getAllProperties());
 
-                    Node john = nodeIterator.next();
-                    assertEquals(asList(label("Father")), john.getLabels());
-                    assertTrue(john.getId() < 0);
-                    assertEquals(johnMap, john.getAllProperties());
+                    Node robert = nodeIterator.next();
+                    assertEquals(asList(label("Person")), robert.getLabels());
+                    assertTrue(robert.getId() < 0);
+                    assertEquals(robertMap, robert.getAllProperties());
 
                     Relationship rel = relationshipIterator.next();
                     assertEquals(RelationshipType.withName("SON"), rel.getType());
@@ -572,6 +591,8 @@ public class GraphsTest {
                     assertEquals(1L, res.get("count"));
                 });
         db.execute("MATCH p = (a:User)-[r:BOUGHT]->(c:Console)<-[r1:BOUGHT]-(b:User) detach delete p").close();
+        long count = db.execute("MATCH p = (a:User)-[r:BOUGHT]->(c:Console)<-[r1:BOUGHT]-(b:User) RETURN count(p) AS count").<Long>columnAs("count").next();
+        assertEquals(0L, count);
     }
 
     @Test(expected = RuntimeException.class)
@@ -665,14 +686,14 @@ public class GraphsTest {
                     assertEquals(2, relationships.size());
                     Iterator<Node> nodeIterator = nodes.iterator();
                     Iterator<Relationship> relationshipIterator = relationships.iterator();
-                    Node album = nodeIterator.next();
-                    assertEquals(asList(label("Album")), album.getLabels());
-                    assertTrue(album.getId() < 0);
-                    assertEquals(album1Map, album.getAllProperties());
                     Node artist = nodeIterator.next();
                     assertEquals(asList(label("Artist")), artist.getLabels());
                     assertTrue(artist.getId() < 0);
                     assertEquals(genesisMap, artist.getAllProperties());
+                    Node album = nodeIterator.next();
+                    assertEquals(asList(label("Album")), album.getLabels());
+                    assertTrue(album.getId() < 0);
+                    assertEquals(album1Map, album.getAllProperties());
                     Node album2 = nodeIterator.next();
                     assertEquals(asList(label("Album")), album2.getLabels());
                     assertTrue(album2.getId() < 0);
@@ -705,11 +726,10 @@ public class GraphsTest {
                     assertEquals(genesisMap.get("type"), artist.getProperty("type"));
                     assertEquals(genesisMap.get("name"), artist.getProperty("name"));
                     assertEquals(genesisMap.get("id"), artist.getProperty("id"));
-                    Arrays.equals((Long[]) genesisMap.get("years"), (Long[]) artist.getProperty("years"));
-                    Arrays.equals((String[]) genesisMap.get("members"), (String[]) artist.getProperty("members"));
+                    assertArrayEquals((Long[]) genesisMap.get("years"), (Long[]) artist.getProperty("years"));
+                    assertArrayEquals((String[]) genesisMap.get("members"), (String[]) artist.getProperty("members"));
                 });
     }
-
 
     @Test
     public void shouldFindDuplicatesWithValidation() {
@@ -771,4 +791,80 @@ public class GraphsTest {
                 });
     }
 
+    @Test
+    public void shouldCreateTheGraphMappingObjectAccordingToThePattern() {
+        GraphsConfig.GraphMapping mapping = GraphsConfig.GraphMapping.from("Person{*,@sizes}");
+        assertEquals(Arrays.asList("sizes"), mapping.getValueObjects());
+        assertEquals(Collections.emptyList(), mapping.getProperties());
+        assertEquals(Collections.emptyList(), mapping.getIds());
+        assertTrue(mapping.isAllProps());
+        assertEquals(Arrays.asList("Person"), mapping.getLabels());
+
+        mapping = GraphsConfig.GraphMapping.from("Book{!title, released}");
+        assertEquals(Collections.emptyList(), mapping.getValueObjects());
+        assertEquals(Arrays.asList("released", "title"), mapping.getProperties());
+        assertEquals(Arrays.asList("title"), mapping.getIds());
+        assertEquals(Arrays.asList("Book"), mapping.getLabels());
+        assertFalse(mapping.isAllProps());
+    }
+
+    @Test
+    public void shouldCreateFlattenValueObjectAndNewNodes() {
+        String[] strings = {"foo", "bar"};
+        Map<String, Object> book1 = map("title", "Flow My Tears, the Policeman Said", "released", 1974);
+        Map<String, Object> book2 = map("title", "The man in the High Castle", "released", 1962);
+        Map<String, Object> inputMap = map("id", 1, "type", "Person", "name", "Andrea",
+                "sizes", map("weight", map("value", 70, "um", "Kg"), "height", map("value", 174, "um", "cm"),
+                        "array", strings),
+                "books", Arrays.asList(book1,book2)
+        );
+        Map<String, Object> expectedMap = map("id", 1, "type", "Person", "name", "Andrea",
+                "sizes.weight.value", 70, "sizes.weight.um", "Kg", "sizes.height.value", 174, "sizes.height.um", "cm");
+
+        TestUtil.testResult(db, "CALL apoc.graph.fromDocument({json}, {config}) yield graph",
+                Util.map("json", inputMap, "config", map("mappings", map("$", "Person:Reader{*,@sizes}", "$.books", "Book{!title, released}"))), result -> {
+                    Map<String, Object> map = result.next();
+                    assertEquals("Graph", ((Map) map.get("graph")).get("name"));
+                    Collection<Node> nodes = (Collection<Node>) ((Map) map.get("graph")).get("nodes");
+                    Collection<Relationship> rels = (Collection<Relationship>) ((Map) map.get("graph")).get("relationships");
+                    assertEquals(3, nodes.size());
+                    assertEquals(2, rels.size());
+                    Iterator<Node> nodeIterator = nodes.iterator();
+                    Iterator<Relationship> relationshipIterator = rels.iterator();
+
+                    Node person = nodeIterator.next();
+                    assertEquals(asList(label("Person"), label("Reader")), person.getLabels());
+                    assertTrue(person.getId() < 0);
+                    Map<String, Object> allProperties = new HashMap<>(person.getAllProperties());
+                    allProperties.remove("sizes.array"); // we test only non-array properties
+                    assertEquals(expectedMap, allProperties);
+                    assertArrayEquals(strings, (String[]) person.getProperty("sizes.array"));
+
+                    Node book1Node = nodeIterator.next();
+                    assertEquals(asList(label("Book")), book1Node.getLabels());
+                    assertTrue(book1Node.getId() < 0);
+                    allProperties = book1Node.getAllProperties();
+                    assertEquals(book1, allProperties);
+
+                    Node book2Node = nodeIterator.next();
+                    assertEquals(asList(label("Book")), book2Node.getLabels());
+                    assertTrue(book2Node.getId() < 0);
+                    allProperties = book2Node.getAllProperties();
+                    assertEquals(book2, allProperties);
+
+                    Relationship rel = relationshipIterator.next();
+                    assertEquals(RelationshipType.withName("BOOKS"), rel.getType());
+                    assertTrue(rel.getId() < 0);
+                    assertEquals(person, rel.getStartNode());
+                    assertEquals(book1Node, rel.getEndNode());
+
+                    rel = relationshipIterator.next();
+                    assertEquals(RelationshipType.withName("BOOKS"), rel.getType());
+                    assertTrue(rel.getId() < 0);
+                    assertEquals(person, rel.getStartNode());
+                    assertEquals(book2Node, rel.getEndNode());
+
+                    assertFalse("should not have next", result.hasNext());
+                });
+    }
 }


### PR DESCRIPTION
Fixes #1245

Add support to store value object via `valueObjects` map. The properties of the value objects will be flattened with this general rule:

A json like this:
```json
{
    "id": 1,
    "type": "Person",
    "name": "Andrea",
    "sizes": {
        "weight": {
            "value": 70,
            "um": "Kg"
        },
        "height": {
            "value": 174,
            "um": "cm"
        }
    }
}
```

Will be flattened as follows:

```json
{
    "id": 1,
    "type": "Person",
    "name": "Andrea",
    "sizes.weight.value": 70,
    "sizes.weight.um": "Kg",
    "sizes.height.value": 174,
    "sizes.height.um": "cm"
}
```

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

 - added the support via the property configuration `valueObjects`
 - updated the documentation
