### PR TITLE
Only register with kernel if there are triggers

### DIFF
--- a/src/test/java/apoc/trigger/TriggerTest.java
+++ b/src/test/java/apoc/trigger/TriggerTest.java
@@ -138,7 +138,7 @@ public class TriggerTest {
     @Test
     public void testLowerCaseName() throws Exception {
         db.execute("create constraint on (p:Person) assert p.id is unique").close();
-        Trigger.TriggerHandler.add("timestamp","UNWIND apoc.trigger.nodesByLabel({assignedLabels},'Person') AS n SET n.id = toLower(n.name)",null);
+        Trigger.TriggerHandler.getInstance().add("timestamp","UNWIND apoc.trigger.nodesByLabel({assignedLabels},'Person') AS n SET n.id = toLower(n.name)",null);
 //        Trigger.TriggerHandler.add("lowercase","UNWIND {createdNodes} AS n SET n.id = toLower(n.name)",null);
         db.execute("CREATE (f:Person {name:'John Doe'})").close();
         TestUtil.testCall(db, "MATCH (f:Person) RETURN f", (row) -> {
@@ -149,7 +149,7 @@ public class TriggerTest {
     @Test
     public void testSetLabels() throws Exception {
         db.execute("CREATE (f {name:'John Doe'})").close();
-        Trigger.TriggerHandler.add("timestamp","UNWIND apoc.trigger.nodesByLabel({assignedLabels},'Person') AS n SET n:Man",null);
+        Trigger.TriggerHandler.getInstance().add("timestamp","UNWIND apoc.trigger.nodesByLabel({assignedLabels},'Person') AS n SET n:Man",null);
         db.execute("MATCH (f) SET f:Person").close();
         TestUtil.testCall(db, "MATCH (f:Man) RETURN f", (row) -> {
             assertEquals("John Doe", ((Node)row.get("f")).getProperty("name"));
@@ -161,7 +161,7 @@ public class TriggerTest {
     }
     @Test
     public void testTxId() throws Exception {
-        Trigger.TriggerHandler.add("txInfo","UNWIND {createdNodes} AS n SET n.txId = {transactionId}, n.txTime = {commitTime}", map("phase","after"));
+        Trigger.TriggerHandler.getInstance().add("txInfo","UNWIND {createdNodes} AS n SET n.txId = {transactionId}, n.txTime = {commitTime}", map("phase","after"));
         db.execute("CREATE (f:Bar)").close();
         TestUtil.testCall(db, "MATCH (f:Bar) RETURN f", (row) -> {
             assertEquals(true, (Long)((Node)row.get("f")).getProperty("txId") > -1L);
@@ -171,7 +171,7 @@ public class TriggerTest {
     
     @Test
     public void testPauseResult() throws Exception {
-        Trigger.TriggerHandler.add("test","UNWIND {createdNodes} AS n SET n.txId = {transactionId}, n.txTime = {commitTime}", map("phase","after") );
+        Trigger.TriggerHandler.getInstance().add("test","UNWIND {createdNodes} AS n SET n.txId = {transactionId}, n.txTime = {commitTime}", map("phase","after") );
         TestUtil.testCall(db, "CALL apoc.trigger.pause('test')", (row) -> {
             assertEquals("test", row.get("name"));
             assertEquals(true, row.get("installed"));
@@ -181,7 +181,7 @@ public class TriggerTest {
 
     @Test
     public void testPauseOnCallList() throws Exception {
-        Trigger.TriggerHandler.add("test","UNWIND {createdNodes} AS n SET n.txId = {transactionId}, n.txTime = {commitTime}", map("phase","after") );
+        Trigger.TriggerHandler.getInstance().add("test","UNWIND {createdNodes} AS n SET n.txId = {transactionId}, n.txTime = {commitTime}", map("phase","after") );
         db.execute("CALL apoc.trigger.pause('test')");
         TestUtil.testCall(db, "CALL apoc.trigger.list()", (row) -> {
             assertEquals("test", row.get("name"));
@@ -192,7 +192,7 @@ public class TriggerTest {
 
     @Test
     public void testResumeResult() throws Exception {
-        Trigger.TriggerHandler.add("test","UNWIND {createdNodes} AS n SET n.txId = {transactionId}, n.txTime = {commitTime}", map("phase","after") );
+        Trigger.TriggerHandler.getInstance().add("test","UNWIND {createdNodes} AS n SET n.txId = {transactionId}, n.txTime = {commitTime}", map("phase","after") );
         db.execute("CALL apoc.trigger.pause('test')");
         TestUtil.testCall(db, "CALL apoc.trigger.resume('test')", (row) -> {
             assertEquals("test", row.get("name"));


### PR DESCRIPTION
The kernel event handling creates a big expensive transaction snapshot
for every transaction if there are registered event handlers.

To avoid paying that overhead, unregister from the kernel if there
are no triggers.

This works as a complement to the config option, so you can deploy
large groups of databases with the config enabled but only pay the
overhead on those databases that use trigger.

This is backporting the respective commit from 4.0 branch.

Fixes #<Replace with the number of the issue, Mandatory>

One sentence summary of the change.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  -
  -
  -
