### PR TITLE
fixes #1270 add optional recursive-parameter to map.removeKeys

### DIFF
--- a/docs/asciidoc/utilities/map.adoc
+++ b/docs/asciidoc/utilities/map.adoc
@@ -22,8 +22,8 @@ endif::[]
 | apoc.map.merge({first},{second}) yield value | creates map from merging the two source maps
 | apoc.map.mergeList([{maps}]) yield value | merges all maps in the list into one
 | apoc.map.setKey(map,key,value) | returns the map with the value for this key added or replaced
-| apoc.map.removeKey(map,key) | returns the map with the key removed
-| apoc.map.removeKeys(map,[keys]) | returns the map with the keys removed
+| apoc.map.removeKey(map,key,recursive:false) | returns the map with the key removed (recursively if recursive is true)
+| apoc.map.removeKeys(map,[keys],recursive:false) | returns the map with the keys removed (recursively if recursive is true)
 | apoc.map.clean(map,[keys],[values]) yield value | removes the keys and values (e.g. null-placeholders) contained in those lists, good for data cleaning from CSV/JSON
 | apoc.map.groupBy([maps/nodes/relationships],'key') yield value | creates a map of the list keyed by the given property, with single values
 | apoc.map.groupByMulti([maps/nodes/relationships],'key') yield value | creates a map of the list keyed by the given property, with list values

--- a/docs/asciidoc/utilities/map.adoc
+++ b/docs/asciidoc/utilities/map.adoc
@@ -22,8 +22,8 @@ endif::[]
 | apoc.map.merge({first},{second}) yield value | creates map from merging the two source maps
 | apoc.map.mergeList([{maps}]) yield value | merges all maps in the list into one
 | apoc.map.setKey(map,key,value) | returns the map with the value for this key added or replaced
-| apoc.map.removeKey(map,key,recursive:false) | returns the map with the key removed (recursively if recursive is true)
-| apoc.map.removeKeys(map,[keys],recursive:false) | returns the map with the keys removed (recursively if recursive is true)
+| apoc.map.removeKey(map,key,{recursive:true/false}) | returns the map with the key removed (recursively if recursive is true)
+| apoc.map.removeKeys(map,[keys],{recursive:true/false}) | returns the map with the keys removed (recursively if recursive is true)
 | apoc.map.clean(map,[keys],[values]) yield value | removes the keys and values (e.g. null-placeholders) contained in those lists, good for data cleaning from CSV/JSON
 | apoc.map.groupBy([maps/nodes/relationships],'key') yield value | creates a map of the list keyed by the given property, with single values
 | apoc.map.groupByMulti([maps/nodes/relationships],'key') yield value | creates a map of the list keyed by the given property, with list values

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -1641,12 +1641,12 @@ CALL apoc.trigger.add('count-removed-rels','MATCH (c:Counter) SET c.count = c.co
 <td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the value for this key added or replaced</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKey(map,key)</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the key removed</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKey(map,key,recursive:false)</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the key removed (recursively if recursive is true)</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKeys(map,[keys])</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the keys removed</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKeys(map,[keys],recursive:false)</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the keys removed (recursively if recursive is true)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.clean(map,[keys],[values]) yield value</code></p></td>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -1641,11 +1641,11 @@ CALL apoc.trigger.add('count-removed-rels','MATCH (c:Counter) SET c.count = c.co
 <td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the value for this key added or replaced</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKey(map,key,recursive:false)</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKey(map,key,{recursive:true/false})</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the key removed (recursively if recursive is true)</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKeys(map,[keys],recursive:false)</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKeys(map,[keys],{recursive:true/false})</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the keys removed (recursively if recursive is true)</p></td>
 </tr>
 <tr>

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -1641,12 +1641,12 @@ CALL apoc.trigger.add('count-removed-rels','MATCH (c:Counter) SET c.count = c.co
 <td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the value for this key added or replaced</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKey(map,key,{recursive:true/false})</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the key removed (recursively if recursive is true)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKey(map,key)</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the key removed</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKeys(map,[keys],{recursive:true/false})</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the keys removed (recursively if recursive is true)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKeys(map,[keys])</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the keys removed</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.clean(map,[keys],[values]) yield value</code></p></td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2307,12 +2307,12 @@ CALL apoc.trigger.add('lowercase-by-label','UNWIND apoc.trigger.nodesByLabel({as
 <td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the value for this key added or replaced</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKey(map,key)</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the key removed</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKey(map,key,recursive:false)</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the key removed (recursively if recursive is true)</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKeys(map,[keys])</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the keys removed</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKeys(map,[keys],recursive:false)</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the keys removed (recursively if recursive is true)</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.clean(map,[keys],[values]) yield value</code></p></td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2307,12 +2307,12 @@ CALL apoc.trigger.add('lowercase-by-label','UNWIND apoc.trigger.nodesByLabel({as
 <td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the value for this key added or replaced</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKey(map,key,{recursive:true/false})</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the key removed (recursively if recursive is true)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKey(map,key)</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the key removed</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKeys(map,[keys],{recursive:true/false})</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the keys removed (recursively if recursive is true)</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKeys(map,[keys])</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the keys removed</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.clean(map,[keys],[values]) yield value</code></p></td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -2307,11 +2307,11 @@ CALL apoc.trigger.add('lowercase-by-label','UNWIND apoc.trigger.nodesByLabel({as
 <td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the value for this key added or replaced</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKey(map,key,recursive:false)</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKey(map,key,{recursive:true/false})</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the key removed (recursively if recursive is true)</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKeys(map,[keys],recursive:false)</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>apoc.map.removeKeys(map,[keys],{recursive:true/false})</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">returns the map with the keys removed (recursively if recursive is true)</p></td>
 </tr>
 <tr>

--- a/src/main/java/apoc/map/Maps.java
+++ b/src/main/java/apoc/map/Maps.java
@@ -186,7 +186,7 @@ public class Maps {
         Map<String, Object> res = new LinkedHashMap<>(map);
         res.remove(key);
         Map<String, Object> checkedConfig = config == null ? Collections.emptyMap() : config;
-        if (checkedConfig.get("recursive") == Boolean.TRUE) {
+        if (Util.toBoolean(config.getOrDefault("recursive", false))) {
             for (Map.Entry<String, Object> entry : res.entrySet()) {
                 if (entry.getValue() instanceof Map) {
                     Map<String, Object> updatedMap = removeKey((Map<String, Object>) entry.getValue(), key, checkedConfig);
@@ -211,7 +211,7 @@ public class Maps {
         Map<String, Object> res = new LinkedHashMap<>(map);
         res.keySet().removeAll(keys);
         Map<String, Object> checkedConfig = config == null ? Collections.emptyMap() : config;
-        if (checkedConfig.get("recursive") == Boolean.TRUE) {
+        if (Util.toBoolean(config.getOrDefault("recursive", false))) {
             for (Map.Entry<String, Object> entry : res.entrySet()) {
                 if (entry.getValue() instanceof Map) {
                     Map<String, Object> updatedMap = removeKeys((Map<String, Object>) entry.getValue(), keys, checkedConfig);

--- a/src/main/java/apoc/map/Maps.java
+++ b/src/main/java/apoc/map/Maps.java
@@ -187,18 +187,26 @@ public class Maps {
         res.remove(key);
         Map<String, Object> checkedConfig = config == null ? Collections.emptyMap() : config;
         if (Util.toBoolean(config.getOrDefault("recursive", false))) {
-            for (Map.Entry<String, Object> entry : res.entrySet()) {
+            for (Iterator<Map.Entry<String, Object>> iterator = res.entrySet().iterator(); iterator.hasNext(); ) {
+                Map.Entry<String, Object> entry = iterator.next();
                 if (entry.getValue() instanceof Map) {
                     Map<String, Object> updatedMap = removeKey((Map<String, Object>) entry.getValue(), key, checkedConfig);
-                    if (updatedMap != entry.getValue()) {
+                    if (updatedMap.isEmpty()) {
+                        iterator.remove();
+                    } else if (!updatedMap.equals(entry.getValue())) {
                         entry.setValue(updatedMap);
                     }
                 } else if (entry.getValue() instanceof Collection) {
                     Collection<Object> values = (Collection<Object>) entry.getValue();
                     List<Object> updatedValues = values.stream()
                             .map(value -> value instanceof Map ? removeKey((Map<String, Object>) value, key, checkedConfig) : value)
+                            .filter(value -> value instanceof Map ? !((Map<String, Object>) value).isEmpty() : true)
                             .collect(Collectors.toList());
-                    entry.setValue(updatedValues);
+                    if (updatedValues.isEmpty()) {
+                        iterator.remove();
+                    } else  {
+                        entry.setValue(updatedValues);
+                    }
                 }
             }
         }
@@ -212,16 +220,26 @@ public class Maps {
         res.keySet().removeAll(keys);
         Map<String, Object> checkedConfig = config == null ? Collections.emptyMap() : config;
         if (Util.toBoolean(config.getOrDefault("recursive", false))) {
-            for (Map.Entry<String, Object> entry : res.entrySet()) {
+            for (Iterator<Map.Entry<String, Object>> iterator = res.entrySet().iterator(); iterator.hasNext(); ) {
+                Map.Entry<String, Object> entry = iterator.next();
                 if (entry.getValue() instanceof Map) {
                     Map<String, Object> updatedMap = removeKeys((Map<String, Object>) entry.getValue(), keys, checkedConfig);
-                    entry.setValue(updatedMap);
+                    if (updatedMap.isEmpty()) {
+                        iterator.remove();
+                    } else if (!updatedMap.equals(entry.getValue())) {
+                        entry.setValue(updatedMap);
+                    }
                 } else if (entry.getValue() instanceof Collection) {
                     Collection<Object> values = (Collection<Object>) entry.getValue();
                     List<Object> updatedValues = values.stream()
                             .map(value -> value instanceof Map ? removeKeys((Map<String, Object>) value, keys, checkedConfig) : value)
+                            .filter(value -> value instanceof Map ? !((Map<String, Object>) value).isEmpty() : true)
                             .collect(Collectors.toList());
-                    entry.setValue(updatedValues);
+                    if (updatedValues.isEmpty()) {
+                        iterator.remove();
+                    } else {
+                        entry.setValue(updatedValues);
+                    }
                 }
             }
         }

--- a/src/main/java/apoc/map/Maps.java
+++ b/src/main/java/apoc/map/Maps.java
@@ -185,16 +185,19 @@ public class Maps {
         }
         Map<String, Object> res = new LinkedHashMap<>(map);
         res.remove(key);
-        if (config!=null && config.get("recursive")==Boolean.TRUE) {
+        Map<String, Object> checkedConfig = config == null ? Collections.emptyMap() : config;
+        if (checkedConfig.get("recursive") == Boolean.TRUE) {
             for (Map.Entry<String, Object> entry : res.entrySet()) {
                 if (entry.getValue() instanceof Map) {
-                    Map<String, Object> updatedMap = removeKey((Map<String, Object>) entry.getValue(), key, config);
-                    if (updatedMap!=entry.getValue()) {
+                    Map<String, Object> updatedMap = removeKey((Map<String, Object>) entry.getValue(), key, checkedConfig);
+                    if (updatedMap != entry.getValue()) {
                         entry.setValue(updatedMap);
                     }
                 } else if (entry.getValue() instanceof Collection) {
-                    Collection<Map<String, Object>> values = (Collection<Map<String, Object>>) entry.getValue();
-                    List<Map<String, Object>> updatedValues = values.stream().map(value -> removeKey(value, key, config)).collect(Collectors.toList());
+                    Collection<Object> values = (Collection<Object>) entry.getValue();
+                    List<Object> updatedValues = values.stream()
+                            .map(value -> value instanceof Map ? removeKey((Map<String, Object>) value, key, checkedConfig) : value)
+                            .collect(Collectors.toList());
                     entry.setValue(updatedValues);
                 }
             }
@@ -204,17 +207,20 @@ public class Maps {
 
     @UserFunction
     @Description("apoc.map.removeKeys(map,[keys],{recursive:true/false}) - remove the keys from the map (recursively if recursive is true)")
-    public Map<String,Object> removeKeys(@Name("map") Map<String,Object> map, @Name("keys") List<String> keys, @Name(value="config", defaultValue = "{}") Map<String, Object> config) {
+    public Map<String, Object> removeKeys(@Name("map") Map<String, Object> map, @Name("keys") List<String> keys, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
         Map<String, Object> res = new LinkedHashMap<>(map);
         res.keySet().removeAll(keys);
-        if (config!=null && config.get("recursive")==Boolean.TRUE) {
+        Map<String, Object> checkedConfig = config == null ? Collections.emptyMap() : config;
+        if (checkedConfig.get("recursive") == Boolean.TRUE) {
             for (Map.Entry<String, Object> entry : res.entrySet()) {
                 if (entry.getValue() instanceof Map) {
-                    Map<String, Object> updatedMap = removeKeys((Map<String, Object>) entry.getValue(), keys, config);
+                    Map<String, Object> updatedMap = removeKeys((Map<String, Object>) entry.getValue(), keys, checkedConfig);
                     entry.setValue(updatedMap);
                 } else if (entry.getValue() instanceof Collection) {
-                    Collection<Map<String, Object>> values = (Collection<Map<String, Object>>) entry.getValue();
-                    List<Map<String, Object>> updatedValues = values.stream().map(value -> removeKeys(value, keys, config)).collect(Collectors.toList());
+                    Collection<Object> values = (Collection<Object>) entry.getValue();
+                    List<Object> updatedValues = values.stream()
+                            .map(value -> value instanceof Map ? removeKeys((Map<String, Object>) value, keys, checkedConfig) : value)
+                            .collect(Collectors.toList());
                     entry.setValue(updatedValues);
                 }
             }

--- a/src/main/java/apoc/map/Maps.java
+++ b/src/main/java/apoc/map/Maps.java
@@ -180,13 +180,18 @@ public class Maps {
     @UserFunction
     @Description("apoc.map.removeKey(map,key,recursive:false) - remove the key from the map (recursively if recursive is true)")
     public Map<String,Object> removeKey(@Name("map") Map<String,Object> map, @Name("key") String key, @Name(value="recursive", defaultValue = "false") boolean recursive) {
+        if (!map.containsKey(key)) {
+            return map;
+        }
         Map<String, Object> res = new LinkedHashMap<>(map);
         res.remove(key);
         if (recursive) {
             for (Map.Entry<String, Object> entry : res.entrySet()) {
                 if (entry.getValue() instanceof Map) {
                     Map<String, Object> updatedMap = removeKey((Map<String, Object>) entry.getValue(), key, true);
-                    entry.setValue(updatedMap);
+                    if (updatedMap!=entry.getValue()) {
+                        entry.setValue(updatedMap);
+                    }
                 }
             }
         }

--- a/src/test/java/apoc/map/MapsTest.java
+++ b/src/test/java/apoc/map/MapsTest.java
@@ -196,6 +196,13 @@ public class MapsTest {
     }
 
     @Test
+    public void testRemoveLastKey() throws Exception {
+        TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1},'a') AS value", (r) -> {
+            assertEquals(map(),r.get("value"));
+        });
+    }
+
+    @Test
     public void testRemoveKeyRecursively() throws Exception {
         TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2,c:{a:3,b:4}},'a', {recursive:true}) AS value", (r) -> {
             assertEquals(map("b",2L, "c", map("b",4L)),r.get("value"));
@@ -203,9 +210,23 @@ public class MapsTest {
     }
 
     @Test
-    public void testRemoveKeyRecursivelyIncludingCollection() throws Exception {
+    public void testRemoveLastKeyRecursively() throws Exception {
+        TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2,c:{a:3}},'a', {recursive:true}) AS value", (r) -> {
+            assertEquals(map("b",2L, "c", map()),r.get("value"));
+        });
+    }
+
+    @Test
+    public void testRemoveKeyRecursivelyIncludingCollectionOfMaps() throws Exception {
         TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2,c:[{a:3,b:4}, {a:4,b:5}]},'a', {recursive:true}) AS value", (r) -> {
             assertEquals(map("b",2L, "c", asList(map("b",4L), map("b",5L))), r.get("value"));
+        });
+    }
+
+    @Test
+    public void testRemoveKeyRecursivelyIncludingCollectionOfStrings() throws Exception {
+        TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2,c:['a', 'b']},'a', {recursive:true}) AS value", (r) -> {
+            assertEquals(map("b", 2L, "c", asList("a", "b")), r.get("value"));
         });
     }
 
@@ -224,9 +245,16 @@ public class MapsTest {
     }
 
     @Test
-    public void testRemoveKeysRecursivelyIncludingCollection() throws Exception {
+    public void testRemoveKeysRecursivelyIncludingCollectionOfMaps() throws Exception {
         TestUtil.testCall(db, "RETURN apoc.map.removeKeys({a:1,b:2,c:[{a:3,b:4,d:1}, {a:4,b:5,d:3}]},['a','b'],{recursive:true}) AS value", (r) -> {
             assertEquals(map("c", asList(map("d",1L),map("d",3L))), r.get("value"));
+        });
+    }
+
+    @Test
+    public void testRemoveKeysRecursivelyIncludingCollectionOfInts() throws Exception {
+        TestUtil.testCall(db, "RETURN apoc.map.removeKeys({a:1,b:2,c:[1,2,3]},['a','b'],{recursive:true}) AS value", (r) -> {
+            assertEquals(map("c", asList(1L, 2L, 3L)), r.get("value"));
         });
     }
 

--- a/src/test/java/apoc/map/MapsTest.java
+++ b/src/test/java/apoc/map/MapsTest.java
@@ -12,8 +12,7 @@ import java.util.*;
 
 import static apoc.util.MapUtil.map;
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
+import static java.util.Collections.*;
 import static org.junit.Assert.*;
 import static org.neo4j.helpers.collection.Iterators.asSet;
 
@@ -198,8 +197,15 @@ public class MapsTest {
 
     @Test
     public void testRemoveKeyRecursively() throws Exception {
-        TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2,c:{a:3,b:4}},'a', true) AS value", (r) -> {
+        TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2,c:{a:3,b:4}},'a', {recursive:true}) AS value", (r) -> {
             assertEquals(map("b",2L, "c", map("b",4L)),r.get("value"));
+        });
+    }
+
+    @Test
+    public void testRemoveKeyRecursivelyIncludingCollection() throws Exception {
+        TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2,c:[{a:3,b:4}, {a:4,b:5}]},'a', {recursive:true}) AS value", (r) -> {
+            assertEquals(map("b",2L, "c", asList(map("b",4L), map("b",5L))), r.get("value"));
         });
     }
 
@@ -212,8 +218,15 @@ public class MapsTest {
 
     @Test
     public void testRemoveKeysRecursively() throws Exception {
-        TestUtil.testCall(db, "RETURN apoc.map.removeKeys({a:1,b:2,c:{a:3,b:4}},['a','b'], true) AS value", (r) -> {
+        TestUtil.testCall(db, "RETURN apoc.map.removeKeys({a:1,b:2,c:{a:3,b:4}},['a','b'], {recursive:true}) AS value", (r) -> {
             assertEquals(map("c", map()),r.get("value"));
+        });
+    }
+
+    @Test
+    public void testRemoveKeysRecursivelyIncludingCollection() throws Exception {
+        TestUtil.testCall(db, "RETURN apoc.map.removeKeys({a:1,b:2,c:[{a:3,b:4,d:1}, {a:4,b:5,d:3}]},['a','b'],{recursive:true}) AS value", (r) -> {
+            assertEquals(map("c", asList(map("d",1L),map("d",3L))), r.get("value"));
         });
     }
 

--- a/src/test/java/apoc/map/MapsTest.java
+++ b/src/test/java/apoc/map/MapsTest.java
@@ -219,7 +219,7 @@ public class MapsTest {
     @Test
     public void testRemoveLastKeyRecursively() throws Exception {
         TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2,c:{a:3}},'a', {recursive:true}) AS value", (r) -> {
-            assertEquals(map("b",2L, "c", map()),r.get("value"));
+            assertEquals(map("b",2L),r.get("value"));
         });
     }
 
@@ -238,7 +238,7 @@ public class MapsTest {
     }
 
     @Test
-    public void testRemoveKeys() throws Exception {
+    public void testRemoveAllKeys() throws Exception {
         TestUtil.testCall(db, "RETURN apoc.map.removeKeys({a:1,b:2},['a','b']) AS value", (r) -> {
             assertEquals(map(),r.get("value"));
         });
@@ -247,7 +247,7 @@ public class MapsTest {
     @Test
     public void testRemoveKeysRecursively() throws Exception {
         TestUtil.testCall(db, "RETURN apoc.map.removeKeys({a:1,b:2,c:{a:3,b:4}},['a','b'], {recursive:true}) AS value", (r) -> {
-            assertEquals(map("c", map()),r.get("value"));
+            assertEquals(map(),r.get("value"));
         });
     }
 
@@ -255,6 +255,12 @@ public class MapsTest {
     public void testRemoveKeysRecursivelyIncludingCollectionOfMaps() throws Exception {
         TestUtil.testCall(db, "RETURN apoc.map.removeKeys({a:1,b:2,c:[{a:3,b:4,d:1}, {a:4,b:5,d:3}]},['a','b'],{recursive:true}) AS value", (r) -> {
             assertEquals(map("c", asList(map("d",1L),map("d",3L))), r.get("value"));
+        });
+    }
+    @Test
+    public void testRemoveKeysRecursivelyRemovingCollectionCompletely() throws Exception {
+        TestUtil.testCall(db, "RETURN apoc.map.removeKeys({a:1,b:2,c:[{d:1}, {b:5,d:3}]},['d','b'],{recursive:true}) AS value", (r) -> {
+            assertEquals(map("a", 1L), r.get("value"));
         });
     }
 

--- a/src/test/java/apoc/map/MapsTest.java
+++ b/src/test/java/apoc/map/MapsTest.java
@@ -210,6 +210,13 @@ public class MapsTest {
     }
 
     @Test
+    public void testRemoveKeyRecursivelySimpleProperties() throws Exception {
+        TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2},'b', {recursive:true}) AS value", (r) -> {
+            assertEquals(map("a",1L), r.get("value"));
+        });
+    }
+
+    @Test
     public void testRemoveLastKeyRecursively() throws Exception {
         TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2,c:{a:3}},'a', {recursive:true}) AS value", (r) -> {
             assertEquals(map("b",2L, "c", map()),r.get("value"));

--- a/src/test/java/apoc/map/MapsTest.java
+++ b/src/test/java/apoc/map/MapsTest.java
@@ -195,10 +195,25 @@ public class MapsTest {
             assertEquals(map("b",2L),r.get("value"));
         });
     }
+
+    @Test
+    public void testRemoveKeyRecursively() throws Exception {
+        TestUtil.testCall(db, "RETURN apoc.map.removeKey({a:1,b:2,c:{a:3,b:4}},'a', true) AS value", (r) -> {
+            assertEquals(map("b",2L, "c", map("b",4L)),r.get("value"));
+        });
+    }
+
     @Test
     public void testRemoveKeys() throws Exception {
         TestUtil.testCall(db, "RETURN apoc.map.removeKeys({a:1,b:2},['a','b']) AS value", (r) -> {
             assertEquals(map(),r.get("value"));
+        });
+    }
+
+    @Test
+    public void testRemoveKeysRecursively() throws Exception {
+        TestUtil.testCall(db, "RETURN apoc.map.removeKeys({a:1,b:2,c:{a:3,b:4}},['a','b'], true) AS value", (r) -> {
+            assertEquals(map("c", map()),r.get("value"));
         });
     }
 


### PR DESCRIPTION
Fixes #1270 

add optional recursive-parameter to map.removeKeys

## Proposed Changes

  - added the "recursive" optional parameter with default set to false to the map.removeKey and map.removeKeys procedures (similar to what is done for coll.flatten)

  
