### PR TITLE
apoc.uuid.install yeild batchComputationResult

### DIFF
--- a/src/main/java/apoc/uuid/Uuid.java
+++ b/src/main/java/apoc/uuid/Uuid.java
@@ -31,7 +31,7 @@ public class Uuid {
     @Procedure(mode = Mode.DBMS)
     @Description("CALL apoc.uuid.install(label, {addToExistingNodes: true/false, uuidProperty: 'uuid'}) yield label, installed, properties, batchComputationResult | it will add the uuid transaction handler\n" +
             "for the provided `label` and `uuidProperty`, in case the UUID handler is already present it will be replaced by the new one")
-    public Stream<UuidInfo> install(@Name("label") String label, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
+    public Stream<UuidInstallInfo> install(@Name("label") String label, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
         UuidConfig uuidConfig = new UuidConfig(config);
         uuidHandler.checkConstraintUuid(tx, label, uuidConfig.getUuidProperty());
 


### PR DESCRIPTION
The procedure now yeilds batchComputationResult in line with what is
documented.

Fixes #1447

apoc.uuid.install yeild batchComputationResult

## Proposed Changes

A brief list of proposed changes in order to fix the issue:

  - Uuid install method returning UuidInstallInfo
  - New unit test

![Screenshot 2020-03-20 at 12 21 52](https://user-images.githubusercontent.com/3027755/77159539-d7269700-6aa5-11ea-9ebd-aa951cbfba69.png)

