### PR TITLE
fixes #1187: 3.5.x apoc.schema.nodes fails

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ description = """neo4j-apoc-procedures"""
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "3.5.3"
+    neo4jVersion = "3.5.7"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.11.0'


### PR DESCRIPTION
Fixes #1187 

The tests of `apoc.schema.nodes` were all green; only when deployed the error pops up.
I tested with a running instance of neo4j 3.5.3 but with the error is still there, with this bump it starts working from v 3.5.4

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - bump Neo4j version to `3.5.7` (the latest)