### PR TITLE
fix #1304 removeRelProperties expects only 2 params

### DIFF
--- a/docs/asciidoc/graph-updates/data-creation.adoc
+++ b/docs/asciidoc/graph-updates/data-creation.adoc
@@ -22,15 +22,15 @@ endif::[]
 | CALL apoc.create.addLabels( [node,id,ids,nodes], ['Label',...]) | adds the given labels to the node or nodes
 | CALL apoc.create.removeLabels( [node,id,ids,nodes], ['Label',...]) | removes the given labels from the node or nodes
 | CALL apoc.create.setProperty( [node,id,ids,nodes], key, value) | sets the given property on the node(s)
-| CALL apoc.create.setProperties( [node,id,ids,nodes], [keys], [values]) | sets the given property on the nodes(s)
+| CALL apoc.create.setProperties( [node,id,ids,nodes], [keys], [values]) | sets the given properties on the nodes(s)
 | CALL apoc.create.setRelProperty( [rel,id,ids,rels], key, value) | sets the given property on the relationship(s)
-| CALL apoc.create.setRelProperties( [rel,id,ids,rels], [keys], [values]) | sets the given property on the relationship(s)
+| CALL apoc.create.setRelProperties( [rel,id,ids,rels], [keys], [values]) | sets the given properties on the relationship(s)
 | CALL apoc.create.relationship(person1,'KNOWS',{key:value,...}, person2) | create relationship with dynamic rel-type
 | CALL apoc.nodes.link([nodes],'REL_TYPE') | creates a linked list of nodes from first to last
 | CALL apoc.merge.node(['Label'], identProps:{key:value, ...}, onCreateProps:{key:value,...}, onMatchProps:{key:value,...}}) | merge nodes with dynamic labels, with support for setting properties ON CREATE or ON MATCH
 | CALL apoc.merge.relationship(startNode, relType, identProps:{key:value, ...}, onCreateProps:{key:value, ...}, endNode, onMatchProps:{key:value, ...}) | merge relationship with dynamic type, with support for setting properties ON CREATE or ON MATCH
-| CALL apoc.create.removeProperties( [node,id,ids,nodes], [keys]) | removes the given property from the nodes(s)
-| CALL apoc.create.removeRelProperties( [rel,id,ids,rels], [keys], [values]) | removes the given property from the relationship(s)
+| CALL apoc.create.removeProperties( [node,id,ids,nodes], [keys]) | removes the given properties from the nodes(s)
+| CALL apoc.create.removeRelProperties( [rel,id,ids,rels], [keys]) | removes the given properties from the relationship(s)
 |===
 
 

--- a/src/main/java/apoc/create/Create.java
+++ b/src/main/java/apoc/create/Create.java
@@ -58,7 +58,7 @@ public class Create {
     }
 
     @Procedure(mode = Mode.WRITE)
-    @Description("apoc.create.setProperties( [node,id,ids,nodes], [keys], [values]) - sets the given property on the nodes(s)")
+    @Description("apoc.create.setProperties( [node,id,ids,nodes], [keys], [values]) - sets the given properties on the nodes(s)")
     public Stream<NodeResult> setProperties(@Name("nodes") Object nodes, @Name("keys") List<String> keys, @Name("values") List<Object> values) {
         return new Get(db).nodes(nodes).map((r) -> {
             setProperties(r.node, Util.mapFromLists(keys, values));
@@ -67,7 +67,7 @@ public class Create {
     }
 
     @Procedure(mode = Mode.WRITE)
-    @Description("apoc.create.removeProperties( [node,id,ids,nodes], [keys]) - removes the given property from the nodes(s)")
+    @Description("apoc.create.removeProperties( [node,id,ids,nodes], [keys]) - removes the given properties from the nodes(s)")
     public Stream<NodeResult> removeProperties(@Name("nodes") Object nodes, @Name("keys") List<String> keys) {
         return new Get(db).nodes(nodes).map((r) -> {
             keys.forEach(r.node::removeProperty);
@@ -76,7 +76,7 @@ public class Create {
     }
 
     @Procedure(mode = Mode.WRITE)
-    @Description("apoc.create.setRelProperties( [rel,id,ids,rels], [keys], [values]) - sets the given property on the relationship(s)")
+    @Description("apoc.create.setRelProperties( [rel,id,ids,rels], [keys], [values]) - sets the given properties on the relationship(s)")
     public Stream<RelationshipResult> setRelProperties(@Name("rels") Object rels, @Name("keys") List<String> keys, @Name("values") List<Object> values) {
         return new Get(db).rels(rels).map((r) -> {
             setProperties(r.rel, Util.mapFromLists(keys, values));
@@ -85,7 +85,7 @@ public class Create {
     }
 
     @Procedure(mode = Mode.WRITE)
-    @Description("apoc.create.removeRelProperties( [rel,id,ids,rels], [keys], [values]) - removes the given property from the relationship(s)")
+    @Description("apoc.create.removeRelProperties( [rel,id,ids,rels], [keys]) - removes the given properties from the relationship(s)")
     public Stream<RelationshipResult> removeRelProperties(@Name("rels") Object rels, @Name("keys") List<String> keys) {
         return new Get(db).rels(rels).map((r) -> {
             keys.forEach(r.rel::removeProperty);


### PR DESCRIPTION
Fixes #1304

The removeRelProperties expect 2 parameters, but 3 are described in the doc

(this is another try at #1310, hopefully on the right files/branch this time!)

## Proposed Changes

  - removed the values parameter from the removeRelProperties description
  - changed the description of the *Properties procedure to apply the plural form there too
  