### PR TITLE
apoc.datetime.parse like apoc.date.parse but returns a datetime

### DIFF
--- a/src/main/java/apoc/date/Date.java
+++ b/src/main/java/apoc/date/Date.java
@@ -181,6 +181,13 @@ public class Date {
 	}
 
 	@UserFunction
+	@Description("apoc.date.parse('2012-12-23','yyyy-MM-dd') parse date string using the specified format at the specified timezone")
+	public ZonedDateTime parse(@Name("time") String time, @Name(value = "format",defaultValue = DEFAULT_FORMAT) String format, final @Name(value = "timezone", defaultValue = "UTC") String timezone) {
+		Long value = parseOrThrow(time, getFormat(format, timezone));
+		return value == null ? null : Instant.ofEpochMilli(value).atZone(ZoneId.of(timezone));
+	}
+
+	@UserFunction
 	@Description("apoc.date.systemTimezone() returns the system timezone display name")
 	public String systemTimezone() {
 		return TimeZone.getDefault().getID();

--- a/src/main/java/apoc/date/Date.java
+++ b/src/main/java/apoc/date/Date.java
@@ -181,8 +181,8 @@ public class Date {
 	}
 
 	@UserFunction
-	@Description("apoc.date.parse('2012-12-23','yyyy-MM-dd') parse date string using the specified format at the specified timezone")
-	public ZonedDateTime parse(@Name("time") String time, @Name(value = "format",defaultValue = DEFAULT_FORMAT) String format, final @Name(value = "timezone", defaultValue = "UTC") String timezone) {
+	@Description("apoc.date.parseAsZonedDateTime('2012-12-23 23:59:59','yyyy-MM-dd HH:mm:ss', 'UTC') parse date string using the specified format at the specified timezone")
+	public ZonedDateTime parseAsZonedDateTime(@Name("time") String time, @Name(value = "format", defaultValue = DEFAULT_FORMAT) String format, final @Name(value = "timezone", defaultValue = "UTC") String timezone) {
 		Long value = parseOrThrow(time, getFormat(format, timezone));
 		return value == null ? null : Instant.ofEpochMilli(value).atZone(ZoneId.of(timezone));
 	}

--- a/src/test/java/apoc/date/DateTest.java
+++ b/src/test/java/apoc/date/DateTest.java
@@ -18,6 +18,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
@@ -129,6 +130,41 @@ public class DateTest {
 		testCall(db,
 				"RETURN apoc.date.format(null,'s') AS value",
 				row -> assertEquals(null, row.get("value")));
+	}
+
+	@Test public void testParseAsZonedDateTimeWithCorrectFormat() throws Exception {
+		testCall(db,
+				"RETURN apoc.date.parseAsZonedDateTime('03/23/1965 00:00:00','MM/dd/yyyy HH:mm:ss','America/New_York') AS value",
+				row -> assertEquals(ZonedDateTime.of(LocalDateTime.of(1965, 3, 23, 0, 0), ZoneId.of("America/New_York")),
+						row.get("value")));
+	}
+
+	@Test public void testParseAsZonedDateTimeWithDefaultTimezone() throws Exception {
+		testCall(db,
+				"RETURN apoc.date.parseAsZonedDateTime('03/23/1965 00:00:00','MM/dd/yyyy HH:mm:ss') AS value",
+				row -> assertEquals(ZonedDateTime.of(LocalDateTime.of(1965, 3, 23, 0, 0), ZoneId.of("UTC")),
+						row.get("value")));
+	}
+
+	@Test public void testParseAsZonedDateTimeWithDefaultFormatAndTimezone() throws Exception {
+		testCall(db,
+				"RETURN apoc.date.parseAsZonedDateTime('1965-03-23 00:00:00') AS value",
+				row -> assertEquals(ZonedDateTime.of(LocalDateTime.of(1965, 3, 23, 0, 0), ZoneId.of("UTC")),
+						row.get("value")));
+	}
+
+	@Test public void testParseAsZonedDateTimeWithIncorrectPatternFormat() throws Exception {
+		expected.expect(instanceOf(QueryExecutionException.class));
+		testCall(db,
+				"RETURN apoc.date.parseAsZonedDateTime('03/23/1965 00:00:00','MM/dd/yyyy HH:mm:ss/neo4j','America/New_York') AS value",
+				row -> assertEquals(ZonedDateTime.of(LocalDateTime.of(1965, 3, 23, 0, 0), ZoneId.of("America/New_York")),
+						row.get("value")));
+	}
+
+	@Test public void testToZonedDateTimeWithNullInput() throws Exception {
+		testCall(db,
+				"RETURN apoc.date.parseAsZonedDateTime(NULL) AS value",
+				row -> assertNull(row.get("value")));
 	}
 
 	@Test public void testToISO8601() throws Exception {


### PR DESCRIPTION
Fixes #1298

A companion to apoc.date.parse which returns a datetime rather than a Long.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - new class apoc.datetime.DateTime
  - new method apoc.datetime.DateTime.parse which takes date/time string, format, and timezone (with defaults)
  - returns a ZonedDateTime

This preview PR just added the method into apoc.date.Date with a different function signature which will be moved to DateTime class and adding tests if this approach is acceptable.

It wasn't quite clear in the issue description what type of DateTime it should return. I'm not yet very familiar with Neo4j and couldn't see any other DateTime types to go by.

Also the implementation assumes Java8 or later.