### PR TITLE
[WIP] fixes #1336: Create apoc.export.cypher format and outputs optimised for passing to apoc.bolt.execute

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ dependencies {
     testCompile group: 'com.sun.mail', name: 'javax.mail', version: '1.6.0'
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
     compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
-    compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '1.7.3'
+    compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '1.7.5'
     compile group: 'com.novell.ldap', name: 'jldap', version: '2009-10-07'
 
     def withoutAntlr =  {

--- a/src/main/java/apoc/cypher/Cypher.java
+++ b/src/main/java/apoc/cypher/Cypher.java
@@ -56,7 +56,7 @@ public class Cypher {
     ProcedureTransaction procedureTransaction;
      */
 
-    @Procedure
+    @Procedure(mode = WRITE)
     @Description("apoc.cypher.run(fragment, params) yield value - executes reading fragment with the given parameters")
     public Stream<MapResult> run(@Name("cypher") String statement, @Name("params") Map<String, Object> params) {
         if (params == null) params = Collections.emptyMap();


### PR DESCRIPTION
Fixes #1336

This (WIP) PR proposes two procedures in order to address the request or the related issue:

- `apoc.bolt.load.fromLocal($url, $localStatement, $remoteStatement, $config)`: which allow to execute a statement into `local` Neo4j instance with the `localStatement` variable and use the result of the execution in order use them in combination with the `remoteStatement` in the `remote` Neo4j instance. **The procedure can be useful when the user needs to call `apoc.bolt.load` more than once (maybe in an unwind) because on each call we create a new Driver (& Session) instance that can slow down the performances, while into the `fromLocal` procedure we create them once**
Please look at the related tests `testLoadFromLocal` and `testLoadFromLocalStream` into the `BoltTest` class
It the `config` contains `streamStatements` as true, the procedure assumes that the output of the `localStatement` execution is a table rows of two columns:
  - `statement`: a cypher string executed into the remote statement (mandatory)
  - `params`: a map of params related to the cypher statement (optional)
- `apoc.bolt.clone.all($url)`: under-the-hood uses the `ExportCypher` business logic in order to stream statements to the remote instance.

So while the first procedure is more general, the second one is focused on cloning the database. The first idea with @mneedham was to provide only the `apoc.bolt.clone.all` but when I start to work on it I found that maybe a general approach can be useful for other use-cases.

I created this as WIP because I want to chat with you guys about the approach.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Implemented the procedures
  - Added tests


