### PR TITLE
Add apoc.coll.fill function

### DIFF
--- a/docs/asciidoc/utilities/collection.adoc
+++ b/docs/asciidoc/utilities/collection.adoc
@@ -61,6 +61,7 @@ endif::[]
 | apoc.coll.insertAll(coll, index, values) | insert values at index
 | apoc.coll.remove(coll, index, [length=1]) | remove range of values from index to length
 | apoc.coll.different(values) | returns true if value are different
+| apoc.coll.fill(item, count) | returns a list with the given count of items
 |===
 
 .The following computes the sum of values in a list:

--- a/src/main/java/apoc/coll/Coll.java
+++ b/src/main/java/apoc/coll/Coll.java
@@ -891,7 +891,6 @@ public class Coll {
     @UserFunction
     @Description("apoc.coll.fill(item, count) - returns a list with the given count of items")
     public List<Object> fill(@Name("item") String item, @Name("count") long count) {
-        List<Object> newList = new ArrayList<Object>(Collections.nCopies((int) count, item));
-        return newList;
+        return Collections.nCopies((int) count, item);
     }
 }

--- a/src/main/java/apoc/coll/Coll.java
+++ b/src/main/java/apoc/coll/Coll.java
@@ -887,4 +887,11 @@ public class Coll {
 
         return newList;
     }
+
+    @UserFunction
+    @Description("apoc.coll.fill(item, count) - returns a list with the given count of items")
+    public List<Object> fill(@Name("item") String item, @Name("count") long count) {
+        List<Object> newList = new ArrayList<Object>(Collections.nCopies((int) count, item));
+        return newList;
+    }
 }

--- a/src/test/java/apoc/coll/CollTest.java
+++ b/src/test/java/apoc/coll/CollTest.java
@@ -870,5 +870,13 @@ public class CollTest {
                 });
     }
 
+    @Test
+    public void testFill() throws Exception {
+        testResult(db, "RETURN apoc.coll.fill('abc',2) as value",
+                (row) -> {
+                    assertEquals(asList("abc","abc"), row.next().get("value"));
+                });
+    }
+
 }
 


### PR DESCRIPTION
Fixes https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/1339

Added apoc.coll.fill function

Proposed Changes

apoc.coll.fill(item, count) function returns a list with the "count" number of items

Example

return apoc.coll.fill('ab', 2)

returns ['ab', 'ab'] 
