### PR TITLE
Fixed path expander node filters with respect to filterStartNode and minLevel

### DIFF
--- a/docs/asciidoc/path-finding/expand.adoc
+++ b/docs/asciidoc/path-finding/expand.adoc
@@ -176,6 +176,16 @@ Each of these config parameter accepts a list of nodes, or a list of node ids.
 | blacklistNodes | None of the paths returned will include these nodes. | Spring 2018 APOC releases.
 |===
 
+==== Updated behavior for Fall 2019 releases
+
+The node filters behavior will now more closely match those of the label filters, with respect to the `filterStartNode` and `minLevel` config options.
+
+1. None of the filters will apply to the start node in any way when `filterStartNode=false`.
+
+2. The `endNodes` and `terminatorNodes` filters will not apply when evaluating nodes below the configured `minLevel`.
+(`blacklistNodes` and `whitelistNodes` will continue to apply in all cases, excepting the above mentioned case of the start node when `filterStartNode=false`)
+
+
 === Expand paths
 
 Expand from start node following the given relationships from min to max-level adhering to the label filters. Several variations exist:

--- a/src/main/java/apoc/path/PathExplorer.java
+++ b/src/main/java/apoc/path/PathExplorer.java
@@ -277,10 +277,10 @@ public class PathExplorer {
 			}
 
 			if (!blacklistNodes.isEmpty()) {
-				td = td.evaluator(NodeEvaluators.blacklistNodeEvaluator(blacklistNodes));
+				td = td.evaluator(NodeEvaluators.blacklistNodeEvaluator(filterStartNode, (int) minLevel, blacklistNodes));
 			}
 
-			Evaluator endAndTerminatorNodeEvaluator = NodeEvaluators.endAndTerminatorNodeEvaluator(endNodes, terminatorNodes);
+			Evaluator endAndTerminatorNodeEvaluator = NodeEvaluators.endAndTerminatorNodeEvaluator(filterStartNode, (int) minLevel, endNodes, terminatorNodes);
 			if (endAndTerminatorNodeEvaluator != null) {
 				td = td.evaluator(endAndTerminatorNodeEvaluator);
 			}
@@ -289,7 +289,7 @@ public class PathExplorer {
 				// ensure endNodes and terminatorNodes are whitelisted
 				whitelistNodes.addAll(endNodes);
 				whitelistNodes.addAll(terminatorNodes);
-				td = td.evaluator(NodeEvaluators.whitelistNodeEvaluator(whitelistNodes));
+				td = td.evaluator(NodeEvaluators.whitelistNodeEvaluator(filterStartNode, (int) minLevel, whitelistNodes));
 			}
 		}
 


### PR DESCRIPTION
Fixes #1289 

Updates path expander node filter behavior to match existing label filter behavior with respect to `filterStartNode` and `minLevel`

## Proposed Changes (Mandatory)

1. Node filters will no longer apply in any way to the start node when `filterStartNode:false` in the config parameters. 

2. `endNodes` and `terminatorNodes` will not apply when evaluating nodes below the configured `minLevel`.  

`whitelistNodes` and `blacklistNodes` will continue to apply to every node in the path regardless of `minLevel`, excepting the case mentioned above when evaluating the start node when `filterStartNode:false`.