### PR TITLE
fix deadlock situation in concurrent executions

### DIFF
--- a/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -11,9 +11,16 @@ import org.apache.commons.lang3.StringUtils;
 import org.neo4j.cypher.export.CypherResultSubGraph;
 import org.neo4j.cypher.export.DatabaseSubGraph;
 import org.neo4j.cypher.export.SubGraph;
-import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.procedure.*;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.TerminationGuard;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -111,7 +118,7 @@ public class ExportCypher {
             ProgressReporter reporterWithConsumer = reporter.withConsumer(
                     (pi) -> Util.put(queue,pi == ProgressInfo.EMPTY ? DataProgressInfo.EMPTY : new DataProgressInfo(pi).enrich(cypherFileManager),timeout));
             Util.inTxFuture(Pools.DEFAULT, db, () -> { doExport(graph, c, onlySchema, reporterWithConsumer, cypherFileManager); return true; });
-            QueueBasedSpliterator<DataProgressInfo> spliterator = new QueueBasedSpliterator<>(queue, DataProgressInfo.EMPTY, terminationGuard, timeout);
+            QueueBasedSpliterator<DataProgressInfo> spliterator = new QueueBasedSpliterator<>(queue, DataProgressInfo.EMPTY, terminationGuard);
             return StreamSupport.stream(spliterator, false);
         } else {
             doExport(graph, c, onlySchema, reporter, cypherFileManager);

--- a/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -6,6 +6,7 @@ import apoc.export.util.NodesAndRelsSubGraph;
 import apoc.export.util.ProgressReporter;
 import apoc.result.ProgressInfo;
 import apoc.util.QueueBasedSpliterator;
+import apoc.util.QueueUtil;
 import apoc.util.Util;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.cypher.export.CypherResultSubGraph;
@@ -116,9 +117,9 @@ public class ExportCypher {
             long timeout = c.getTimeoutSeconds();
             final BlockingQueue<DataProgressInfo> queue = new ArrayBlockingQueue<>(1000);
             ProgressReporter reporterWithConsumer = reporter.withConsumer(
-                    (pi) -> Util.put(queue,pi == ProgressInfo.EMPTY ? DataProgressInfo.EMPTY : new DataProgressInfo(pi).enrich(cypherFileManager),timeout));
+                    (pi) -> QueueUtil.put(queue,pi == ProgressInfo.EMPTY ? DataProgressInfo.EMPTY : new DataProgressInfo(pi).enrich(cypherFileManager),timeout));
             Util.inTxFuture(Pools.DEFAULT, db, () -> { doExport(graph, c, onlySchema, reporterWithConsumer, cypherFileManager); return true; });
-            QueueBasedSpliterator<DataProgressInfo> spliterator = new QueueBasedSpliterator<>(queue, DataProgressInfo.EMPTY, terminationGuard);
+            QueueBasedSpliterator<DataProgressInfo> spliterator = new QueueBasedSpliterator<>(queue, DataProgressInfo.EMPTY, terminationGuard, Integer.MAX_VALUE);
             return StreamSupport.stream(spliterator, false);
         } else {
             doExport(graph, c, onlySchema, reporter, cypherFileManager);

--- a/src/main/java/apoc/export/util/ExportUtils.java
+++ b/src/main/java/apoc/export/util/ExportUtils.java
@@ -32,7 +32,7 @@ public class ExportUtils {
             dump.accept(reporterWithConsumer);
             return true;
         });
-        QueueBasedSpliterator<ProgressInfo> spliterator = new QueueBasedSpliterator<>(queue, ProgressInfo.EMPTY, terminationGuard, timeout);
+        QueueBasedSpliterator<ProgressInfo> spliterator = new QueueBasedSpliterator<>(queue, ProgressInfo.EMPTY, terminationGuard);
         return StreamSupport.stream(spliterator, false);
     }
 }

--- a/src/main/java/apoc/export/util/ExportUtils.java
+++ b/src/main/java/apoc/export/util/ExportUtils.java
@@ -4,6 +4,7 @@ import apoc.Pools;
 import apoc.export.cypher.ExportFileManager;
 import apoc.result.ProgressInfo;
 import apoc.util.QueueBasedSpliterator;
+import apoc.util.QueueUtil;
 import apoc.util.Util;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.procedure.TerminationGuard;
@@ -26,13 +27,13 @@ public class ExportUtils {
         long timeout = exportConfig.getTimeoutSeconds();
         final ArrayBlockingQueue<ProgressInfo> queue = new ArrayBlockingQueue<>(1000);
         ProgressReporter reporterWithConsumer = reporter.withConsumer(
-                (pi) -> Util.put(queue, pi == ProgressInfo.EMPTY ? ProgressInfo.EMPTY : new ProgressInfo(pi).drain(cypherFileManager.getStringWriter(format)), timeout)
+                (pi) -> QueueUtil.put(queue, pi == ProgressInfo.EMPTY ? ProgressInfo.EMPTY : new ProgressInfo(pi).drain(cypherFileManager.getStringWriter(format)), timeout)
         );
         Util.inTxFuture(Pools.DEFAULT, db, () -> {
             dump.accept(reporterWithConsumer);
             return true;
         });
-        QueueBasedSpliterator<ProgressInfo> spliterator = new QueueBasedSpliterator<>(queue, ProgressInfo.EMPTY, terminationGuard);
+        QueueBasedSpliterator<ProgressInfo> spliterator = new QueueBasedSpliterator<>(queue, ProgressInfo.EMPTY, terminationGuard, (int) timeout);
         return StreamSupport.stream(spliterator, false);
     }
 }

--- a/src/main/java/apoc/index/SchemaIndex.java
+++ b/src/main/java/apoc/index/SchemaIndex.java
@@ -1,39 +1,56 @@
 package apoc.index;
 
 import apoc.result.ListResult;
+import apoc.result.NodeResult;
 import apoc.util.MapUtil;
 import apoc.util.QueueBasedSpliterator;
-import org.neo4j.graphdb.*;
-import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.schema.IndexDefinition;
-import org.neo4j.helpers.collection.Pair;
-import org.neo4j.internal.kernel.api.*;
-import org.neo4j.internal.kernel.api.exceptions.KernelException;
-import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
-import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
-import org.neo4j.procedure.*;
-import apoc.result.NodeResult;
+import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
-import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.schema.IndexDefinition;
+import org.neo4j.helpers.collection.Pair;
+import org.neo4j.internal.kernel.api.CursorFactory;
+import org.neo4j.internal.kernel.api.IndexOrder;
+import org.neo4j.internal.kernel.api.IndexReference;
+import org.neo4j.internal.kernel.api.NodeValueIndexCursor;
+import org.neo4j.internal.kernel.api.Read;
+import org.neo4j.internal.kernel.api.SchemaRead;
+import org.neo4j.internal.kernel.api.TokenRead;
+import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.schema.LabelSchemaDescriptor;
+import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.impl.api.KernelStatement;
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.TerminationGuard;
 import org.neo4j.values.storable.NoValue;
 import org.neo4j.values.storable.Value;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static apoc.util.MapUtil.map;
 import static apoc.path.RelationshipTypeAndDirections.parse;
+import static apoc.util.MapUtil.map;
 
 /**
  * @author mh
@@ -146,7 +163,7 @@ public class SchemaIndex {
                 .collect(new QueuePoisoningCollector(queue, POISON))
         ).start();
 
-        return StreamSupport.stream(new QueueBasedSpliterator<>(queue, POISON, terminationGuard, Long.MAX_VALUE),false);
+        return StreamSupport.stream(new QueueBasedSpliterator<>(queue, POISON, terminationGuard),false);
     }
 
     private Object scanIndexDefinitionForKeys(IndexDefinition indexDefinition, @Name(value = "key", defaultValue = "") String keyName, ThreadToStatementContextBridge ctx, BlockingQueue<PropertyValueCount> queue) {

--- a/src/main/java/apoc/index/SchemaIndex.java
+++ b/src/main/java/apoc/index/SchemaIndex.java
@@ -163,7 +163,7 @@ public class SchemaIndex {
                 .collect(new QueuePoisoningCollector(queue, POISON))
         ).start();
 
-        return StreamSupport.stream(new QueueBasedSpliterator<>(queue, POISON, terminationGuard),false);
+        return StreamSupport.stream(new QueueBasedSpliterator<>(queue, POISON, terminationGuard, Integer.MAX_VALUE),false);
     }
 
     private Object scanIndexDefinitionForKeys(IndexDefinition indexDefinition, @Name(value = "key", defaultValue = "") String keyName, ThreadToStatementContextBridge ctx, BlockingQueue<PropertyValueCount> queue) {

--- a/src/main/java/apoc/util/QueueBasedSpliterator.java
+++ b/src/main/java/apoc/util/QueueBasedSpliterator.java
@@ -6,8 +6,6 @@ import java.util.Spliterator;
 import java.util.concurrent.BlockingQueue;
 import java.util.function.Consumer;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-
 /**
  * @author mh
  * @since 06.12.17
@@ -15,40 +13,35 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class QueueBasedSpliterator<T> implements Spliterator<T> {
     private final BlockingQueue<T> queue;
     private T tombstone;
-    private T entry;
     private TerminationGuard terminationGuard;
-    private final long timeout;
+    private int resultCounter = 0;
 
     public QueueBasedSpliterator(BlockingQueue<T> queue, T tombstone, TerminationGuard terminationGuard) {
-        this(queue, tombstone, terminationGuard, 10);
-    }
-
-    public QueueBasedSpliterator(BlockingQueue<T> queue, T tombstone, TerminationGuard terminationGuard, long timeout) {
         this.queue = queue;
         this.tombstone = tombstone;
         this.terminationGuard = terminationGuard;
-        this.timeout = timeout;
-        entry = poll();
     }
 
     @Override
     public boolean tryAdvance(Consumer<? super T> action) {
         if (Util.transactionIsTerminated(terminationGuard)) return false;
-        if (isEnd()) return false;
-        action.accept(entry);
-        entry = poll();
-        return !isEnd();
-    }
-
-    private boolean isEnd() {
-        return entry == null || entry == tombstone;
-    }
-
-    private T poll() {
         try {
-            return queue.poll(timeout, SECONDS);
+            T element = queue.take();
+            resultCounter++;
+/*
+            if (resultCounter % 100 == 0 || element.equals(tombstone)) {
+                System.out.println(Thread.currentThread().getName() + " took from queue " + resultCounter);
+            }
+*/
+            if (element.equals(tombstone)) {
+                return false;
+            } else {
+                action.accept(element);
+                return true;
+            }
+
         } catch (InterruptedException e) {
-            return null;
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/apoc/util/QueueUtil.java
+++ b/src/main/java/apoc/util/QueueUtil.java
@@ -1,0 +1,73 @@
+package apoc.util;
+
+import org.neo4j.function.ThrowingSupplier;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+public class QueueUtil {
+
+    public static final int WAIT = 1;
+    public static final TimeUnit WAIT_UNIT = TimeUnit.SECONDS;
+
+    public static <T> void put(BlockingQueue<T> queue, T item, long timeoutSeconds) {
+        put(queue, item, timeoutSeconds, true, () -> {});
+    }
+
+    /**
+     * to be used instead of {@link BlockingQueue#put}
+     * @param queue
+     * @param item
+     * @param timeoutSeconds
+     * @param failWithExecption true if a {@link RuntimeException} should be thrown in case we couldn't add item into the queue within timeframe
+     * @param checkDuringOffering a callback supposed to throw an exception to terminate
+     * @param <T>
+     */
+    public static <T> void put(BlockingQueue<T> queue, T item, long timeoutSeconds, boolean failWithExecption, Runnable checkDuringOffering) {
+        withHandlingInterrupted("Queue offer interrupted before " + timeoutSeconds + " seconds", () -> {
+            long started = System.currentTimeMillis();
+            while (started + timeoutSeconds * 1000 > System.currentTimeMillis()) {
+                boolean success = queue.offer(item, WAIT, WAIT_UNIT);
+                if (success) {
+                    return null;
+                }
+                checkDuringOffering.run();
+            }
+            if (failWithExecption) {
+                throw new RuntimeException("Error queuing item before timeout of " + timeoutSeconds + " seconds");
+            }
+            return null;
+        });
+    }
+
+    /**
+     * to be used instead of {@link BlockingQueue#take}
+     * @param queue
+     * @param timeoutSeconds
+     * @param checkDuringPolling a callback supposed to throw an exception to terminate
+     * @param <T>
+     * @return
+     */
+    public static <T> T take(BlockingQueue<T> queue, long timeoutSeconds, Runnable checkDuringPolling) {
+        return withHandlingInterrupted("Queue poll interrupted before " + timeoutSeconds + " seconds", () -> {
+            long started = System.currentTimeMillis();
+            while (started + timeoutSeconds * 1000 > System.currentTimeMillis()) {
+                T polled = queue.poll(WAIT, WAIT_UNIT);
+                if (polled != null) {
+                    return polled;
+                }
+                checkDuringPolling.run();
+            }
+            throw new RuntimeException("Error polling, timeout of " + timeoutSeconds + " seconds reached.");
+        });
+    }
+
+    public static <T> T withHandlingInterrupted(String msg, ThrowingSupplier<T, InterruptedException> consumer) {
+        try {
+            return consumer.get();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(msg, e);
+        }
+    }
+
+}

--- a/src/main/java/apoc/util/Util.java
+++ b/src/main/java/apoc/util/Util.java
@@ -772,16 +772,6 @@ public class Util {
         }
     }
 
-    public static <T> void put(BlockingQueue<T> queue, T item, long timeoutSeconds) {
-        try {
-            boolean success = queue.offer(item, timeoutSeconds, TimeUnit.SECONDS);
-            if (!success)
-                throw new RuntimeException("Error queuing item before timeout of " + timeoutSeconds + " seconds");
-        } catch (InterruptedException e) {
-            throw new RuntimeException("Queue offer interrupted before " + timeoutSeconds + " seconds", e);
-        }
-    }
-
     public static Optional<String> getLoadUrlByConfigFile(String loadType, String key, String suffix){
         key = Optional.ofNullable(key).map(s -> s + "." + suffix).orElse(StringUtils.EMPTY);
         Object value = ApocConfiguration.get(loadType).get(key);

--- a/src/test/java/apoc/cypher/CypherTest.java
+++ b/src/test/java/apoc/cypher/CypherTest.java
@@ -1,12 +1,22 @@
 package apoc.cypher;
 
+import apoc.text.Strings;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import apoc.util.Utils;
 import org.hamcrest.Matchers;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
@@ -16,6 +26,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -24,7 +35,10 @@ import static apoc.util.TestUtil.testResult;
 import static apoc.util.Util.map;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.Matchers.hasEntry;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author mh
@@ -49,6 +63,7 @@ public class CypherTest {
         TestUtil.registerProcedure(db, Utils.class);
         TestUtil.registerProcedure(db, CypherFunctions.class);
         TestUtil.registerProcedure(db, Timeboxed.class);
+        TestUtil.registerProcedure(db, Strings.class);
     }
 
     @AfterClass
@@ -145,6 +160,7 @@ public class CypherTest {
                 r -> assertEquals( size * 10,Iterators.count(r) ));
     }
     @Test
+    @Ignore
     public void testMapParallel2() throws Exception {
         int size = 10_000;
         testResult(db, "CALL apoc.cypher.mapParallel2('UNWIND range(0,9) as b RETURN b',{},range(1,{size}),10)", map("size", size),
@@ -462,5 +478,21 @@ public class CypherTest {
     public void testRunFileWithEmptyFile() throws Exception {
         testResult(db, "CALL apoc.cypher.runFile('src/test/resources/empty.cypher')",
                 r -> assertFalse("should be empty", r.hasNext()));
+    }
+
+    @Test
+    public void lengthyRunManyShouldTerminate() {
+        String repetetiveStatement= "CALL apoc.cypher.runFile(\"src/test/resources/enrollment-incremental.cypher\",{parameters: {SubID: \"218598584\", Account_Number: \"\", AccountType: \"\",Source: \"VerizonMASnapshot\", MDN: \"\", Offering: \"\", Enroll_Date: \"\", Product_SKU: \"\", Device_Model: \"\", Device_Make: \"\", First_Name: \"\", Last_Name: \"\",Email1: \"\", Email2: \"\", Email3: \"\", Postal_CD: \"\", City: \"\", State: \"\", BillingStatus: \"\", ActionType: \"Drop\", Text_Date : \"2020-03-11\"}}) yield result return sum(result.total) as total;\n" +
+                "CALL apoc.cypher.runFile(\"src/test/resources/enrollment-incremental.cypher\",{parameters: {SubID: \"7898935\", Account_Number: \"\", AccountType: \"\",Source: \"VerizonNorthSnapshot\", MDN: \"\", Offering: \"\", Enroll_Date: \"\", Product_SKU: \"\", Device_Model: \"\", Device_Make: \"\", First_Name: \"\", Last_Name: \"\",Email1: \"\", Email2: \"\", Email3: \"\", Postal_CD: \"\", City: \"\", State: \"\", BillingStatus: \"\", ActionType: \"Drop\", Text_Date : \"2020-03-11\"}}) yield result return sum(result.total) as total;\n";
+
+        String cypher = String.format("CALL apoc.cypher.runMany('%s',{statistics:true,timeout:60}) yield result return sum(result.total) as total;",
+                String.join("", Collections.nCopies(25, repetetiveStatement)));
+
+        testResult(db, cypher,
+                result -> {
+                    Map<String, Object> single = Iterators.single(result);
+                    assertEquals(50l, single.get("total"));
+                });
+
     }
 }

--- a/src/test/java/apoc/cypher/CypherTest.java
+++ b/src/test/java/apoc/cypher/CypherTest.java
@@ -160,7 +160,6 @@ public class CypherTest {
                 r -> assertEquals( size * 10,Iterators.count(r) ));
     }
     @Test
-    @Ignore
     public void testMapParallel2() throws Exception {
         int size = 10_000;
         testResult(db, "CALL apoc.cypher.mapParallel2('UNWIND range(0,9) as b RETURN b',{},range(1,{size}),10)", map("size", size),

--- a/src/test/resources/enrollment-incremental.cypher
+++ b/src/test/resources/enrollment-incremental.cypher
@@ -1,0 +1,176 @@
+WITH
+  $SubID as subid,
+  $Account_Number as account_number,
+  $AccountType as account_type,
+  apoc.text.upperCamelCase($ActionType) as status,
+  $MDN as mdn,
+//  date(r.Text_Date) as enroll_date,
+  case when $Offering = 'TMP MD' then date($Text_Date) else date(trim(left(case when size($Enroll_Date)=0 then $Text_Date else $Enroll_Date end,10))) end as enroll_date,
+//  date(trim(left(case when size($Enroll_Date)=0 then $Text_Date else $Enroll_Date end,10))) as enroll_date,
+  $Offering as offering,
+  $Product_SKU as product_sku,
+  $Device_Model as device_model,
+  $Device_Make as device_make,
+  $First_Name as first_name,
+  $Last_Name as last_name,
+  $Postal_CD as postal_cd,
+  $City as city,
+  $State as state,
+  $BillingStatus as billing_status,
+  $Email1 as email,
+  $Email2 as email2,
+  $Email3 as email3,
+  case
+    when ($AccountType = 'ME') then 'E'
+    when ($AccountType IN ['CI','DD','DJ','FA','FL','FM','FS','FT','FW','FX','HR','LG','SG','SN','SS','US','UU','WH','FG'] and $Source = 'VerizonB2BSnapshot') then 'G'
+    when (NOT $AccountType IN ['CI','DD','DJ','FA','FL','FM','FS','FT','FW','FX','HR','LG','SG','SN','SS','US','UU','WH','FG'] and $Source = 'VerizonB2BSnapshot') then 'B'
+    else 'I'
+  end as sub_type,
+  date($Text_Date) as transaction_date
+
+OPTIONAL MATCH (po:Offering{subid:subid})<-[p_o:CURRENT_OFFERING]-(:Subscriber)
+OPTIONAL MATCH (pd:Device{subid:subid})<-[p_d:HAS_DEVICE]-(:Subscriber)
+OPTIONAL MATCH (pp:Pii{subid:subid})<-[p_p:HAS_PII]-(:Subscriber)
+OPTIONAL MATCH (pm:Mdn{mdn:mdn})-[p_m:MDN_USER]-(:Subscriber)
+WITH subid, account_number, account_type, status, mdn, enroll_date, offering, product_sku, device_model, device_make, first_name,
+    last_name, postal_cd, city, state, billing_status, email, email2, email3, sub_type,
+    transaction_date, po.name  as prev_offering, po, p_o, pd, p_d,pp, p_p, pm, p_m, pm.mdn as prev_mdn,
+    case
+        when status = 'Add' then status
+        when status = 'Drop' then status
+        when status ='Update' then
+            case when po.name is null then 'Add'
+              when po.name = 'WPP' and offering = 'TEC' then 'Transfer'
+              when po.name = 'TEC' and offering = 'WPP' then 'Transfer'
+              when po.name = 'TMP MD' and offering = 'TMP' then 'Transfer'
+              when po.name = 'TMP' and offering = 'TMP MD' then 'Transfer'
+              when po.name IN ['WPP','TEC'] and offering IN ['TMP MD','TMP'] then 'Upgrade'
+              when po.name IN ['TMP MD','TMP'] and offering IN ['WPP','TEC'] then 'Downgrade'
+              else 'NA' end
+        when status = 'React' then
+            case when po.name is null then status
+              when (offering = po.name) and (duration.inDays(po.drop_date,enroll_date).days <= 90) then 'ReActivateMe'
+              when (offering = po.name) and (duration.inDays(po.drop_date,enroll_date).days > 90) then 'React>90'
+              when (offering <> po.name) and (duration.inDays(po.drop_date,enroll_date).days <= 90) then 'React<=90'
+              when (offering <> po.name) and (duration.inDays(po.drop_date,enroll_date).days > 90) then 'React<=90'
+              else status end
+        else
+            status
+        end as add_type,
+        case
+          when status = 'Add' then 1
+          when status = 'Drop' then 0
+          when status ='Update' then
+            case when po.name is null then 1
+              when po.name = 'WPP' and offering = 'TEC' then 1
+              when po.name = 'TEC' and offering = 'WPP' then 1
+              when po.name = 'TMP MD' and offering = 'TMP' then 1
+              when po.name = 'TMP' and offering = 'TMP MD' then 1
+              when po.name IN ['WPP','TEC'] and offering IN ['TMP MD','TMP'] then 1
+              when po.name IN ['TMP MD','TMP'] and offering IN ['WPP','TEC'] then 1
+              else 0 end
+          when status = 'React' then
+            case when po.name is null then 1
+              when (offering = po.name) and (duration.inDays(po.drop_date,enroll_date).days <= 90) then 0
+              when (offering = po.name) and (duration.inDays(po.drop_date,enroll_date).days > 90) then 1
+              when (offering <> po.name) and (duration.inDays(po.drop_date,enroll_date).days <= 90) then 1
+              when (offering <> po.name) and (duration.inDays(po.drop_date,enroll_date).days > 90) then 1
+              else 0 end
+          else
+            status
+        end as new_node_offering,
+        coalesce(first_name,'')+coalesce(last_name,'')+coalesce(email,'')+coalesce(email2,'')+coalesce(email3,'')+coalesce(postal_cd,'')+coalesce(city,'')+coalesce(state,'') as pii,
+        coalesce(pp.first_name,'')+coalesce(pp.last_name,'')+coalesce(pp.email,'')+coalesce(pp.email2,'')+coalesce(pp.email3,'')+coalesce(pp.postal_cd,'')+coalesce(pp.city,'')+coalesce(pp.state,'') as prev_pii
+
+with  subid, account_number, mdn, account_type, status,  enroll_date, offering, product_sku, device_model,
+        device_make, first_name, last_name, postal_cd, city, state, billing_status, email, email2, email3, sub_type,
+        transaction_date, prev_offering, add_type, new_node_offering,
+        case
+            when status = 'Add' then 1
+            when status = 'Drop' then 0
+            when pd is null then 1
+	          when status IN ['Update','React'] and pd.model <> device_model then 1 else 0
+        end as new_node_device,
+        case when pii<>prev_pii  and status <> 'Drop' then 1 else 0 end as new_node_pii,
+        case when pm.subid is null and status <> 'Drop' then 1 when pm.subid<>subid and status <> 'Drop' then 1 else 0 end as new_node_mdn
+        ,po, p_o, pd, p_d,pp, p_p, pm, p_m
+order by transaction_date
+
+//Create Account & Subscriber
+MERGE (a:Account{account_number:account_number})
+MERGE (s:Subscriber {subid:subid}) ON CREATE SET s.account_number = account_number, s.sub_type = sub_type
+MERGE (a)-[:HAS_SUBSCRIBER]->(s)
+
+//Drops(set the Drop Date and Drop Flag) & Reacts<=90(remove Drop Date & Drop Flag in case of same offering)
+FOREACH(counter IN CASE WHEN add_type IN ['ReActivateMe','Drop'] THEN [1] ELSE [] END |
+             SET po.drop_date = enroll_date,
+                po.drop_flag = add_type,
+                po.transaction_dt = transaction_date
+        )
+
+FOREACH(counter IN CASE WHEN NOT add_type IN ['ReActivateMe','Drop'] THEN [1] ELSE [] END |
+  //Offering Adds, Reacts>90, Reacts<=90(in case of offering chagnes)
+  FOREACH(counter IN CASE WHEN new_node_offering = 1 THEN [1] ELSE [] END |
+    MERGE(o:Offering{subid:subid, name:offering, event_date:enroll_date})
+    ON CREATE SET
+      o.add_type = add_type,
+      o.product_sku = product_sku,
+      o.billing_status = billing_status,
+      o.transaction_dt = transaction_date,
+      o.first_enroll_date = enroll_date
+    ON MATCH SET
+      o.product_sku = product_sku,
+      o.billing_status = billing_status,
+      o.transaction_dt = transaction_date
+
+    MERGE (s:Subscriber{subid:o.subid})
+    MERGE (s)-[:HAS_OFFERING]->(o)
+
+    FOREACH(counter IN CASE WHEN new_node_offering = 1 THEN [1] ELSE [] END |
+      MERGE (s)-[:CURRENT_OFFERING]->(o))
+    FOREACH(counter IN CASE WHEN new_node_offering = 1 AND po is NULL THEN [1] ELSE [] END |
+      MERGE (s)-[:FIRST_OFFERING]->(o))
+    FOREACH(counter IN CASE WHEN new_node_offering = 1 AND po IS NOT null AND po <> o THEN [1] ELSE [] END |
+      MERGE (po)-[:NEXT]->(o)
+      SET po.drop_date = o.enroll_date, po.drop_flag = o.add_type, o.first_enroll_date = po.first_enroll_date
+      DELETE p_o)
+  )
+  //Devices
+  FOREACH(counter IN CASE WHEN new_node_device = 1 THEN [1] ELSE [] END |
+    MERGE(d:Device{subid:subid})
+    SET
+			d.event_date = enroll_date,
+      d.make = device_make,
+      d.model = device_model,
+      d.prev_make = case when pd is not null then pd.make end,
+      d.prev_model = case when pd is not null then pd.model end,
+      d.transaction_dt = transaction_date
+
+    MERGE (s:Subscriber{subid:d.subid})
+    MERGE (s)-[:HAS_DEVICE]->(d)
+  )
+  //PII
+  FOREACH(counter IN CASE WHEN new_node_pii = 1 THEN [1] ELSE [] END |
+    MERGE(p:Pii{subid:subid})
+    SET
+      p.first_name = first_name,
+      p.last_name = last_name,
+      p.email = email,
+      p.email2 = email2,
+      p.email3 = email3,
+      p.postal_cd = postal_cd,
+      p.city = city,
+      p.state = state,
+      p.transaction_dt = transaction_date
+
+    MERGE (s:Subscriber{subid:p.subid})
+    MERGE (s)-[:HAS_PII]->(p)
+  )
+  //MDN
+  FOREACH(counter IN CASE WHEN new_node_mdn = 1 THEN [1] ELSE [] END |
+    MERGE(m:Mdn{subid:subid, mdn:mdn})
+    MERGE (s:Subscriber{subid:m.subid})
+    MERGE (m)-[:MDN_USER{mdn_date:enroll_date}]->(s)
+  )
+)
+RETURN count(*) as total


### PR DESCRIPTION
We did use the default thread pool for the thread sending eventually the tombstone object to a queue. If used in a nested way this could lead to a situation when default pool is full that the tombstone sending thread waits for the queue. Queue consumer waits as well -> deadlock situation.

By using a new thread instead we ensure that the tombstone is always sent correctly. Also QueueBasedSpliterator has been refactor and uses `take` instead of `poll`.