### PR TITLE
Tables4Labels - 4.x

### DIFF
--- a/docs/asciidoc/introspection/meta.adoc
+++ b/docs/asciidoc/introspection/meta.adoc
@@ -14,6 +14,8 @@ image::apoc.meta.graph.jpg[scaledwidth="100%"]
 | CALL apoc.meta.data | examines a subset of the graph to provide a tabular meta information
 | CALL apoc.meta.schema | examines a subset of the graph to provide a map-like meta information
 | CALL apoc.meta.stats  yield labelCount, relTypeCount, propertyKeyCount, nodeCount, relCount, labels, relTypes, stats | returns the information stored in the transactional database statistics
+| CALL apoc.meta.nodeTypeProperties({includeLabels:[label,...],includeRels:[rel-type,...],excludeLabels:[label,,...],excludeRels:[rel-type,...]}) | replaces built-in function for node property schema to provide a sample-based result for high performance - used by the Neo4J BI Connector
+| CALL apoc.meta.relTypeProperties({includeLabels:[label,...],includeRels:[rel-type,...],excludeLabels:[label,...],excludeRels:[rel-type,...]}) | replaces built-in function for relationship property schema to provide a sample-based result for high performance - used by the Neo4J BI Connector
 |===
 
 .Functions

--- a/src/main/java/apoc/meta/Meta.java
+++ b/src/main/java/apoc/meta/Meta.java
@@ -6,6 +6,7 @@ import apoc.result.VirtualNode;
 import apoc.result.VirtualRelationship;
 import apoc.util.MapUtil;
 import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.schema.ConstraintType;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.graphdb.schema.Schema;
@@ -15,6 +16,7 @@ import org.neo4j.internal.helpers.collection.Pair;
 import org.neo4j.internal.kernel.api.Read;
 import org.neo4j.internal.kernel.api.TokenRead;
 import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.procedure.*;
 import org.neo4j.values.storable.DurationValue;
 
@@ -429,6 +431,126 @@ public class Meta {
         nodes.putAll(relationships);
         return Stream.of(new MapResult(nodes));
     }
+
+
+    // Start new code
+
+    /**
+     * This procedure is intended to replicate what's in the core Neo4j product, but with the crucial difference that it
+     * supports flexible sampling options, and does not scan the entire database.  The result is producing a table of
+     * metadata that is useful for generating "Tables 4 Labels" schema designs for RDBMSs, but in a more performant way.
+     */
+    @Procedure
+    @Description("apoc.meta.nodeTypeProperties()")
+    public Stream<Tables4LabelsProfile.NodeTypePropertiesEntry> nodeTypeProperties(@Name(value = "config",defaultValue = "{}") Map<String,Object> config) {
+        MetaConfig metaConfig = new MetaConfig(config);
+        try {
+            return collectTables4LabelsProfile(metaConfig).asNodeStream();
+        } catch (Exception exc) {
+            exc.printStackTrace();
+        }
+
+        return null;
+    }
+
+    /**
+     * This procedure is intended to replicate what's in the core Neo4j product, but with the crucial difference that it
+     * supports flexible sampling options, and does not scan the entire database.  The result is producing a table of
+     * metadata that is useful for generating "Tables 4 Labels" schema designs for RDBMSs, but in a more performant way.
+     */
+    @Procedure
+    @Description("apoc.meta.relTypeProperties()")
+    public Stream<Tables4LabelsProfile.RelTypePropertiesEntry> relTypeProperties(@Name(value = "config",defaultValue = "{}") Map<String,Object> config) {
+        MetaConfig metaConfig = new MetaConfig(config);
+        try {
+            return collectTables4LabelsProfile(metaConfig).asRelStream();
+        } catch (Exception exc) {
+            exc.printStackTrace();
+        }
+
+        return null;
+    }
+
+    private Tables4LabelsProfile collectTables4LabelsProfile (MetaConfig config) {
+        Tables4LabelsProfile profile = new Tables4LabelsProfile();
+
+        Schema schema = tx.schema();
+
+        Map<String, Iterable<ConstraintDefinition>> relConstraints = new HashMap<>(20);
+
+        for (RelationshipType type : tx.getAllRelationshipTypesInUse()) {
+            List<ConstraintDefinition> tcd = new ArrayList<ConstraintDefinition>();
+            for (ConstraintDefinition cd : schema.getConstraints(type)) {
+                if (cd.isConstraintType(ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE)) {
+                    tcd.add(cd);
+                }
+            }
+            relConstraints.put(type.name(),tcd);
+        }
+
+        Map<String, Long> countStore = getLabelCountStore();
+
+        Set<String> includeLabels = config.getIncludesLabels();
+        Set<String> excludes = config.getExcludes();
+
+        Set<String> includeRels = config.getIncludesRels();
+        Set<String> excludeRels = config.getExcludeRels();
+
+        for (Label label : tx.getAllLabelsInUse()) {
+            String labelName = label.name();
+
+            if (excludes.contains(labelName)) {
+                // Skip if explicitly excluded
+                continue;
+            } else if(!includeLabels.isEmpty() && !includeLabels.contains(labelName)) {
+                // Skip if included set is specified and this is not in it.
+                continue;
+            }
+
+            List<ConstraintDefinition> constraints = new ArrayList<ConstraintDefinition>();
+
+            for (ConstraintDefinition cd : schema.getConstraints(label)) {
+                if (cd.isConstraintType(ConstraintType.NODE_PROPERTY_EXISTENCE)) {
+                    constraints.add(cd);
+                }
+            }
+
+            for (ConstraintDefinition cd : schema.getConstraints(label)) { profile.noteConstraint(label, cd); }
+            for (IndexDefinition index : schema.getIndexes(label)) { profile.noteIndex(label, index); }
+
+            long labelCount = countStore.get(labelName);
+            long sample = getSampleForLabelCount(labelCount, config.getSample());
+
+            //System.out.println("Sampling " + sample + " for " + labelName);
+
+            try (ResourceIterator<Node> nodes = tx.findNodes(label)) {
+                int count = 1;
+                while (nodes.hasNext()) {
+                    Node node = nodes.next();
+                    if(count++ % sample == 0) {
+                        boolean skipNode = false;
+                        for (RelationshipType rel : node.getRelationshipTypes()) {
+                            String relName = rel.name();
+                            if (excludeRels.contains(relName)) {
+                                // Skip if explicitly excluded
+                                skipNode = true;
+                            } else if (!includeRels.isEmpty() && !includeRels.contains(relName)) {
+                                // Skip if included set is specified and this is not in it.
+                                skipNode = true;
+                            }
+                        }
+                        if (skipNode != true) {
+                            profile.observe(node, config, constraints, relConstraints);
+                        }
+                    }
+                }
+            }
+        }
+
+        return profile.finished();
+    }
+
+    // End new code
 
     private Map<String, Map<String, MetaResult>> collectMetaData (MetaConfig config) {
         Map<String,Map<String,MetaResult>> metaData = new LinkedHashMap<>(100);

--- a/src/main/java/apoc/meta/Meta.java
+++ b/src/main/java/apoc/meta/Meta.java
@@ -1,5 +1,6 @@
 package apoc.meta;
 
+import org.neo4j.logging.Log;
 import apoc.result.GraphResult;
 import apoc.result.MapResult;
 import apoc.result.VirtualNode;
@@ -46,6 +47,8 @@ public class Meta {
 
     @Context
     public Transaction transaction;
+
+    @Context public Log log;
 
     public enum Types {
         INTEGER,FLOAT,STRING,BOOLEAN,RELATIONSHIP,NODE,PATH,NULL,ANY,MAP,LIST,POINT,DATE,DATE_TIME,LOCAL_TIME,LOCAL_DATE_TIME,TIME,DURATION;
@@ -446,11 +449,10 @@ public class Meta {
         MetaConfig metaConfig = new MetaConfig(config);
         try {
             return collectTables4LabelsProfile(metaConfig).asNodeStream();
-        } catch (Exception exc) {
-            exc.printStackTrace();
+        } catch (Exception e) {
+            log.debug("meta.nodeTypeProperties(): Failed to return stream", e);
+            throw new RuntimeException(e);
         }
-
-        return null;
     }
 
     /**
@@ -464,11 +466,10 @@ public class Meta {
         MetaConfig metaConfig = new MetaConfig(config);
         try {
             return collectTables4LabelsProfile(metaConfig).asRelStream();
-        } catch (Exception exc) {
-            exc.printStackTrace();
+        } catch (Exception e) {
+            log.debug("meta.relTypeProperties(): Failed to return stream", e);
+            throw new RuntimeException(e);
         }
-
-        return null;
     }
 
     private Tables4LabelsProfile collectTables4LabelsProfile (MetaConfig config) {
@@ -499,48 +500,44 @@ public class Meta {
         for (Label label : tx.getAllLabelsInUse()) {
             String labelName = label.name();
 
-            if (excludes.contains(labelName)) {
-                // Skip if explicitly excluded
-                continue;
-            } else if(!includeLabels.isEmpty() && !includeLabels.contains(labelName)) {
-                // Skip if included set is specified and this is not in it.
-                continue;
-            }
+            if (!excludes.contains(labelName) && (includeLabels.isEmpty() || includeLabels.contains(labelName))) {
+                // Skip if explicitly excluded or at least 1 include specified and not included
 
-            List<ConstraintDefinition> constraints = new ArrayList<ConstraintDefinition>();
+                List<ConstraintDefinition> constraints = new ArrayList<ConstraintDefinition>();
 
-            for (ConstraintDefinition cd : schema.getConstraints(label)) {
-                if (cd.isConstraintType(ConstraintType.NODE_PROPERTY_EXISTENCE)) {
-                    constraints.add(cd);
+                for (ConstraintDefinition cd : schema.getConstraints(label)) {
+                    if (cd.isConstraintType(ConstraintType.NODE_PROPERTY_EXISTENCE)) {
+                        constraints.add(cd);
+                    }
                 }
-            }
 
-            for (ConstraintDefinition cd : schema.getConstraints(label)) { profile.noteConstraint(label, cd); }
-            for (IndexDefinition index : schema.getIndexes(label)) { profile.noteIndex(label, index); }
+                for (ConstraintDefinition cd : schema.getConstraints(label)) { profile.noteConstraint(label, cd); }
+                for (IndexDefinition index : schema.getIndexes(label)) { profile.noteIndex(label, index); }
 
-            long labelCount = countStore.get(labelName);
-            long sample = getSampleForLabelCount(labelCount, config.getSample());
+                long labelCount = countStore.get(labelName);
+                long sample = getSampleForLabelCount(labelCount, config.getSample());
 
-            //System.out.println("Sampling " + sample + " for " + labelName);
+                //System.out.println("Sampling " + sample + " for " + labelName);
 
-            try (ResourceIterator<Node> nodes = tx.findNodes(label)) {
-                int count = 1;
-                while (nodes.hasNext()) {
-                    Node node = nodes.next();
-                    if(count++ % sample == 0) {
-                        boolean skipNode = false;
-                        for (RelationshipType rel : node.getRelationshipTypes()) {
-                            String relName = rel.name();
-                            if (excludeRels.contains(relName)) {
-                                // Skip if explicitly excluded
-                                skipNode = true;
-                            } else if (!includeRels.isEmpty() && !includeRels.contains(relName)) {
-                                // Skip if included set is specified and this is not in it.
-                                skipNode = true;
+                try (ResourceIterator<Node> nodes = tx.findNodes(label)) {
+                    int count = 1;
+                    while (nodes.hasNext()) {
+                        Node node = nodes.next();
+                        if(count++ % sample == 0) {
+                            boolean skipNode = false;
+                            for (RelationshipType rel : node.getRelationshipTypes()) {
+                                String relName = rel.name();
+                                if (excludeRels.contains(relName)) {
+                                    // Skip if explicitly excluded
+                                    skipNode = true;
+                                } else if (!includeRels.isEmpty() && !includeRels.contains(relName)) {
+                                    // Skip if included set is specified and this is not in it.
+                                    skipNode = true;
+                                }
                             }
-                        }
-                        if (skipNode != true) {
-                            profile.observe(node, config, constraints, relConstraints);
+                            if (skipNode != true) {
+                                profile.observe(node, config, constraints, relConstraints);
+                            }
                         }
                     }
                 }

--- a/src/main/java/apoc/meta/MetaConfig.java
+++ b/src/main/java/apoc/meta/MetaConfig.java
@@ -1,5 +1,9 @@
 package apoc.meta;
 
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+
 import java.util.*;
 
 public class MetaConfig {
@@ -7,17 +11,54 @@ public class MetaConfig {
     private Set<String> includesLabels;
     private Set<String> includesRels;
     private Set<String> excludes;
+    private Set<String> excludeRels;
     private long maxRels;
     private long sample;
 
+    /**
+     * A map of values, with the following keys and meanings.
+     * - labels: a list of strings, which are whitelisted node labels. If this list
+     * is specified **only these labels** will be examined.
+     * - rels: a list of strings, which are whitelisted rel types.  If this list is
+     * specified, **only these reltypes** will be examined.
+     * - excludes: a list of strings, which are node labels.  This
+     * works like a blacklist: if listed here, the thing won't be considered.  Everything
+     * else (subject to the whitelist) will be.
+     * - sample: a long number, i.e. "1 in (SAMPLE)".  If set to 1000 this means that
+     * every 1000th node will be examined.  It does **not** mean that a total of 1000 nodes
+     * will be sampled.
+     * - maxRels: the maximum number of relationships of a given type to look at.
+     * @param config
+     */
+
     public MetaConfig(Map<String,Object> config) {
         config = config != null ? config : Collections.emptyMap();
-        this.includesLabels = new HashSet<>((Collection<String>)config.getOrDefault("labels",Collections.EMPTY_SET));
-        this.includesRels = new HashSet<>((Collection<String>)config.getOrDefault("rels",Collections.EMPTY_SET));
-        this.excludes = new HashSet<>((Collection<String>)config.getOrDefault("excludes",Collections.EMPTY_SET));
+
+        // To maintain backwards compatibility, need to still support "labels", "rels" and "excludes" for "includeLabels", "includeRels" and "excludeLabels" respectively.
+
+        Set<String> includesLabelsLocal = new HashSet<>((Collection<String>)config.getOrDefault("labels",Collections.EMPTY_SET));
+        Set<String> includesRelsLocal = new HashSet<>((Collection<String>)config.getOrDefault("rels",Collections.EMPTY_SET));
+        Set<String> excludesLocal = new HashSet<>((Collection<String>)config.getOrDefault("excludes",Collections.EMPTY_SET));
+
+
+        if (includesLabelsLocal.isEmpty()) {
+            includesLabelsLocal = new HashSet<>((Collection<String>)config.getOrDefault("includeLabels",Collections.EMPTY_SET));
+        }
+        if (includesRelsLocal.isEmpty()) {
+            includesRelsLocal = new HashSet<>((Collection<String>)config.getOrDefault("includeRels",Collections.EMPTY_SET));
+        }
+        if (excludesLocal.isEmpty()) {
+            excludesLocal = new HashSet<>((Collection<String>)config.getOrDefault("excludeLabels",Collections.EMPTY_SET));
+        }
+
+        this.includesLabels = includesLabelsLocal;
+        this.includesRels = includesRelsLocal;
+        this.excludes = excludesLocal;
+        this.excludeRels = new HashSet<>((Collection<String>)config.getOrDefault("excludeRels",Collections.EMPTY_SET));
         this.sample = (long) config.getOrDefault("sample", 1000L);
         this.maxRels = (long) config.getOrDefault("maxRels", 100L);
     }
+
 
     public Set<String> getIncludesLabels() {
         return includesLabels;
@@ -35,12 +76,60 @@ public class MetaConfig {
         this.excludes = excludes;
     }
 
+    public Set<String> getExcludeRels() {
+        return excludeRels;
+    }
+
     public long getSample() {
         return sample;
     }
 
-
     public long getMaxRels() {
         return maxRels;
+    }
+
+    /**
+     * @param l
+     * @return true if the label matches the mask expressed by this object, false otherwise.
+     */
+    public boolean matches(Label l) {
+        if (getExcludes().contains(l.name())) { return false; }
+        if (getIncludesLabels().isEmpty()) { return true; }
+        return getIncludesLabels().contains(l.name());
+    }
+
+    /**
+     * @param labels
+     * @return true if any of the labels matches the mask expressed by this object, false otherwise.
+     */
+    public boolean matches(Iterable<Label> labels) {
+        // If it matches any label, it gets looked at, because labels can co-occur.
+        boolean match = true;
+
+        for(Label l : labels) {
+            match = match || matches(l);
+        }
+
+        return match;
+    }
+
+    /**
+     * @param r
+     * @return true if the relationship matches the mask expressed by this object, false otherwise.
+     */
+    public boolean matches(Relationship r) {
+        return matches(r.getType());
+    }
+
+    /**
+     * @param rt
+     * @return true if the relationship type matches the mask expressed by this object, false otherwise.
+     */
+    public boolean matches(RelationshipType rt) {
+        String name = rt.name();
+
+        if (getExcludeRels().contains(name)) { return false; }
+        if (getIncludesRels().isEmpty()) { return true; }
+        return getIncludesRels().contains(name);
     }
 }

--- a/src/main/java/apoc/meta/Tables4LabelsProfile.java
+++ b/src/main/java/apoc/meta/Tables4LabelsProfile.java
@@ -1,0 +1,313 @@
+package apoc.meta;
+
+import apoc.meta.tablesforlabels.PropertyContainerProfile;
+import apoc.meta.tablesforlabels.OrderedLabels;
+import apoc.meta.tablesforlabels.PropertyTracker;
+import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.schema.ConstraintDefinition;
+import org.neo4j.graphdb.schema.IndexDefinition;
+import org.neo4j.graphdb.schema.*;
+
+import java.util.*;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import java.util.stream.Collectors;
+
+public class Tables4LabelsProfile {
+    Map<OrderedLabels, PropertyContainerProfile> labelMap;
+    Map<String, PropertyContainerProfile> relMap;
+    Map<OrderedLabels,Long> obsByNode;
+    Map<String,Long> obsByRelType;
+    Map<String,Map<String,List<String>>> relGlobalMeta;
+
+    /**
+     * DAO class that the stored procedure returns
+     */
+    public class NodeTypePropertiesEntry {
+        public String nodeType;
+        public List<String> nodeLabels;
+        public String propertyName;
+        public List<String> propertyTypes;
+        public boolean mandatory;
+        public long propertyObservations;
+        public long totalObservations;
+
+        public NodeTypePropertiesEntry(String nodeType, List<String> nodeLabels, String propertyName, List<String>propertyTypes, boolean mandatory, long propertyObservations, long totalObservations) {
+            this.nodeType = nodeType;
+            this.nodeLabels = nodeLabels;
+            this.propertyName = propertyName;
+            this.propertyTypes = propertyTypes;
+            this.mandatory = mandatory;
+            this.propertyObservations = propertyObservations;
+            this.totalObservations = totalObservations;
+        }
+    }
+
+    public class RelTypePropertiesEntry {
+        public String relType;
+        public List<String> sourceNodeLabels;
+        public List<String> targetNodeLabels;
+        public String propertyName;
+        public List<String>propertyTypes;
+        public boolean mandatory;
+        public long propertyObservations;
+        public long totalObservations;
+
+        public RelTypePropertiesEntry(String relType, List<String> sourceNodeLabels, List<String> targetNodeLabels, String propertyName, List<String>propertyTypes, boolean mandatory, long propertyObservations, long totalObservations) {
+            this.relType = relType;
+            this.sourceNodeLabels = sourceNodeLabels;
+            this.targetNodeLabels = targetNodeLabels;
+            this.propertyName = propertyName;
+            this.propertyTypes = propertyTypes;
+            this.mandatory = mandatory;
+            this.propertyObservations = propertyObservations;
+            this.totalObservations = totalObservations;
+        }
+    }
+
+    public Tables4LabelsProfile() {
+        labelMap = new LinkedHashMap(100);
+        relMap = new LinkedHashMap(100);
+        obsByNode = new LinkedHashMap(100);
+        obsByRelType = new LinkedHashMap(100);
+        relGlobalMeta = new LinkedHashMap(100);
+    }
+
+    public void noteIndex(Label label, IndexDefinition id) {
+
+    }
+
+    public void noteConstraint(Label label, ConstraintDefinition cd) {
+
+    }
+
+    public PropertyContainerProfile getNodeProfile(OrderedLabels ol) {
+        if (labelMap.containsKey(ol)) {
+            return labelMap.get(ol);
+        } else {
+            PropertyContainerProfile p = new PropertyContainerProfile();
+            labelMap.put(ol, p);
+            return p;
+        }
+    }
+
+    public PropertyContainerProfile getRelProfile(String relType) {
+        if (relMap.containsKey(relType)) {
+            return relMap.get(relType);
+        } else {
+            PropertyContainerProfile p = new PropertyContainerProfile();
+            relMap.put(relType, p);
+            return p;
+        }
+    }
+
+    public Long sawNode(OrderedLabels labels) {
+        if (obsByNode.containsKey(labels)) {
+            Long val = obsByNode.get(labels) + 1;
+            obsByNode.put(labels, val);
+            return val;
+        } else {
+            obsByNode.put(labels, 1L);
+            return 1L;
+        }
+    }
+
+    public Long sawRel(String typeName) {
+        if (obsByRelType.containsKey(typeName)) {
+            Long val = obsByRelType.get(typeName) + 1;
+            obsByRelType.put(typeName, val);
+            return val;
+        } else {
+            obsByRelType.put(typeName, 1L);
+            return 1L;
+        }
+    }
+
+    public boolean compareLabelLists(Map<String, List<String>> a, Map<String, List<String>> b) {
+        boolean equal = true;
+        for (Map.Entry<String, List<String>> comp : a.entrySet()) {
+            List<String> list1 = comp.getValue();
+            Collections.sort(list1);
+            if (b.containsKey(comp.getKey())) {
+                List<String> list2 = b.get(comp.getKey());
+                Collections.sort(list2);
+                if (!list1.equals(list2)) {
+                    equal = false;
+                }
+            }
+        }
+        if (equal) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    public static String labelJoin(Iterable<Label> labels) {
+        return StreamSupport.stream(labels.spliterator(), true)
+        .map(Label::name)
+        .collect(Collectors.joining("__"));
+    }
+
+    public static class decipherRelMap {
+        public static List<String> getSourceLabels(String relMapIdentifier) {
+            String[] components = relMapIdentifier.split("###");
+            List<String> sourceNodeLabels = Arrays.asList(components[0].split("__"));
+            return sourceNodeLabels;
+        }
+        public static List<String> getTargetLabels(String relMapIdentifier) {
+            String[] components = relMapIdentifier.split("###");
+            List<String> targetNodeLabels = Arrays.asList(components[1].split("__"));
+            return targetNodeLabels;
+        }
+        public static String getRelType(String relMapIdentifier) {
+            String[] components = relMapIdentifier.split("###");
+            String relTypeName = components[2];
+            return relTypeName;
+        }
+    }
+
+    public void observe(Node n, MetaConfig config, Iterable<ConstraintDefinition> constraints, Map<String, Iterable<ConstraintDefinition>> relConstraints) {
+        OrderedLabels labels = new OrderedLabels(n.getLabels());
+        PropertyContainerProfile localNodeProfile = getNodeProfile(labels);
+
+        Set<String> excludes = config.getExcludes();
+        Set<String> includesRels = config.getIncludesRels();
+
+        // Only descend and look at properties if it's in our match list.
+        if (config.matches(n.getLabels())) {
+            sawNode(labels);
+            localNodeProfile.observe(n, constraints, true, relConstraints);
+        }
+
+        for (RelationshipType type : n.getRelationshipTypes()) {
+            String labelString = "";
+            for (Label label : n.getLabels()) {
+                labelString += "__" + label.name();
+            }
+        }
+
+        // Even if the node isn't in our match list, do rel processing.  This
+        // is because our profiling is "node-first" to get to the relationships,
+        // and if we don't do it this way, it's possible to blacklist nodes and
+        // thereby miss relationships that were of interest.
+        for (RelationshipType type : n.getRelationshipTypes()) {
+            String typeName = type.name();
+
+            if (!config.matches(type)) { continue; }
+
+            int out = n.getDegree(type, Direction.OUTGOING);
+            if (out == 0) continue;
+
+            for(Relationship r : n.getRelationships(Direction.OUTGOING, type)) {
+                Iterable relStartNode = r.getStartNode().getLabels();
+                Iterable relEndNode = r.getEndNode().getLabels();
+
+                String relIdentifier = labelJoin(relStartNode) + "###" + labelJoin(relEndNode) + "###" + typeName;
+
+                PropertyContainerProfile localRelProfile = getRelProfile(relIdentifier);
+                long seenSoFar = sawRel(relIdentifier);
+                boolean isNode = false;
+
+                if (seenSoFar > config.getMaxRels()) {
+                    // We've seen more than the maximum sample size for this rel, so
+                    // we don't need to keep looking.
+                    continue;
+                }
+
+                localRelProfile.observe(r, constraints, isNode, relConstraints);
+            }
+        }
+    }
+
+    public Tables4LabelsProfile finished() {
+        for (PropertyContainerProfile prof : labelMap.values()) {
+            prof.finished();
+        }
+
+        for(PropertyContainerProfile prof : relMap.values()) {
+            prof.finished();
+        }
+
+        return this;
+    }
+
+    public Stream<NodeTypePropertiesEntry> asNodeStream() {
+        Set<OrderedLabels> labels = labelMap.keySet();
+        List<NodeTypePropertiesEntry> results = new ArrayList<NodeTypePropertiesEntry>(100);
+
+        for(OrderedLabels ol : labels) {
+            PropertyContainerProfile prof = labelMap.get(ol);
+            Long totalObservations = obsByNode.get(ol);
+
+            // Base case: the node never had any properties.
+            if (prof.propertyNames().size() == 0) {
+                results.add(new NodeTypePropertiesEntry(
+                        ol.asNodeType(),
+                        ol.nodeLabels(),
+                        null,
+                        null,
+                        false, 0L,
+                        totalObservations));
+                continue;
+            }
+
+            for (String propertyName : prof.propertyNames()) {
+                PropertyTracker tracker = prof.trackerFor(propertyName);
+
+                NodeTypePropertiesEntry entry = new NodeTypePropertiesEntry(
+                        ol.asNodeType(),
+                        ol.nodeLabels(),
+                        propertyName,
+                        tracker.propertyTypes(),
+                        tracker.mandatory,
+                        tracker.observations,
+                        totalObservations);
+
+                results.add(entry);
+            }
+        }
+
+        return results.stream();
+    }
+
+    public Stream<RelTypePropertiesEntry> asRelStream() {
+        Set<String> relTypes = relMap.keySet();
+        List<RelTypePropertiesEntry> results = new ArrayList<>(100);
+
+        for (String relType : relTypes) {
+            PropertyContainerProfile prof = relMap.get(relType);
+            Long totalObservations = obsByRelType.get(relType);
+
+            // Base case: the rel type never had any properties.
+            if (prof.propertyNames().size() == 0) {
+                results.add(new RelTypePropertiesEntry(
+                        ":`" + decipherRelMap.getRelType(relType) + "`",
+                        decipherRelMap.getSourceLabels(relType),
+                        decipherRelMap.getTargetLabels(relType),
+                        null,
+                        null,
+                        false,
+                        0L,
+                        totalObservations));
+                continue;
+            }
+
+            for (String propertyName : prof.propertyNames()) {
+                PropertyTracker tracker = prof.trackerFor(propertyName);
+
+                results.add(new RelTypePropertiesEntry(
+                        ":`" + decipherRelMap.getRelType(relType) + "`",
+                        decipherRelMap.getSourceLabels(relType),
+                        decipherRelMap.getTargetLabels(relType),
+                        propertyName,
+                        tracker.propertyTypes(),
+                        tracker.mandatory,
+                        tracker.observations,
+                        totalObservations));
+            }
+        }
+
+        return results.stream();
+    }
+}

--- a/src/main/java/apoc/meta/Tables4LabelsProfile.java
+++ b/src/main/java/apoc/meta/Tables4LabelsProfile.java
@@ -146,18 +146,18 @@ public class Tables4LabelsProfile {
     public static String labelJoin(Iterable<Label> labels) {
         return StreamSupport.stream(labels.spliterator(), true)
         .map(Label::name)
-        .collect(Collectors.joining("__"));
+        .collect(Collectors.joining("@@@"));
     }
 
     public static class decipherRelMap {
         public static List<String> getSourceLabels(String relMapIdentifier) {
             String[] components = relMapIdentifier.split("###");
-            List<String> sourceNodeLabels = Arrays.asList(components[0].split("__"));
+            List<String> sourceNodeLabels = Arrays.asList(components[0].split("@@@"));
             return sourceNodeLabels;
         }
         public static List<String> getTargetLabels(String relMapIdentifier) {
             String[] components = relMapIdentifier.split("###");
-            List<String> targetNodeLabels = Arrays.asList(components[1].split("__"));
+            List<String> targetNodeLabels = Arrays.asList(components[1].split("@@@"));
             return targetNodeLabels;
         }
         public static String getRelType(String relMapIdentifier) {
@@ -183,7 +183,7 @@ public class Tables4LabelsProfile {
         for (RelationshipType type : n.getRelationshipTypes()) {
             String labelString = "";
             for (Label label : n.getLabels()) {
-                labelString += "__" + label.name();
+                labelString += "@@@" + label.name();
             }
         }
 

--- a/src/main/java/apoc/meta/Tables4LabelsProfile.java
+++ b/src/main/java/apoc/meta/Tables4LabelsProfile.java
@@ -167,7 +167,7 @@ public class Tables4LabelsProfile {
         }
     }
 
-    public void observe(Node n, MetaConfig config, Iterable<ConstraintDefinition> constraints, Map<String, Iterable<ConstraintDefinition>> relConstraints) {
+    public void observe(Node n, MetaConfig config) {
         OrderedLabels labels = new OrderedLabels(n.getLabels());
         PropertyContainerProfile localNodeProfile = getNodeProfile(labels);
 
@@ -177,7 +177,7 @@ public class Tables4LabelsProfile {
         // Only descend and look at properties if it's in our match list.
         if (config.matches(n.getLabels())) {
             sawNode(labels);
-            localNodeProfile.observe(n, constraints, true, relConstraints);
+            localNodeProfile.observe(n, true);
         }
 
         for (RelationshipType type : n.getRelationshipTypes()) {
@@ -215,7 +215,7 @@ public class Tables4LabelsProfile {
                     continue;
                 }
 
-                localRelProfile.observe(r, constraints, isNode, relConstraints);
+                localRelProfile.observe(r, isNode);
             }
         }
     }

--- a/src/main/java/apoc/meta/tablesforlabels/OrderedLabels.java
+++ b/src/main/java/apoc/meta/tablesforlabels/OrderedLabels.java
@@ -1,0 +1,43 @@
+package apoc.meta.tablesforlabels;
+
+import apoc.meta.Tables4LabelsProfile;
+import org.neo4j.graphdb.Label;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Abstraction on an ordered label set, used as a key for tables for labels profiles
+ */
+public class OrderedLabels {
+    List<String> labels;
+
+    public OrderedLabels(Iterable<Label> input) {
+        labels = new ArrayList<>(3);
+        for (Label l : input) {
+            labels.add(l.name());
+        }
+
+        Collections.sort(labels);
+    }
+
+    @Override
+    public int hashCode() {
+        return labels.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof OrderedLabels && nodeLabels().equals(((OrderedLabels)o).nodeLabels());
+    }
+
+    public String asNodeType() {
+        return ":" + labels.stream()
+                .map(s -> "`" + s + "`")
+                .collect(Collectors.joining( ":" ));
+    }
+
+    public List<String> nodeLabels() { return labels; }
+}

--- a/src/main/java/apoc/meta/tablesforlabels/PropertyContainerProfile.java
+++ b/src/main/java/apoc/meta/tablesforlabels/PropertyContainerProfile.java
@@ -1,0 +1,78 @@
+package apoc.meta.tablesforlabels;
+
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+//import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.schema.ConstraintDefinition;
+
+import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A profile of a particular ordered label set (or relationship type) has a set of possible properties that can exist, and
+ * stats about those properties.
+ */
+public class PropertyContainerProfile {
+    public long observations;
+    Map<String, PropertyTracker> profile;
+
+    public PropertyContainerProfile() {
+        observations = 0;
+        profile = new HashMap<>(3);
+    }
+
+    public Set<String> propertyNames() { return profile.keySet(); }
+    public PropertyTracker trackerFor(String propName) { return profile.get(propName); }
+
+    public void observe(Entity n, Iterable<ConstraintDefinition> constraints, boolean isNode, Map<String, Iterable<ConstraintDefinition>> relConstraints) {
+        observations++;
+
+        for (String propName : n.getPropertyKeys()) {
+            PropertyTracker tracker;
+
+            if (profile.containsKey(propName)) {
+                tracker = profile.get(propName);
+            } else {
+                tracker = new PropertyTracker(propName);
+                profile.put(propName, tracker);
+            }
+
+            tracker.addObservation(n.getProperty(propName));
+
+            if (isNode) {
+
+                // Check for node constraints
+
+                tracker.mandatory = false;
+                for (ConstraintDefinition cd : constraints) {
+                    for (String pk : cd.getPropertyKeys()) {
+                        if (pk == propName) {
+                            tracker.mandatory = true;
+                        }
+                    }
+                }
+            } else {
+
+                // Check for relationship constraints - NOTE: Could probably improve the efficiency here a bit. Too many nested loops.
+
+                tracker.mandatory = false;
+                for (Map.Entry<String,Iterable<ConstraintDefinition>> entry : relConstraints.entrySet()) {
+                    for (ConstraintDefinition cd : entry.getValue()) {
+                        for (String pk : cd.getPropertyKeys()) {
+                            if (pk == propName) {
+                                tracker.mandatory = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public PropertyContainerProfile finished() {
+        return this;
+    }
+}

--- a/src/main/java/apoc/meta/tablesforlabels/PropertyTracker.java
+++ b/src/main/java/apoc/meta/tablesforlabels/PropertyTracker.java
@@ -1,0 +1,74 @@
+package apoc.meta.tablesforlabels;
+import org.neo4j.graphdb.Label;
+
+import java.util.*;
+
+public class PropertyTracker {
+    public String name;
+    public Set<String> types;
+    public boolean mandatory;
+    public long observations;
+    public long nulls;
+
+    public PropertyTracker(String name) {
+        this.name = name;
+        types = new HashSet<>(3);
+        mandatory = false;
+        observations = 0L;
+        nulls = 0L;
+    }
+
+    public void addObservation(Object value) {
+        observations++;
+        if (value == null) { nulls++; }
+        types.add(assignTypeName(value));
+    }
+
+    private String assignTypeName(Object value) {
+        String typeName = value.getClass().getCanonicalName();
+        if (typeMappings.containsKey(typeName)) {
+            return typeMappings.get(typeName);
+        }
+
+        return typeName.replace("java.lang.", "");
+    }
+
+    public List<String> propertyTypes() {
+        List<String> ret = new ArrayList<>(types);
+        Collections.sort(ret);
+        return ret;
+    }
+
+    public static final Map<String,String> typeMappings = new HashMap<String,String>();
+    static {
+        typeMappings.put("java.lang.String", "String");
+        typeMappings.put("java.lang.String[]", "StringArray");
+        typeMappings.put("java.lang.Double", "Double");
+        typeMappings.put("java.lang.Double[]", "DoubleArray");
+        typeMappings.put("double[]", "DoubleArray");
+        typeMappings.put("java.lang.Integer", "Integer");
+        typeMappings.put("java.lang.Integer[]", "IntegerArray");
+        typeMappings.put("int[]", "IntegerArray");
+        typeMappings.put("java.lang.Long", "Long");
+        typeMappings.put("java.lang.Long[]", "LongArray");
+        typeMappings.put("long[]", "LongArray");
+        typeMappings.put("org.neo4j.values.storable.PointValue", "Point");
+        typeMappings.put("org.neo4j.values.storable.PointValue[]", "PointArray");
+        typeMappings.put("java.time.ZonedDateTime", "DateTime");
+        typeMappings.put("java.time.ZonedDateTime[]", "DateTimeArray");
+        typeMappings.put("java.lang.Boolean", "Boolean");
+        typeMappings.put("java.lang.Boolean[]", "BooleanArray");
+        typeMappings.put("boolean", "Boolean");
+        typeMappings.put("boolean[]", "BooleanArray");
+        typeMappings.put("java.time.LocalDate", "Date");
+        typeMappings.put("java.time.LocalDate[]", "DateArray");
+        typeMappings.put("java.time.LocalDateTime", "LocalDateTime");
+        typeMappings.put("java.time.LocalDateTime[]", "LocalDateTimeArray");
+        typeMappings.put("java.time.LocalTime", "LocalTime");
+        typeMappings.put("java.time.LocalTime[]", "LocalTimeArray");
+        typeMappings.put("org.neo4j.values.storable.DurationValue", "Duration");
+        typeMappings.put("org.neo4j.values.storable.DurationValue[]", "DurationArray");
+        typeMappings.put("java.time.OffsetTime", "Time");
+        typeMappings.put("java.time.OffsetTime[]", "TimeArray");
+    }
+}

--- a/src/test/java/apoc/meta/MetaEnterpriseFeaturesTest.java
+++ b/src/test/java/apoc/meta/MetaEnterpriseFeaturesTest.java
@@ -1,0 +1,111 @@
+package apoc.schema;
+
+import apoc.util.Neo4jContainerExtension;
+import apoc.util.TestUtil;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import java.util.function.Predicate;
+import org.neo4j.values.storable.*;
+import org.neo4j.graphdb.*;
+import org.neo4j.driver.Session;
+
+import java.util.*;
+import java.util.List;
+import java.util.Map;
+
+import static apoc.util.TestContainerUtil.*;
+import static apoc.util.TestUtil.isTravis;
+import static java.util.Arrays.asList;
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeNotNull;
+
+/**
+ * @author as
+ * @since 12.02.19
+ */
+public class MetaEnterpriseFeaturesTest {
+
+    private static Neo4jContainerExtension neo4jContainer;
+    private static Session session;
+
+    @BeforeClass
+    public static void beforeAll() {
+        assumeFalse(isTravis());
+        executeGradleTasks("clean", "shadow");
+        TestUtil.ignoreException(() -> {
+            // We build the project, the artifact will be placed into ./build/libs
+            neo4jContainer = createEnterpriseDB(!TestUtil.isTravis());
+            neo4jContainer.start();
+        }, Exception.class);
+        assumeNotNull(neo4jContainer);
+        session = neo4jContainer.getSession();
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        if (neo4jContainer != null) {
+            session.close();
+            neo4jContainer.close();
+        }
+    }
+
+    public static boolean hasRecordMatching(List<Map<String,Object>> records, Map<String,Object> record) {
+        return hasRecordMatching(records, row -> {
+            boolean okSoFar = true;
+
+            for(String k : record.keySet()) {
+                okSoFar = okSoFar && row.containsKey(k) &&
+                        (row.get(k) == null ?
+                                (record.get(k) == null) :
+                                row.get(k).equals(record.get(k)));
+            }
+
+            return okSoFar;
+        });
+    }
+
+    public static boolean hasRecordMatching(List<Map<String,Object>> records, Predicate<Map<String,Object>> predicate) {
+        return records.stream().filter(predicate).count() > 0;
+    }
+
+    public static List<Map<String,Object>> gatherRecords(Iterator<Map<String,Object>> r) {
+        List<Map<String,Object>> rows = new ArrayList<>();
+        while(r.hasNext()) {
+            Map<String,Object> row = r.next();
+            rows.add(row);
+        }
+        return rows;
+    }
+
+    @Test
+    public void testNodeTypePropertiesBasic() {
+        session.writeTransaction(tx -> {
+            tx.run("CREATE (:Foo { l: 1, s: 'foo', d: datetime(), ll: ['a', 'b'], dl: [2.0, 3.0] });");
+            tx.run("CREATE CONSTRAINT ON (f:Foo) ASSERT EXISTS (f.s);");
+            tx.commit();
+            return null;
+        });
+        testResult(session, "CALL apoc.meta.nodeTypeProperties();", (r) -> {
+            List<Map<String,Object>> records = gatherRecords(r);
+            assertEquals(true, hasRecordMatching(records, m ->
+                        m.get("nodeType").equals(":`Foo`") &&
+                                ((List)m.get("nodeLabels")).get(0).equals("Foo") &&
+                                m.get("propertyName").equals("s") &&
+                                m.get("mandatory").equals(true)));
+
+                    assertEquals(true, hasRecordMatching(records, m ->
+                            m.get("propertyName").equals("s") &&
+                                    ((List)m.get("propertyTypes")).get(0).equals("String")));
+
+                    assertEquals(true, hasRecordMatching(records, m ->
+                        m.get("nodeType").equals(":`Foo`") &&
+                                ((List)m.get("nodeLabels")).get(0).equals("Foo") &&
+                                m.get("propertyName").equals("dl") &&
+                                m.get("mandatory").equals(false)));
+                    assertEquals(5, records.size());
+        });
+    }
+}

--- a/src/test/java/apoc/meta/MetaTest.java
+++ b/src/test/java/apoc/meta/MetaTest.java
@@ -19,6 +19,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
@@ -46,6 +49,86 @@ public class MetaTest {
             testResult(db,"CALL apoc.meta.stats", (r) -> assertEquals(true, r.hasNext()));
         }
     */
+
+    public static boolean hasRecordMatching(List<Map<String,Object>> records, Map<String,Object> record) {
+        return hasRecordMatching(records, row -> {
+            boolean okSoFar = true;
+
+            for(String k : record.keySet()) {
+                okSoFar = okSoFar && row.containsKey(k) &&
+                        (row.get(k) == null ?
+                                (record.get(k) == null) :
+                                row.get(k).equals(record.get(k)));
+            }
+
+            return okSoFar;
+        });
+    }
+
+    public static boolean hasRecordMatching(List<Map<String,Object>> records, Predicate<Map<String,Object>> predicate) {
+        return records.stream().filter(predicate).count() > 0;
+    }
+
+    public static List<Map<String,Object>> gatherRecords(Result r) {
+        List<Map<String,Object>> rows = new ArrayList<>();
+        while(r.hasNext()) {
+            Map<String,Object> row = r.next();
+            rows.add(row);
+        }
+        return rows;
+    }
+
+    private static String toCSV(List<Map<String, Object>> list) {
+        List<String> headers = list.stream().flatMap(map -> map.keySet().stream()).distinct().collect(Collectors.toList());
+        final StringBuffer sb = new StringBuffer();
+        for (int i = 0; i < headers.size(); i++) {
+            sb.append(headers.get(i));
+            sb.append(i == headers.size()-1 ? "\n" : ",");
+        }
+        for (Map<String, Object> map : list) {
+            for (int i = 0; i < headers.size(); i++) {
+                sb.append(map.get(headers.get(i)));
+                sb.append(i == headers.size()-1 ? "\n" : ",");
+            }
+        }
+        return sb.toString();
+    }
+
+    public static boolean testDBCallEquivalence(GraphDatabaseService db, String testCall, String equivalentToCall) {
+        AtomicReference<List<Map<String,Object>>> compareTo = new AtomicReference<>();
+        AtomicReference<List<Map<String,Object>>> testSet = new AtomicReference<>();
+
+        TestUtil.testResult(db, equivalentToCall, r -> {
+            compareTo.set(gatherRecords(r));
+        });
+
+        TestUtil.testResult(db, testCall, r -> {
+            testSet.set(gatherRecords(r));
+        });
+
+        System.out.println("COMPARE TO:");
+        System.out.println(toCSV(compareTo.get()));
+
+        System.out.println("TEST SET:");
+        System.out.println(toCSV(testSet.get()));
+
+        return resultSetsEquivalent(compareTo.get(), testSet.get());
+    }
+
+    public static boolean resultSetsEquivalent(List<Map<String,Object>> baseSet, List<Map<String,Object>> testSet) {
+        if (baseSet.size() != testSet.size()) {
+            System.err.println("Result sets have different cardinality");
+            return false;
+        }
+
+        boolean allMatch = true;
+
+        for(Map<String,Object> baseRecord : baseSet) {
+            allMatch = allMatch && hasRecordMatching(testSet, baseRecord);
+        }
+
+        return allMatch;
+    }
 
     @Test
     public void testMetaGraphExtraRels() throws Exception {
@@ -652,4 +735,200 @@ public class MetaTest {
         });
     }
 
+    // Tests for T4L
+
+    @Test
+    public void testRelTypePropertiesBasic() throws Exception {
+        db.executeTransactionally("CREATE (:Base)-[:RELTYPE { a: 1, d: null }]->(:Target)");
+        db.executeTransactionally("CREATE (:Base)-[:RELTYPE { a: 2, b: 2, c: 2, d: 4 }]->(:Target);");
+
+        TestUtil.testResult(db, "CALL apoc.meta.relTypeProperties()", r -> {
+            List<Map<String,Object>> records = gatherRecords(r);
+
+            System.out.println("REL TYPE PROPERTIES");
+            System.out.println(toCSV(records));
+
+            assertEquals(true, hasRecordMatching(records, m ->
+                    m.get("propertyName").equals("a") &&
+                            ((List)m.get("propertyTypes")).get(0).equals("Long") &&
+                            m.get("mandatory").equals(false)));
+
+            assertEquals(true, hasRecordMatching(records, m ->
+                    m.get("propertyName").equals("b") &&
+                            ((List)m.get("propertyTypes")).get(0).equals("Long") &&
+                            m.get("mandatory").equals(false)));
+
+            assertEquals(true, hasRecordMatching(records, m ->
+                    m.get("propertyName").equals("c") &&
+                            ((List)m.get("propertyTypes")).get(0).equals("Long") &&
+                            m.get("mandatory").equals(false)));
+
+            assertEquals(true, hasRecordMatching(records, m ->
+                    m.get("propertyName").equals("d") &&
+                            ((List)m.get("propertyTypes")).get(0).equals("Long") &&
+                            m.get("mandatory").equals(false)));
+        });
+    }
+
+    @Test
+    public void testRelTypePropertiesIncludes() throws Exception {
+        db.executeTransactionally("CREATE (:A)-[:CATCHME { c: 1 }]->(:B)");
+        db.executeTransactionally("CREATE (:A)-[:IGNOREME { d: 1 }]->(:B)");
+
+        TestUtil.testResult(db, "CALL apoc.meta.relTypeProperties({ includeRels: ['CATCHME'] })", r -> {
+            List<Map<String,Object>> records = gatherRecords(r);
+            assertEquals(1, records.size());
+            assertEquals(records.get(0).get("propertyName").equals("c"), true);
+        });
+    }
+
+    @Test
+    public void testNodeTypePropertiesNodeExcludes() throws Exception {
+        db.executeTransactionally("CREATE (:ExcludeMe)");
+        db.executeTransactionally("CREATE (:IncludeMe)");
+
+        TestUtil.testResult(db, "CALL apoc.meta.nodeTypeProperties({ excludeLabels: ['ExcludeMe'] })", r -> {
+            List<Map<String,Object>> records = gatherRecords(r);
+            assertEquals(1, records.size());
+            assertEquals(true, records.get(0).get("nodeType").equals(":`IncludeMe`"));
+        });
+    }
+
+    @Test
+    public void testNodeTypePropertiesNodeIncludes() throws Exception {
+        db.executeTransactionally("CREATE (:ExcludeMe)");
+        db.executeTransactionally("CREATE (:IncludeMe)");
+
+        TestUtil.testResult(db, "CALL apoc.meta.nodeTypeProperties({ includeLabels: ['IncludeMe'] })", r -> {
+            List<Map<String,Object>> records = gatherRecords(r);
+            assertEquals(1, records.size());
+            assertEquals(true, records.get(0).get("nodeType").equals(":`IncludeMe`"));
+        });
+    }
+
+    @Test
+    public void testNodeTypePropertiesRelExcludes() throws Exception {
+        db.executeTransactionally("CREATE (:A)-[:RELA { x: 1 }]->(:C)");
+        db.executeTransactionally("CREATE (:B)-[:RELB { x: 1 }]->(:D)");
+
+        TestUtil.testResult(db, "CALL apoc.meta.nodeTypeProperties({ excludeRels: ['RELA'] })", r -> {
+            List<Map<String,Object>> records = gatherRecords(r);
+            assertEquals(2, records.size());
+            for (Map<String,Object> rec : records) {
+                if (rec.get("nodeType").equals(":`A`")) {
+                    assertEquals(true, rec.get("nodeType").equals(":`B`"));
+                }
+                if (rec.get("nodeType").equals(":`C`")) {
+                    assertEquals(true, rec.get("nodeType").equals(":`D`"));
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testNodeTypePropertiesRelIncludes() throws Exception {
+        db.executeTransactionally("CREATE (:A)-[:RELA { x: 1 }]->(:C)");
+        db.executeTransactionally("CREATE (:B)-[:RELB { x: 1 }]->(:D)");
+
+        TestUtil.testResult(db, "CALL apoc.meta.nodeTypeProperties({ includeRels: ['RELA'] })", r -> {
+            List<Map<String,Object>> records = gatherRecords(r);
+            assertEquals(2, records.size());
+            for (Map<String,Object> rec : records) {
+                if (rec.get("nodeType").equals(":`A`")) {
+                    assertEquals(true, rec.get("nodeType").equals(":`A`"));
+                }
+                if (rec.get("nodeType").equals(":`C`")) {
+                    assertEquals(true, rec.get("nodeType").equals(":`C`"));
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testRelTypePropertiesRelExcludes() throws Exception {
+        db.executeTransactionally("CREATE (:A)-[:RELA { x: 1 }]->(:C)");
+        db.executeTransactionally("CREATE (:B)-[:RELB { x: 1 }]->(:D)");
+
+        TestUtil.testResult(db, "CALL apoc.meta.relTypeProperties({ excludeRels: ['RELA'] })", r -> {
+            List<Map<String,Object>> records = gatherRecords(r);
+            assertEquals(1, records.size());
+            assertEquals(true, records.get(0).get("relType").equals(":`RELB`"));
+        });
+    }
+
+    @Test
+    public void testRelTypePropertiesRelIncludes() throws Exception {
+        db.executeTransactionally("CREATE (:A)-[:RELA { x: 1 }]->(:C)");
+        db.executeTransactionally("CREATE (:B)-[:RELB { x: 1 }]->(:D)");
+
+        TestUtil.testResult(db, "CALL apoc.meta.relTypeProperties({ includeRels: ['RELA'] })", r -> {
+            List<Map<String,Object>> records = gatherRecords(r);
+            assertEquals(1, records.size());
+            assertEquals(true, records.get(0).get("relType").equals(":`RELA`"));
+        });
+    }
+
+    @Test
+    public void testRelTypePropertiesNodeExcludes() throws Exception {
+        db.executeTransactionally("CREATE (:A)-[:RELA { x: 1 }]->(:C)");
+        db.executeTransactionally("CREATE (:B)-[:RELB { x: 1 }]->(:D)");
+
+        TestUtil.testResult(db, "CALL apoc.meta.relTypeProperties({ excludeLabels: ['A'] })", r -> {
+            List<Map<String,Object>> records = gatherRecords(r);
+            assertEquals(1, records.size());
+            for (Map<String,Object> rec : records) {
+                if (rec.get("relType").equals(":`RELB`")) {
+                    assertEquals(true, rec.get("relType").equals(":`RELB`"));
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testRelTypePropertiesNodeIncludes() throws Exception {
+        db.executeTransactionally("CREATE (:A)-[:RELA { x: 1 }]->(:C)");
+        db.executeTransactionally("CREATE (:B)-[:RELB { x: 1 }]->(:D)");
+
+        TestUtil.testResult(db, "CALL apoc.meta.relTypeProperties({ includeLabels: ['A'] })", r -> {
+            List<Map<String,Object>> records = gatherRecords(r);
+            assertEquals(1, records.size());
+            for (Map<String,Object> rec : records) {
+                if (rec.get("relType").equals(":`RELA`")) {
+                    assertEquals(true, rec.get("relType").equals(":`RELA`"));
+                }
+            }
+        });
+    }
+
+    @Test
+    public void testNodeTypePropertiesEquivalenceAdvanced() throws Exception {
+        db.executeTransactionally("CREATE (:Foo { l: 1, s: 'foo', d: datetime(), ll: ['a', 'b'], dl: [2.0, 3.0] });");
+        // Missing all properties to make everything non-mandatory.
+        db.executeTransactionally("CREATE (:Foo { z: 1 });");
+        assertEquals(true, testDBCallEquivalence(db, "CALL apoc.meta.nodeTypeProperties()", "CALL db.schema.nodeTypeProperties()"));
+    }
+
+    @Test
+    public void testNodeTypePropertiesEquivalenceTypeMapping() throws Exception {
+        String q =
+            "CREATE (:Test {" +
+            "    longProp: 1," +
+            "    doubleProp: 3.14," +
+            "    stringProp: 'Hello'," +
+            "    longArrProp: [1,2,3]," +
+            "    doubleArrProp: [3.14, 3.14]," +
+            "    stringArrProp: ['Hello', 'World']," +
+            "    dateTimeProp: datetime()," +
+            "    dateProp: date()," +
+            "    pointProp: point({ x:0, y:4, z:1 })," +
+            "    pointArrProp: [point({ x:0, y:4, z:1 }), point({ x:0, y:4, z:1 })]," +
+            "    boolProp: true," +
+            "    boolArrProp: [true, false]\n" +
+            "})" +
+            "CREATE (:Test { randomProp: 'this property is here to make everything mandatory = false'});";
+
+
+        db.executeTransactionally(q);
+        assertEquals(true, testDBCallEquivalence(db, "CALL apoc.meta.nodeTypeProperties()", "CALL db.schema.nodeTypeProperties()"));
+    }
 }


### PR DESCRIPTION
Fixes #1388 (for 4.x)

Full list of features:

1. **Tables4Labels**. Base functionality to replace nodeTypeProperties() and relTypeProperties() with sampling versions.
2. **Relationships4Labels**. Adds two columns to relTypeProperties() to show source and target labels for each relationship that has a valid property.
3. **Mandatory handling functionality change**. Forces "mandatory" flag to true only if a constraint exists for this property (only works for Enterprise Edition as constraints are a licensed function of Neo4J).
4. **Allow inclusion/exclusion of nodes by relationships**. When calling nodeTypeProperties(), include/exclude a node if it has a specifically has/doesn't have a relationship type associated).

Work-in-progress PR. Still requires:

- Complete unit tests (some are complete, some are not)
- Documentation
 
