### PR TITLE
Allow dashes in id spaces in CSV headers

### DIFF
--- a/src/main/java/apoc/export/csv/CsvLoaderConstants.java
+++ b/src/main/java/apoc/export/csv/CsvLoaderConstants.java
@@ -4,7 +4,7 @@ import java.util.regex.Pattern;
 
 public class CsvLoaderConstants {
 
-    public static final Pattern FIELD_PATTERN = Pattern.compile("^(?<name>[^:]*)(:(?<type>\\w+))?(\\((?<idspace>\\w+)\\))?(?<array>\\[\\])?$");
+    public static final Pattern FIELD_PATTERN = Pattern.compile("^(?<name>[^:]*)(:(?<type>\\w+))?(\\((?<idspace>[-a-zA-Z_0-9]+)\\))?(?<array>\\[\\])?$");
     public static final String ARRAY_PATTERN = "[]";
 
     public static final String IGNORE_FIELD = "IGNORE";

--- a/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -61,6 +61,9 @@ public class ImportCsvTest {
                     new AbstractMap.SimpleEntry<>("id-idspaces", ":ID(Person)|name:STRING\n" +
                             "1|John\n" +
                             "2|Jane\n"),
+                    new AbstractMap.SimpleEntry<>("id-idspaces-with-dash", ":ID(Person-Id)|name:STRING\n" +
+                            "1|John\n" +
+                            "2|Jane\n"),
                     new AbstractMap.SimpleEntry<>("id", "id:ID|name:STRING\n" +
                             "1|John\n" +
                             "2|Jane\n"),
@@ -155,6 +158,25 @@ public class ImportCsvTest {
                 "CALL apoc.import.csv([{fileName: $file, labels: ['Person']}], [], $config)",
                 map(
                         "file", "file:/id-idspaces.csv",
+                        "config", map("delimiter", '|')
+                ),
+                (r) -> {
+                    assertEquals(2L, r.get("nodes"));
+                    assertEquals(0L, r.get("relationships"));
+                }
+        );
+
+        List<String> names = TestUtil.firstColumn(db, "MATCH (n:Person) RETURN n.name AS name ORDER BY name");
+        assertThat(names, Matchers.containsInAnyOrder("Jane", "John"));
+    }
+
+    @Test
+    public void testNodesWithIdSpacesWithDash() {
+        TestUtil.testCall(
+                db,
+                "CALL apoc.import.csv([{fileName: $file, labels: ['Person']}], [], $config)",
+                map(
+                        "file", "file:/id-idspaces-with-dash.csv",
                         "config", map("delimiter", '|')
                 ),
                 (r) -> {


### PR DESCRIPTION
Fixes #1412

Allow dashes in id spaces in CSV headers.

## Proposed Changes (Mandatory)

Change the regex for matching id spaces from `\w+` to `[-a-zA-Z_0-9]+`.