### PR TITLE
fixes #1136: Nodes versions of relationship.types|exists

### DIFF
--- a/docs/asciidoc/_path_finding.adoc
+++ b/docs/asciidoc/_path_finding.adoc
@@ -79,7 +79,10 @@ This section describes functions that can be used to query nodes.
 | apoc.nodes.isDense(node) | returns true if it is a dense node
 | apoc.nodes.connected(start, end, rel-direction-pattern) | returns true when the node is connected to the other node, optimized for dense nodes
 | apoc.node.relationship.exists(node, rel-direction-pattern) | returns true when the node has the relationships of the pattern
+| apoc.node.relationships.exist(node, rel-direction-pattern) | returns a map with rel-pattern, boolean for the given relationship patterns
+| apoc.nodes.relationships.exist(node\|nodes\|id\|[ids], rel-direction-pattern) | returns a list of maps where each one has two fields: `node` which is the node subject of the analysis and `exists` which is a map with <rel-pattern, boolean> for the given relationship patterns
 | apoc.node.relationship.types(node, rel-direction-pattern) | returns a list of distinct relationship types
+| apoc.nodes.relationship.types(node\|nodes\|id\|[ids], rel-direction-pattern) | returns a list of maps where each one has two fields: `node` which is the node subject of the analysis and `types` which is a list of distinct relationship types
 | apoc.node.degree(node, rel-direction-pattern) | returns total degrees of the given relationships in the pattern, can use `'>'` or `'<'` for all outgoing or incoming relationships
 | apoc.node.id(node) | returns id for (virtual) nodes
 | apoc.node.degree.in(node, relationshipName) | returns total number of incoming relationship

--- a/src/main/java/apoc/path/RelationshipTypeAndDirections.java
+++ b/src/main/java/apoc/path/RelationshipTypeAndDirections.java
@@ -24,8 +24,6 @@ public abstract class RelationshipTypeAndDirections {
                 return type + ">";
             case INCOMING:
                 return "<" + type;
-            case BOTH:
-                return type;
             default:
                 return type;
         }

--- a/src/test/java/apoc/nodes/NodesTest.java
+++ b/src/test/java/apoc/nodes/NodesTest.java
@@ -8,17 +8,28 @@ import apoc.util.Util;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.helpers.collection.Iterables;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static apoc.util.Util.map;
 import static java.util.Arrays.asList;
-import static java.util.Collections.*;
-import static org.junit.Assert.*;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.helpers.collection.Iterators.asSet;
-import org.neo4j.helpers.collection.Iterables;
 
 /**
  * @author mh
@@ -80,7 +91,53 @@ public class NodesTest {
     }
 
     @Test
-    public void hasRelationhip() throws Exception {
+    public void nodesTypes() throws Exception {
+        // given
+        db.execute("CREATE (f:Foo), (f)-[:Y]->(f), (f)-[:X]->(f)").close();
+        db.execute("CREATE (f:Bar), (f)-[:YY]->(f), (f)-[:XX]->(f)").close();
+
+        // when
+        TestUtil.testCall(db, "MATCH (n) RETURN apoc.nodes.relationship.types(collect(n)) AS value",
+                (result) -> {
+                    // then
+                    List<Map<String, Object>> list = (List<Map<String, Object>>) result.get("value");
+                    assertFalse("value should not be empty", list.isEmpty());
+                    list.forEach(map -> {
+                        Node node = (Node) map.get("node");
+                        List<String> data = (List<String>) map.get("types");
+                        if (node.hasLabel(Label.label("Foo"))) {
+                            assertEquals(asSet("X", "Y"), asSet(data.iterator()));
+                        } else {
+                            assertEquals(asSet("XX", "YY"), asSet(data.iterator()));
+                        }
+                    });
+                });
+    }
+
+    @Test
+    public void nodesHasRelationship() throws Exception {
+        // given
+        db.execute("CREATE (:Foo)-[:Y]->(:Bar),(n:FooBar) WITH n UNWIND range(1,100) as _ CREATE (n)-[:X]->(n)").close();
+
+        // when
+        TestUtil.testCall(db,"MATCH (n) RETURN apoc.nodes.relationships.exist(collect(n), 'Y|X') AS value", (result) -> {
+            // then
+            List<Map<String, Object>> list = (List<Map<String, Object>>) result.get("value");
+            assertFalse("value should not be empty", list.isEmpty());
+            list.forEach(map -> {
+                Node node = (Node) map.get("node");
+                Map<String, Boolean> data = (Map<String, Boolean>) map.get("exists");
+                if (node.hasLabel(Label.label("Foo")) || node.hasLabel(Label.label("Bar"))) {
+                    assertEquals(map("Y", true, "X", false), data);
+                } else {
+                    assertEquals(map("Y", false, "X", true), data);
+                }
+            });
+        });
+    }
+
+    @Test
+    public void hasRelationship() throws Exception {
         db.execute("CREATE (:Foo)-[:Y]->(:Bar),(n:FooBar) WITH n UNWIND range(1,100) as _ CREATE (n)-[:X]->(n)").close();
         TestUtil.testCall(db,"MATCH (n:Foo) RETURN apoc.node.relationship.exists(n,'Y') AS value",(r)-> assertEquals(true,r.get("value")));
         TestUtil.testCall(db,"MATCH (n:Foo) RETURN apoc.node.relationship.exists(n,'Y>') AS value", (r)-> assertEquals(true,r.get("value")));
@@ -97,9 +154,9 @@ public class NodesTest {
         TestUtil.testCall(db,"MATCH (n:FooBar) RETURN apoc.node.relationship.exists(n,'<X') AS value", (r)-> assertEquals(true,r.get("value")));
         TestUtil.testCall(db,"MATCH (n:FooBar) RETURN apoc.node.relationship.exists(n,'Y') AS value", (r)-> assertEquals(false,r.get("value")));
     }
-    @Test
 
-    public void hasRelationhips() throws Exception {
+    @Test
+    public void hasRelationships() throws Exception {
         db.execute("CREATE (:Foo)-[:Y]->(:Bar),(n:FooBar) WITH n UNWIND range(1,100) as _ CREATE (n)-[:X]->(n)").close();
         TestUtil.testCall(db,"MATCH (n:Foo) RETURN apoc.node.relationships.exist(n,'Y') AS value",(r)-> assertEquals(map("Y",true),r.get("value")));
         TestUtil.testCall(db,"MATCH (n:Foo) RETURN apoc.node.relationships.exist(n,'Y>') AS value", (r)-> assertEquals(map("Y>",true),r.get("value")));


### PR DESCRIPTION
Fixes #1136

Added the procedures

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added `apoc.nodes.relationships.exist` and `apoc.nodes.relationship.types`
  - Added tests
  - Updated documentation
