### PR TITLE
fixes #1436: duplicate nodes in apoc.export.csv.graph from a apoc.create.graph

### DIFF
--- a/src/main/java/apoc/result/VirtualGraph.java
+++ b/src/main/java/apoc/result/VirtualGraph.java
@@ -4,9 +4,10 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.internal.helpers.collection.MapUtil;
 
-
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  * @author mh
@@ -17,6 +18,11 @@ public class VirtualGraph {
     public final Map<String,Object> graph;
 
     public VirtualGraph(String name, Iterable<Node> nodes, Iterable<Relationship> relationships, Map<String,Object> properties) {
-        this.graph = MapUtil.map("name",name,"nodes",nodes,"relationships",relationships,"properties",properties);
+        this.graph = MapUtil.map("name", name,
+                "nodes", nodes instanceof Set ? nodes : StreamSupport.stream(nodes.spliterator(), false)
+                        .collect(Collectors.toSet()),
+                "relationships", relationships instanceof Set ? relationships : StreamSupport.stream(relationships.spliterator(), false)
+                        .collect(Collectors.toSet()),
+                "properties", properties);
     }
 }


### PR DESCRIPTION

Fixes #1436

The `VirtualGraph` doesn't manage duplicate entities.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Transformed `nodes` and `relationships` field of `VirtualGraph` into `Sets`
  - Added test case
