### PR TITLE
semaphore constrained execution

### DIFF
--- a/docs/asciidoc/_concurrent.adoc
+++ b/docs/asciidoc/_concurrent.adoc
@@ -1,0 +1,13 @@
+[[concurrent]]
+== Concurrency
+
+[abstract]
+--
+This chapter describes procedures dealing with concurrency in the APOC library.
+--
+
+For more information on how to use these procedures, see:
+
+* <<semaphore>>
+
+include::concurrent/semaphore.adoc[leveloffset=2]

--- a/docs/asciidoc/concurrent/semaphore.adoc
+++ b/docs/asciidoc/concurrent/semaphore.adoc
@@ -1,0 +1,69 @@
+[[semaphore]]
+= Cypher execution in semaphores
+
+[abstract]
+--
+This section describes a hook to run Cypher commands after database initialization.
+--
+
+Using a semaphore you can control concurrency. You can define semaphores either via configuration or create them explicitly.
+Semaphores do have a name and a number of available permits.
+
+### Configuration
+
+In `apoc.conf` you can define multiple semaphores
+
+[source,config]
+----
+apoc.semaphore.<mysemaphoreName>=<numberOfPermits>
+----
+
+Example:
+[source,config]
+----
+apoc.semaphore.onlyOnce=1
+----
+
+### Managing semaphores
+
+Additionally to config based setup you can use:
+
+[source,cypher]
+----
+CALL apoc.concurrent.addSemaphore("onlyOnce", 1)
+----
+
+To remove semaphores:
+
+[source,cypher]
+----
+CALL apoc.concurrent.removeSemaphore("onlyOnce")  // removes that specific semaphores
+CALL apoc.concurrent.removeAllSemaphores() // removes all semaphores
+----
+
+Note that the procedure based setup will only affect this instance.
+If you use them in a cluster, you have to run them on each cluster member to stay in sync.
+
+### Using semaphores
+
+You can wrap any cypher statement into a semaphore based execution:
+
+[source,cypher]
+----
+CALL apoc.concurrent.runInSemaphore(<semaphoreName>, <cypher>, <params / optional>) YIELD value
+RETURN value.n
+----
+
+`runInSemaphores` acquires a permit from the named semaphore. If there's no permit is available it will wait.
+While waiting a check for termination is run, effectively making it possible to kill waiting queries.
+After a permit has been acquired, the statement is run with the optionally provided parameters.
+Once finishing consuming the results the permit is passed back to the semaphore.
+
+If you have a semaphore with 1 permit this means effectively serialization of all operations on this semaphore.
+
+Example:
+[source,cypher]
+----
+CALL apoc.concurrent.runInSemaphore("onlyOnce", "MATCH (n) RETURN n") YIELD value
+RETURN value.n
+----

--- a/docs/asciidoc/config.adoc
+++ b/docs/asciidoc/config.adoc
@@ -52,9 +52,6 @@ apoc.spatial.geocode.<providerName>.<key>=<value>
 | apoc.ttl.schedule=<secs> (default `60`) | Set frequency in seconds to run ttl background task
 | apoc.ttl.limit=<number> (default 1000) | Maximum number of nodes being deleted in one background transaction
 | apoc.uuid.enabled=false/true (default false) | global switch to enable uuid handlers
-
-
-//public static final String APOC_JSON_ZIP_URL = "apoc.json.zip.url";
-//public static final String APOC_JSON_SIMPLE_JSON_URL = "apoc.json.simpleJson.url";
-
+| apoc.semaphore.default.name (default null) | default <<semaphore>> to be used in <<commit-batching, apoc.periodic.iterate>> if not given explicitly
+| apoc.semaphore.<someIdentifier> = <number>  | a semaphore defined with name and number of permits
 |===

--- a/docs/asciidoc/graph-updates/periodic-iterate.adoc
+++ b/docs/asciidoc/graph-updates/periodic-iterate.adoc
@@ -30,6 +30,7 @@ The results of the outer statement are passed to the inner statement as paramete
 | params | {} | externally pass in map of params
 | concurrency | 50 | number of concurrent tasks are generated when using `parallel:true`
 | failedParams | -1 | if set to a non-negative value, each failed batch up to `failedParams` parameter sets are returned in `yield failedParams`.
+| semaphore | value of config option `apoc.semaphore.default.name` | Name of the <<semaphore>> to be used.
 |===
 
 .Examples

--- a/docs/asciidoc/index.adoc
+++ b/docs/asciidoc/index.adoc
@@ -37,6 +37,7 @@ The guide covers the following areas:
 * <<job-management>> -- A detailed guide to procedures that can be used for background job management.
 * <<database-introspection>> -- A detailed guide to procedures that can be used to introspect the database.
 * <<operational>> -- A detailed guide to operational procedures.
+* <<concurrent>> -- A detailed guide to semaphore and other concurrency procedures.
 * <<misc>> -- A detailed guide to miscellaneous procedures and functions, including map and collection functions, text functions, and spatial functionality.
 * <<indexes>> -- A detailed guide to indexing procedures.
 * <<algorithms>> -- A detailed guide to Graph Algorithms.
@@ -153,6 +154,8 @@ include::_job_management.adoc[]
 include::_database_introspection.adoc[]
 
 include::_operational.adoc[]
+
+include::_concurrent.adoc[]
 
 include::_misc.adoc[]
 

--- a/src/main/java/apoc/ApocConfig.java
+++ b/src/main/java/apoc/ApocConfig.java
@@ -58,6 +58,8 @@ public class ApocConfig extends LifecycleAdapter {
     public static final String APOC_CONFIG_JOBS_SCHEDULED_NUM_THREADS = "apoc.jobs.scheduled.num_threads";
     public static final String APOC_CONFIG_JOBS_POOL_NUM_THREADS = "apoc.jobs.pool.num_threads";
     public static final String APOC_CONFIG_INITIALIZER_CYPHER = "apoc.initializer.cypher";
+    public static final String APOC_SEMAPHORE_PREFIX = "apoc.semaphore";
+    public static final String APOC_SEMAPHORE_DEFAULT_NAME = APOC_SEMAPHORE_PREFIX + ".default.name";
 
     private static final List<Setting> NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES = new ArrayList<>(Arrays.asList(
             data_directory,

--- a/src/main/java/apoc/concurrent/SemaphoreExtensionFactory.java
+++ b/src/main/java/apoc/concurrent/SemaphoreExtensionFactory.java
@@ -1,0 +1,31 @@
+package apoc.concurrent;
+
+import apoc.ApocConfig;
+import org.neo4j.kernel.extension.ExtensionFactory;
+import org.neo4j.kernel.extension.ExtensionType;
+import org.neo4j.kernel.extension.context.ExtensionContext;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.logging.internal.LogService;
+import org.neo4j.procedure.impl.GlobalProceduresRegistry;
+
+public class SemaphoreExtensionFactory extends ExtensionFactory<apoc.PoolExtensionFactory.Dependencies> {
+
+    public SemaphoreExtensionFactory() {
+        super(ExtensionType.GLOBAL, "APOC_SEMAPHORES");
+    }
+
+    public interface Dependencies {
+        GlobalProceduresRegistry globalProceduresRegistry();
+
+        LogService log();
+
+        ApocConfig apocConfig();
+    }
+
+    @Override
+    public Lifecycle newInstance(ExtensionContext context, apoc.PoolExtensionFactory.Dependencies dependencies) {
+        return new Semaphores(dependencies.log(), dependencies.globalProceduresRegistry(), dependencies.apocConfig());
+    }
+
+
+}

--- a/src/main/java/apoc/concurrent/SemaphoreProcedures.java
+++ b/src/main/java/apoc/concurrent/SemaphoreProcedures.java
@@ -1,0 +1,59 @@
+package apoc.concurrent;
+
+import apoc.result.MapResult;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Mode;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.TerminationGuard;
+import org.neo4j.procedure.UserFunction;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class SemaphoreProcedures {
+
+    @Context
+    public Transaction tx;
+
+    @Context
+    public TerminationGuard terminationGuard;
+
+    @Context
+    public Semaphores semaphores;
+
+    @Procedure(mode = Mode.WRITE)
+    @Description("apoc.concurrent.runInSemaphore('mySemaphoreName', '<cypher>', {somekey: 'someValue', ...}) - runs the given cypher statement inside a semaphore to control concurrent access")
+    public Stream<MapResult> runInSemaphore(
+            @Name("semaphoreName") String semaphoreName,
+            @Name("cypher") String cypher,
+            @Name(value="params", defaultValue="{}") Map<String, Object> params) {
+        return semaphores.withSemaphore(terminationGuard, semaphoreName, () -> tx.execute(cypher, params).stream().map(MapResult::new));
+    }
+
+    @Procedure(mode = Mode.WRITE)
+    @Description("apoc.concurrent.removeAllSemaphores() - removes all registered semaphores")
+    public void removeAllSemaphores() {
+        semaphores.removeAll();
+    }
+
+    @Procedure(mode = Mode.WRITE)
+    @Description("apoc.concurrent.addSemaphores('myName', 1) - creates a semaphore with given number of permits")
+    public void addSemaphore(@Name("semaphoreName") String semaphoreName, @Name("permits") long permits) {
+        semaphores.add(semaphoreName, (int) permits);
+    }
+
+    @Procedure(mode = Mode.WRITE)
+    @Description("apoc.concurrent.removeSemaphore() - removes given semaphore")
+    public void removeSemaphore(@Name("semaphoreName") String semaphoreName) {
+        semaphores.remove(semaphoreName);
+    }
+
+    @UserFunction()
+    @Description("apoc.concurrent.availablePermits(semaphoreName) - function returning the available number of permits for given semaphore")
+    public long availablePermits(@Name("semaphoreName") String semaphoreName) {
+        return semaphores.availablePermits(semaphoreName);
+    }
+}

--- a/src/main/java/apoc/concurrent/Semaphores.java
+++ b/src/main/java/apoc/concurrent/Semaphores.java
@@ -1,0 +1,105 @@
+package apoc.concurrent;
+
+import apoc.ApocConfig;
+import org.neo4j.internal.helpers.collection.Iterators;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.internal.LogService;
+import org.neo4j.procedure.TerminationGuard;
+import org.neo4j.procedure.impl.GlobalProceduresRegistry;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+/**
+ * holds a per-database level map of declared semaphores
+ */
+public class Semaphores extends LifecycleAdapter {
+
+    private final Map<String, Semaphore> semaphoreMap = new ConcurrentHashMap<>();
+
+    private final Log log;
+    private final GlobalProceduresRegistry globalProceduresRegistry;
+    private final ApocConfig apocConfig;
+
+    public Semaphores(LogService log, GlobalProceduresRegistry globalProceduresRegistry, ApocConfig apocConfig) {
+
+        this.log = log.getInternalLog(Semaphores.class);
+        this.globalProceduresRegistry = globalProceduresRegistry;
+        this.apocConfig = apocConfig;
+
+        // expose this config instance via `@Context ApocConfig config`
+        globalProceduresRegistry.registerComponent((Class<Semaphores>) getClass(), ctx -> this, true);
+        this.log.info("successfully registered Pools for @Context");
+    }
+
+    @Override
+    public void init() throws Exception {
+        Iterators.stream(apocConfig.getKeys("apoc.semaphore")).forEach(key -> {
+            int permits = apocConfig.getInt(key, -1);
+            semaphoreMap.put(key, new Semaphore(permits));
+            log.debug("created semaphore %s with %d permits", key, permits);
+        });
+    }
+
+    public <T> Stream<T> withSemaphore(TerminationGuard terminationGuard, String semaphoreName, Supplier<Stream<T>> supplier) {
+        Semaphore semaphore = getSemaphoreOrThrow(semaphoreName);
+        long now = System.currentTimeMillis();
+        boolean permitAcquired = false;
+        try {
+
+            // we can't simply use semaphore.acquire() here since it blocks and doesn't give us a chance for checking termination status
+            log.debug("about to acquire semaphore %s", semaphoreName);
+            while (!semaphore.tryAcquire(100, TimeUnit.MILLISECONDS)) {
+                terminationGuard.check();
+            }
+            permitAcquired = true;
+            log.debug("acquired semaphore %s in %d millis", semaphoreName, System.currentTimeMillis()-now);
+
+            return supplier.get().onClose(() -> {
+                semaphore.release();
+                log.debug("released semaphore %s after %d millis", semaphoreName, System.currentTimeMillis()-now);
+            });
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        } catch (RuntimeException e) {
+            if (permitAcquired) {
+                semaphore.release();
+            }
+            log.debug("released semaphore %s after %d millis due to %s", semaphoreName, System.currentTimeMillis()-now, e.getMessage());
+            throw e;
+        }
+    }
+
+    public int availablePermits(String semaphoreName) {
+        Semaphore semaphore = getSemaphoreOrThrow(semaphoreName);
+        return semaphore.availablePermits();
+    }
+
+    public void add(String semaphoreName, int permits) {
+        if (semaphoreMap.get(semaphoreName) != null) {
+            throw new IllegalArgumentException("already existing semaphore :" + semaphoreName + ". Use remove first");
+        }
+        semaphoreMap.put(semaphoreName, new Semaphore(permits));
+    }
+
+    public void remove(String semaphoreName) {
+        semaphoreMap.remove(semaphoreName);
+    }
+
+    private Semaphore getSemaphoreOrThrow(String semaphoreName) {
+        Semaphore semaphore = semaphoreMap.get(semaphoreName);
+        if (semaphore == null) {
+            throw new IllegalArgumentException("no declared semaphore: " + semaphoreName);
+        }
+        return semaphore;
+    }
+
+    public void removeAll() {
+        semaphoreMap.clear();
+    }
+}

--- a/src/main/java/apoc/refactor/rename/Rename.java
+++ b/src/main/java/apoc/refactor/rename/Rename.java
@@ -1,15 +1,27 @@
 package apoc.refactor.rename;
 
+import apoc.ApocConfig;
 import apoc.Pools;
+import apoc.concurrent.Semaphores;
 import apoc.periodic.Periodic;
 import apoc.periodic.Periodic.BatchAndTotalResult;
 import apoc.util.MapUtil;
 import apoc.util.Util;
-import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.logging.Log;
-import org.neo4j.procedure.*;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Mode;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.TerminationGuard;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +54,12 @@ public class Rename {
 
     @Context
 	public Transaction tx;
+
+    @Context
+	public ApocConfig apocConfig;
+
+    @Context
+	public Semaphores semaphores;
 
     /**
 	 * Rename the Label of a node by creating a new one and deleting the old.
@@ -108,6 +126,8 @@ public class Rename {
         periodic.terminationGuard = this.terminationGuard;
         periodic.pools = this.pools;
         periodic.tx = this.tx;
+        periodic.apocConfig = this.apocConfig;
+        periodic.semaphores = this.semaphores;
         return periodic;
     }
 

--- a/src/main/resources/META-INF/services/org.neo4j.kernel.extension.ExtensionFactory
+++ b/src/main/resources/META-INF/services/org.neo4j.kernel.extension.ExtensionFactory
@@ -2,3 +2,4 @@ apoc.RegisterComponentFactory
 apoc.ApocConfigExtensionFactory
 apoc.PoolExtensionFactory
 apoc.ApocExtensionFactory
+apoc.concurrent.SemaphoreExtensionFactory

--- a/src/test/java/apoc/ApocConfigTest.java
+++ b/src/test/java/apoc/ApocConfigTest.java
@@ -45,15 +45,15 @@ public class ApocConfigTest {
 
     @Test
     public void testDetermineNeo4jConfFolder() {
-        System.setProperty(SUN_JAVA_COMMAND, "com.neo4j.server.enterprise.CommercialEntryPoint --home-dir=/home/stefan/neo4j-enterprise-4.0.0-alpha09mr02 --config-dir=/home/stefan/neo4j-enterprise-4.0.0-alpha09mr02/conf");
+        System.setProperty(SUN_JAVA_COMMAND, "com.neo4j.server.enterprise.CommercialEntryPoint --home-dir=/home/stefan/neo4j-enterprise-4.0.3 --config-dir=/home/stefan/neo4j-enterprise-4.0.3/conf");
 
-        assertEquals("/home/stefan/neo4j-enterprise-4.0.0-alpha09mr02/conf", cut.determineNeo4jConfFolder());
+        assertEquals("/home/stefan/neo4j-enterprise-4.0.3/conf", cut.determineNeo4jConfFolder());
     }
 
     @Test
     public void testApocConfFileBeingLoaded() throws Exception {
         String confDir = new File(getClass().getClassLoader().getResource("apoc.conf").toURI()).getParent();
-        System.setProperty(SUN_JAVA_COMMAND, "com.neo4j.server.enterprise.CommercialEntryPoint --home-dir=/home/stefan/neo4j-enterprise-4.0.0-alpha09mr02 --config-dir=" + confDir);
+        System.setProperty(SUN_JAVA_COMMAND, "com.neo4j.server.enterprise.CommercialEntryPoint --home-dir=/home/stefan/neo4j-enterprise-4.0.3 --config-dir=" + confDir);
         cut.init();
 
         assertEquals("bar", cut.getConfig().getString("foo"));
@@ -61,8 +61,8 @@ public class ApocConfigTest {
 
     @Test
     public void testDetermineNeo4jConfFolderWithWhitespaces() {
-        System.setProperty(SUN_JAVA_COMMAND, "com.neo4j.server.enterprise.CommercialEntryPoint --config-dir=/home/stefan/neo4j enterprise-4.0.0-alpha09mr02/conf --home-dir=/home/stefan/neo4j enterprise-4.0.0-alpha09mr02");
+        System.setProperty(SUN_JAVA_COMMAND, "com.neo4j.server.enterprise.CommercialEntryPoint --config-dir=/home/stefan/neo4j enterprise-4.0.3/conf --home-dir=/home/stefan/neo4j enterprise-4.0.3");
 
-        assertEquals("/home/stefan/neo4j enterprise-4.0.0-alpha09mr02/conf", cut.determineNeo4jConfFolder());
+        assertEquals("/home/stefan/neo4j enterprise-4.0.3/conf", cut.determineNeo4jConfFolder());
     }
 }

--- a/src/test/java/apoc/concurrent/SemaphoreProceduresTest.java
+++ b/src/test/java/apoc/concurrent/SemaphoreProceduresTest.java
@@ -2,7 +2,6 @@ package apoc.concurrent;
 
 import apoc.util.TestUtil;
 import apoc.util.Utils;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -18,6 +17,7 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
@@ -25,6 +25,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class SemaphoreProceduresTest {
+
+    private final static String SEMAPHORE_SINGLE = "single";
+    private final static String SEMAPHORE_ZERO = "zero";
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -35,11 +38,8 @@ public class SemaphoreProceduresTest {
     @BeforeClass
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, SemaphoreProcedures.class, Utils.class);
-    }
-
-    @AfterClass
-    public static void tearDown() throws Exception {
-        db.executeTransactionally("call apoc.concurrent.removeAllSemaphores()");
+        db.executeTransactionally("call apoc.concurrent.addSemaphore($semaphoreName, 1)", Collections.singletonMap("semaphoreName", SEMAPHORE_SINGLE));
+        db.executeTransactionally("call apoc.concurrent.addSemaphore($semaphoreName, 0)", Collections.singletonMap("semaphoreName", SEMAPHORE_ZERO));
     }
 
     @Test
@@ -54,14 +54,12 @@ public class SemaphoreProceduresTest {
 
     @Test
     public void testThatSemaphoreSerializesOperations() throws InterruptedException {
-        long duration = 500;
+        long duration = 200;
+        String cypher = "call apoc.concurrent.runInSemaphore($semaphoreName, 'call apoc.util.sleep($duration) return 1', {duration: $duration})";
         Map<String, Object> params = MapUtil.map(
                 "duration", duration,
                 "semaphoreName", "single"
         );
-        db.executeTransactionally("call apoc.concurrent.addSemaphore($semaphoreName, 1)", params);
-
-        String cypher = "call apoc.concurrent.runInSemaphore($semaphoreName, 'call apoc.util.sleep($duration) return 1', {duration: $duration})";
         db.executeTransactionally(cypher, params, Iterators::single); // ensure query plan cache gets populated
         long now = System.currentTimeMillis();
 
@@ -86,10 +84,8 @@ public class SemaphoreProceduresTest {
 
     @Test
     public void testSemaphoreReleasedOnFailure() throws InterruptedException {
-        Map<String, Object> params = MapUtil.map("semaphoreName", "single");
-        db.executeTransactionally("call apoc.concurrent.addSemaphore($semaphoreName, 1)", params);
-
         String cypher = "call apoc.concurrent.runInSemaphore($semaphoreName, 'call does.not.exist() return 1')";
+        Map<String, Object> params = MapUtil.map("semaphoreName", "single");
         Set<Thread> threads = Iterators.asSet(
                 new Thread(() -> db.executeTransactionally(cypher, params, Iterators::single)),
                 new Thread(() -> db.executeTransactionally(cypher, params, Iterators::single))
@@ -110,13 +106,8 @@ public class SemaphoreProceduresTest {
 
     @Test(timeout = 10000)
     public void testRunInSemaphoreIsKillable() throws InterruptedException {
-        Map<String, Object> params = MapUtil.map(
-                "semaphoreName", "single"
-        );
-        db.executeTransactionally("call apoc.concurrent.addSemaphore($semaphoreName, 0)", params);
-
         Thread thread = new Thread(() -> {
-            db.executeTransactionally("call apoc.concurrent.runInSemaphore($semaphoreName, 'return 1')", params, Iterators::single);
+            db.executeTransactionally("call apoc.concurrent.runInSemaphore($semaphoreName, 'return 1')", Collections.singletonMap("semaphoreName", SEMAPHORE_ZERO), Iterators::single);
         });
         thread.start();
         Thread.sleep(100);  // await planning

--- a/src/test/java/apoc/concurrent/SemaphoreProceduresTest.java
+++ b/src/test/java/apoc/concurrent/SemaphoreProceduresTest.java
@@ -1,0 +1,134 @@
+package apoc.concurrent;
+
+import apoc.util.TestUtil;
+import apoc.util.Utils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.common.DependencyResolver;
+import org.neo4j.graphdb.QueryExecutionException;
+import org.neo4j.internal.helpers.collection.Iterators;
+import org.neo4j.internal.helpers.collection.MapUtil;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.impl.api.KernelTransactions;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SemaphoreProceduresTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule();
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        TestUtil.registerProcedure(db, SemaphoreProcedures.class, Utils.class);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        db.executeTransactionally("call apoc.concurrent.removeAllSemaphores()");
+    }
+
+    @Test
+    public void failOnUndeclaredSemaphore() {
+        thrown.expect(QueryExecutionException.class);
+        thrown.expectMessage("java.lang.IllegalArgumentException: no declared semaphore: undeclaredSemaphore");
+        String cypher = "call apoc.concurrent.runInSemaphore($name, 'return 1')";
+
+        Map<String, Object> params = MapUtil.map("name", "undeclaredSemaphore");
+        db.executeTransactionally(cypher, params, Iterators::single);
+    }
+
+    @Test
+    public void testThatSemaphoreSerializesOperations() throws InterruptedException {
+        long duration = 500;
+        Map<String, Object> params = MapUtil.map(
+                "duration", duration,
+                "semaphoreName", "single"
+        );
+        db.executeTransactionally("call apoc.concurrent.addSemaphore($semaphoreName, 1)", params);
+
+        String cypher = "call apoc.concurrent.runInSemaphore($semaphoreName, 'call apoc.util.sleep($duration) return 1', {duration: $duration})";
+        db.executeTransactionally(cypher, params, Iterators::single); // ensure query plan cache gets populated
+        long now = System.currentTimeMillis();
+
+        Set<Thread> threads = Iterators.asSet(
+                new Thread(() -> db.executeTransactionally(cypher, params, Iterators::single)),
+                new Thread(() -> db.executeTransactionally(cypher, params, Iterators::single))
+        );
+
+        threads.forEach(Thread::start);
+        threads.forEach(thread -> {
+            try {
+                thread.join();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        assertTrue( (System.currentTimeMillis()- now) >= 2*duration);
+        long availablePermits = TestUtil.singleResultFirstColumn(db, "return apoc.concurrent.availablePermits($semaphoreName)", params);
+        assertEquals(1l, availablePermits);
+    }
+
+    @Test
+    public void testSemaphoreReleasedOnFailure() throws InterruptedException {
+        Map<String, Object> params = MapUtil.map("semaphoreName", "single");
+        db.executeTransactionally("call apoc.concurrent.addSemaphore($semaphoreName, 1)", params);
+
+        String cypher = "call apoc.concurrent.runInSemaphore($semaphoreName, 'call does.not.exist() return 1')";
+        Set<Thread> threads = Iterators.asSet(
+                new Thread(() -> db.executeTransactionally(cypher, params, Iterators::single)),
+                new Thread(() -> db.executeTransactionally(cypher, params, Iterators::single))
+        );
+
+        threads.forEach(Thread::start);
+        threads.forEach(thread -> {
+            try {
+                thread.join();
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        long availablePermits = TestUtil.singleResultFirstColumn(db, "return apoc.concurrent.availablePermits($semaphoreName)", params);
+        assertEquals("Ensure 'release' has been called.", 1l, availablePermits);
+    }
+
+    @Test(timeout = 10000)
+    public void testRunInSemaphoreIsKillable() throws InterruptedException {
+        Map<String, Object> params = MapUtil.map(
+                "semaphoreName", "single"
+        );
+        db.executeTransactionally("call apoc.concurrent.addSemaphore($semaphoreName, 0)", params);
+
+        Thread thread = new Thread(() -> {
+            db.executeTransactionally("call apoc.concurrent.runInSemaphore($semaphoreName, 'return 1')", params, Iterators::single);
+        });
+        thread.start();
+        Thread.sleep(100);  // await planning
+
+        // kill all active queries
+        DependencyResolver dependencyResolver = ((GraphDatabaseAPI) db).getDependencyResolver();
+        KernelTransactions kernelTransactions = dependencyResolver.resolveDependency(KernelTransactions.class);
+        long numberOfKilledTransaction = kernelTransactions.activeTransactions().stream()
+                .filter(kernelTransactionHandle -> kernelTransactionHandle.markForTermination(Status.Transaction.Terminated))
+                .count();
+        assertEquals(1l, numberOfKilledTransaction);
+        thread.join();
+    }
+
+}


### PR DESCRIPTION
I've added couple of procedures to manage named semaphores. E.g. using apoc.concurrent.runInSemaphore you can run a given statement inside a semaphore.
By configuration or a procedure call you can setup semaphores with a defined number of permits.
This enables to control of concurrency in environments where you have "stupid" clients that potentially overload the system. Or if you want prevent locking issues you can just set a default semaphore of 1.
