### PR TITLE
fixes #1314: ensure Future.cancel(false) is used everywhere

### DIFF
--- a/src/main/java/apoc/custom/CypherProcedures.java
+++ b/src/main/java/apoc/custom/CypherProcedures.java
@@ -447,7 +447,7 @@ public class CypherProcedures {
         @Override
         public void unavailable() {
             if (restoreProceduresHandle != null) {
-                restoreProceduresHandle.cancel(true);
+                restoreProceduresHandle.cancel(false);
             }
             properties = null;
         }

--- a/src/main/java/apoc/index/IndexUpdateTransactionEventHandler.java
+++ b/src/main/java/apoc/index/IndexUpdateTransactionEventHandler.java
@@ -362,7 +362,7 @@ public class IndexUpdateTransactionEventHandler extends TransactionEventHandler.
 
     private void stopPeriodicIndexConfigChangeUpdates() {
         if (configUpdateFuture!=null) {
-            configUpdateFuture.cancel(true);
+            configUpdateFuture.cancel(false);
         }
     }
 

--- a/src/main/java/apoc/periodic/Periodic.java
+++ b/src/main/java/apoc/periodic/Periodic.java
@@ -148,7 +148,7 @@ public class Periodic {
         JobInfo info = new JobInfo(name);
         Future future = list.remove(info);
         if (future != null) {
-            future.cancel(true);
+            future.cancel(false);
             return Stream.of(info.update(future));
         }
         return Stream.empty();

--- a/src/main/java/apoc/ttl/TTLLifeCycle.java
+++ b/src/main/java/apoc/ttl/TTLLifeCycle.java
@@ -68,7 +68,7 @@ public class TTLLifeCycle {
     }
 
     public void stop() {
-        if (ttlIndexJobHandle != null) ttlIndexJobHandle.cancel(true);
-        if (ttlJobHandle != null) ttlJobHandle.cancel(true);
+        if (ttlIndexJobHandle != null) ttlIndexJobHandle.cancel(false);
+        if (ttlJobHandle != null) ttlJobHandle.cancel(false);
     }
 }

--- a/src/main/java/apoc/util/Util.java
+++ b/src/main/java/apoc/util/Util.java
@@ -564,7 +564,7 @@ public class Util {
         try {
             if (f.isDone()) return f.get();
             else {
-                f.cancel(true);
+                f.cancel(false );
                 errors.incrementAndGet();
             }
         } catch (InterruptedException | ExecutionException e) {


### PR DESCRIPTION
PR ensures that we use `Future.cancel(false)` instead if `Future.cancel(true)` consistently in APOC's codebase.
The new test succeeds with this change applied, but fails in a sporadic way (~ 4 out of 5 attempts) when `Future.cancel(true)` is used. I was not able to make the test consistently failing.
Of course the PR is about to fix #1314 