### PR TITLE
fixes #1163: apoc.cypher.parallel() procedures need tx termination guards

### DIFF
--- a/src/test/java/apoc/cypher/CypherEnterpriseTest.java
+++ b/src/test/java/apoc/cypher/CypherEnterpriseTest.java
@@ -1,0 +1,62 @@
+package apoc.cypher;
+
+import apoc.util.Neo4jContainerExtension;
+import apoc.util.TestUtil;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.driver.Session;
+
+import static apoc.util.TestContainerUtil.createEnterpriseDB;
+import static apoc.util.TestContainerUtil.testResult;
+import static apoc.util.TestUtil.isTravis;
+import static apoc.util.Util.map;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeNotNull;
+
+public class CypherEnterpriseTest {
+
+    private static Neo4jContainerExtension neo4jContainer;
+    private static Session session;
+
+    @BeforeClass
+    public static void beforeAll() {
+        assumeFalse(isTravis());
+        TestUtil.ignoreException(() -> {
+            // We build the project, the artifact will be placed into ./build/libs
+            neo4jContainer = createEnterpriseDB(!TestUtil.isTravis())
+                    .withNeo4jConfig("dbms.transaction.timeout", "5s");
+            neo4jContainer.start();
+        }, Exception.class);
+        assumeNotNull(neo4jContainer);
+        session = neo4jContainer.getSession();
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        if (neo4jContainer != null) {
+            session.close();
+            neo4jContainer.close();
+        }
+    }
+
+    @Test
+    public void testParallelTransactionGuard() {
+        // given
+        int txCountBefore = neo4jContainer.getSession().readTransaction(tx -> tx.run("CALL dbms.listTransactions()").list()).size();
+
+        // when
+        try {
+            int size = 10_000;
+            testResult(neo4jContainer.getSession(),
+                    "CALL apoc.cypher.parallel2('UNWIND range(0,9) as id CALL apoc.util.sleep(10000) WITH id RETURN id', {a: range(1, $size)}, 'a')",
+                    map("size", size),
+                    r -> {});
+        } catch (Exception ignored) {}
+
+        // then
+        int txCountAfter = neo4jContainer.getSession().readTransaction(tx -> tx.run("CALL dbms.listTransactions()").list()).size();
+        Assert.assertEquals(txCountBefore, txCountAfter);
+    }
+}


### PR DESCRIPTION
Fixes #1163

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added `TerminationGuard` right before the query execution
  - Added `CypherEnterpriseTest` in order to test it
