### PR TITLE
fixes #1064: Add procedure to compare graphs

### DIFF
--- a/docs/asciidoc/database-integration/bolt.adoc
+++ b/docs/asciidoc/database-integration/bolt.adoc
@@ -66,7 +66,9 @@ apoc.bolt.production.url=bolt://password:test@localhost:7688
 Config available are:
 
 * `statistics`: possible values are true/false, the default value is false. This config print the execution statistics;
-* `virtual`: possible values are true/false, the default value is false. This config return result in virtual format and not in map format, in apoc.bolt.load.
+* `virtual`: possible values are true/false, the default value is false. This config return result in virtual format and not in map format. *N.B.* If `withRelationshipNodeProperties=false` the `VirtualRelationship` contains only the ids about the nodes connected by the edge
+* `readOnly`: possible values are true/false, the default value is true. Defines the operation performed over the remote instance.
+* `withRelationshipNodeProperties`: possible values are true/false, the default value is false. If `virtual=true` it returns the `VirtualRelationship` with nodes that also contains properties attached to them.
 
 == Driver configuration
 

--- a/docs/asciidoc/utilities/diff.adoc
+++ b/docs/asciidoc/utilities/diff.adoc
@@ -1,6 +1,8 @@
 [[node-difference]]
 = Diff
 
+== `apoc.diff.nodes` function
+
 [abstract]
 --
 This section describes a function that displays the difference between two nodes.
@@ -42,3 +44,66 @@ return apoc.diff.nodes(n,m)
   }
 }
 ----
+
+== `apoc.diff.graphs` procedure
+
+[abstract]
+--
+This section describes a procedure that compares two graphs
+--
+
+The `apoc.diff.graphs` compares two graphs and returns the differences in term of:
+
+* same node count
+* same count per label
+* same relationship counter
+* same count per rel-type
+
+For each node in the `source` graph with a certain label, find the same node (in the `dest` graph) by keys or internal id in the other graph and if found:
+* compare all labels
+* compare all properties
+
+For each relationship in the `source` graph we'll get the two nodes of the relationship and look into the the `dest`
+graph if there is a relationship with the same properties and the same start/end node.
+
+=== How can you use it?
+
+You can use it for comparing a local Neo4j instance with a remote one
+by adding the BOLT remote url in the configuration map as follows:
+
+.Example
+[source,cypher]
+----
+CALL apoc.diff.graphs(
+    'MATCH (n) OPTIONAL MATCH (n)-[r]->(m) RETURN n, r, m',
+    'MATCH (n) OPTIONAL MATCH (n)-[r]->(m) RETURN n, r, m',
+    {dest: {target: {value: '<remote url>'}, params: {<query params>}}}) YIELD difference, entityType, id, sourceLabel, destLabel, source, dest
+RETURN difference, entityType, id, sourceLabel, destLabel, source, dest
+----
+
+The second query will be performed in the remote instance identified by the value inside the field `value` as shown in the query above.
+
+*N.B.* the two queries are equals just to extract the full graph from the two instances.
+
+
+=== Config Params
+
+[options="header",cols="2a,a,2m"]
+|===
+| Param | default value | description
+
+| findById | false | If no node by is found by keys, it tries to find the node by the same internal id
+| source | Map<String, Object> | A map configuration param related to the first query argument
+| dest | Map<String, Object> | A map configuration param related to the second query argument
+
+|===
+
+Following the parameters of `source/dest` map:
+[options="header",cols="2a,a,2m"]
+|===
+| Param | default value | description
+
+| target | Map<String, String> | The target map
+| params | Map<String, Object> | A list of params applied to the cypher query
+
+|===

--- a/src/main/java/apoc/bolt/BoltConfig.java
+++ b/src/main/java/apoc/bolt/BoltConfig.java
@@ -1,0 +1,40 @@
+package apoc.bolt;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static apoc.util.Util.toBoolean;
+
+public class BoltConfig {
+
+    private final boolean virtual;
+    private final boolean addStatistics;
+    private final boolean readOnly;
+    private final boolean withRelationshipNodeProperties;
+
+    public BoltConfig(Map<String, Object> configMap) {
+        if (configMap == null) {
+            configMap = Collections.emptyMap();
+        }
+        this.virtual = toBoolean(configMap.getOrDefault("virtual", false));
+        this.addStatistics = toBoolean(configMap.getOrDefault("statistics", false));
+        this.readOnly = toBoolean(configMap.getOrDefault("readOnly", true));
+        this.withRelationshipNodeProperties = toBoolean(configMap.getOrDefault("withRelationshipNodeProperties", false));
+    }
+
+    public boolean isVirtual() {
+        return virtual;
+    }
+
+    public boolean isAddStatistics() {
+        return addStatistics;
+    }
+
+    public boolean isReadOnly() {
+        return readOnly;
+    }
+
+    public boolean isWithRelationshipNodeProperties() {
+        return withRelationshipNodeProperties;
+    }
+}

--- a/src/main/java/apoc/diff/Diff.java
+++ b/src/main/java/apoc/diff/Diff.java
@@ -1,13 +1,41 @@
 package apoc.diff;
 
 import apoc.Description;
-import apoc.util.MapUtil;
+import apoc.export.util.FormatUtils;
+import apoc.export.util.MapSubGraph;
+import apoc.export.util.NodesAndRelsSubGraph;
+import apoc.util.Util;
+import org.apache.commons.lang3.StringUtils;
+import org.neo4j.cypher.export.CypherResultSubGraph;
+import org.neo4j.cypher.export.SubGraph;
+import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
-import org.neo4j.procedure.*;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.schema.ConstraintDefinition;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.UserFunction;
 
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static apoc.util.Util.map;
 
 /**
  * @author Benjamin Clauss
@@ -15,6 +43,9 @@ import java.util.Map;
  */
 public class Diff {
 
+    public static final String NODE = "Node";
+    public static final String RELATIONSHIP = "Relationship";
+    public static final String DESTINATION_ENTITY_NOT_FOUND = "Destination Entity not found";
     @Context
     public GraphDatabaseService db;
 
@@ -61,5 +92,338 @@ public class Diff {
             }
         }
         return different;
+    }
+
+    public static class SourceDestResult {
+        public final String difference;
+        public final String entityType;
+        public final Long id;
+        public final String sourceLabel;
+        public final String destLabel;
+        public final Object source;
+        public final Object dest;
+
+        public SourceDestResult(String difference, String entityType, Long id, String sourceLabel,
+                                String destLabel, Object source, Object dest) {
+            this.difference = difference;
+            this.entityType = entityType;
+            this.id = id;
+            this.sourceLabel = sourceLabel;
+            this.destLabel = destLabel;
+            this.source = source;
+            this.dest = dest;
+        }
+
+        public SourceDestResult(String difference, String entityType, Object source, Object dest) {
+            this.difference = difference;
+            this.entityType = entityType;
+            this.id = null;
+            this.sourceLabel = null;
+            this.destLabel = null;
+            this.source = source;
+            this.dest = dest;
+        }
+
+        private boolean areSourceAndDestEqual() {
+            if (source == null && dest == null) return true;
+            if (source == null || dest == null) return false;
+            return source.equals(dest);
+        }
+    }
+
+    @Procedure("apoc.diff.graphs")
+    @Description("CALL apoc.diff.nodes(<source>, <dest>, <config>) YIELD difference, entityType, id, sourceLabel, destLabel, source, dest - compares two graphs and returns the results")
+    public Stream<SourceDestResult> compare(@Name(value = "source") Object source,
+                                        @Name(value = "dest") Object dest,
+                                        @Name(value = "config", defaultValue = "{}") Map<String,Object> config) {
+        config = config == null ? Collections.emptyMap() : config;
+        SubGraph sourceGraph = toSubGraph(source, config, SourceDestConfig.fromMap((Map<String, Object>) config.get("source")));
+        SubGraph destGraph = toSubGraph(dest, config, SourceDestConfig.fromMap((Map<String, Object>) config.get("dest")));
+
+        Function<Map<String, Long>, Long> sum = (map) -> map.values().stream().reduce(0L, (x, y) -> x + y);
+        final SourceDestResult labelNodeCount = sourceDestCountByLabel(sourceGraph, destGraph);
+        final SourceDestResult nodeCount = labelNodeCount.areSourceAndDestEqual() ?
+                null : new SourceDestResult("Total count", NODE,
+                    sum.apply((Map<String, Long>) labelNodeCount.source), sum.apply((Map<String, Long>) labelNodeCount.dest));
+        final SourceDestResult typeRelCount = sourceDestCountByType(sourceGraph, destGraph);
+        final SourceDestResult relCount = typeRelCount.areSourceAndDestEqual() ?
+                null : new SourceDestResult("Total count", RELATIONSHIP,
+                    sum.apply((Map<String, Long>) typeRelCount.source), sum.apply((Map<String, Long>) typeRelCount.dest));
+
+        final Stream<SourceDestResult> generalStream = Stream.of(
+                nodeCount, nodeCount != null ? labelNodeCount : null,
+                relCount, relCount != null ? typeRelCount : null)
+                .filter(elem -> elem != null);
+        DiffConfig diffConfig = new DiffConfig(config);
+        final Stream<SourceDestResult> nodeStream = compareNodes(sourceGraph, destGraph, diffConfig);
+        final Stream<SourceDestResult> relStream = compareRels(sourceGraph, destGraph);
+        return Stream.of(generalStream, nodeStream, relStream)
+                .reduce(Stream::concat)
+                .orElse(Stream.empty());
+    }
+
+    private SubGraph toSubGraph(Object input, Map<String, Object> config, SourceDestConfig sourceDestConfig) {
+        if (input == null) {
+            throw new NullPointerException("Input data is null");
+        }
+        if (input instanceof Map) {
+            Map<String, Object> graph = (Map<String, Object>) input;
+            if (graph.containsKey("schema")) {
+                return new MapSubGraph(graph);
+            } else {
+                Collection<Node> nodes = (Collection<Node>) graph.get("nodes");
+                Collection<Relationship> rels = (Collection<Relationship>) graph.get("relationships");
+                return new NodesAndRelsSubGraph(db, nodes, rels);
+            }
+        }
+        if (input instanceof String) {
+            final String inputString = (String) input;
+            if (sourceDestConfig != null) {
+                if (StringUtils.isNotBlank(sourceDestConfig.getTarget().getValue())) {
+                    switch (sourceDestConfig.getTarget().getType()) {
+                        case URL:
+                            final Map<String, List<Object>> graph = createMapFromRemoteDb(inputString,
+                                    sourceDestConfig.getTarget().getValue(),
+                                    sourceDestConfig.getParams());
+                            return toSubGraph(graph, config, null);
+                        default:
+                            throw new IllegalArgumentException("The following type is not supported: " + sourceDestConfig.getTarget().getType());
+                    }
+                } else {
+                    return toSubGraph(db.execute(inputString, sourceDestConfig.getParams()), config, null);
+                }
+            }
+            return toSubGraph(db.execute(inputString), config, null);
+        }
+        if (input instanceof Result) {
+            Result result = (Result) input;
+            return CypherResultSubGraph.from(result, db, Util.toBoolean(config.getOrDefault("relsInBetween", false)));
+        }
+        if (input instanceof Path) {
+            Path path = (Path) input;
+            return new NodesAndRelsSubGraph(db, Iterables.asCollection(path.nodes()),
+                    Iterables.asCollection(path.relationships()));
+        }
+        throw new IllegalArgumentException("Unsupported input type: " + input.getClass().getName());
+    }
+
+    private Map<String, List<Object>> createMapFromRemoteDb(String inputString, String url, Map<String, Object> params) {
+        params = params == null ? Collections.emptyMap() : params;
+        String boltLoadQuery = "CALL apoc.bolt.load($url, $boltQuery, $params, $boltConfig) YIELD row";
+        final Map<String, Object> boltConfig = map("virtual", true, "withRelationshipNodeProperties", true);
+
+        final Result execute = db.execute(boltLoadQuery, map("boltConfig", boltConfig, "boltQuery", inputString, "url", url, "params", params));
+
+        final Map<String, List<Object>> graph = createBaseMapFromRemoteDb(execute);
+
+        final Optional<List<Object>> schemaOpt = retrieveSchemaFromRemoteDB(boltLoadQuery, boltConfig, url);
+        schemaOpt.ifPresent((schema) -> graph.put("schema", schema));
+        return graph;
+    }
+
+    private Optional<List<Object>> retrieveSchemaFromRemoteDB(String boltLoadQuery,
+                                                              Map<String, Object> boltConfig,
+                                                              String url) {
+        String boltQuery = "CALL db.indexes() YIELD tokenNames, properties, state, type\n" +
+                "WHERE state = 'ONLINE' AND type = 'node_unique_property'\n" +
+                "RETURN collect({labels: tokenNames, properties: properties, type: type}) AS schema\n";
+        return db.execute(boltLoadQuery, map("boltConfig", boltConfig, "boltQuery", boltQuery, "url", url, "params", Collections.emptyMap()))
+                .stream()
+                .map(row -> (Map<String, Object>) row.get("row"))
+                .map(row -> (List<Object>) row.get("schema"))
+                .findFirst();
+    }
+
+    private Map<String, List<Object>> createBaseMapFromRemoteDb(Result execute) {
+        return execute.stream()
+                .map(row -> row.get("row"))
+                .map(this::extractGraphEntity)
+                .flatMap(elem -> elem instanceof Collection ? ((Collection<Object>) elem).stream() : Stream.of(elem))
+                .map(value -> {
+                    final String key;
+                    if (value instanceof Node) {
+                        key = "nodes";
+                    } else {
+                        key = "relationships";
+                    }
+                    return new AbstractMap.SimpleEntry<>(key, value);
+                })
+                .collect(Collectors.groupingBy(e -> e.getKey(), Collectors.mapping(e -> e.getValue(), Collectors.toList())));
+    }
+
+    private Object extractGraphEntity(Object input) {
+        if (input instanceof Collection) {
+            return ((Collection) input).stream()
+                    .flatMap(elem -> elem instanceof Collection ? ((Collection<Object>) elem).stream() : Stream.of(elem))
+                    .map(this::extractGraphEntity)
+                    .collect(Collectors.toList());
+        }
+        if (input instanceof Map) {
+            final Map<String, Object> map = (Map<String, Object>) input;
+            return extractGraphEntity(map.values());
+        }
+        if (input instanceof Node || input instanceof Relationship) {
+            return input;
+        }
+        throw new RuntimeException("Type not managed: " + input.getClass().getSimpleName());
+    }
+
+    private Map<String, Long> countByLabel(SubGraph graph) {
+        return StreamSupport.stream(graph.getNodes().spliterator(), false)
+                .flatMap(n -> StreamSupport.stream(n.getLabels().spliterator(), false)
+                        .map(Label::name))
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+    }
+
+    private Map<String, Long> countByType(SubGraph graph) {
+        return StreamSupport.stream(graph.getRelationships().spliterator(), false)
+                .map(r -> r.getType().name())
+                .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+    }
+
+    private SourceDestResult sourceDestCountByLabel(SubGraph source, SubGraph dest) {
+        return new SourceDestResult("Count by Label", NODE, countByLabel(source), countByLabel(dest));
+    }
+
+    private SourceDestResult sourceDestCountByType(SubGraph source, SubGraph dest) {
+        return new SourceDestResult("Count by Type", RELATIONSHIP, countByType(source), countByType(dest));
+    }
+
+    private <T extends Entity> T findEntityById(Iterable<T> it, long id) {
+        return StreamSupport.stream(it.spliterator(), true)
+                .filter(entity -> entity.getId() == id)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private Node findNode(Iterable<Node> it, Node node, SubGraph graph, DiffConfig config) {
+        ConstraintDefinition constraintDefinition = getConstraint(node, graph);
+        if (constraintDefinition == null) {
+            return config.isFindById() ? findEntityById(it, node.getId()) : null;
+        }
+        Map<String, Object> keys = getNodeKeys(node, constraintDefinition);
+        return StreamSupport.stream(it.spliterator(), true)
+                .filter(entity -> entity.getProperties(Iterables.asArray(String.class, keys.keySet())).equals(keys))
+                .findFirst()
+                .orElse(null);
+    }
+
+    private ConstraintDefinition getConstraint(Node node, SubGraph graph) {
+        ConstraintDefinition constraintDefinition = null;
+        for (Label label : node.getLabels()) {
+            for (ConstraintDefinition constr : graph.getConstraints()) {
+                if (!constr.getLabel().name().equals(label.name())) continue;
+                final long count = Iterables.count(constr.getPropertyKeys());
+                if (constraintDefinition == null || Iterables.count(constraintDefinition.getPropertyKeys()) > count) {
+                    constraintDefinition = constr;
+                    if (count == 1) {
+                        break;
+                    }
+                }
+            }
+        }
+        return constraintDefinition;
+    }
+
+    private SourceDestDTO sourceDestMap(Object sourceVal, Object destVal) {
+        return new SourceDestDTO(sourceVal, destVal);
+    }
+
+    private SourceDestDTO transformDiff(Map<String, Map<String, Object>> propDiffs) {
+        Map<String, Object> sourceFields = new HashMap<>();
+        Map<String, Object> destFields = new HashMap<>();
+        propDiffs.forEach((prop, diff) -> {
+            sourceFields.put(prop, diff.get("left"));
+            destFields.put(prop, diff.get("right"));
+        });
+        return sourceDestMap(sourceFields, destFields);
+    }
+
+    private class SourceDestDTO {
+        private final Object source;
+        private final Object dest;
+        SourceDestDTO(Object source, Object dest) {
+            this.source = source;
+            this.dest = dest;
+        }
+    }
+
+    private Stream<SourceDestResult> compareRels(SubGraph sourceGraph, SubGraph destGraph) {
+        return StreamSupport.stream(sourceGraph.getRelationships().spliterator(), true)
+                .map(sourceRel -> {
+                    final Map<String, Object> startKeys = getNodeKeys(sourceRel.getStartNode(), sourceGraph);
+                    final Map<String, Object> endKeys = getNodeKeys(sourceRel.getEndNode(), sourceGraph);
+                    final Map<String, Object> sourceRelAllProperties = sourceRel.getAllProperties();
+                    final Relationship destRel = StreamSupport.stream(destGraph.getRelationships().spliterator(), true)
+                            .filter(elem -> {
+                                final Map<String, Object> startDestKeys = getNodeKeys(elem.getStartNode(), destGraph);
+                                final Map<String, Object> endDestKeys = getNodeKeys(elem.getEndNode(), destGraph);
+                                boolean areKeysEqual = startKeys.equals(startDestKeys) && endKeys.equals(endDestKeys);
+                                if (!sourceRelAllProperties.isEmpty()) {
+                                    return areKeysEqual && sourceRelAllProperties.equals(elem.getAllProperties());
+                                } else {
+                                    return areKeysEqual;
+                                }
+                            })
+                            .findFirst()
+                            .orElse(null);
+                    return destRel == null ? new SourceDestResult(DESTINATION_ENTITY_NOT_FOUND,
+                            RELATIONSHIP, sourceRel.getId(), sourceRel.getType().name(), null,
+                            Util.map("start", startKeys, "end", endKeys, "properties", sourceRelAllProperties), null) : null;
+                })
+                .filter(entity -> entity != null);
+    }
+
+    private Map<String, Object> getNodeKeys(Node node, ConstraintDefinition constraint) {
+        if (constraint == null) return null;
+        String[] propKeys = Iterables.asList(constraint.getPropertyKeys()).toArray(new String[0]);
+        return node.getProperties(propKeys);
+    }
+
+    private Map<String, Object> getNodeKeys(Node node, SubGraph subGraph) {
+        ConstraintDefinition constraint = getConstraint(node, subGraph);
+        return getNodeKeys(node, constraint);
+    }
+
+    private Stream<SourceDestResult> compareNodes(SubGraph source, SubGraph dest, DiffConfig config) {
+        return StreamSupport.stream(source.getNodes().spliterator(), true)
+               .map(node -> new AbstractMap.SimpleEntry<>(node, findNode(dest.getNodes(), node, dest, config)))
+               .flatMap(entry -> {
+                   List<SourceDestResult> diffs = new ArrayList<>();
+                   final Node sourceNode = entry.getKey();
+                   final Node destNode = entry.getValue();
+
+                   final String sourceLabel = getFirstLabel(sourceNode);
+                   final long id = sourceNode.getId();
+
+                   if (destNode == null) {
+                       final Map<String, Object> nodeKeys = getNodeKeys(sourceNode, getConstraint(sourceNode, source));
+                       diffs.add(new SourceDestResult(DESTINATION_ENTITY_NOT_FOUND, NODE, id, sourceLabel, null, nodeKeys, null));
+                   } else {
+                       final String destLabel = getFirstLabel(destNode);
+                       List<String> sourceLabels = FormatUtils.getLabelsSorted(sourceNode);
+                       List<String> destLabels = FormatUtils.getLabelsSorted(destNode);
+                       if (!sourceLabels.equals(destLabels)) {
+                           diffs.add(new SourceDestResult("Different Labels", NODE, id, sourceLabel, destLabel, sourceLabels, destLabels));
+                       } else {
+                           final Map<String, Map<String, Object>> propDiff = getPropertiesDiffering(sourceNode.getAllProperties(),
+                                   destNode.getAllProperties());
+                           if (!propDiff.isEmpty()) {
+                               final SourceDestDTO sourceDestDTO = transformDiff(propDiff);
+                               diffs.add(new SourceDestResult("Different Properties", NODE, id, sourceLabel, destLabel, sourceDestDTO.source, sourceDestDTO.dest));
+                           } else { // if the two nodes are equal lets compare the relationships
+                               return diffs.stream();
+                           }
+                       }
+                   }
+                   return diffs.stream();
+               });
+    }
+
+    private String getFirstLabel(Node sourceNode) {
+        return StreamSupport.stream(sourceNode.getLabels().spliterator(), false)
+                .map(Label::name)
+                .findFirst()
+                .orElse(null);
     }
 }

--- a/src/main/java/apoc/diff/DiffConfig.java
+++ b/src/main/java/apoc/diff/DiffConfig.java
@@ -1,0 +1,46 @@
+package apoc.diff;
+
+import apoc.util.Util;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class DiffConfig {
+
+    private final boolean leftOnly;
+    private final boolean rightOnly;
+    private final boolean inCommon;
+    private final boolean different;
+    private final boolean findById;
+
+    public DiffConfig(Map<String, Object> config) {
+        if (config == null) {
+            config = Collections.emptyMap();
+        }
+        this.leftOnly = Util.toBoolean(config.getOrDefault("leftOnly", true));
+        this.rightOnly = Util.toBoolean(config.getOrDefault("rightOnly", true));
+        this.inCommon = Util.toBoolean(config.getOrDefault("inCommon", true));
+        this.different = Util.toBoolean(config.getOrDefault("different", true));
+        this.findById = Util.toBoolean(config.getOrDefault("findById", false));
+    }
+
+    public boolean isLeftOnly() {
+        return leftOnly;
+    }
+
+    public boolean isRightOnly() {
+        return rightOnly;
+    }
+
+    public boolean isInCommon() {
+        return inCommon;
+    }
+
+    public boolean isDifferent() {
+        return different;
+    }
+
+    public boolean isFindById() {
+        return findById;
+    }
+}

--- a/src/main/java/apoc/diff/SourceDestConfig.java
+++ b/src/main/java/apoc/diff/SourceDestConfig.java
@@ -1,0 +1,56 @@
+package apoc.diff;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class SourceDestConfig {
+    public enum SourceDestConfigType { URL, DATABASE }
+
+    static class TargetConfig {
+        private final SourceDestConfigType type;
+        private final String value;
+
+        public TargetConfig(SourceDestConfigType type, String value) {
+            this.type = type;
+            this.value = value;
+        }
+
+        public SourceDestConfigType getType() {
+            return type;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    private final Map<String, Object> params;
+    private final TargetConfig target;
+
+    public SourceDestConfig(SourceDestConfigType type, String value, Map<String, Object> params) {
+        this.target = new TargetConfig(type, value);
+        this.params = params;
+    }
+
+    public TargetConfig getTarget() {
+        return target;
+    }
+
+    public Map<String, Object> getParams() {
+        return params;
+    }
+
+    public static SourceDestConfig fromMap(Map<String, Object> map) {
+        map = map == null ? Collections.emptyMap() : map;
+        if (map.isEmpty()) {
+            return null;
+        } else {
+            Map<String, Object> target = (Map<String, Object>) map.getOrDefault("target", Collections.emptyMap());
+            SourceDestConfigType type = SourceDestConfigType
+                    .valueOf((String) target.getOrDefault("type", SourceDestConfigType.URL.toString()));
+            return new SourceDestConfig(type,
+                    (String) target.get("value"),
+                    (Map<String, Object>) map.getOrDefault("params", Collections.emptyMap()));
+        }
+    }
+}

--- a/src/main/java/apoc/export/util/MapSubGraph.java
+++ b/src/main/java/apoc/export/util/MapSubGraph.java
@@ -1,0 +1,184 @@
+package apoc.export.util;
+
+import org.neo4j.cypher.export.SubGraph;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.schema.ConstraintDefinition;
+import org.neo4j.graphdb.schema.ConstraintType;
+import org.neo4j.graphdb.schema.IndexDefinition;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+
+public class MapSubGraph implements SubGraph {
+
+    public static class MapIndexDefinition implements IndexDefinition {
+        private final Label label;
+        private final Collection<Label> labels;
+        private final Collection<String> properties;
+        private final String type;
+
+        public MapIndexDefinition(Map<String, Object> map) {
+            Collection<String> labels = (Collection<String>) map.get("labels");
+            Collection<String> properties = (Collection<String>) map.get("properties");
+            String type = (String) map.get("type");
+            this.labels = labels.stream().map(Label::label).collect(Collectors.toList());
+            this.label = this.labels.iterator().next();
+            this.properties = properties;
+            this.type = type;
+        }
+
+        @Override
+        public Label getLabel() {
+            return label;
+        }
+
+        @Override
+        public Iterable<Label> getLabels() {
+            return labels;
+        }
+
+        @Override
+        public RelationshipType getRelationshipType() {
+            throw new UnsupportedOperationException("Method not implemented");
+        }
+
+        @Override
+        public Iterable<RelationshipType> getRelationshipTypes() {
+            throw new UnsupportedOperationException("Method not implemented");
+        }
+
+        @Override
+        public Iterable<String> getPropertyKeys() {
+            return properties;
+        }
+
+        @Override
+        public void drop() {}
+
+        @Override
+        public boolean isConstraintIndex() {
+            return false;
+        }
+
+        @Override
+        public boolean isNodeIndex() {
+            return true;
+        }
+
+        @Override
+        public boolean isRelationshipIndex() {
+            return false;
+        }
+
+        @Override
+        public boolean isMultiTokenIndex() {
+            return false;
+        }
+
+        @Override
+        public boolean isCompositeIndex() {
+            return properties.size() > 1;
+        }
+
+        @Override
+        public String getName() {
+            return null;
+        }
+    }
+
+    public static class MapConstraintDefinition implements ConstraintDefinition {
+        private final Label label;
+        private final Collection<Label> labels;
+        private final Collection<String> properties;
+
+        public MapConstraintDefinition(Map<String, Object> map) {
+            Collection<String> labels = (Collection<String>) map.get("labels");
+            Collection<String> properties = (Collection<String>) map.get("properties");
+            this.labels = labels.stream().map(Label::label).collect(Collectors.toList());
+            this.label = this.labels.iterator().next();
+            this.properties = properties;
+        }
+
+
+        @Override
+        public Label getLabel() {
+            return label;
+        }
+
+        @Override
+        public RelationshipType getRelationshipType() {
+            throw new UnsupportedOperationException("Method not implemented");
+        }
+
+        @Override
+        public Iterable<String> getPropertyKeys() {
+            return properties;
+        }
+
+        @Override
+        public void drop() {}
+
+        @Override
+        public ConstraintType getConstraintType() {
+            return properties.size() == 1 ? ConstraintType.UNIQUENESS : ConstraintType.NODE_KEY;
+        }
+
+        @Override
+        public boolean isConstraintType(ConstraintType type) {
+            return getConstraintType().equals(type);
+        }
+    }
+
+    private final Collection<Node> nodes;
+    private final Collection<Relationship> rels;
+    private final Set<String> labels;
+    private final Collection<IndexDefinition> indexes;
+    private final Collection<ConstraintDefinition> constraints;
+
+    public MapSubGraph(Map<String, Object> map) {
+        this.nodes = (Collection<Node>) map.getOrDefault("nodes", Collections.emptyList());
+        this.labels = this.nodes.stream()
+                .flatMap(node -> StreamSupport.stream(node.getLabels().spliterator(), true)
+                .map(Label::name))
+                .collect(Collectors.toSet());
+        Collection<Relationship> rels = (Collection<Relationship>) map.getOrDefault("relationships", Collections.emptyList());
+        this.rels = new HashSet<>(rels);
+        Collection<Map<String, Object>> schema = (Collection<Map<String, Object>>) map.getOrDefault("schema", Collections.emptyList());
+        this.indexes = schema.stream().map(MapIndexDefinition::new).collect(Collectors.toList());
+        this.constraints = schema.stream().map(MapConstraintDefinition::new).collect(Collectors.toList());
+    }
+
+    @Override
+    public Iterable<Node> getNodes() {
+        return nodes;
+    }
+
+    @Override
+    public Iterable<Relationship> getRelationships() {
+        return rels;
+    }
+
+    @Override
+    public boolean contains(Relationship relationship) {
+        return rels.contains(relationship);
+    }
+
+    @Override
+    public Iterable<IndexDefinition> getIndexes() {
+        return indexes;
+    }
+
+    @Override
+    public Iterable<ConstraintDefinition> getConstraints() {
+        return constraints;
+    }
+}

--- a/src/main/java/apoc/export/util/NodesAndRelsSubGraph.java
+++ b/src/main/java/apoc/export/util/NodesAndRelsSubGraph.java
@@ -13,7 +13,6 @@ import org.neo4j.helpers.collection.Iterables;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 
 /**
  * @author mh

--- a/src/test/java/apoc/bolt/BoltTest.java
+++ b/src/test/java/apoc/bolt/BoltTest.java
@@ -15,13 +15,20 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static apoc.util.TestContainerUtil.cleanBuild;
 import static apoc.util.TestUtil.isTravis;
-import static org.junit.Assert.*;
+import static apoc.util.Util.map;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
 import static org.neo4j.driver.v1.Values.isoDuration;
@@ -76,6 +83,26 @@ public class BoltTest {
                 assertEquals(true, node.getProperty("state"));
                 assertEquals(54L, node.getProperty("age"));
             });
+    }
+
+    @Test
+    public void shouldReturnMapOfCollection() throws Exception {
+        TestUtil.testCall(db, "call apoc.bolt.load($url,'MATCH (p:Person {name: $name}) RETURN {nodes: collect(p)} AS map', $params, $config)",
+                map("url", neo4jContainer.getBoltUrl(),
+                        "params", map("name", "Tom"),
+                        "config", map("virtual", true)),
+                r -> {
+                    assertNotNull(r);
+                    Map<String, Object> row = (Map<String, Object>) r.get("row");
+                    Map<String, Collection<Node>> map = (Map<String, Collection<Node>>) row.get("map");
+                    Collection<Node> nodes = map.get("nodes");
+                    assertEquals(2, nodes.size());
+                    Set<Map<String, Object>> expected = new HashSet<>(Arrays.asList(map("name", "Tom", "surname", "Loagan"), map("name", "Tom", "surname", "Burton")));
+                    Set<Map<String, Object>> actual = nodes.stream()
+                            .map(n -> n.getProperties("name", "surname"))
+                            .collect(Collectors.toSet());
+                    assertEquals(expected, actual);
+                });
     }
 
     @Test
@@ -138,6 +165,31 @@ public class BoltTest {
                 assertEquals(2016L, rel.getProperty("since"));
                 assertEquals(OffsetTime.parse("12:50:35.556+01:00"), rel.getProperty("time"));
             });
+    }
+
+    @Test
+    public void testLoadRelWithNodeProperties() throws Exception {
+        // given
+        String query = "MATCH (:Person{name: 'John', surname: 'Green'})-[r]->(:Person{name: 'Jim', surname: 'Brown'}) RETURN r";
+
+        // when
+        TestUtil.testCall(db, "call apoc.bolt.load($url, $query, null, $config)",
+                map("url", neo4jContainer.getBoltUrl(), "query", query, "config", map("virtual", true, "withRelationshipNodeProperties", true)),
+                r -> {
+                    // then
+                    assertNotNull(r);
+                    Map<String, Object> row = (Map<String, Object>) r.get("row");
+                    final Relationship rel = (Relationship) row.get("r");
+                    assertEquals("KNOWS", rel.getType().name());
+                    final Map<String, Object> expectedRel = map("born", point(4979, 56.7, 12.78, 100.0).asPoint(), "since", OffsetTime.parse("12:50:35.556+01:00"));
+                    assertEquals(expectedRel, rel.getAllProperties());
+                    final Node start = rel.getStartNode();
+                    final Map<String, Object> expectedStartNode = map("name", "John", "surname", "Green", "born", point(7203, 2.3, 4.5).asPoint());
+                    assertEquals(expectedStartNode, start.getAllProperties());
+                    final Node end = rel.getEndNode();
+                    final Map<String, Object> expectedEndNode = map("name", "Jim", "surname", "Brown");
+                    assertEquals(expectedEndNode, end.getAllProperties());
+                });
     }
 
     @Test

--- a/src/test/java/apoc/diff/DiffTest.java
+++ b/src/test/java/apoc/diff/DiffTest.java
@@ -1,18 +1,36 @@
 package apoc.diff;
 
+import apoc.bolt.Bolt;
+import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestUtil;
+import apoc.util.Util;
+import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
+import java.time.OffsetTime;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Scanner;
 
-import static org.junit.Assert.*;
+import static apoc.util.TestUtil.isTravis;
+import static apoc.util.Util.map;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeNotNull;
 
 /**
  * @author Benjamin Clauss
@@ -24,13 +42,43 @@ public class DiffTest {
     private static Node node2;
     private static Node node3;
 
-    private static GraphDatabaseService db;
+    private GraphDatabaseService db;
+
+    private static Neo4jContainerExtension neo4jContainer;
 
     @BeforeClass
     public static void setup() throws Exception {
-        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
-        TestUtil.registerProcedure(db, Diff.class);
+        assumeFalse(isTravis());
+        TestUtil.ignoreException(() -> {
+            neo4jContainer = new Neo4jContainerExtension()
+                    .withInitScript("init_neo4j_diff.cypher")
+                    .withLogging()
+                    .withoutAuthentication();
+            neo4jContainer.start();
+        }, Exception.class);
+        assumeNotNull(neo4jContainer);
+    }
 
+    @AfterClass
+    public static void tearDown() {
+        if (neo4jContainer != null) {
+            neo4jContainer.close();
+
+        }
+    }
+
+    @Before
+    public void before() throws KernelException {
+        db = new TestGraphDatabaseFactory().newImpermanentDatabaseBuilder().newGraphDatabase();
+        TestUtil.registerProcedure(db, Bolt.class, Diff.class);
+    }
+
+    @After
+    public void after() {
+        db.shutdown();
+    }
+
+    private void createNodes() {
         try (Transaction tx = db.beginTx()) {
             node1 = db.createNode();
             node1.setProperty("prop1", "val1");
@@ -51,6 +99,7 @@ public class DiffTest {
 
     @Test
     public void nodesSame() {
+        createNodes();
         Map<String, Object> params = new HashMap<>();
         params.put("leftNode", node1);
         params.put("rightNode", node1);
@@ -78,6 +127,7 @@ public class DiffTest {
 
     @Test
     public void nodesDiffering() {
+        createNodes();
         Map<String, Object> params = new HashMap<>();
         params.put("leftNode", node2);
         params.put("rightNode", node3);
@@ -106,8 +156,247 @@ public class DiffTest {
         assertEquals("val1", inCommon.get("prop1"));
     }
 
-    @AfterClass
-    public static void tearDown() {
-        db.shutdown();
+    @Test
+    public void shouldCompareTwoEqualGraphsByQuery() {
+        // given
+        initLocalGraph();
+
+        // when
+        final String query = "MATCH (n) OPTIONAL MATCH (n)-[r]->(m) RETURN n, r, m";
+        final String boltQuery = "CALL db.indexes() YIELD tokenNames, properties, state, type\n" +
+                "WHERE state = 'ONLINE' AND type = 'node_unique_property'\n" +
+                "WITH collect({labels: tokenNames, properties: properties, type: type}) AS schema\n" +
+                "MATCH (n)\n" +
+                "OPTIONAL MATCH (n)-[r]->(m)\n" +
+                "WITH collect(n) + collect(m) AS nodes, collect(r) AS relationships, schema\n" +
+                "UNWIND nodes AS node\n" +
+                "RETURN {nodes: collect(DISTINCT node), relationships: relationships, schema: schema} AS graph\n";
+        TestUtil.testResult(db, "CALL apoc.bolt.load($url, $boltQuery, {}, $boltConfig) YIELD row\n" +
+                        "CALL apoc.diff.graphs($sourceQuery, row.graph, $diffConfig) YIELD difference, entityType, id, sourceLabel, destLabel, source, dest\n" +
+                        "RETURN difference, entityType, id, sourceLabel, destLabel, source, dest",
+                map("sourceQuery", query,
+                        "boltQuery", boltQuery,
+                        "url", neo4jContainer.getBoltUrl(),
+                        "boltConfig", map("virtual", true, "withRelationshipNodeProperties", true),
+                        "diffConfig", Collections.emptyMap()),
+                (r) -> {
+                    // then
+                    assertFalse(r.hasNext()); // the two graphs are equal
+                });
     }
+
+    @Test
+    public void shouldCompareTwoDifferentGraphsByQuery() {
+        // given
+        initLocalGraph();
+
+        // when
+        final String query = "MATCH (n) OPTIONAL MATCH (n)-[r]->(m) RETURN n, r, m";
+        final String boltQuery = "CALL db.indexes() YIELD tokenNames, properties, state, type\n" +
+                "WHERE state = 'ONLINE' AND type = 'node_unique_property'\n" +
+                "WITH collect({labels: tokenNames, properties: properties, type: type}) AS schema\n" +
+                "MATCH (n:Person{name: 'Michael Jordan'})\n" +
+                "OPTIONAL MATCH (n)-[r]->(m)\n" +
+                "WITH collect(n) + collect(m) AS nodes, collect(r) AS relationships, schema\n" +
+                "UNWIND nodes AS node\n" +
+                "RETURN {nodes: collect(DISTINCT node), relationships: relationships, schema: schema} AS graph\n";
+        TestUtil.testResult(db, "CALL apoc.bolt.load($url, $boltQuery, {}, $boltConfig) YIELD row\n" +
+                        "CALL apoc.diff.graphs($sourceQuery, row.graph, $diffConfig) YIELD difference, entityType, id, sourceLabel, destLabel, source, dest\n" +
+                        "RETURN difference, entityType, id, sourceLabel, destLabel, source, dest",
+                map("sourceQuery", query,
+                        "boltQuery", boltQuery,
+                        "url", neo4jContainer.getBoltUrl(),
+                        "boltConfig", map("virtual", true, "withRelationshipNodeProperties", true),
+                        "diffConfig", Collections.emptyMap()),
+                (r) -> {
+                    // then
+                    final List<Map<String, Object>> expectedRows = Arrays.asList(
+                            map("entityType", "Node", "sourceLabel", null, "difference", "Total count", "id", null, "source", 3L, "dest", 1L, "destLabel", null),
+                            map("entityType", "Node", "sourceLabel", null, "difference", "Count by Label", "id", null, "source", map("Person", 3L), "dest", map("Person", 1L), "destLabel", null),
+                            map("entityType", "Relationship", "sourceLabel", null, "difference", "Total count", "id", null, "source", 1L, "dest", 0L, "destLabel", null),
+                            map("entityType", "Relationship", "sourceLabel", null, "difference", "Count by Type", "id", null, "source", map("KNOWS", 1L), "dest", map(), "destLabel", null),
+                            map("entityType", "Node", "sourceLabel", "Person", "difference", "Destination Entity not found", "id", 20L, "source", map("name", "Tom Burton"), "dest", null, "destLabel", null),
+                            map("entityType", "Node", "sourceLabel", "Person", "difference", "Destination Entity not found", "id", 21L, "source", map("name", "John William"), "dest", null, "destLabel", null),
+                            map("entityType", "Relationship", "sourceLabel", "KNOWS", "difference", "Destination Entity not found", "id", 0L, "source", map("start", map("name", "Tom Burton"),
+                                    "end", map("name", "John William"),
+                                    "properties", map("time", OffsetTime.parse("12:50:35.556+01:00"), "since", 2016L)
+                            ), "dest", null, "destLabel", null)
+                    );
+                    int index = 0;
+                    while (r.hasNext()) {
+                        final Map<String, Object> next = r.next();
+                        assertEquals(expectedRows.get(index), next);
+                        ++index;
+                    }
+                    assertEquals(index, expectedRows.size());
+                });
+    }
+
+    @Test
+    public void shouldCompareTwoDifferentNodesByQuery() {
+        // given
+        initLocalGraph();
+        db.execute("MERGE (n:Person{name: 'Michael Jordan'}) ON MATCH SET n.age = 55");
+
+        // when
+        final String query = "MATCH (n:Person{name: 'Michael Jordan'}) OPTIONAL MATCH (n)-[r]->(m) RETURN n, r, m";
+        final String boltQuery = "CALL db.indexes() YIELD tokenNames, properties, state, type\n" +
+                "WHERE state = 'ONLINE' AND type = 'node_unique_property'\n" +
+                "WITH collect({labels: tokenNames, properties: properties, type: type}) AS schema\n" +
+                "MATCH (n:Person{name: 'Michael Jordan'})\n" +
+                "OPTIONAL MATCH (n)-[r]->(m)\n" +
+                "WITH collect(n) + collect(m) AS nodes, collect(r) AS relationships, schema\n" +
+                "UNWIND nodes AS node\n" +
+                "RETURN {nodes: collect(DISTINCT node), relationships: relationships, schema: schema} AS graph\n";
+        TestUtil.testResult(db, "CALL apoc.bolt.load($url, $boltQuery, {}, $boltConfig) YIELD row\n" +
+                        "CALL apoc.diff.graphs($sourceQuery, row.graph, $diffConfig) YIELD difference, entityType, id, sourceLabel, destLabel, source, dest\n" +
+                        "RETURN difference, entityType, id, sourceLabel, destLabel, source, dest",
+                map("sourceQuery", query,
+                        "boltQuery", boltQuery,
+                        "url", neo4jContainer.getBoltUrl(),
+                        "boltConfig", map("virtual", true, "withRelationshipNodeProperties", true),
+                        "diffConfig", Collections.emptyMap()),
+                (r) -> {
+                    // then
+                    final Map<String, Object> expected = map("entityType", "Node", "sourceLabel", "Person", "difference", "Different Properties", "id", 0L, "source", map("age", 55L), "dest", map("age", 54L), "destLabel", "Person");
+                    assertTrue(r.hasNext()); // the two nodes have different properties
+                    assertEquals(expected, r.next());
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    @Test
+    public void shouldCompareTwoDifferentPathsByQuery() {
+        // given
+        initLocalGraph();
+        db.execute("MATCH ()-[r:KNOWS]-() SET r.since = 2000");
+
+        // when
+        final String query = "MATCH p = ()-[:KNOWS]->() RETURN p";
+        final String boltQuery = "CALL db.indexes() YIELD tokenNames, properties, state, type\n" +
+                "WHERE state = 'ONLINE' AND type = 'node_unique_property'\n" +
+                "WITH collect({labels: tokenNames, properties: properties, type: type}) AS schema\n" +
+                "MATCH p = ()-[:KNOWS]->()\n" +
+                "RETURN {nodes: nodes(p), relationships: relationships(p), schema: schema} AS graph\n";
+        TestUtil.testResult(db, "CALL apoc.bolt.load($url, $boltQuery, {}, $boltConfig) YIELD row\n" +
+                        "CALL apoc.diff.graphs($sourceQuery, row.graph, $diffConfig) YIELD difference, entityType, id, sourceLabel, destLabel, source, dest\n" +
+                        "RETURN difference, entityType, id, sourceLabel, destLabel, source, dest",
+                map("sourceQuery", query,
+                        "boltQuery", boltQuery,
+                        "url", neo4jContainer.getBoltUrl(),
+                        "boltConfig", map("virtual", true, "withRelationshipNodeProperties", true),
+                        "diffConfig", Collections.emptyMap()),
+                (r) -> {
+                    // then
+                    final Map<String, Object> expected = map("entityType", "Relationship", "sourceLabel", "KNOWS", "difference", "Destination Entity not found", "id", 0L, "source", map(
+                            "start", map("name", "Tom Burton"),
+                            "end", map("name", "John William"),
+                            "properties", map("time", OffsetTime.parse("12:50:35.556+01:00"), "since", 2000L)
+                    ), "dest", null, "destLabel", null);
+                    assertTrue(r.hasNext()); // the relationships have different properties
+                    final Map<String, Object> next = r.next();
+                    assertEquals(expected, next);
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    @Test
+    public void shouldCompareTwoDifferentPathsByBoltQueryUrl() {
+        // given
+        initLocalGraph();
+        db.execute("MATCH ()-[r:KNOWS]-() SET r.since = 2000");
+
+        // when
+        final String localQuery = "MATCH p = ()-[:KNOWS]->() RETURN p";
+        final String remoteQuery = "MATCH p = ()-[:KNOWS]->() RETURN p";
+        TestUtil.testResult(db, "CALL apoc.diff.graphs($localQuery, $remoteQuery, $diffConfig) YIELD difference, entityType, id, sourceLabel, destLabel, source, dest\n" +
+                        "RETURN difference, entityType, id, sourceLabel, destLabel, source, dest",
+                map("localQuery", localQuery, "remoteQuery", remoteQuery,
+                        "diffConfig", Collections.singletonMap("dest", Util.map("target", Collections.singletonMap("value", neo4jContainer.getBoltUrl())))),
+                (r) -> {
+                    // then
+                    final Map<String, Object> expected = map("entityType", "Relationship", "sourceLabel", "KNOWS", "difference", "Destination Entity not found", "id", 0L, "source", map(
+                            "start", map("name", "Tom Burton"),
+                            "end", map("name", "John William"),
+                            "properties", map("time", OffsetTime.parse("12:50:35.556+01:00"), "since", 2000L)
+                    ), "dest", null, "destLabel", null);
+                    assertTrue(r.hasNext()); // the relationships have different properties
+                    final Map<String, Object> next = r.next();
+                    assertEquals(expected, next);
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    @Test
+    public void shouldInjectQueryParams() {
+        // given
+        initLocalGraph();
+        db.execute("MATCH ()-[r:KNOWS]-() SET r.since = 2000");
+
+        // when
+        final String localQuery = "MATCH p = (n:Person{name: $name})-[:KNOWS]->() RETURN p";
+        final String remoteQuery = "MATCH p = (n:Person{name: $name})-[:KNOWS]->() RETURN p";
+        TestUtil.testResult(db, "CALL apoc.diff.graphs($localQuery, $remoteQuery, $diffConfig) YIELD difference, entityType, id, sourceLabel, destLabel, source, dest\n" +
+                        "RETURN difference, entityType, id, sourceLabel, destLabel, source, dest",
+                map("localQuery", localQuery, "remoteQuery", remoteQuery,
+                        "diffConfig", Util.map("dest", Util.map("target", Collections.singletonMap("value", neo4jContainer.getBoltUrl()),
+                                "params", Util.map("name", "Tom Burton")),
+                                "source", Util.map("params", Util.map("name", "John William")))),
+                (r) -> {
+                    // then
+
+                    /*
+                    +-----------------------------------------------------------------------------------------------+
+                    | difference       | entityType     | id     | sourceLabel | destLabel | source | dest          |
+                    +-----------------------------------------------------------------------------------------------+
+                    | "Count by Label" | "Node"         | <null> | <null>      | <null>    | {}     | {Person -> 2} |
+                    | "Total count"    | "Relationship" | <null> | <null>      | <null>    | 0      | 1             |
+                    | "Count by Type"  | "Relationship" | <null> | <null>      | <null>    | {}     | {KNOWS -> 1}  |
+                    +-----------------------------------------------------------------------------------------------+
+                    3 rows
+                     */
+
+                    Map<String, Object> expected = map("entityType", "Node", "sourceLabel", null, "difference", "Total count", "id", null,
+                            "source", 0L, "dest", 2L, "destLabel", null);
+                    assertTrue(r.hasNext()); // the relationships have different properties
+                    Map<String, Object> next = r.next();
+                    assertEquals(expected, next);
+
+                    assertTrue(r.hasNext()); // the relationships have different properties
+                    expected = map("entityType", "Node", "sourceLabel", null, "difference", "Count by Label", "id", null,
+                            "source", Collections.emptyMap(), "dest", Collections.singletonMap("Person", 2L), "destLabel", null);
+                    next = r.next();
+                    assertEquals(expected, next);
+
+                    assertTrue(r.hasNext()); // the relationships have different properties
+                    expected = map("entityType", "Relationship", "sourceLabel", null, "difference", "Total count", "id", null,
+                            "source", 0L, "dest", 1L, "destLabel", null);
+                    next = r.next();
+                    assertEquals(expected, next);
+
+                    assertTrue(r.hasNext()); // the relationships have different properties
+                    expected = map("entityType", "Relationship", "sourceLabel", null, "difference", "Count by Type", "id", null,
+                            "source", Collections.emptyMap(), "dest", Collections.singletonMap("KNOWS", 1L), "destLabel", null);
+                    next = r.next();
+                    assertEquals(expected, next);
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    private void initLocalGraph() {
+        try (Scanner scanner = new Scanner(Thread
+                    .currentThread()
+                    .getContextClassLoader()
+                    .getResourceAsStream("init_neo4j_diff.cypher"))
+                .useDelimiter(";")) {
+            while (scanner.hasNext()) {
+                String statement = scanner.next().trim();
+                if (statement.isEmpty()) {
+                    continue;
+                }
+                db.execute(statement);
+            }
+        }
+    }
+
 }

--- a/src/test/resources/init_neo4j_diff.cypher
+++ b/src/test/resources/init_neo4j_diff.cypher
@@ -1,0 +1,5 @@
+CREATE CONSTRAINT ON (p:Person) ASSERT p.name IS UNIQUE;
+CREATE (m:Person {name: 'Michael Jordan', age: 54});
+CREATE (q:Person {name: 'Tom Burton', age: 23})
+CREATE (p:Person {name: 'John William', age: 22})
+CREATE (q)-[:KNOWS{since:2016, time:time('125035.556+0100')}]->(p);


### PR DESCRIPTION
Fixes #1064

This procedure implements the changes in the related issue, with small changes in the requirement about the relationship comparison.

The `apoc.diff.graphs` compares two graphs and returns the differences in term of:

* same node count
* same count per label
* same relationship counter
* same count per rel-type

For each node in the `source` graph with a certain label, find the same node (in the `dest` graph) by keys or internal id in the other graph and if found:
* compare all labels
* compare all properties

For each relationship in the `source` graph, we'll get the two nodes of the relationship and look into the the `dest`
graph if there is a relationship with the same properties and the same start/end node.

In order to allow to use this procedure with the `apoc.bolt.*` I had to do changes into this one because the procedure didn't manage `map` and `collection` return types.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Implemented `apoc.diff.graphs`
  - Extended the behaviour of `apoc.bolt.*` in order to manage collections and maps
  - In `apoc.bolt.*` added a new property `withRelationshipNodeProperties` that retrieves the node properties attaching them into `VirtualRelationship` nodes.
  - Update the documentation
