### PR TITLE
fixes #1437: Fix node retival in apoc.neighbors.*

### DIFF
--- a/src/test/java/apoc/neighbors/NeighborsTest.java
+++ b/src/test/java/apoc/neighbors/NeighborsTest.java
@@ -8,7 +8,9 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
@@ -21,9 +23,9 @@ public class NeighborsTest {
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db, Neighbors.class);
         db.executeTransactionally("CREATE (a:First), " +
-                "(b:Neighbor), " +
-                "(c:Neighbor), " +
-                "(d:Neighbor), " +
+                "(b:Neighbor{name: 'b'}), " +
+                "(c:Neighbor{name: 'c'}), " +
+                "(d:Neighbor{name: 'd'}), " +
                 "(a)-[:KNOWS]->(b), " +
                 "(b)-[:KNOWS]->(a), " +
                 "(b)-[:KNOWS]->(c), " +
@@ -38,6 +40,8 @@ public class NeighborsTest {
                 (row) -> {
                     List<Node> neighbors = (List<Node>) row.get("neighbors");
                     assertEquals(2, neighbors.size());
+                    assertEquals(Arrays.asList("b", "c"),
+                            neighbors.stream().map(n -> n.getProperty("name")).collect(Collectors.toList()));
                 });
     }
 
@@ -49,6 +53,8 @@ public class NeighborsTest {
                 (row) -> {
                     List<Node> neighbors = (List<Node>) row.get("neighbors");
                     assertEquals(3, neighbors.size());
+                    assertEquals(Arrays.asList("b", "c", "d"),
+                            neighbors.stream().map(n -> n.getProperty("name")).collect(Collectors.toList()));
                 });
     }
 
@@ -76,6 +82,10 @@ public class NeighborsTest {
                 (row) -> {
                     List<List<Node>> neighbors = (List<List<Node>>) row.get("neighbors");
                     assertEquals(2, neighbors.size());
+                    assertEquals(Arrays.asList(Arrays.asList("b"), Arrays.asList("c")),
+                            neighbors.stream()
+                                    .map(l -> l.stream().map(n -> n.getProperty("name")).collect(Collectors.toList()))
+                                    .collect(Collectors.toList()));
                 });
     }
 
@@ -87,6 +97,10 @@ public class NeighborsTest {
                 (row) -> {
                     List<List<Node>> neighbors = (List<List<Node>>) row.get("neighbors");
                     assertEquals(3, neighbors.size());
+                    assertEquals(Arrays.asList(Arrays.asList("b"), Arrays.asList("c"), Arrays.asList("d")),
+                            neighbors.stream()
+                                    .map(l -> l.stream().map(n -> n.getProperty("name")).collect(Collectors.toList()))
+                                    .collect(Collectors.toList()));
                 });
     }
 
@@ -120,6 +134,8 @@ public class NeighborsTest {
                 (row) -> {
                     List<Node> neighbors = (List<Node>) row.get("neighbors");
                     assertEquals(1, neighbors.size());
+                    assertEquals(Arrays.asList("c"),
+                            neighbors.stream().map(n -> n.getProperty("name")).collect(Collectors.toList()));
                 });
     }
 
@@ -131,6 +147,8 @@ public class NeighborsTest {
                 (row) -> {
                     List<Node> neighbors = (List<Node>) row.get("neighbors");
                     assertEquals(1, neighbors.size());
+                    assertEquals(Arrays.asList("d"),
+                            neighbors.stream().map(n -> n.getProperty("name")).collect(Collectors.toList()));
                 });
     }
 


### PR DESCRIPTION
Fixes #1437

One sentence summary of the change.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - remove the true source node
  - fixed the NPE exception in case you provide `>` as pattern, now it manges all the outgoing relationships
  - improved tests in order to understand the content of the returned nodes are correct 
