### PR TITLE
fixes #1367: Improve logging when there is NullPointerException with apoc.periodic.iterate/apoc.load.csv

### DIFF
--- a/src/main/java/apoc/periodic/Periodic.java
+++ b/src/main/java/apoc/periodic/Periodic.java
@@ -100,7 +100,7 @@ public class Periodic {
         do {
             errors.add(e.getMessage());
             e = e.getCause();
-        } while (e.getCause() != null && !e.getCause().equals(e));
+        } while (e != null && e.getCause() != null && !e.getCause().equals(e));
         return String.join("\n",errors);
     }
 
@@ -437,7 +437,7 @@ public class Periodic {
                         }).mapToLong(l -> l).sum();
                 };
             }
-            futures.add(Util.inTxFuture(pool, db, task));
+            futures.add(Util.inTxFuture(pool, db, log, task));
             batches++;
             if (futures.size() > concurrency) {
                 while (futures.stream().noneMatch(Future::isDone)) { // none done yet, block for a bit


### PR DESCRIPTION
Fixes #1367

Related to: https://neotechnology.zendesk.com/agent/tickets/8171
Fixed the bug and improved the logging mechanism.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Improved the logging mechanism for `Util#inTxFuture`
  - managed a possible `NullPointerException` scenario for `Periodic#getMessages`
