### PR TITLE
fixes #1505: apoc.load.csv does not skip properly

### DIFF
--- a/src/main/java/apoc/load/LoadCsv.java
+++ b/src/main/java/apoc/load/LoadCsv.java
@@ -225,7 +225,7 @@ public class LoadCsv {
             this.nullValues = nullValues;
             this.results = results;
             this.ignoreErrors = ignoreErrors;
-            this.limit = skip + limit;
+            this.limit = Util.isSumOutOfRange(skip, limit) ? Long.MAX_VALUE : (skip + limit);
             lineNo = skip;
             while (skip-- > 0) {
                 csv.readNext();

--- a/src/main/java/apoc/load/util/LoadCsvConfig.java
+++ b/src/main/java/apoc/load/util/LoadCsvConfig.java
@@ -45,7 +45,8 @@ public class LoadCsvConfig {
         separator = parseCharFromConfig(config, "sep", DEFAULT_SEP);
         arraySep = parseCharFromConfig(config, "arraySep", DEFAULT_ARRAY_SEP);
         quoteChar = parseCharFromConfig(config,"quoteChar", DEFAULT_QUOTE_CHAR);
-        skip = (long) config.getOrDefault("skip", 0L);
+        long skip = (long) config.getOrDefault("skip", 0L);
+        this.skip = skip > -1 ? skip : 0L;
         hasHeader = (boolean) config.getOrDefault("header", true);
         limit = (long) config.getOrDefault("limit", Long.MAX_VALUE);
         failOnError = (boolean) config.getOrDefault("failOnError", true);

--- a/src/main/java/apoc/util/Util.java
+++ b/src/main/java/apoc/util/Util.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.InvocationTargetException;
+import java.math.BigInteger;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -627,6 +628,21 @@ public class Util {
             errorMessages.compute(e.getMessage(),(s, i) -> i == null ? 1 : i + 1);
         }
         return errorValue;
+    }
+
+    public static boolean isSumOutOfRange(long... numbers) {
+        try {
+            sumLongs(numbers).longValueExact();
+            return false;
+        } catch (ArithmeticException ae) {
+            return true;
+        }
+    }
+
+    public static BigInteger sumLongs(long... numbers) {
+        return LongStream.of(numbers)
+                .mapToObj(BigInteger::valueOf)
+                .reduce(BigInteger.ZERO, (x, y) -> x.add(y));
     }
 
     public static void logErrors(String message, Map<String, Long> errors, Log log) {

--- a/src/test/java/apoc/load/LoadCsvTest.java
+++ b/src/test/java/apoc/load/LoadCsvTest.java
@@ -108,7 +108,7 @@ RETURN m.col_1,m.col_2,m.col_3
         assertEquals(lineNo, row.get("lineNo"));
     }
 
-    @Test public void testLoadCsvSkip() throws Exception {
+    @Test public void testLoadCsvSkipLimit() throws Exception {
         URL url = getUrlFileName("test.csv");
         testResult(db, "CALL apoc.load.csv($url,{skip:1,limit:1,results:['map','list','stringMap','strings']})", map("url",url.toString()), // 'file:test.csv'
                 (r) -> {
@@ -116,6 +116,18 @@ RETURN m.col_1,m.col_2,m.col_3
                     assertEquals(false, r.hasNext());
                 });
     }
+
+    @Test public void testLoadCsvSkip() throws Exception {
+        URL url = getUrlFileName("test.csv");
+        testResult(db, "CALL apoc.load.csv($url,{skip:1,results:['map','list','stringMap','strings']})", map("url",url.toString()), // 'file:test.csv'
+                (r) -> {
+                    assertRow(r, "Rana", "11", 1L);
+                    assertEquals(true, r.hasNext());
+                    assertRow(r, "Selina", "18", 2L);
+                    assertEquals(false, r.hasNext());
+                });
+    }
+
     @Test public void testLoadCsvTabSeparator() throws Exception {
         URL url = getUrlFileName("test-tab.csv");
         testResult(db, "CALL apoc.load.csv($url,{sep:'TAB',results:['map','list','stringMap','strings']})", map("url",url.toString()), // 'file:test.csv'


### PR DESCRIPTION
Fixes #1505

The `skip + limit` exceeds `Long.MAX_VALUE` in case no limit is provided (because the limit default is `Long.MAX_VALUE`)

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added a check in case `skip + limit > Long.MAX_VALUE`
  - Added test case
