### PR TITLE
fixes #1424: ApocConfig does not load neo4j.conf properly if dir contains whitespace

### DIFF
--- a/src/test/java/apoc/ApocConfigTest.java
+++ b/src/test/java/apoc/ApocConfigTest.java
@@ -58,4 +58,11 @@ public class ApocConfigTest {
 
         assertEquals("bar", cut.getConfig().getString("foo"));
     }
+
+    @Test
+    public void testDetermineNeo4jConfFolderWithWhitespaces() {
+        System.setProperty(SUN_JAVA_COMMAND, "com.neo4j.server.enterprise.CommercialEntryPoint --config-dir=/home/stefan/neo4j enterprise-4.0.0-alpha09mr02/conf --home-dir=/home/stefan/neo4j enterprise-4.0.0-alpha09mr02");
+
+        assertEquals("/home/stefan/neo4j enterprise-4.0.0-alpha09mr02/conf", cut.determineNeo4jConfFolder());
+    }
 }


### PR DESCRIPTION
Fixes #1424

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - changed parsing of the neo4j.conf dir
  - added test
