### PR TITLE
fixes #1262: apoc.cypher.runFile fails when there is a empty transaction

### DIFF
--- a/src/main/java/apoc/cypher/Cypher.java
+++ b/src/main/java/apoc/cypher/Cypher.java
@@ -172,7 +172,9 @@ public class Cypher {
     private String removeShellControlCommands(String stmt) {
         Matcher matcher = shellControl.matcher(stmt.trim());
         if (matcher.find()) {
-            stmt = matcher.replaceAll("");
+            // an empty file get transformed into ":begin\n:commit" and that statement is not matched by the pattern
+            // because ":begin\n:commit".replaceAll("") => "\n:commit" with the recursion we avoid the problem
+            return removeShellControlCommands(matcher.replaceAll(""));
         }
         return stmt;
     }

--- a/src/test/java/apoc/cypher/CypherTest.java
+++ b/src/test/java/apoc/cypher/CypherTest.java
@@ -457,4 +457,10 @@ public class CypherTest {
                     assertEquals("C", ((Map) r.get("value")).get("cName"));
                 });
     }
+
+    @Test
+    public void testRunFileWithEmptyFile() throws Exception {
+        testResult(db, "CALL apoc.cypher.runFile('src/test/resources/empty.cypher')",
+                r -> assertFalse("should be empty", r.hasNext()));
+    }
 }

--- a/src/test/resources/empty.cypher
+++ b/src/test/resources/empty.cypher
@@ -1,0 +1,2 @@
+:begin
+:commit


### PR DESCRIPTION
Fixes #1262

Fixed the bug

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added a recursion into the `removeShellControlCommands` method
  - Added test
