### PR TITLE
Allow minLevel of 1 in subgraphNodes(), subgraphAll(), and spanningTree()

### DIFF
--- a/docs/asciidoc/path-finding/expand-spanning-tree.adoc
+++ b/docs/asciidoc/path-finding/expand-spanning-tree.adoc
@@ -7,13 +7,13 @@ This section describes a procedure that finds a spanning tree that starts from a
 --
 
 ----
-apoc.path.spanningTree(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit:-1, optional:false}) yield path
+apoc.path.spanningTree(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit:-1, optional:false}) yield path
 ----
 
 Expand a spanning tree reachable from start node following relationships to max-level adhering to the label filters.
 The paths returned collectively form a spanning tree.
 
-Accepts the same `config` values as in `expandConfig()`, though `uniqueness` and `minLevel` are not configurable.
+Accepts the same `config` values as in `expandConfig()`, though `uniqueness` is not configurable and `minLevel`, if present, must be 0 or 1.
 
 .Example
 

--- a/docs/asciidoc/path-finding/expand-subgraph.adoc
+++ b/docs/asciidoc/path-finding/expand-subgraph.adoc
@@ -7,13 +7,13 @@ This section describes a procedure that expands a subgraph from a set of start n
 --
 
 ----
-apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit:-1}) yield nodes, relationships
+apoc.path.subgraphAll(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit:-1}) yield nodes, relationships
 ----
 
 Expand to subgraph nodes reachable from the start node following relationships to max-level adhering to the label filters.
 Returns the collection of nodes in the subgraph, and the collection of relationships between all subgraph nodes.
 
-Accepts the same `config` values as in `expandConfig()`, though `uniqueness` and `minLevel` are not configurable.
+Accepts the same `config` values as in `expandConfig()`, though `uniqueness` is not configurable and `minLevel`, if present, must be 0 or 1.
 
 The `optional` config value isn't needed, as empty lists are yielded if there are no results, so rows are never eliminated.
 

--- a/docs/asciidoc/path-finding/expand.adoc
+++ b/docs/asciidoc/path-finding/expand.adoc
@@ -21,9 +21,9 @@ Variations allow more configurable expansions, and expansions for more specific 
 [cols="1m,5"]
 |===
 | call apoc.path.expandConfig(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, uniqueness:'RELATIONSHIP_PATH', filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, sequence, beginSequenceAtStart:true}) yield path | expand from given nodes(s) taking the provided restrictions into account
-| call apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, sequence, beginSequenceAtStart:true}) yield node | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns all nodes in the subgraph
-| call apoc.path.subgraphAll(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, endNodes, terminatorNodes, sequence, beginSequenceAtStart:true}) yield nodes, relationships | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns the collection of subgraph nodes, and the collection of all relationships within the subgraph
-| call apoc.path.spanningTree(startNode <id>Node/list, {maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, sequence, beginSequenceAtStart:true}) yield path | expand a spanning tree from given nodes(s) taking the provided restrictions into account; the paths returned collectively form a spanning tree
+| call apoc.path.subgraphNodes(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, sequence, beginSequenceAtStart:true}) yield node | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns all nodes in the subgraph
+| call apoc.path.subgraphAll(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, endNodes, terminatorNodes, sequence, beginSequenceAtStart:true}) yield nodes, relationships | expand a subgraph from given nodes(s) taking the provided restrictions into account; returns the collection of subgraph nodes, and the collection of all relationships within the subgraph
+| call apoc.path.spanningTree(startNode <id>Node/list, {minLevel, maxLevel, relationshipFilter, labelFilter, bfs:true, filterStartNode:true, limit, optional:false, endNodes, terminatorNodes, sequence, beginSequenceAtStart:true}) yield path | expand a spanning tree from given nodes(s) taking the provided restrictions into account; the paths returned collectively form a spanning tree
 |===
 
 === Relationship Filter
@@ -507,7 +507,7 @@ apoc.path.subgraphNodes(startNode <id>Node/list, {maxLevel, relationshipFilter, 
 
 Expand to subgraph nodes reachable from the start node following relationships to max-level adhering to the label filters.
 
-Accepts the same `config` values as in `expandConfig()`, though `uniqueness` and `minLevel` are not configurable.
+Accepts the same `config` values as in `expandConfig()`, though `uniqueness` is not configurable and `minLevel`, if present, must be 0 or 1 if present.
 
 .Examples
 

--- a/src/main/java/apoc/path/PathExplorer.java
+++ b/src/main/java/apoc/path/PathExplorer.java
@@ -57,8 +57,8 @@ public class PathExplorer {
 		Map<String, Object> configMap = new HashMap<>(config);
 		configMap.put("uniqueness", "NODE_GLOBAL");
 
-		if (config.containsKey("minLevel")) {
-			throw new IllegalArgumentException("minLevel not supported in subgraphNodes");
+		if (config.containsKey("minLevel") && !config.get("minLevel").equals(0l) && !config.get("minLevel").equals(1l)) {
+			throw new IllegalArgumentException("minLevel can only be 0 or 1 in subgraphNodes()");
 		}
 
 		return expandConfigPrivate(start, configMap).map( path -> path == null ? new NodeResult(null) : new NodeResult(path.endNode()) );
@@ -71,8 +71,8 @@ public class PathExplorer {
 		configMap.remove("optional"); // not needed, will return empty collections anyway if no results
 		configMap.put("uniqueness", "NODE_GLOBAL");
 
-		if (config.containsKey("minLevel")) {
-			throw new IllegalArgumentException("minLevel not supported in subgraphAll");
+		if (config.containsKey("minLevel") && !config.get("minLevel").equals(0l) && !config.get("minLevel").equals(1l)) {
+			throw new IllegalArgumentException("minLevel can only be 0 or 1 in subgraphAll()");
 		}
 
 		List<Node> subgraphNodes = expandConfigPrivate(start, configMap).map( Path::endNode ).collect(Collectors.toList());
@@ -87,8 +87,8 @@ public class PathExplorer {
 		Map<String, Object> configMap = new HashMap<>(config);
 		configMap.put("uniqueness", "NODE_GLOBAL");
 
-		if (config.containsKey("minLevel")) {
-			throw new IllegalArgumentException("minLevel not supported in spanningTree");
+		if (config.containsKey("minLevel") && !config.get("minLevel").equals(0l) && !config.get("minLevel").equals(1l)) {
+			throw new IllegalArgumentException("minLevel can only be 0 or 1 in spanningTree()");
 		}
 
 		return expandConfigPrivate(start, configMap).map( PathResult::new );

--- a/src/test/java/apoc/path/SubgraphTest.java
+++ b/src/test/java/apoc/path/SubgraphTest.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -235,5 +237,85 @@ public class SubgraphTest {
 			assertEquals(subgraph.size(), subgraphNodes.size());
 			assertTrue(subgraph.containsAll(subgraphNodes));
 		});
+	}
+
+	@Test
+	public void testSubgraphNodesAllowsMinLevel0() throws Throwable {
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphNodes(m,{minLevel:0}) yield node return count(distinct node) as cnt";
+		TestUtil.testCall(db, query, (row) -> assertEquals(fullGraphCount, row.get("cnt")));
+	}
+
+	@Test
+	public void testSubgraphNodesAllowsMinLevel1() throws Throwable {
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphNodes(m,{minLevel:1}) yield node return count(distinct node) as cnt";
+		TestUtil.testCall(db, query, (row) -> assertEquals(fullGraphCount - 1, row.get("cnt")));
+	}
+
+	@Test
+	public void testSubgraphNodesErrorsAboveMinLevel1() throws Throwable {
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphNodes(m,{minLevel:2}) yield node return count(distinct node) as cnt";
+		try {
+			db.execute(query);
+		} catch(Throwable t) {
+			assertTrue(TestUtil.hasCauses(t, IllegalArgumentException.class));
+			assertTrue(t.getMessage().contains("minLevel can only be 0 or 1 in subgraphNodes()"));
+			return;
+		}
+
+		fail();
+	}
+
+	@Test
+	public void testSubgraphAllAllowsMinLevel0() throws Throwable {
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphAll(m,{minLevel:0}) yield nodes return size(nodes) as cnt";
+		TestUtil.testCall(db, query, (row) -> assertEquals(fullGraphCount, row.get("cnt")));
+	}
+
+	@Test
+	public void testSubgraphAllAllowsMinLevel1() throws Throwable {
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphAll(m,{minLevel:1}) yield nodes return size(nodes) as cnt";
+		TestUtil.testCall(db, query, (row) -> assertEquals(fullGraphCount - 1, row.get("cnt")));
+	}
+
+	@Test
+	public void testSubgraphAllErrorsAboveMinLevel1() throws Throwable {
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.subgraphAll(m,{minLevel:2}) yield nodes return size(nodes) as cnt";
+		try {
+			Result execute = db.execute(query);
+			while (execute.hasNext()) execute.next();
+			execute.close();
+		} catch(Throwable t) {
+			assertTrue(TestUtil.hasCauses(t, IllegalArgumentException.class));
+			assertTrue(t.getMessage().contains("minLevel can only be 0 or 1 in subgraphAll()"));
+			return;
+		}
+
+		fail();
+	}
+
+	@Test
+	public void testSpanningTreeAllowsMinLevel0() throws Throwable {
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.spanningTree(m,{minLevel:0}) yield path return count(distinct path) as cnt";
+		TestUtil.testCall(db, query, (row) -> assertEquals(fullGraphCount, row.get("cnt")));
+	}
+
+	@Test
+	public void testSpanningTreeAllowsMinLevel1() throws Throwable {
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.spanningTree(m,{minLevel:1}) yield path return count(distinct path) as cnt";
+		TestUtil.testCall(db, query, (row) -> assertEquals(fullGraphCount - 1, row.get("cnt")));
+	}
+
+	@Test
+	public void testSpanningTreeErrorsAboveMinLevel1() throws Throwable {
+		String query = "MATCH (m:Movie {title: 'The Matrix'}) CALL apoc.path.spanningTree(m,{minLevel:2}) yield path return count(distinct path) as cnt";
+		try {
+			db.execute(query);
+		} catch(Throwable t) {
+			assertTrue(TestUtil.hasCauses(t, IllegalArgumentException.class));
+			assertTrue(t.getMessage().contains("minLevel can only be 0 or 1 in spanningTree()"));
+			return;
+		}
+
+		fail();
 	}
 }


### PR DESCRIPTION
Fixes #1293 

Allows `minLevel` to be used in subgraphNodes(), subgraphAll(), and spanningTree() for values of 0 or 1.

## Proposed Changes (Mandatory)
Previously attempts to set this config property triggered an error, since consequences of using minLevel with these NODE_GLOBAL uniqueness procs isn't intuitive and can lead to some unexpected results. minLevel of 1 however only skips the starting node and doesn't do anything surprising, so this now allows it.

A brief list of proposed changes in order to fix the issue:
Allow minLevel values of 0 and 1 for these procs.