### PR TITLE
fixes #1458: apoc.load.jdbcUpdate doesn't work with apoc.periodic.iterate

### DIFF
--- a/src/main/java/apoc/load/Jdbc.java
+++ b/src/main/java/apoc/load/Jdbc.java
@@ -8,6 +8,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Mode;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
@@ -54,7 +55,7 @@ public class Jdbc {
         }
     }
 
-    @Procedure
+    @Procedure(mode = Mode.WRITE)
     @Description("apoc.load.jdbc('key or url','table or statement', params, config) YIELD row - load from relational database, from a full table or a sql statement")
     public Stream<RowResult> jdbc(@Name("jdbc") String urlOrKey, @Name("tableOrSql") String tableOrSelect, @Name
             (value = "params", defaultValue = "[]") List<Object> params, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
@@ -103,7 +104,7 @@ public class Jdbc {
         }
     }
 
-    @Procedure
+    @Procedure(mode = Mode.DBMS)
     @Description("apoc.load.jdbcUpdate('key or url','statement',[params],config) YIELD row - update relational database, from a SQL statement with optional parameters")
     public Stream<RowResult> jdbcUpdate(@Name("jdbc") String urlOrKey, @Name("query") String query, @Name(value = "params", defaultValue = "[]") List<Object> params,  @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
         log.info( String.format( "Executing SQL update: %s", query ) );


### PR DESCRIPTION
Fixes #1458

Fixed the bug

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Changed procedure modes so they will work so with `apoc.iterate`