### PR TITLE
apoc.coll.min and max comparsion operator logic like cypher

### DIFF
--- a/src/test/java/apoc/coll/CollTest.java
+++ b/src/test/java/apoc/coll/CollTest.java
@@ -105,6 +105,16 @@ public class CollTest {
     }
 
     @Test
+    public void testMaxDate() throws Exception {
+        testCall(db, "RETURN apoc.coll.max([date('2020-04-01'), date('2020-03-01')]) as value",
+                (row) -> assertEquals("2020-04-01", row.get("value").toString()));
+        testCall(db, "RETURN apoc.coll.max([datetime('2020-03-30T12:17:43.175Z'), datetime('2020-03-30T12:17:39.982Z')]) as value",
+                (row) -> assertEquals("2020-03-30T12:17:43.175Z", row.get("value").toString()));
+        testCall(db, "RETURN apoc.coll.max([null, datetime('2020-03-30T11:17:39.982Z'), datetime('2020-03-30T12:17:39.982Z'), datetime('2020-03-30T11:17:39.982Z')]) as value",
+                (row) -> assertEquals("2020-03-30T12:17:39.982Z", row.get("value").toString()));
+    }
+
+    @Test
     public void testPartition() throws Exception {
         testResult(db, "CALL apoc.coll.partition([1,2,3,4,5],2)",
                 (result) -> {


### PR DESCRIPTION
Fixes #1463

One sentence summary of the change.

## comparsion operator logic like cypher

A brief list of proposed changes in order to fix the issue:

  - apoc.coll.min and max doing a reduce db call
  - Added unit test for max date/datetime

Note 1: I ran some performance test with jmh and could not see any significant impact

Note 2: There is a ton of other places where we can discuss if apoc is implementing "cypher like" operator logic.
