### PR TITLE
fixes #1367: Improve logging when there is NullPointerException with  apoc.periodic.iterate/apoc.load.csv (3.4)

### DIFF
--- a/src/main/java/apoc/periodic/Periodic.java
+++ b/src/main/java/apoc/periodic/Periodic.java
@@ -99,7 +99,7 @@ public class Periodic {
         do {
             errors.add(e.getMessage());
             e = e.getCause();
-        } while (e.getCause() != null && !e.getCause().equals(e));
+        } while (e != null && e.getCause() != null && !e.getCause().equals(e));
         return String.join("\n",errors);
     }
 
@@ -389,7 +389,7 @@ public class Periodic {
                         }).mapToLong(l -> l).sum();
                 };
             }
-            futures.add(Util.inTxFuture(pool, db, task));
+            futures.add(Util.inTxFuture(pool, db, log, task));
             batches++;
             if (futures.size() > concurrency) {
                 while (futures.stream().noneMatch(Future::isDone)) { // none done yet, block for a bit


### PR DESCRIPTION
**This is the cherry-picked commit of #1402**

Related to: https://neotechnology.zendesk.com/agent/tickets/8171
Fixed the bug and improved the logging mechanism.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Improved the logging mechanism for `Util#inTxFuture`
  - managed a possible `NullPointerException` scenario for `Periodic#getMessages`
