### PR TITLE
fixes #1317: Add apoc.custom.delete/remove

### DIFF
--- a/docs/asciidoc/cypher-execution/custom.adoc
+++ b/docs/asciidoc/cypher-execution/custom.adoc
@@ -129,6 +129,48 @@ The the output will look like the following table:
 |===
 
 
+=== Remove a procedure `apoc.custom.removeProcedure`
+
+The procedure `apoc.custom.removeProcedure` allows to delete the targeted custom procedure.
+
+
+Given the this call:
+
+[source,cypher]
+----
+CALL apoc.custom.removeProcedure(<name>)
+----
+
+Fields:
+
+[%autowidth,opts=header]
+|===
+| argument | description
+| name  | the procedure name
+|===
+
+
+=== Remove a procedure `apoc.custom.removeFunction`
+
+The procedure `apoc.custom.removeFunction` allows to delete the targeted custom function.
+
+
+Given the this call:
+
+[source,cypher]
+----
+CALL apoc.custom.removeFunction(<name>)
+----
+
+Fields:
+
+[%autowidth,opts=header]
+|===
+| argument | description
+| name  | the function name
+|===
+
+
 === How to manage procedure/function replication in a Causal Cluster
 
 In order to replicate the procedure/function in a cluster environment you can tune the following parameters:

--- a/src/test/java/apoc/custom/CypherProceduresClusterTest.java
+++ b/src/test/java/apoc/custom/CypherProceduresClusterTest.java
@@ -5,14 +5,21 @@ import apoc.util.TestContainerUtil;
 import apoc.util.TestUtil;
 import apoc.util.TestcontainersCausalCluster;
 import apoc.util.Util;
-import org.junit.*;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.driver.v1.exceptions.DatabaseException;
 
 import java.util.List;
 import java.util.Map;
 
-import static apoc.util.TestContainerUtil.*;
+import static apoc.util.TestContainerUtil.cleanBuild;
+import static apoc.util.TestContainerUtil.executeGradleTasks;
+import static apoc.util.TestContainerUtil.testCall;
+import static apoc.util.TestContainerUtil.testCallInReadTransaction;
 import static apoc.util.TestUtil.isTravis;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
 
@@ -92,5 +99,55 @@ public class CypherProceduresClusterTest {
         Thread.sleep(1000);
         // then
         testCallInReadTransaction(cluster.getSession(), "call custom.answerProcedure2()", (row) -> assertEquals(55L, row.get("answer")));
+    }
+
+    @Test(expected = DatabaseException.class)
+    public void shouldRemoveProcedureOnOtherClusterMembers() throws InterruptedException {
+        // given
+        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asProcedure('answerToRemove', 'RETURN 33 as answer', 'read', [['answer','long']])")); // we create a procedure
+        Thread.sleep(1000);
+        try {
+            testCallInReadTransaction(cluster.getSession(), "call custom.answerToRemove()", (row) -> assertEquals(33L, row.get("answer")));
+        } catch (Exception e) {
+            fail("Exception while calling the procedure");
+        }
+
+        // when
+        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.removeProcedure('answerToRemove')")); // we remove procedure
+
+        // then
+        Thread.sleep(1000);
+        try {
+            testCallInReadTransaction(cluster.getSession(), "call custom.answerToRemove()", (row) -> fail("Procedure not removed"));
+        } catch (DatabaseException e) {
+            String expectedMessage = "There is no procedure with the name `custom.answerToRemove` registered for this database instance. Please ensure you've spelled the procedure name correctly and that the procedure is properly deployed.";
+            assertEquals(expectedMessage, e.getMessage());
+            throw e;
+        }
+    }
+
+    @Test(expected = DatabaseException.class)
+    public void shouldRemoveFunctionOnOtherClusterMembers() throws InterruptedException {
+        // given
+        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.asFunction('answerFunctionToRemove', 'RETURN 42 as answer')")); // we create a function
+        Thread.sleep(1000);
+        try {
+            testCallInReadTransaction(cluster.getSession(), "return custom.answerFunctionToRemove() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        } catch (Exception e) {
+            fail("Exception while calling the function");
+        }
+
+        // when
+        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.removeFunction('answerFunctionToRemove')")); // we remove procedure
+
+        // then
+        Thread.sleep(1000);
+        try {
+            testCallInReadTransaction(cluster.getSession(), "return custom.answerFunctionToRemove() as row", (row) -> fail("Function not removed"));
+        } catch (DatabaseException e) {
+            String expectedMessage = "Unknown function 'custom.answerFunctionToRemove'";
+            assertEquals(expectedMessage, e.getMessage());
+            throw e;
+        }
     }
 }


### PR DESCRIPTION
Fixes #1317

Added procedure `apoc.custom.remove` which allows removing custom procedures/functions

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added the `apoc.custom.remove` procedure 
  - managed the custom procedure remove into a cluster environment, by adding a new property `removed` into the `apoc.custom` graph property to track the removed procedures
  - updated documentation
