### PR TITLE
fixes #826: apoc.refactor.categorize duplicated categorization nodes

### DIFF
--- a/src/main/java/apoc/Pools.java
+++ b/src/main/java/apoc/Pools.java
@@ -1,6 +1,9 @@
 package apoc;
 
 import apoc.util.Util;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.scheduler.JobScheduler;
 
 import java.util.Arrays;
 import java.util.List;
@@ -18,10 +21,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-
-import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Transaction;
-import org.neo4j.scheduler.JobScheduler;
 
 public class Pools {
 
@@ -124,6 +123,18 @@ public class Pools {
                 return future.get();
             } catch (InterruptedException e) {
                 Thread.interrupted();
+            }
+        }
+    }
+
+    public static <T> T forceSilently(Future<T> future)  {
+        while (true) {
+            try {
+                return future.get();
+            } catch (InterruptedException e) {
+                Thread.interrupted();
+            } catch (ExecutionException e) {
+                throw new RuntimeException(e);
             }
         }
     }

--- a/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -3,6 +3,7 @@ package apoc.refactor;
 import apoc.create.Create;
 import apoc.util.ArrayBackedList;
 import apoc.util.TestUtil;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -10,6 +11,7 @@ import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.ResourceIterator;
@@ -292,10 +294,13 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
 
 
         final boolean outgoing = direction == Direction.OUTGOING ? true : false;
+        final String label = "Letter";
+        final String targetKey = "name";
+        db.execute("CREATE CONSTRAINT ON (n:`" + label + "`) ASSERT n.`" + targetKey + "` IS UNIQUE");
         testCallEmpty(
                 db,
-                "CALL apoc.refactor.categorize('prop','IS_A', $direction, 'Letter','name',['k'],1)",
-                map("direction", outgoing)
+                "CALL apoc.refactor.categorize('prop', 'IS_A', $direction, $label, $targetKey, ['k'], 1)",
+                map("direction", outgoing, "label", label, "targetKey", targetKey)
         );
 
         String traversePattern = (outgoing ? "" : "<") + "-[:IS_A]-" + (outgoing ? ">" : "");
@@ -316,6 +321,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
         }
 
         testCall(db, "MATCH (n) WHERE n.prop IS NOT NULL RETURN count(n) AS count", (r) -> assertThat(((Number)r.get("count")).longValue(), equalTo(0L)));
+        db.execute("DROP CONSTRAINT ON (n:`" + label + "`) ASSERT n.`" + targetKey + "` IS UNIQUE");
     }
 
     @Test
@@ -641,9 +647,11 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                 });
     }
 
-    @Test
-    public void testRefactorCategorizeNoDups() {
+    @Test(expected = QueryExecutionException.class)
+    public void testRefactorCategorizeExceptionWithNoConstraint() {
         // given
+        final String label = "Country";
+        final String targetKey = "name";
         db.execute("with [\"IT\", \"DE\"] as countries\n" +
                 "unwind countries as country\n" +
                 "foreach (no in RANGE(1, 4) |\n" +
@@ -651,7 +659,33 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                 ")").close();
 
         // when
-        db.execute("CALL apoc.refactor.categorize('country', 'OPERATES_IN', true, 'Country', 'name', [], 1)").close();
+        try {
+            db.execute("CALL apoc.refactor.categorize('country', 'OPERATES_IN', true, $label, $targetKey, [], 1)",
+                    map("label", label, "targetKey", targetKey)).close();
+        } catch (QueryExecutionException e) {
+            // then
+            String expectedMessage = "Before execute this procedure you must define an unique constraint for the label and the targetKey:\n" +
+                    "CREATE CONSTRAINT ON (n:`" + label + "`) ASSERT n.`" + targetKey + "` IS UNIQUE";
+            assertEquals(expectedMessage, ExceptionUtils.getRootCause(e).getMessage());
+            throw e;
+        }
+    }
+
+    @Test
+    public void testRefactorCategorizeNoDups() {
+        // given
+        final String label = "Country";
+        final String targetKey = "name";
+        db.execute("CREATE CONSTRAINT ON (n:`" + label + "`) ASSERT n.`" + targetKey + "` IS UNIQUE");
+        db.execute("with [\"IT\", \"DE\"] as countries\n" +
+                "unwind countries as country\n" +
+                "foreach (no in RANGE(1, 4) |\n" +
+                "  create (n:Company {name: country + no, country: country})\n" +
+                ")").close();
+
+        // when
+        db.execute("CALL apoc.refactor.categorize('country', 'OPERATES_IN', true, $label, $targetKey, [], 1)",
+                map("label", label, "targetKey", targetKey)).close();
 
         // then
         final long countries = db.execute("MATCH (c:Country) RETURN count(c) AS countries").<Long>columnAs("countries").next();
@@ -661,6 +695,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
 
         final long relsCount = db.execute("MATCH p = (c:Company)-[:OPERATES_IN]->(cc:Country) RETURN count(p) AS relsCount").<Long>columnAs("relsCount").next();
         assertEquals(8, relsCount);
+        db.execute("DROP CONSTRAINT ON (n:`" + label + "`) ASSERT n.`" + targetKey + "` IS UNIQUE");
     }
 }
 

--- a/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -1,16 +1,27 @@
 package apoc.refactor;
 
+import apoc.create.Create;
 import apoc.util.ArrayBackedList;
 import apoc.util.TestUtil;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Result;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
@@ -20,7 +31,11 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.CoreMatchers.equalTo;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author mh
@@ -33,7 +48,7 @@ public class GraphRefactoringTest {
     @Before
     public void setUp() throws Exception {
         db = new TestGraphDatabaseFactory().newImpermanentDatabase();
-        TestUtil.registerProcedure(db, GraphRefactoring.class);
+        TestUtil.registerProcedure(db, GraphRefactoring.class, Create.class);
     }
 
     /*
@@ -624,6 +639,28 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                     assertEquals(true, node.hasLabel(Label.label("Person")));
                     assertEquals(2L, node.getProperty("ID"));
                 });
+    }
+
+    @Test
+    public void testRefactorCategorizeNoDups() {
+        // given
+        db.execute("with [\"IT\", \"DE\"] as countries\n" +
+                "unwind countries as country\n" +
+                "foreach (no in RANGE(1, 4) |\n" +
+                "  create (n:Company {name: country + no, country: country})\n" +
+                ")").close();
+
+        // when
+        db.execute("CALL apoc.refactor.categorize('country', 'OPERATES_IN', true, 'Country', 'name', [], 1)").close();
+
+        // then
+        final long countries = db.execute("MATCH (c:Country) RETURN count(c) AS countries").<Long>columnAs("countries").next();
+        assertEquals(2, countries);
+        final List<String> countryNames = db.execute("MATCH (c:Country) RETURN collect(c.name) AS countries").<List<String>>columnAs("countries").next();
+        assertEquals(new HashSet<>(Arrays.asList("IT", "DE")), new HashSet<>(countryNames));
+
+        final long relsCount = db.execute("MATCH p = (c:Company)-[:OPERATES_IN]->(cc:Country) RETURN count(p) AS relsCount").<Long>columnAs("relsCount").next();
+        assertEquals(8, relsCount);
     }
 }
 


### PR DESCRIPTION
Fixes #826

Fixed the bug

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

- Split the categorization into two phases
  - First, we create the categorization nodes
  - Second, we create the connection between the categorization nodes and "old" nodes 