### PR TITLE
fixes #1331: Mongo procedure throws NullPointerException if a field is null

### DIFF
--- a/src/main/java/apoc/mongodb/MongoDBColl.java
+++ b/src/main/java/apoc/mongodb/MongoDBColl.java
@@ -101,7 +101,7 @@ class MongoDBColl implements MongoDB.Coll {
                         }
                         return new AbstractMap.SimpleEntry(e.getKey(), value);
                     })
-                    .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
+                    .collect(HashMap::new, (m, e)-> m.put(e.getKey(), e.getValue()), HashMap::putAll); // please look at https://bugs.openjdk.java.net/browse/JDK-8148463
         }
         if (data instanceof Collection) {
             Collection<Object> collection = (Collection<Object>) data;

--- a/src/test/java/apoc/mongodb/MongoDBTest.java
+++ b/src/test/java/apoc/mongodb/MongoDBTest.java
@@ -86,7 +86,7 @@ public class MongoDBTest {
         productCollection.deleteMany(new Document());
         LongStream.range(0, NUM_OF_RECORDS)
                 .forEach(i -> testCollection.insertOne(new Document(map("name", "testDocument",
-                                    "date", currentTime, "longValue", longValue))));
+                                    "date", currentTime, "longValue", longValue, "nullField", null))));
 
         productCollection.insertOne(new Document(map("name", "My Awesome Product",
                 "price", 800,


### PR DESCRIPTION
Fixes #1331

Changed the call `Collectors.toMap` with a new one that manages null values.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Fixed the bug