### PR TITLE
fixes #1268: apoc.periodic.repeat doesn't provide any feedback when query is bad

### DIFF
--- a/src/main/java/apoc/periodic/Periodic.java
+++ b/src/main/java/apoc/periodic/Periodic.java
@@ -56,6 +56,7 @@ public class Periodic {
     @Procedure(mode = Mode.WRITE)
     @Description("apoc.periodic.commit(statement,params) - runs the given statement in separate transactions until it returns 0")
     public Stream<RundownResult> commit(@Name("statement") String statement, @Name(value = "params", defaultValue = "") Map<String,Object> parameters) throws ExecutionException, InterruptedException {
+        validateQuery(statement);
         Map<String,Object> params = parameters == null ? Collections.emptyMap() : parameters;
         long total = 0, executions = 0, updates = 0;
         long start = nanoTime();
@@ -157,6 +158,7 @@ public class Periodic {
     @Procedure(mode = Mode.WRITE)
     @Description("apoc.periodic.submit('name',statement) - submit a one-off background statement")
     public Stream<JobInfo> submit(@Name("name") String name, @Name("statement") String statement) {
+        validateQuery(statement);
         JobInfo info = submit(name, () -> {
             try {
                 Iterators.count(db.execute(statement));
@@ -170,14 +172,20 @@ public class Periodic {
     @Procedure(mode = Mode.WRITE)
     @Description("apoc.periodic.repeat('name',statement,repeat-rate-in-seconds, config) submit a repeatedly-called background statement. Fourth parameter 'config' is optional and can contain 'params' entry for nested statement.")
     public Stream<JobInfo> repeat(@Name("name") String name, @Name("statement") String statement, @Name("rate") long rate, @Name(value = "config", defaultValue = "{}") Map<String,Object> config ) {
+        validateQuery(statement);
         Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());
         JobInfo info = schedule(name, () -> Iterators.count(db.execute(statement, params)),0,rate);
         return Stream.of(info);
     }
 
+    private void validateQuery(String statement) {
+        db.execute("EXPLAIN " + statement).close();
+    }
+
     @Procedure(mode = Mode.WRITE)
     @Description("apoc.periodic.countdown('name',statement,repeat-rate-in-seconds) submit a repeatedly-called background statement until it returns 0")
     public Stream<JobInfo> countdown(@Name("name") String name, @Name("statement") String statement, @Name("rate") long rate) {
+        validateQuery(statement);
         JobInfo info = submit(name, new Countdown(name, statement, rate));
         info.rate = rate;
         return Stream.of(info);
@@ -227,7 +235,10 @@ public class Periodic {
             @Name("cypherIterate") String cypherIterate,
             @Name("cypherAction") String cypherAction,
             @Name("batchSize") long batchSize) {
-
+        Map<String, String> fieldStatement = Util.map(
+                "cypherLoop", cypherLoop,
+                "cypherIterate", cypherIterate);
+        validateQueries(fieldStatement);
         Stream<LoopingBatchAndTotalResult> allResults = Stream.empty();
 
         Map<String,Object> loopParams = new HashMap<>(1);
@@ -251,6 +262,24 @@ public class Periodic {
         }
     }
 
+    private void validateQueries(Map<String, String> fieldStatement) {
+        String error = fieldStatement.entrySet()
+                .stream()
+                .map(e -> {
+                    try {
+                        validateQuery(e.getValue());
+                        return null;
+                    } catch (Exception exception) {
+                        return String.format("Exception for field `%s`, message: %s", e.getKey(), exception.getMessage());
+                    }
+                })
+                .filter(e -> e != null)
+                .collect(Collectors.joining("\n"));
+        if (!error.isEmpty()) {
+            throw new RuntimeException(error);
+        }
+    }
+
     /**
      * invoke cypherAction in batched transactions being feeded from cypherIteration running in main thread
      * @param cypherIterate
@@ -262,6 +291,7 @@ public class Periodic {
             @Name("cypherIterate") String cypherIterate,
             @Name("cypherAction") String cypherAction,
             @Name("config") Map<String,Object> config) {
+        validateQuery(cypherIterate);
 
         long batchSize = Util.toLong(config.getOrDefault("batchSize", 10000));
         int concurrency = Util.toInteger(config.getOrDefault("concurrency", 50));
@@ -323,6 +353,10 @@ public class Periodic {
             @Name("cypherIterate") String cypherIterate,
             @Name("cypherAction") String cypherAction,
             @Name("batchSize") long batchSize) {
+        Map<String, String> fieldStatement = Util.map(
+                "cypherIterate", cypherIterate,
+                "cypherAction", cypherAction);
+        validateQueries(fieldStatement);
 
         log.info("starting batched operation using iteration `%s` in separate thread", cypherIterate);
         try (Result result = db.execute(cypherIterate)) {

--- a/src/test/java/apoc/coll/CollTest.java
+++ b/src/test/java/apoc/coll/CollTest.java
@@ -2,17 +2,20 @@ package apoc.coll;
 
 import apoc.convert.Json;
 import apoc.util.TestUtil;
-import org.apache.commons.lang.exception.ExceptionUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
@@ -20,7 +23,9 @@ import static apoc.util.Util.map;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.neo4j.helpers.collection.Iterables.asSet;
 
 public class CollTest {

--- a/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/src/test/java/apoc/periodic/PeriodicTest.java
@@ -6,7 +6,11 @@ import apoc.util.TestUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.QueryExecutionException;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.TransientTransactionFailureException;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.query.ExecutingQuery;
@@ -26,7 +30,11 @@ import static apoc.util.Util.map;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.neo4j.graphdb.DependencyResolver.SelectionStrategy.FIRST;
 
 public class PeriodicTest {
@@ -493,5 +501,95 @@ System.out.println("call list" + db.execute(callList).resultAsString());
         try (ResourceIterator<Long> it = db.execute(statement).columnAs("count")) {
             return Iterators.single(it);
         }
+    }
+
+    @Test(expected = QueryExecutionException.class)
+    public void testCommitFail() {
+        final String query = "CALL apoc.periodic.commit('UNWIND range(0,1000) as id WITH id CREATE (::Foo {id: id}) limit 1000', {})";
+        testFail(query);
+    }
+
+    @Test(expected = QueryExecutionException.class)
+    public void testSubmitFail() {
+        final String query = "CALL apoc.periodic.submit('foo','create (::Foo)')";
+        testFail(query);
+    }
+
+    @Test(expected = QueryExecutionException.class)
+    public void testRepeatFail() {
+        final String query = "CALL apoc.periodic.repeat('repeat-params', 'MERGE (person:Person {name: {nameValue}})', 2, {params: {nameValue: 'John Doe'}}) YIELD name RETURN nam";
+        testFail(query);
+    }
+
+    @Test(expected = QueryExecutionException.class)
+    public void testCountdownFail() {
+        final String query = "CALL apoc.periodic.countdown('decrement', 'MATCH (counter:Counter) SET counter.c == counter.c - 1 RETURN counter.c as count', 1)";
+        testFail(query);
+    }
+
+    @Test(expected = QueryExecutionException.class)
+    public void testRockNRollWhileLoopFail() {
+        final String query = "CALL apoc.periodic.rock_n_roll_while('return coalescence({previous}, 3) - 1 as loop', " +
+                "'match (p:Person) return p', " +
+                "'MATCH (p) where p = {p} SET p.lastname = p.name', " +
+                "10)";
+        testFail(query);
+    }
+
+    @Test(expected = QueryExecutionException.class)
+    public void testRockNRollWhileIterateFail() {
+        final String query = "CALL apoc.periodic.rock_n_roll_while('return coalesce({previous}, 3) - 1 as loop', " +
+                "'match (p:Person) return pp', " +
+                "'MATCH (p) where p = {p} SET p.lastname = p.name', " +
+                "10)";
+        testFail(query);
+    }
+
+    @Test(expected = QueryExecutionException.class)
+    public void testIterateQueryFail() {
+        final String query = "CALL apoc.periodic.iterate('UNWIND range(0, 1000) as id RETURN ids', " +
+                "'WITH $id as id CREATE (:Foo {id: $id})', " +
+                "{batchSize:1,parallel:true})";
+        testFail(query);
+    }
+
+    @Test(expected = QueryExecutionException.class)
+    public void testRockNRollIterateFail() {
+        final String query = "CALL apoc.periodic.rock_n_roll('match (pp:Person) return p', " +
+                "'WITH {p} as p SET p.lastname = p.name REMOVE p.name', " +
+                "10)";
+        testFail(query);
+    }
+
+    @Test(expected = QueryExecutionException.class)
+    public void testRockNRollActionFail() {
+        final String query = "CALL apoc.periodic.rock_n_roll('match (p:Person) return p', " +
+                "'WITH {p} as p SET pp.lastname = p.name REMOVE p.name', " +
+                "10)";
+        testFail(query);
+    }
+
+    @Test(expected = QueryExecutionException.class)
+    public void testRockNRollWhileFail() {
+        final String query = "CALL apoc.periodic.rock_n_roll_while('return coalescence({previous}, 3) - 1 as loop', " +
+                "'match (p:Person) return pp', " +
+                "'MATCH (p) where p = {p} SET p.lastname = p.name', " +
+                "10)";
+        try {
+            testFail(query);
+        } catch (QueryExecutionException e) {
+            String expected = "Failed to invoke procedure `apoc.periodic.rock_n_roll_while`: Caused by: java.lang.RuntimeException: Exception for field `cypherLoop`, message: Unknown function 'coalescence' (line 1, column 16 (offset: 15))\n" +
+                    "\"return coalescence({previous}, 3) - 1 as loop\"\n" +
+                    "                ^\n" +
+                    "Exception for field `cypherIterate`, message: Variable `pp` not defined (line 1, column 33 (offset: 32))\n" +
+                    "\"EXPLAIN match (p:Person) return pp\"\n" +
+                    "                                 ^";
+            assertEquals(expected, e.getMessage());
+            throw e;
+        }
+    }
+
+    private void testFail(String query) {
+        testCall(db, query, row -> fail("The test should fail but it didn't"));
     }
 }


### PR DESCRIPTION
Fixes #1268
Added query validation in each `apoc.periodic.*` procedure

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added the validation in each procedure
  - Added test for each procedure/arguments
