### PR TITLE
Retool apoc.load.ldap to use LDAP URLs

### DIFF
--- a/docs/asciidoc/database-integration/loadldap.adoc
+++ b/docs/asciidoc/database-integration/loadldap.adoc
@@ -22,27 +22,21 @@ include::../../../build/generated-documentation/apoc.load.csv[lines=1;12]
 [options="header",cols="a,3m,a"]
 |===
 |Parameter | Property | Description
-|{connectionMap} | ldapHost | the ldapserver:port if port is omitted the default port 389 will be used
-|  | loginDN | This is the dn of the ldap server user who has read access on the ldap server
-|  | loginPW | This is the password used by the loginDN
-|{searchMap} | searchBase | From this entry a search is executed
-|  | searchScope | SCOPE_ONE (one level) or
-                   SCOPE_SUB (all sub levels) or
-                   SCOPE_BASE (only the base node)
-|  | searchFilter | Place here a standard ldap search filter for example: (objectClass=*) means that the ldap entry must have an objectClass attribute.
-|  | attributes | optional. If omitted all the attributes of the entries will be returned.
-                            When specified only the specified attributes will be returned. Regardless the attributes setting a returned entry will always have a "dn" property.
+|{connectionMap} | ldapURL | a URL formatted according to https://tools.ietf.org/html/rfc2255[RFC2255]
+|  | loginDN | OPTIONAL: This is the dn of the ldap server user who has read access on the ldap server
+|  | loginPW | OPTIONAL: This is the password used by the loginDN
+
 |===
+
+If credentials are not provided, an anonymous bind will be attempted.
 
 === Load LDAP Example
 
 .Retrieve group member information from the ldap server
 [source,cypher]
 ----
-call apoc.load.ldap({ldapHost : "ldap.forumsys.com", loginDN : "cn=read-only-admin,dc=example,dc=com", loginPW : "password"},
-{searchBase : "dc=example,dc=com",searchScope : "SCOPE_SUB"
-,attributes : ["uniqueMember","cn","uid","objectClass"]
-,searchFilter: "(&(objectClass=*)(uniqueMember=*))"}) yield entry
+call apoc.load.ldap({ldapURL : "ldap://ldap.forumsys.com:389/dc=example,dc=com?uid?one?(&(objectClass=*)(uid=training))", loginDN : "cn=read-only-admin,dc=example,dc=com", loginPW : "password"})
+yield entry
 return entry.dn,  entry.uniqueMember
 ----
 
@@ -59,10 +53,8 @@ return entry.dn,  entry.uniqueMember
 .Retrieve group member information from the ldap server and create structure in Neo4j
 [source,cypher]
 ----
-call apoc.load.ldap({ldapHost : "ldap.forumsys.com", loginDN : "cn=read-only-admin,dc=example,dc=com", loginPW : "password"},
-{searchBase : "dc=example,dc=com",searchScope : "SCOPE_SUB"
-,attributes : ["uniqueMember","cn","uid","objectClass"]
-,searchFilter: "(&(objectClass=*)(uniqueMember=*))"}) yield entry
+call apoc.load.ldap({ldapURL : "ldap://ldap.forumsys.com:389/dc=example,dc=com?uid?one?(&(objectClass=*)(uid=training))", loginDN : "cn=read-only-admin,dc=example,dc=com", loginPW : "password"})
+yield entry
 merge (g:Group {dn : entry.dn})
 on create set g.cn = entry.cn
 foreach (member in entry.uniqueMember |
@@ -78,25 +70,21 @@ To protect credentials, you can configure aliases in `conf/neo4j.conf`:
 
 .neo4j.conf Syntax
 ----
-apoc.loadldap.myldap.config=<host>:<port> <loginDN> <loginPW>
+apoc.loadldap.myldap.config=<ldapURL>[;<loginDN>;<loginPW>]
 ----
 
 
 .neo4j.conf:
 ----
-apoc.loadldap.myldap.config=ldap.forumsys.com:389 cn=read-only-admin,dc=example,dc=com password
+apoc.loadldap.myldap.config=ldap://ldap.forumsys.com:389/dc=example,dc=com?uid?one?(&(objectClass=*)(uid=training));cn=read-only-admin,dc=example,dc=com;password
 ----
 
 Then
 
 [source,cypher]
 ----
-call apoc.load.ldap({ldapHost : "ldap.forumsys.com", loginDN : "cn=read-only-admin,dc=example,dc=com", loginPW : "password"}
-, {searchBase : "dc=example,dc=com"
-  ,searchScope : "SCOPE_SUB"
-  ,attributes : ["cn","uid","objectClass"]
-  ,searchFilter: "(&(objectClass=*))"
-  }) yield entry
+call apoc.load.ldap({ldapURL : "ldap://ldap.forumsys.com:389/dc=example,dc=com?uid?one?(&(objectClass=*)(uid=training))", loginDN : "cn=read-only-admin,dc=example,dc=com", loginPW : "password"})
+yield entry
 return entry.dn,  entry
 ----
 
@@ -104,11 +92,7 @@ becomes
 
 [source,cypher]
 ----
-call apoc.load.ldap("myldap"
-,{searchBase : "dc=example,dc=com"
- ,searchScope : "SCOPE_SUB"
- ,attributes : ["cn","uid","objectClass"]
- ,searchFilter: "(&(objectClass=*))"
- }) yield entry
+call apoc.load.ldap("myldap")
+yield entry
 return entry.dn,  entry
 ----

--- a/src/test/java/apoc/load/LoadLdapTest.java
+++ b/src/test/java/apoc/load/LoadLdapTest.java
@@ -2,37 +2,88 @@ package apoc.load;
 
 
 import com.novell.ldap.LDAPEntry;
+import com.novell.ldap.LDAPException;
 import com.novell.ldap.LDAPSearchResults;
 import org.junit.Test;
 
-import java.util.ArrayList;
+import java.net.MalformedURLException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 
 public class LoadLdapTest {
+    @Test(expected = MalformedURLException.class)
+    public void testBadURL() throws MalformedURLException {
+        Map<String, String> connParms = new HashMap<>();
+        connParms.put("ldapURL", "ldap://bad.example.com/?????");
+        connParms.put("loginDN", "cn=someuser");
+        connParms.put("loginPW", "password");
+        LoadLdap.LDAPManager mgr = new LoadLdap.LDAPManager(connParms);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testEmptyURL() throws RuntimeException, MalformedURLException {
+        Map<String, String> connParms = new HashMap<>();
+        connParms.put("ldapURL", "");
+        connParms.put("loginDN", "");
+        connParms.put("loginPW", "");
+        LoadLdap.LDAPManager mgr = new LoadLdap.LDAPManager(connParms);
+    }
 
     @Test
-    public void testLoadLDAP() throws Exception {
-        Map<String, Object> connParms = new HashMap<>();
-        connParms.put("ldapHost", "ldap.forumsys.com");
-        connParms.put("ldapPort", 389l);
-        connParms.put("loginDN", "cn=read-only-admin,dc=example,dc=com");
-        connParms.put("loginPW", "password");
-        LoadLdap.LDAPManager mgr = new LoadLdap.LDAPManager(LoadLdap.getConnectionMap(connParms));
-        Map<String, Object> searchParms = new HashMap<>();
-        searchParms.put("searchBase", "dc=example,dc=com");
-        searchParms.put("searchScope", "SCOPE_ONE");
-        searchParms.put("searchFilter", "(&(objectClass=*)(uid=training))");
-        ArrayList<String> ats = new ArrayList<>();
-        ats.add("uid");
-        searchParms.put("attributes", ats);
-        LDAPSearchResults results = mgr.doSearch(searchParms);
+    public void testAnonBindViaNoDNorPW() throws MalformedURLException, LDAPException {
+        Map<String, String> connParms = new HashMap<>();
+        connParms.put("ldapURL", "ldap://ldap.forumsys.com:389/dc=example,dc=com?uid?one?(&(objectClass=*)(uid=training))");
+        //connParms.put("loginDN", "");
+        //connParms.put("loginPW", "");
+        LoadLdap.LDAPManager mgr = new LoadLdap.LDAPManager(connParms);
+        LDAPSearchResults results = mgr.doSearch();
         LDAPEntry le = results.next();
         assertEquals("uid=training,dc=example,dc=com", le.getDN());
         assertEquals("training", le.getAttribute("uid").getStringValue());
     }
 
+    @Test
+    public void testLoadLDAP() throws Exception {
+        Map<String, String> connParms = new HashMap<>();
+        connParms.put("ldapURL", "ldap://ldap.forumsys.com:389/dc=example,dc=com?uid?one?(&(objectClass=*)(uid=training))");
+        connParms.put("loginDN", "cn=read-only-admin,dc=example,dc=com");
+        connParms.put("loginPW", "password");
+        LoadLdap.LDAPManager mgr = new LoadLdap.LDAPManager(connParms);
+        LDAPSearchResults results = mgr.doSearch();
+        LDAPEntry le = results.next();
+        assertEquals("uid=training,dc=example,dc=com", le.getDN());
+        assertEquals("training", le.getAttribute("uid").getStringValue());
+    }
+
+    @Test
+    public void testLDAPAggregation() throws MalformedURLException {
+        Map<String, String> connParms = new HashMap<>();
+        connParms.put("ldapURL", "ldap://ipa.demo1.freeipa.org/dc=demo1,dc=freeipa,dc=org?uid?sub?(objectClass=posixAccount)");
+        connParms.put("loginDN", "uid=admin,cn=users,cn=accounts,dc=demo1,dc=freeipa,dc=org");
+        connParms.put("loginPW", "Secret123");
+        LoadLdap.LDAPManager mgr = new LoadLdap.LDAPManager(connParms);
+        Stream<LDAPResult> result = mgr.executeSearch();
+        /*
+            Note, the expect result is prone to changing as the server is refreshed
+            every so often. Best to manually verify the count using an LDAP client
+            before running the test
+         */
+        assertEquals(13, result.count());
+    }
+
+    @Test
+    public void testLDAPSConnection() throws MalformedURLException {
+        // Assume that we're using a truststore that contains the Let's Encrypt CA (which is in the Java default)
+        Map<String, String> connParms = new HashMap<>();
+        connParms.put("ldapURL", "ldaps://db.debian.org/dc=debian,dc=org?uid?sub?(uid=dbharris)");
+        connParms.put("loginDN", "");
+        connParms.put("loginPW", "");
+        LoadLdap.LDAPManager mgr = new LoadLdap.LDAPManager(connParms);
+        Stream<LDAPResult> result = mgr.executeSearch();
+        assertEquals(1, result.count());
+    }
 }
 


### PR DESCRIPTION


Fixes #1378

Mandates the usage of LDAP URLs for `LoadLdap` searches

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:
- Allows queries to be run via an alias only
- Standardized format allows pre-existing queries to be dropped in
- LDAP URLs contain the same search parameters as the prior interface
- Clarify the usage of anonymous binds
