### PR TITLE
Upgraded com.jayway.jsonpath:json-path from version 2.2.0 to 2.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     compile group: 'commons-codec', name: 'commons-codec', version: '1.9'
     compileOnly group: 'com.sun.mail', name: 'javax.mail', version: '1.6.0'
     testCompile group: 'com.sun.mail', name: 'javax.mail', version: '1.6.0'
-    compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.2.0'
+    compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
     compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
     compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '1.7.3'
     compile group: 'com.novell.ldap', name: 'jldap', version: '2009-10-07'


### PR DESCRIPTION
## Proposed Changes (Mandatory)

Upgraded com.jayway.jsonpath:json-path from version 2.2.0 to 2.4.0 as the older version comes with a dependency to net.minidev:accessors-smart (version 1.1) which contains a shaded but outdated version of ASM, see https://github.com/netplex/json-smart-v2/pull/35. 

(caused troubles using Neo4j/APOC embedded in jQAssistant)
 