### PR TITLE
adding the fatjar to maven artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ configurations {
 }
 
 shadowJar {
-    classifier = 'all'  
+    archiveClassifier.set('all')
 }
 
 compileJava {
@@ -368,8 +368,6 @@ task myJavadocJar(type: Jar) {
 
 
 publishing {
-
-
     repositories {
         maven {
             name = 'pipeline'
@@ -377,6 +375,11 @@ publishing {
         }
     }
     publications {
+        shadow(MavenPublication) { publication ->
+            project.shadow.component(publication)
+            artifactId = archivesBaseName
+        }
+
         full(MavenPublication) {
             pom {
                 name = "neo4j-apoc-procedure"
@@ -408,7 +411,6 @@ publishing {
                 artifact(mySourcesJar)
                 artifact(myJavadocJar)
             }
-
         }
     }
 }


### PR DESCRIPTION
@sarmbruster Trying to figure out how to publish the fat jar to Maven. Not sure if this is the right way?

```
$ ./gradlew publish
> Task :publishShadowPublicationToPipelineRepository
Multiple publications with coordinates 'org.neo4j.procedure:apoc:4.0.0.5' are published to repository 'pipeline'. The publications will overwrite each other!

BUILD SUCCESSFUL in 18s
13 actionable tasks: 11 executed, 2 up-to-date
```

Is the warning a problem or can we safely ignore it?

```
$ ls -alh build/repo/org/neo4j/procedure/apoc/4.0.0.5/
total 21M
drwxr-xr-x 2 markhneedham markhneedham 4.0K Apr  1 09:23 .
drwxr-xr-x 3 markhneedham markhneedham 4.0K Apr  1 09:22 ..
-rw-r--r-- 1 markhneedham markhneedham  18M Apr  1 09:35 apoc-4.0.0.5-all.jar
-rw-r--r-- 1 markhneedham markhneedham   32 Apr  1 09:35 apoc-4.0.0.5-all.jar.md5
-rw-r--r-- 1 markhneedham markhneedham   40 Apr  1 09:35 apoc-4.0.0.5-all.jar.sha1
-rw-r--r-- 1 markhneedham markhneedham   64 Apr  1 09:35 apoc-4.0.0.5-all.jar.sha256
-rw-r--r-- 1 markhneedham markhneedham  128 Apr  1 09:35 apoc-4.0.0.5-all.jar.sha512
-rw-r--r-- 1 markhneedham markhneedham 931K Apr  1 09:35 apoc-4.0.0.5.jar
-rw-r--r-- 1 markhneedham markhneedham   32 Apr  1 09:35 apoc-4.0.0.5.jar.md5
-rw-r--r-- 1 markhneedham markhneedham   40 Apr  1 09:35 apoc-4.0.0.5.jar.sha1
-rw-r--r-- 1 markhneedham markhneedham   64 Apr  1 09:35 apoc-4.0.0.5.jar.sha256
-rw-r--r-- 1 markhneedham markhneedham  128 Apr  1 09:35 apoc-4.0.0.5.jar.sha512
-rw-r--r-- 1 markhneedham markhneedham 2.0M Apr  1 09:35 apoc-4.0.0.5-javadoc.jar
-rw-r--r-- 1 markhneedham markhneedham   32 Apr  1 09:35 apoc-4.0.0.5-javadoc.jar.md5
-rw-r--r-- 1 markhneedham markhneedham   40 Apr  1 09:35 apoc-4.0.0.5-javadoc.jar.sha1
-rw-r--r-- 1 markhneedham markhneedham   64 Apr  1 09:35 apoc-4.0.0.5-javadoc.jar.sha256
-rw-r--r-- 1 markhneedham markhneedham  128 Apr  1 09:35 apoc-4.0.0.5-javadoc.jar.sha512
-rw-r--r-- 1 markhneedham markhneedham  11K Apr  1 09:35 apoc-4.0.0.5.module
-rw-r--r-- 1 markhneedham markhneedham   32 Apr  1 09:35 apoc-4.0.0.5.module.md5
-rw-r--r-- 1 markhneedham markhneedham   40 Apr  1 09:35 apoc-4.0.0.5.module.sha1
-rw-r--r-- 1 markhneedham markhneedham   64 Apr  1 09:35 apoc-4.0.0.5.module.sha256
-rw-r--r-- 1 markhneedham markhneedham  128 Apr  1 09:35 apoc-4.0.0.5.module.sha512
-rw-r--r-- 1 markhneedham markhneedham  441 Apr  1 09:35 apoc-4.0.0.5.pom
-rw-r--r-- 1 markhneedham markhneedham   32 Apr  1 09:35 apoc-4.0.0.5.pom.md5
-rw-r--r-- 1 markhneedham markhneedham   40 Apr  1 09:35 apoc-4.0.0.5.pom.sha1
-rw-r--r-- 1 markhneedham markhneedham   64 Apr  1 09:35 apoc-4.0.0.5.pom.sha256
-rw-r--r-- 1 markhneedham markhneedham  128 Apr  1 09:35 apoc-4.0.0.5.pom.sha512
-rw-r--r-- 1 markhneedham markhneedham 395K Apr  1 09:35 apoc-4.0.0.5-sources.jar
-rw-r--r-- 1 markhneedham markhneedham   32 Apr  1 09:35 apoc-4.0.0.5-sources.jar.md5
-rw-r--r-- 1 markhneedham markhneedham   40 Apr  1 09:35 apoc-4.0.0.5-sources.jar.sha1
-rw-r--r-- 1 markhneedham markhneedham   64 Apr  1 09:35 apoc-4.0.0.5-sources.jar.sha256
-rw-r--r-- 1 markhneedham markhneedham  128 Apr  1 09:35 apoc-4.0.0.5-sources.jar.sha512
```

And then to include the fatjar you'd use the classifier `all`