### PR TITLE
Fixed bug with constraint checking after transaction has closed

### DIFF
--- a/src/main/java/apoc/meta/Meta.java
+++ b/src/main/java/apoc/meta/Meta.java
@@ -53,8 +53,8 @@ public class Meta {
     public static class ConstraintTracker {
         // The following maps are (label|rel-type)/constraintdefinition entries
 
-        public static Map<String, List<ConstraintDefinition>> relConstraints = new HashMap<>(20);;
-        public static Map<String, List<ConstraintDefinition>> nodeConstraints = new HashMap<>(20);;
+        public static Map<String, List<String>> relConstraints = new HashMap<>(20);;
+        public static Map<String, List<String>> nodeConstraints = new HashMap<>(20);;
     }
 
     public enum Types {
@@ -486,20 +486,21 @@ public class Meta {
 
         for (ConstraintDefinition cd : schema.getConstraints()) {
             if (cd.isConstraintType(ConstraintType.NODE_PROPERTY_EXISTENCE)) {
-                List<ConstraintDefinition> tcd = new ArrayList<ConstraintDefinition>(10);
+                List<String> props = new ArrayList<String>(10);
                 if (ConstraintTracker.nodeConstraints.containsKey(cd.getLabel().name())) {
-                    tcd = ConstraintTracker.nodeConstraints.get(cd.getLabel().name());
+                    props = ConstraintTracker.nodeConstraints.get(cd.getLabel().name());
                 }
-                tcd.add(cd);
-                ConstraintTracker.nodeConstraints.put(cd.getLabel().name(), tcd);
+                cd.getPropertyKeys().forEach(props::add);
+                ConstraintTracker.nodeConstraints.put(cd.getLabel().name(),props);
 
             } else if (cd.isConstraintType(ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE)) {
                 List<ConstraintDefinition> tcd = new ArrayList<ConstraintDefinition>(10);
+                List<String> props = new ArrayList<String>(10);
                 if (ConstraintTracker.relConstraints.containsKey(cd.getRelationshipType().name())) {
-                    tcd = ConstraintTracker.relConstraints.get(cd.getRelationshipType().name());
+                    props = ConstraintTracker.relConstraints.get(cd.getRelationshipType().name());
                 }
-                tcd.add(cd);
-                ConstraintTracker.relConstraints.put(cd.getRelationshipType().name(), tcd);
+                cd.getPropertyKeys().forEach(props::add);
+                ConstraintTracker.relConstraints.put(cd.getRelationshipType().name(), props);
             }
         }
 

--- a/src/main/java/apoc/meta/tablesforlabels/PropertyContainerProfile.java
+++ b/src/main/java/apoc/meta/tablesforlabels/PropertyContainerProfile.java
@@ -45,6 +45,7 @@ public class PropertyContainerProfile {
             tracker.addObservation(n.getProperty(propName));
 
             tracker.mandatory = false;
+            this.isNode = isNode;
         }
     }
 
@@ -56,13 +57,11 @@ public class PropertyContainerProfile {
 
                 // Check for node constraints
 
-                for (Map.Entry<String,List<ConstraintDefinition>> entry : ConstraintTracker.nodeConstraints.entrySet()) {
-                    for (ConstraintDefinition cd : entry.getValue()) {
-                        for (String pk : cd.getPropertyKeys()) {
-                            if (this.profile.containsKey(pk)) {
-                                tracker = this.profile.get(pk);
-                                tracker.mandatory = true;
-                            }
+                for (Map.Entry<String,List<String>> entry : ConstraintTracker.nodeConstraints.entrySet()) {
+                    for (String pk : entry.getValue()) {
+                        if (this.profile.containsKey(pk)) {
+                            tracker = this.profile.get(pk);
+                            tracker.mandatory = true;
                         }
                     }
                 }
@@ -70,13 +69,11 @@ public class PropertyContainerProfile {
 
                 // Check for relationship constraints
 
-                for (Map.Entry<String,List<ConstraintDefinition>> entry : ConstraintTracker.relConstraints.entrySet()) {
-                    for (ConstraintDefinition cd : entry.getValue()) {
-                        for (String pk : cd.getPropertyKeys()) {
-                            if (this.profile.containsKey(pk)) {
-                                tracker = this.profile.get(pk);
-                                tracker.mandatory = true;
-                            }
+                for (Map.Entry<String,List<String>> entry : ConstraintTracker.relConstraints.entrySet()) {
+                    for (String pk : entry.getValue()) {
+                        if (this.profile.containsKey(pk)) {
+                            tracker = this.profile.get(pk);
+                            tracker.mandatory = true;
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #1414 

Changed constraint tracking to store strings instead of constraintdefinition objects.

## Proposed Changes (Mandatory)

Updated constraint tracking to track strings derived from constraintdefinitions gathered while the transaction is definitely open. Once stored as Map<String, List<String>>, transactions are no longer an issue when setting mandatory flag on the output.
