### PR TITLE
static values docs update

### DIFF
--- a/docs/asciidoc/utilities/static-values.adoc
+++ b/docs/asciidoc/utilities/static-values.adoc
@@ -25,7 +25,7 @@ This section includes the following sub sections:
 [[api-credentials]]
 == Working with API Credentials
 
-The examples below assume that we have the following entries in the Neo4j configuration file:
+The examples below assume that we have the following entries in the APOC configuration file (`conf/apoc.conf`):
 
 ----
 apoc.static.twitter.bearer=ABCDEF


### PR DESCRIPTION
Static values are no longer stored in the Neo4j configuration file but in the APOC configuration file.