### PR TITLE
Fix apoc.coll.min/max limit to slotted runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.gradle.api.internal.artifacts.DefaultExcludeRule
 
 plugins {
     id 'java'
-    id 'com.github.johnrengelman.shadow' version '4.0.2'
+    id 'com.github.johnrengelman.shadow' version '4.0.3'
     id "com.bmuschko.nexus" version "2.3.1"
 //    id "me.champeau.gradle.jmh" version "0.4.8"
     id 'maven-publish'

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ java {
 }
 
 group = 'org.neo4j.procedure'
-version = '4.0.0.7'
+version = '4.0.0.8'
 archivesBaseName = 'apoc'
 description = """neo4j-apoc-procedures"""
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -29,7 +29,7 @@ plugins {
     id 'org.neo4j.doc.build.docbook' version '1.0-alpha12'
 }
 
-if (!project.hasProperty('apocVersion')) { ext.apocVersion = '4.0.0.7' }
+if (!project.hasProperty('apocVersion')) { ext.apocVersion = '4.0.0.8' }
 
 ext {
     versionParts = apocVersion.split('-')

--- a/src/main/java/apoc/coll/Coll.java
+++ b/src/main/java/apoc/coll/Coll.java
@@ -89,7 +89,7 @@ public class Coll {
 		if (list == null || list.isEmpty()) return null;
         if (list.size() == 1) return list.get(0);
 
-        try (Result result = tx.execute("cypher runtime=slotted expressionEngine=compiled return reduce(res=null, x in $list | CASE WHEN res IS NULL OR x<res THEN x ELSE res END) as value", Collections.singletonMap("list", list))) {
+        try (Result result = tx.execute("cypher runtime=slotted return reduce(res=null, x in $list | CASE WHEN res IS NULL OR x<res THEN x ELSE res END) as value", Collections.singletonMap("list", list))) {
             return result.next().get("value");
         }
     }

--- a/src/main/java/apoc/coll/Coll.java
+++ b/src/main/java/apoc/coll/Coll.java
@@ -89,7 +89,7 @@ public class Coll {
 		if (list == null || list.isEmpty()) return null;
         if (list.size() == 1) return list.get(0);
 
-        try (Result result = tx.execute("cypher expressionEngine=compiled return reduce(res=null, x in $list | CASE WHEN res IS NULL OR x<res THEN x ELSE res END) as value", Collections.singletonMap("list", list))) {
+        try (Result result = tx.execute("cypher runtime=slotted expressionEngine=compiled return reduce(res=null, x in $list | CASE WHEN res IS NULL OR x<res THEN x ELSE res END) as value", Collections.singletonMap("list", list))) {
             return result.next().get("value");
         }
     }
@@ -99,7 +99,7 @@ public class Coll {
     public Object max(@Name("values") List<Object> list) {
         if (list == null || list.isEmpty()) return null;
         if (list.size() == 1) return list.get(0);
-        try (Result result = tx.execute("cypher expressionEngine=compiled return reduce(res=null, x in $list | CASE WHEN res IS NULL OR res<x THEN x ELSE res END) as value", Collections.singletonMap("list", list))) {
+        try (Result result = tx.execute("cypher runtime=slotted return reduce(res=null, x in $list | CASE WHEN res IS NULL OR res<x THEN x ELSE res END) as value", Collections.singletonMap("list", list))) {
             return result.next().get("value");
         }
     }

--- a/src/test/java/apoc/coll/CollTest.java
+++ b/src/test/java/apoc/coll/CollTest.java
@@ -78,6 +78,8 @@ public class CollTest {
 
     @Test
     public void testMin() throws Exception {
+        testCall(db, "RETURN apoc.coll.min([1,2]) as value",
+                (row) -> assertEquals(1L, row.get("value")));
         testCall(db, "RETURN apoc.coll.min([1,2,3]) as value",
                 (row) -> assertEquals(1L, row.get("value")));
         testCall(db, "RETURN apoc.coll.min([0.5,1,2.3]) as value",

--- a/src/test/java/apoc/meta/CollEnterpriseTest.java
+++ b/src/test/java/apoc/meta/CollEnterpriseTest.java
@@ -1,0 +1,63 @@
+package apoc.meta;
+
+import apoc.util.Neo4jContainerExtension;
+import apoc.util.TestUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.neo4j.driver.Session;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import static apoc.util.TestContainerUtil.createEnterpriseDB;
+import static apoc.util.TestContainerUtil.testResult;
+import static apoc.util.TestUtil.isTravis;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeNotNull;
+
+public class CollEnterpriseTest {
+
+    private static Neo4jContainerExtension neo4jContainer;
+    private static Session session;
+
+    @BeforeClass
+    public static void beforeAll() {
+        assumeFalse(isTravis());
+        TestUtil.ignoreException(() -> {
+            // We build the project, the artifact will be placed into ./build/libs
+            neo4jContainer = createEnterpriseDB(!TestUtil.isTravis());
+            neo4jContainer.start();
+        }, Exception.class);
+        assumeNotNull(neo4jContainer);
+        session = neo4jContainer.getSession();
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        if (neo4jContainer != null) {
+            session.close();
+            neo4jContainer.close();
+        }
+    }
+
+    @Test
+    public void testMin() throws Exception {
+        assertEquals(1L, session.run("RETURN apoc.coll.min([1,2]) as value").next().get("value").asLong());
+        assertEquals(1L, session.run("RETURN apoc.coll.min([1,2,3]) as value").next().get("value").asLong());
+        assertEquals(0.5D, session.run("RETURN apoc.coll.min([0.5,1,2.3]) as value").next().get("value").asDouble(), 0.1);
+    }
+
+    @Test
+    public void testMax() throws Exception {
+        assertEquals(3L, session.run("RETURN apoc.coll.max([1,2,3]) as value").next().get("value").asLong());
+        assertEquals(2.3D, session.run("RETURN apoc.coll.max([0.5,1,2.3]) as value").next().get("value").asDouble(), 0.1);
+    }
+
+}


### PR DESCRIPTION
Pipelined and expressionEngine=compiled fail in 4.0.3 for apoc.coll.min/max

This (temporarily) fixes the runtime to `slotted`