### PR TITLE
fixes #1336: Create apoc.export.cypher format and outputs optimised for passing to apoc.bolt.execute

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/database-integration/bolt-neo4j.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/bolt-neo4j.adoc
@@ -11,6 +11,8 @@ Bolt procedures allows to accessing other databases via bolt protocol.
 |===
 | CALL apoc.bolt.execute(urlOrKey, statement, params, config) YIELD row  | access to other databases via bolt for read and write
 | CALL apoc.bolt.load(urlOrKey, statement, params, config) YIELD row | access to other databases via bolt for read
+| CALL apoc.bolt.fromLocal(urlOrKey, localStatement, remoteStatement, config) YIELD row | executes the `localStatement`
+on the local instance and uses the results a parameters for the `remoteStatement` executed on the remote instance
 |===
 
 **urlOrKey** param allows users to decide if send url by apoc or if put it into apoc.conf file.
@@ -64,6 +66,8 @@ Config available are:
 
 * `statistics`: possible values are true/false, the default value is false. This config print the execution statistics;
 * `virtual`: possible values are true/false, the default value is false. This config return result in virtual format and not in map format, in apoc.bolt.load.
+* `databaseName`: the database instance name on the remote Neo4j instance
+* `streamStatements`: if true and used in combination with the cypher export procedures it streams the statement from local to remote database.
 
 == Driver configuration
 

--- a/src/main/java/apoc/bolt/Bolt.java
+++ b/src/main/java/apoc/bolt/Bolt.java
@@ -5,28 +5,43 @@ import apoc.result.VirtualNode;
 import apoc.result.VirtualRelationship;
 import apoc.util.UriResolver;
 import apoc.util.Util;
-import org.neo4j.driver.*;
+import org.apache.commons.lang3.StringUtils;
+import org.neo4j.driver.AuthToken;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.GraphDatabase;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.Transaction;
+import org.neo4j.driver.Value;
 import org.neo4j.driver.internal.InternalEntity;
 import org.neo4j.driver.internal.InternalPath;
-import org.neo4j.driver.internal.logging.JULogging;
 import org.neo4j.driver.summary.SummaryCounters;
 import org.neo4j.driver.types.Node;
 import org.neo4j.driver.types.Path;
 import org.neo4j.driver.types.Relationship;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Mode;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
-import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
-import java.util.concurrent.TimeUnit;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
-import java.util.logging.Level;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static apoc.util.MapUtil.map;
@@ -37,28 +52,23 @@ import static apoc.util.MapUtil.map;
  */
 public class Bolt {
 
+    @Context
+    public GraphDatabaseService db;
+
     @Procedure()
     @Description("apoc.bolt.load(url-or-key, kernelTransaction, params, config) - access to other databases via bolt for read")
     public Stream<RowResult> load(@Name("url") String url, @Name("kernelTransaction") String statement, @Name(value = "params", defaultValue = "{}") Map<String, Object> params, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws URISyntaxException {
-        if (config == null) config = Collections.emptyMap();
-        boolean virtual = (boolean) config.getOrDefault("virtual", false);
-        boolean addStatistics = (boolean) config.getOrDefault("statistics", false);
-        boolean readOnly = (boolean) config.getOrDefault("readOnly", true);
-
-        Config driverConfig = toDriverConfig(config.getOrDefault("driverConfig", map()));
+        BoltConfig boltConfig = new BoltConfig(config);
         UriResolver uri = new UriResolver(url, "bolt");
         uri.initialize();
-
-        SessionConfig sessionConfig = SessionConfig.builder().withDefaultAccessMode(readOnly ? AccessMode.READ : AccessMode.WRITE).build();
-
-        return withDriver(uri.getConfiguredUri(), uri.getToken(), driverConfig, driver ->
-                withSession(driver, sessionConfig, session -> {
-                    if (addStatistics) {
+        return withDriver(uri.getConfiguredUri(), uri.getToken(), boltConfig.getDriverConfig(), driver ->
+                withSession(driver, boltConfig.getSessionConfig(), session -> {
+                    if (boltConfig.isAddStatistics()) {
                         Result statementResult = session.run(statement, params);
                         SummaryCounters counters = statementResult.consume().counters();
                         return Stream.of(new RowResult(toMap(counters)));
                     } else
-                        return getRowResultStream(virtual, session, params, statement);
+                        return getRowResultStream(boltConfig.isVirtual(), session, params, statement);
                 }));
     }
 
@@ -80,6 +90,49 @@ public class Bolt {
     private <T> Stream<T> withTransaction(Session session, Function<Transaction, Stream<T>> function) {
         Transaction transaction = session.beginTransaction();
         return function.apply(transaction).onClose(() -> transaction.commit()).onClose(() -> transaction.close());
+    }
+
+    @Procedure(value = "apoc.bolt.load.fromLocal", mode = Mode.WRITE)
+    public Stream<RowResult> fromLocal(@Name("url") String url,
+                                       @Name("localStatement") String localStatement,
+                                       @Name("remoteStatement") String remoteStatement,
+                                       @Name(value = "config", defaultValue = "{}") Map<String, Object> config)  throws URISyntaxException {
+        BoltConfig boltConfig = new BoltConfig(config);
+        UriResolver uri = new UriResolver(url, "bolt");
+        uri.initialize();
+        return withDriver(uri.getConfiguredUri(), uri.getToken(), boltConfig.getDriverConfig(), driver ->
+                withSession(driver, boltConfig.getSessionConfig(), session -> {
+                    try (org.neo4j.graphdb.Transaction tx = db.beginTx()) {
+                        final org.neo4j.graphdb.Result localResult = tx.execute(localStatement, boltConfig.getLocalParams());
+                        String withColumns = "WITH " + localResult.columns().stream()
+                                .map(c -> "$" + c + " AS " + c)
+                                .collect(Collectors.joining(", ")) + "\n";
+                        Map<Long, Object> nodesCache = new HashMap<>();
+                        List<RowResult> response = new ArrayList<>();
+                        while (localResult.hasNext()) {
+                            final Result statementResult;
+                            Map<String, Object> row = localResult.next();
+                            if (boltConfig.isStreamStatements()) {
+                                final String statement = (String) row.get("statement");
+                                if (StringUtils.isBlank(statement)) continue;
+                                final Map<String, Object> params = Collections.singletonMap("params", row.getOrDefault("params", Collections.emptyMap()));
+                                statementResult = session.run(statement, params);
+                            } else {
+                                statementResult = session.run(withColumns + remoteStatement, row);
+                            }
+                            if (boltConfig.isStreamStatements()) {
+                                response.add(new RowResult(toMap(statementResult.consume().counters())));
+                            } else {
+                                response.addAll(
+                                        statementResult.stream()
+                                                .map(record -> buildRowResult(record, nodesCache, boltConfig.isVirtual()))
+                                                .collect(Collectors.toList())
+                                );
+                            }
+                        }
+                        return response.stream();
+                    }
+                }));
     }
 
     @Procedure()
@@ -161,60 +214,6 @@ public class Bolt {
         );
     }
 
-    private Config toDriverConfig(Object driverConfig) {
-        Map<String, Object> driverConfMap = (Map<String, Object>) driverConfig;
-        String logging = (String) driverConfMap.getOrDefault("logging", "INFO");
-        boolean encryption = (boolean) driverConfMap.getOrDefault("encryption", false);
-        boolean logLeakedSessions = (boolean) driverConfMap.getOrDefault("logLeakedSessions", true);
-        Long idleTimeBeforeConnectionTest = (Long) driverConfMap.getOrDefault("idleTimeBeforeConnectionTest", -1L);
-        String trustStrategy = (String) driverConfMap.getOrDefault("trustStrategy", "TRUST_ALL_CERTIFICATES");
-//        Long routingFailureLimit = (Long) driverConfMap.getOrDefault("routingFailureLimit", 1L);
-//        Long routingRetryDelayMillis = (Long) driverConfMap.getOrDefault("routingRetryDelayMillis", 5000L);
-        Long connectionTimeoutMillis = (Long) driverConfMap.get("connectionTimeoutMillis");
-        Long maxRetryTimeMs = (Long) driverConfMap.get("maxRetryTimeMs");
-        Long maxConnectionLifeTime = (Long) driverConfMap.get("maxConnectionLifeTime");
-        Long maxConnectionPoolSize = (Long) driverConfMap.get("maxConnectionPoolSize");
-        Long routingTablePurgeDelay = (Long) driverConfMap.get("routingTablePurgeDelay");
-        Long connectionAcquisitionTimeout = (Long) driverConfMap.get("connectionAcquisitionTimeout");
 
-        Config.ConfigBuilder config = Config.builder();
-
-        config.withLogging(new JULogging(Level.parse(logging)));
-        if(encryption) config.withEncryption();
-        config.withTrustStrategy(Config.TrustStrategy.trustAllCertificates());
-        if(!logLeakedSessions) config.withoutEncryption();
-
-        if (connectionAcquisitionTimeout!=null) {
-            config.withConnectionAcquisitionTimeout(connectionAcquisitionTimeout, TimeUnit.MILLISECONDS);
-        }
-        //config.withDriverMetrics();
-        if (maxConnectionLifeTime!=null) {
-            config.withMaxConnectionLifetime(maxConnectionLifeTime, TimeUnit.MILLISECONDS);
-        }
-        if (maxConnectionPoolSize!=null) {
-            config.withMaxConnectionPoolSize(maxConnectionPoolSize.intValue());
-        }
-        if (routingTablePurgeDelay!=null) {
-            config.withRoutingTablePurgeDelay(routingTablePurgeDelay, TimeUnit.MILLISECONDS);
-        }
-//        config.withRoutingFailureLimit(routingFailureLimit.intValue());
-//        config.withRoutingRetryDelay(routingRetryDelayMillis,TimeUnit.MILLISECONDS);
-        if (idleTimeBeforeConnectionTest!=null) {
-            config.withConnectionLivenessCheckTimeout(idleTimeBeforeConnectionTest, TimeUnit.MILLISECONDS);
-        }
-        if (connectionTimeoutMillis!=null) {
-            config.withConnectionTimeout(connectionTimeoutMillis, TimeUnit.MILLISECONDS);
-        }
-        if (maxRetryTimeMs!=null) {
-            config.withMaxTransactionRetryTime(maxRetryTimeMs, TimeUnit.MILLISECONDS);
-        }
-        if(trustStrategy.equals("TRUST_ALL_CERTIFICATES")) config.withTrustStrategy(Config.TrustStrategy.trustAllCertificates());
-        else if(trustStrategy.equals("TRUST_SYSTEM_CA_SIGNED_CERTIFICATES")) config.withTrustStrategy(Config.TrustStrategy.trustSystemCertificates());
-        else {
-            File file = new File(trustStrategy);
-            config.withTrustStrategy(Config.TrustStrategy.trustCustomCertificateSignedBy(file));
-        }
-        return config.build();
-    }
 
 }

--- a/src/main/java/apoc/bolt/BoltConfig.java
+++ b/src/main/java/apoc/bolt/BoltConfig.java
@@ -1,0 +1,117 @@
+package apoc.bolt;
+
+import org.neo4j.driver.AccessMode;
+import org.neo4j.driver.Config;
+import org.neo4j.driver.SessionConfig;
+import org.neo4j.driver.internal.logging.JULogging;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+
+public class BoltConfig {
+    private final boolean virtual;
+    private final boolean addStatistics;
+    private final boolean readOnly;
+    private final boolean streamStatements;
+    private final Config driverConfig;
+    private final Map<String, Object> localParams;
+    private final Map<String, Object> remoteParams;
+    private final String databaseName;
+
+    public BoltConfig(Map<String, Object> config) {
+        if (config == null) config = Collections.emptyMap();
+        this.virtual = (boolean) config.getOrDefault("virtual", false);
+        this.addStatistics = (boolean) config.getOrDefault("statistics", false);
+        this.readOnly = (boolean) config.getOrDefault("readOnly", true);
+        this.streamStatements = (boolean) config.getOrDefault("streamStatements", false);
+        this.databaseName = (String) config.getOrDefault("databaseName", "neo4j");
+        this.driverConfig = toDriverConfig((Map<String, Object>) config.getOrDefault("driverConfig", Collections.emptyMap()));
+        this.localParams = (Map<String, Object>) config.getOrDefault("localParams", Collections.emptyMap());
+        this.remoteParams = (Map<String, Object>) config.getOrDefault("remoteParams", Collections.emptyMap());
+    }
+
+    private Config toDriverConfig(Map<String, Object> driverConfMap) {
+        String logging = (String) driverConfMap.getOrDefault("logging", "INFO");
+        boolean encryption = (boolean) driverConfMap.getOrDefault("encryption", false);
+        boolean logLeakedSessions = (boolean) driverConfMap.getOrDefault("logLeakedSessions", true);
+        Long idleTimeBeforeConnectionTest = (Long) driverConfMap.getOrDefault("idleTimeBeforeConnectionTest", -1L);
+        String trustStrategy = (String) driverConfMap.getOrDefault("trustStrategy", "TRUST_ALL_CERTIFICATES");
+        Long connectionTimeoutMillis = (Long) driverConfMap.get("connectionTimeoutMillis");
+        Long maxRetryTimeMs = (Long) driverConfMap.get("maxRetryTimeMs");
+        Long maxConnectionLifeTime = (Long) driverConfMap.get("maxConnectionLifeTime");
+        Long maxConnectionPoolSize = (Long) driverConfMap.get("maxConnectionPoolSize");
+        Long routingTablePurgeDelay = (Long) driverConfMap.get("routingTablePurgeDelay");
+        Long connectionAcquisitionTimeout = (Long) driverConfMap.get("connectionAcquisitionTimeout");
+
+        Config.ConfigBuilder config = Config.builder();
+
+        config.withLogging(new JULogging(Level.parse(logging)));
+        if(encryption) config.withEncryption();
+        config.withTrustStrategy(Config.TrustStrategy.trustAllCertificates());
+        if(!logLeakedSessions) config.withoutEncryption();
+
+        if (connectionAcquisitionTimeout!=null) {
+            config.withConnectionAcquisitionTimeout(connectionAcquisitionTimeout, TimeUnit.MILLISECONDS);
+        }
+        if (maxConnectionLifeTime!=null) {
+            config.withMaxConnectionLifetime(maxConnectionLifeTime, TimeUnit.MILLISECONDS);
+        }
+        if (maxConnectionPoolSize!=null) {
+            config.withMaxConnectionPoolSize(maxConnectionPoolSize.intValue());
+        }
+        if (routingTablePurgeDelay!=null) {
+            config.withRoutingTablePurgeDelay(routingTablePurgeDelay, TimeUnit.MILLISECONDS);
+        }
+        if (idleTimeBeforeConnectionTest!=null) {
+            config.withConnectionLivenessCheckTimeout(idleTimeBeforeConnectionTest, TimeUnit.MILLISECONDS);
+        }
+        if (connectionTimeoutMillis!=null) {
+            config.withConnectionTimeout(connectionTimeoutMillis, TimeUnit.MILLISECONDS);
+        }
+        if (maxRetryTimeMs!=null) {
+            config.withMaxTransactionRetryTime(maxRetryTimeMs, TimeUnit.MILLISECONDS);
+        }
+        if(trustStrategy.equals("TRUST_ALL_CERTIFICATES")) config.withTrustStrategy(Config.TrustStrategy.trustAllCertificates());
+        else if(trustStrategy.equals("TRUST_SYSTEM_CA_SIGNED_CERTIFICATES")) config.withTrustStrategy(Config.TrustStrategy.trustSystemCertificates());
+        else {
+            File file = new File(trustStrategy);
+            config.withTrustStrategy(Config.TrustStrategy.trustCustomCertificateSignedBy(file));
+        }
+        return config.build();
+    }
+
+    public SessionConfig getSessionConfig() {
+        return SessionConfig.builder()
+                .withDatabase(this.databaseName)
+                .withDefaultAccessMode(readOnly ? AccessMode.READ : AccessMode.WRITE)
+                .build();
+    }
+
+    public boolean isVirtual() {
+        return virtual;
+    }
+
+    public boolean isAddStatistics() {
+        return addStatistics;
+    }
+
+
+    public boolean isStreamStatements() {
+        return streamStatements;
+    }
+
+    public Config getDriverConfig() {
+        return driverConfig;
+    }
+
+    public Map<String, Object> getLocalParams() {
+        return localParams;
+    }
+
+    public Map<String, Object> getRemoteParams() {
+        return remoteParams;
+    }
+}

--- a/src/test/java/apoc/bolt/BoltTest.java
+++ b/src/test/java/apoc/bolt/BoltTest.java
@@ -1,5 +1,7 @@
 package apoc.bolt;
 
+import apoc.cypher.Cypher;
+import apoc.export.cypher.ExportCypher;
 import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestUtil;
 import apoc.util.Util;
@@ -20,8 +22,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static apoc.util.TestContainerUtil.createEnterpriseDB;
 import static apoc.util.TestUtil.isTravis;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
 import static org.neo4j.driver.Values.isoDuration;
@@ -43,16 +48,15 @@ public class BoltTest {
     public static void setUp() throws Exception {
         assumeFalse(isTravis());
         TestUtil.ignoreException(() -> {
-            neo4jContainer = new Neo4jContainerExtension()
+            neo4jContainer = createEnterpriseDB(!isTravis())
                     .withInitScript("init_neo4j_bolt.cypher")
-                    .withLogging()
                     .withoutAuthentication();
             neo4jContainer.start();
         }, Exception.class);
         assumeNotNull(neo4jContainer);
         BOLT_URL = "'" + neo4jContainer.getBoltUrl() + "'";
 
-        TestUtil.registerProcedure(db, Bolt.class);
+        TestUtil.registerProcedure(db, Bolt.class, ExportCypher.class, Cypher.class);
     }
 
     @AfterClass
@@ -64,338 +68,387 @@ public class BoltTest {
 
     @Test
     public void testLoadNodeVirtual() throws Exception {
-            TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match(p:Person {name:$name}) return p', {name:'Michael'}, {virtual:true})", r -> {
-                assertNotNull(r);
-                Map<String, Object> row = (Map<String, Object>) r.get("row");
-                Node node = (Node) row.get("p");
-                assertEquals(true, node.hasLabel(Label.label("Person")));
-                assertEquals("Michael", node.getProperty("name"));
-                assertEquals("Jordan", node.getProperty("surname"));
-                assertEquals(true, node.getProperty("state"));
-                assertEquals(54L, node.getProperty("age"));
-            });
+        TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match(p:Person {name:$name}) return p', {name:'Michael'}, {virtual:true})", r -> {
+            assertNotNull(r);
+            Map<String, Object> row = (Map<String, Object>) r.get("row");
+            Node node = (Node) row.get("p");
+            assertEquals(true, node.hasLabel(Label.label("Person")));
+            assertEquals("Michael", node.getProperty("name"));
+            assertEquals("Jordan", node.getProperty("surname"));
+            assertEquals(true, node.getProperty("state"));
+            assertEquals(54L, node.getProperty("age"));
+        });
     }
 
     @Test
     public void testLoadNodesVirtual() throws Exception {
-            TestUtil.testResult(db, "call apoc.bolt.load(" + BOLT_URL + ",'match(n) return n', {}, {virtual:true})", r -> {
-                assertNotNull(r);
-                Map<String, Object> row = r.next();
-                Map result = (Map) row.get("row");
-                Node node = (Node) result.get("n");
-                assertEquals(true, node.hasLabel(Label.label("Person")));
-                assertEquals("Michael", node.getProperty("name"));
-                assertEquals("Jordan", node.getProperty("surname"));
-                assertEquals(true, node.getProperty("state"));
-                assertEquals(54L, node.getProperty("age"));
-                row = r.next();
-                result = (Map) row.get("row");
-                node = (Node) result.get("n");
-                assertEquals(true, node.hasLabel(Label.label("Person")));
-                assertEquals("Tom", node.getProperty("name"));
-                assertEquals("Burton", node.getProperty("surname"));
-                assertEquals(23L, node.getProperty("age"));
-                row = r.next();
-                result = (Map) row.get("row");
-                node = (Node) result.get("n");
-                assertEquals(true, node.hasLabel(Label.label("Person")));
-                assertEquals("John", node.getProperty("name"));
-                assertEquals("William", node.getProperty("surname"));
-                assertEquals(22L, node.getProperty("age"));
-            });
+        TestUtil.testResult(db, "call apoc.bolt.load(" + BOLT_URL + ",'match(n) return n', {}, {virtual:true})", r -> {
+            assertNotNull(r);
+            Map<String, Object> row = r.next();
+            Map result = (Map) row.get("row");
+            Node node = (Node) result.get("n");
+            assertEquals(true, node.hasLabel(Label.label("Person")));
+            assertEquals("Michael", node.getProperty("name"));
+            assertEquals("Jordan", node.getProperty("surname"));
+            assertEquals(true, node.getProperty("state"));
+            assertEquals(54L, node.getProperty("age"));
+            row = r.next();
+            result = (Map) row.get("row");
+            node = (Node) result.get("n");
+            assertEquals(true, node.hasLabel(Label.label("Person")));
+            assertEquals("Tom", node.getProperty("name"));
+            assertEquals("Burton", node.getProperty("surname"));
+            assertEquals(23L, node.getProperty("age"));
+            row = r.next();
+            result = (Map) row.get("row");
+            node = (Node) result.get("n");
+            assertEquals(true, node.hasLabel(Label.label("Person")));
+            assertEquals("John", node.getProperty("name"));
+            assertEquals("William", node.getProperty("surname"));
+            assertEquals(22L, node.getProperty("age"));
+        });
     }
 
     @Test
     public void testLoadPathVirtual() throws Exception {
-            TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'START neo=node($idNode)  MATCH path= (neo)-[r:KNOWS*..3]->(other) return path', {idNode:1}, {virtual:true})", r -> {
-                assertNotNull(r);
-                Map<String, Object> row = (Map<String, Object>) r.get("row");
-                List<Object> path = (List<Object>) row.get("path");
-                Node start = (Node) path.get(0);
-                assertEquals(true, start.hasLabel(Label.label("Person")));
-                assertEquals("Tom", start.getProperty("name"));
-                assertEquals("Burton", start.getProperty("surname"));
-                Node end = (Node) path.get(2);
-                assertEquals(true, end.hasLabel(Label.label("Person")));
-                assertEquals("John", end.getProperty("name"));
-                assertEquals("William", end.getProperty("surname"));
-                Relationship rel = (Relationship) path.get(1);
-                assertEquals("KNOWS", rel.getType().name());
-                assertEquals(2016L, rel.getProperty("since"));
-                assertEquals(OffsetTime.parse("12:50:35.556+01:00"), rel.getProperty("time"));
-            });
+        TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'MATCH path= (neo)-[r:KNOWS*..3]->(other) WHERE id(neo) = $idNode return path', {idNode:1}, {virtual:true})", r -> {
+            assertNotNull(r);
+            Map<String, Object> row = (Map<String, Object>) r.get("row");
+            List<Object> path = (List<Object>) row.get("path");
+            Node start = (Node) path.get(0);
+            assertEquals(true, start.hasLabel(Label.label("Person")));
+            assertEquals("Tom", start.getProperty("name"));
+            assertEquals("Burton", start.getProperty("surname"));
+            Node end = (Node) path.get(2);
+            assertEquals(true, end.hasLabel(Label.label("Person")));
+            assertEquals("John", end.getProperty("name"));
+            assertEquals("William", end.getProperty("surname"));
+            Relationship rel = (Relationship) path.get(1);
+            assertEquals("KNOWS", rel.getType().name());
+            assertEquals(2016L, rel.getProperty("since"));
+            assertEquals(OffsetTime.parse("12:50:35.556+01:00"), rel.getProperty("time"));
+        });
     }
 
     @Test
     public void testLoadRel() throws Exception {
-            TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match(p)-[r]->(c) return r limit 1', {}, {virtual:true})", r -> {
-                assertNotNull(r);
-                Map<String, Object> row = (Map<String, Object>) r.get("row");
-                Relationship rel = (Relationship) row.get("r");
-                assertEquals("KNOWS", rel.getType().name());
-                assertEquals(2016L, rel.getProperty("since"));
-                assertEquals(OffsetTime.parse("12:50:35.556+01:00"), rel.getProperty("time"));
-            });
+        TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match(p)-[r]->(c) return r limit 1', {}, {virtual:true})", r -> {
+            assertNotNull(r);
+            Map<String, Object> row = (Map<String, Object>) r.get("row");
+            Relationship rel = (Relationship) row.get("r");
+            assertEquals("KNOWS", rel.getType().name());
+            assertEquals(2016L, rel.getProperty("since"));
+            assertEquals(OffsetTime.parse("12:50:35.556+01:00"), rel.getProperty("time"));
+        });
     }
 
     @Test
     public void testLoadRelsAndNodes() throws Exception {
-            TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match(p:Person {surname:$surnameP})-[r]->(c:Person {surname:$surnameC}) return *', {surnameP:\"Burton\", surnameC:\"William\"}, {virtual:true})", r -> {
-                Map result = (Map) r.get("row");
-                Node node = (Node) result.get("p");
-                assertEquals(true, node.hasLabel(Label.label("Person")));
-                assertEquals("Tom", node.getProperty("name"));
-                assertEquals("Burton", node.getProperty("surname"));
-                assertEquals(23L, node.getProperty("age"));
-                node = (Node) result.get("c");
-                assertEquals(true, node.hasLabel(Label.label("Person")));
-                assertEquals("John", node.getProperty("name"));
-                assertEquals("William", node.getProperty("surname"));
-                assertEquals(22L, node.getProperty("age"));
-            });
+        TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match(p:Person {surname:$surnameP})-[r]->(c:Person {surname:$surnameC}) return *', {surnameP:\"Burton\", surnameC:\"William\"}, {virtual:true})", r -> {
+            Map result = (Map) r.get("row");
+            Node node = (Node) result.get("p");
+            assertEquals(true, node.hasLabel(Label.label("Person")));
+            assertEquals("Tom", node.getProperty("name"));
+            assertEquals("Burton", node.getProperty("surname"));
+            assertEquals(23L, node.getProperty("age"));
+            node = (Node) result.get("c");
+            assertEquals(true, node.hasLabel(Label.label("Person")));
+            assertEquals("John", node.getProperty("name"));
+            assertEquals("William", node.getProperty("surname"));
+            assertEquals(22L, node.getProperty("age"));
+        });
     }
 
     @Test
     public void testLoadNullParams() throws Exception {
-            TestUtil.testCall(db, "call apoc.bolt.load("+BOLT_URL+",\"match(p:Person {name:'Michael'}) return p\")", r -> {
-                assertNotNull(r);
-                Map<String, Object> row = (Map<String, Object>) r.get("row");
-                Map<String, Object> node = (Map<String, Object>) row.get("p");
-                assertTrue(node.containsKey("entityType"));
-                assertEquals("NODE", node.get("entityType"));
-                assertTrue(node.containsKey("properties"));
-                Map<String, Object> properties = (Map<String, Object>) node.get("properties");
-                assertEquals("Michael", properties.get("name"));
-                assertEquals("Jordan", properties.get("surname"));
-                assertEquals(54L, properties.get("age"));
-                assertEquals(true, properties.get("state"));
-            });
+        TestUtil.testCall(db, "call apoc.bolt.load("+BOLT_URL+",\"match(p:Person {name:'Michael'}) return p\")", r -> {
+            assertNotNull(r);
+            Map<String, Object> row = (Map<String, Object>) r.get("row");
+            Map<String, Object> node = (Map<String, Object>) row.get("p");
+            assertTrue(node.containsKey("entityType"));
+            assertEquals("NODE", node.get("entityType"));
+            assertTrue(node.containsKey("properties"));
+            Map<String, Object> properties = (Map<String, Object>) node.get("properties");
+            assertEquals("Michael", properties.get("name"));
+            assertEquals("Jordan", properties.get("surname"));
+            assertEquals(54L, properties.get("age"));
+            assertEquals(true, properties.get("state"));
+        });
     }
 
     @Test
     public void testLoadNode() throws Exception {
-            TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match (p:Person {name:$name}) return p', {name:'Michael'})", r -> {
-                assertNotNull(r);
-                Map<String, Object> row = (Map<String, Object>) r.get("row");
-                Map<String, Object> node = (Map<String, Object>) row.get("p");
-                assertTrue(node.containsKey("entityType"));
-                assertEquals("NODE", node.get("entityType"));
-                assertTrue(node.containsKey("properties"));
-                Map<String, Object> properties = (Map<String, Object>) node.get("properties");
-                assertEquals("Michael", properties.get("name"));
-                assertEquals("Jordan", properties.get("surname"));
-                assertEquals(54L, properties.get("age"));
-                assertEquals(true, properties.get("state"));
-            });
+        TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match (p:Person {name:$name}) return p', {name:'Michael'})", r -> {
+            assertNotNull(r);
+            Map<String, Object> row = (Map<String, Object>) r.get("row");
+            Map<String, Object> node = (Map<String, Object>) row.get("p");
+            assertTrue(node.containsKey("entityType"));
+            assertEquals("NODE", node.get("entityType"));
+            assertTrue(node.containsKey("properties"));
+            Map<String, Object> properties = (Map<String, Object>) node.get("properties");
+            assertEquals("Michael", properties.get("name"));
+            assertEquals("Jordan", properties.get("surname"));
+            assertEquals(54L, properties.get("age"));
+            assertEquals(true, properties.get("state"));
+        });
     }
 
     @Test
     public void testLoadScalarSingleReusult() throws Exception {
-            TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match (n:Person {name:$name}) return n.age as Age', {name:'Michael'})", (r) -> {
-                assertNotNull(r);
-                Map<String, Object> row = (Map<String, Object>) r.get("row");
-                assertTrue(row.containsKey("Age"));
-                assertEquals(54L, row.get("Age"));
-            });
+        TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match (n:Person {name:$name}) return n.age as Age', {name:'Michael'})", (r) -> {
+            assertNotNull(r);
+            Map<String, Object> row = (Map<String, Object>) r.get("row");
+            assertTrue(row.containsKey("Age"));
+            assertEquals(54L, row.get("Age"));
+        });
     }
 
     @Test
     public void testLoadMixedContent() throws Exception {
-            TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match (n:Person {name:$name}) return n.age, n.name, n.state', {name:'Michael'})",
-                    r -> {
-                        assertNotNull(r);
-                        Map<String, Object> row = (Map<String, Object>) r.get("row");
-                        assertTrue(row.containsKey("n.age"));
-                        assertEquals(54L, row.get("n.age"));
-                        assertTrue(row.containsKey("n.name"));
-                        assertEquals("Michael", row.get("n.name"));
-                        assertTrue(row.containsKey("n.state"));
-                        assertEquals(true, row.get("n.state"));
-                    });
+        TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match (n:Person {name:$name}) return n.age, n.name, n.state', {name:'Michael'})",
+                r -> {
+                    assertNotNull(r);
+                    Map<String, Object> row = (Map<String, Object>) r.get("row");
+                    assertTrue(row.containsKey("n.age"));
+                    assertEquals(54L, row.get("n.age"));
+                    assertTrue(row.containsKey("n.name"));
+                    assertEquals("Michael", row.get("n.name"));
+                    assertTrue(row.containsKey("n.state"));
+                    assertEquals(true, row.get("n.state"));
+                });
     }
 
     @Test
     public void testLoadList() throws Exception {
-            TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match (p:Person {name:$name})  with collect({personName:p.name}) as rows return rows', {name:'Michael'})", r -> {
-                assertNotNull(r);
-                Map<String, Object> row = (Map<String, Object>) r.get("row");
-                List<Collections> p = (List<Collections>) row.get("rows");
-                Map<String, Object> result = (Map<String, Object>) p.get(0);
-                assertTrue(result.containsKey("personName"));
-                assertEquals("Michael", result.get("personName"));
-            });
+        TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match (p:Person {name:$name})  with collect({personName:p.name}) as rows return rows', {name:'Michael'})", r -> {
+            assertNotNull(r);
+            Map<String, Object> row = (Map<String, Object>) r.get("row");
+            List<Collections> p = (List<Collections>) row.get("rows");
+            Map<String, Object> result = (Map<String, Object>) p.get(0);
+            assertTrue(result.containsKey("personName"));
+            assertEquals("Michael", result.get("personName"));
+        });
     }
 
     @Test
     public void testLoadMap() throws Exception {
-            TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match (p:Person {name:$name})  with p,collect({personName:p.name}) as rows return p{.*, rows:rows}', {name:'Michael'})", r -> {
-                assertNotNull(r);
-                Map<String, Object> row = (Map<String, Object>) r.get("row");
-                Map<String, Object> p = (Map<String, Object>) row.get("p");
-                assertTrue(p.containsKey("name"));
-                assertEquals("Michael", p.get("name"));
-                assertTrue(p.containsKey("age"));
-                assertEquals(54L, p.get("age"));
-                assertTrue(p.containsKey("surname"));
-                assertEquals("Jordan", p.get("surname"));
-                assertTrue(p.containsKey("state"));
-                assertEquals(true, p.get("state"));
-            });
+        TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match (p:Person {name:$name})  with p,collect({personName:p.name}) as rows return p{.*, rows:rows}', {name:'Michael'})", r -> {
+            assertNotNull(r);
+            Map<String, Object> row = (Map<String, Object>) r.get("row");
+            Map<String, Object> p = (Map<String, Object>) row.get("p");
+            assertTrue(p.containsKey("name"));
+            assertEquals("Michael", p.get("name"));
+            assertTrue(p.containsKey("age"));
+            assertEquals(54L, p.get("age"));
+            assertTrue(p.containsKey("surname"));
+            assertEquals("Jordan", p.get("surname"));
+            assertTrue(p.containsKey("state"));
+            assertEquals(true, p.get("state"));
+        });
     }
 
     @Test
     public void testLoadPath() throws Exception {
-            TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'MATCH path= (neo)-[r:KNOWS*..3]->(other) where id(neo) = $idNode return path', {idNode:1}, {})", r -> {
-                assertNotNull(r);
-                Map<String, Object> row = (Map<String, Object>) r.get("row");
-                List<Object> path = (List<Object>) row.get("path");
-                Map<String, Object> startNode = (Map<String, Object>) path.get(0);
-                assertEquals("NODE", startNode.get("entityType"));
-                assertEquals(Arrays.asList("Person"), startNode.get("labels"));
-                Map<String, Object> startNodeProperties = (Map<String, Object>) startNode.get("properties");
-                assertEquals("Tom", startNodeProperties.get("name"));
-                assertEquals("Burton", startNodeProperties.get("surname"));
-                Map<String, Object> endNode = (Map<String, Object>) path.get(2);
-                assertEquals("NODE", startNode.get("entityType"));
-                assertEquals(Arrays.asList("Person"), startNode.get("labels"));
-                Map<String, Object> endNodeProperties = (Map<String, Object>) endNode.get("properties");
-                assertEquals("John", endNodeProperties.get("name"));
-                assertEquals("William", endNodeProperties.get("surname"));
-                Map<String, Object> rel = (Map<String, Object>) path.get(1);
-                assertEquals("RELATIONSHIP", rel.get("entityType"));
-                assertEquals("KNOWS", rel.get("type"));
-                Map<String, Object> relProperties = (Map<String, Object>) rel.get("properties");
-                assertEquals(2016L, relProperties.get("since"));
-                assertEquals(OffsetTime.parse("12:50:35.556+01:00"), relProperties.get("time"));
-            });
+        TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'MATCH path= (neo)-[r:KNOWS*..3]->(other) where id(neo) = $idNode return path', {idNode:1}, {})", r -> {
+            assertNotNull(r);
+            Map<String, Object> row = (Map<String, Object>) r.get("row");
+            List<Object> path = (List<Object>) row.get("path");
+            Map<String, Object> startNode = (Map<String, Object>) path.get(0);
+            assertEquals("NODE", startNode.get("entityType"));
+            assertEquals(Arrays.asList("Person"), startNode.get("labels"));
+            Map<String, Object> startNodeProperties = (Map<String, Object>) startNode.get("properties");
+            assertEquals("Tom", startNodeProperties.get("name"));
+            assertEquals("Burton", startNodeProperties.get("surname"));
+            Map<String, Object> endNode = (Map<String, Object>) path.get(2);
+            assertEquals("NODE", startNode.get("entityType"));
+            assertEquals(Arrays.asList("Person"), startNode.get("labels"));
+            Map<String, Object> endNodeProperties = (Map<String, Object>) endNode.get("properties");
+            assertEquals("John", endNodeProperties.get("name"));
+            assertEquals("William", endNodeProperties.get("surname"));
+            Map<String, Object> rel = (Map<String, Object>) path.get(1);
+            assertEquals("RELATIONSHIP", rel.get("entityType"));
+            assertEquals("KNOWS", rel.get("type"));
+            Map<String, Object> relProperties = (Map<String, Object>) rel.get("properties");
+            assertEquals(2016L, relProperties.get("since"));
+            assertEquals(OffsetTime.parse("12:50:35.556+01:00"), relProperties.get("time"));
+        });
     }
 
     @Test
     public void testLoadRels() throws Exception {
-            TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match (n)-[r]->(c) return r as rel limit 1', {})", (r) -> {
-                assertNotNull(r);
-                Map<String, Object> row = (Map<String, Object>) r.get("row");
-                Map<String, Object> rel = (Map<String, Object>) row.get("rel");
-                assertEquals(1L, rel.get("start"));
-                assertEquals(2L, rel.get("end"));
-                assertEquals("RELATIONSHIP", rel.get("entityType"));
-                assertEquals("KNOWS", rel.get("type"));
-                Map<String, Object> properties = (Map<String, Object>) rel.get("properties");
-                assertEquals(2016L, properties.get("since"));
-                assertEquals(OffsetTime.parse("12:50:35.556+01:00"), properties.get("time"));
-            });
+        TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'match (n)-[r]->(c) return r as rel limit 1', {})", (r) -> {
+            assertNotNull(r);
+            Map<String, Object> row = (Map<String, Object>) r.get("row");
+            Map<String, Object> rel = (Map<String, Object>) row.get("rel");
+            assertEquals(1L, rel.get("start"));
+            assertEquals(2L, rel.get("end"));
+            assertEquals("RELATIONSHIP", rel.get("entityType"));
+            assertEquals("KNOWS", rel.get("type"));
+            Map<String, Object> properties = (Map<String, Object>) rel.get("properties");
+            assertEquals(2016L, properties.get("since"));
+            assertEquals(OffsetTime.parse("12:50:35.556+01:00"), properties.get("time"));
+        });
     }
 
     @Test
     public void testExecuteCreateNodeStatistic() throws Exception {
-            TestUtil.testResult(db, "call apoc.bolt.execute(" + BOLT_URL + ",'create(n:Node {name:$name})', {name:'Node1'}, {statistics:true})", Collections.emptyMap(),
-                    r -> {
-                        assertNotNull(r);
-                        Map<String, Object> row = r.next();
-                        Map result = (Map) row.get("row");
-                        assertEquals(1L, (long) Util.toLong(result.get("nodesCreated")));
-                        assertEquals(1L, (long) Util.toLong(result.get("labelsAdded")));
-                        assertEquals(1L, (long) Util.toLong(result.get("propertiesSet")));
-                        assertEquals(false, r.hasNext());
-                    });
+        TestUtil.testResult(db, "call apoc.bolt.execute(" + BOLT_URL + ",'create(n:Node {name:$name})', {name:'Node1'}, {statistics:true})", Collections.emptyMap(),
+                r -> {
+                    assertNotNull(r);
+                    Map<String, Object> row = r.next();
+                    Map result = (Map) row.get("row");
+                    assertEquals(1L, (long) Util.toLong(result.get("nodesCreated")));
+                    assertEquals(1L, (long) Util.toLong(result.get("labelsAdded")));
+                    assertEquals(1L, (long) Util.toLong(result.get("propertiesSet")));
+                    assertEquals(false, r.hasNext());
+                });
     }
 
     @Test
     public void testExecuteCreateVirtualNode() throws Exception {
-            TestUtil.testCall(db, "call apoc.bolt.execute(" + BOLT_URL + ",'create(n:Node {name:$name}) return n', {name:'Node1'}, {virtual:true})",
-                    r -> {
-                        assertNotNull(r);
-                        Map<String, Object> row = (Map<String, Object>) r.get("row");
-                        Node node = (Node) row.get("n");
-                        assertEquals(true, node.hasLabel(Label.label("Node")));
-                        assertEquals("Node1", node.getProperty("name"));
-                    });
+        TestUtil.testCall(db, "call apoc.bolt.execute(" + BOLT_URL + ",'create(n:Node {name:$name}) return n', {name:'Node1'}, {virtual:true})",
+                r -> {
+                    assertNotNull(r);
+                    Map<String, Object> row = (Map<String, Object>) r.get("row");
+                    Node node = (Node) row.get("n");
+                    assertEquals(true, node.hasLabel(Label.label("Node")));
+                    assertEquals("Node1", node.getProperty("name"));
+                });
     }
 
     @Test
     public void testLoadNoVirtual() throws Exception {
-            TestUtil.testCall(db, "call apoc.bolt.load("+BOLT_URL+",\"match(p:Person {name:'Michael'}) return p\", {}, {virtual:false, test:false})",
-                    r -> {
-                        assertNotNull(r);
-                        Map<String, Object> row = (Map<String, Object>) r.get("row");
-                        Map<String, Object> node = (Map<String, Object>) row.get("p");
-                        assertTrue(node.containsKey("entityType"));
-                        assertEquals("NODE", node.get("entityType"));
-                        assertTrue(node.containsKey("properties"));
-                        Map<String, Object> properties = (Map<String, Object>) node.get("properties");
-                        assertEquals("Michael", properties.get("name"));
-                        assertEquals("Jordan", properties.get("surname"));
-                        assertEquals(54L, properties.get("age"));
-                        assertEquals(true, properties.get("state"));
-                    });
+        TestUtil.testCall(db, "call apoc.bolt.load("+BOLT_URL+",\"match(p:Person {name:'Michael'}) return p\", {}, {virtual:false, test:false})",
+                r -> {
+                    assertNotNull(r);
+                    Map<String, Object> row = (Map<String, Object>) r.get("row");
+                    Map<String, Object> node = (Map<String, Object>) row.get("p");
+                    assertTrue(node.containsKey("entityType"));
+                    assertEquals("NODE", node.get("entityType"));
+                    assertTrue(node.containsKey("properties"));
+                    Map<String, Object> properties = (Map<String, Object>) node.get("properties");
+                    assertEquals("Michael", properties.get("name"));
+                    assertEquals("Jordan", properties.get("surname"));
+                    assertEquals(54L, properties.get("age"));
+                    assertEquals(true, properties.get("state"));
+                });
     }
 
     @Test
     public void testLoadNodeWithDriverConfig() throws Exception {
-            TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",\"match(p:Person {name:$nameP}) return p\", {nameP:'Michael'}, " +
-                            "{driverConfig:{logging:'WARNING', encryption: false,logLeakedSessions:true, maxIdleConnectionPoolSize:10, idleTimeBeforeConnectionTest:-1," +
-                            " routingFailureLimit: 1, routingRetryDelayMillis:500, connectionTimeoutMillis:500, maxRetryTimeMs:30000 , trustStrategy:'TRUST_ALL_CERTIFICATES'}})",
-                    r -> {
-                        assertNotNull(r);
-                        Map<String, Object> row = (Map<String, Object>) r.get("row");
-                        Map<String, Object> node = (Map<String, Object>) row.get("p");
-                        assertTrue(node.containsKey("entityType"));
-                        assertEquals("NODE", node.get("entityType"));
-                        assertTrue(node.containsKey("properties"));
-                        Map<String, Object> properties = (Map<String, Object>) node.get("properties");
-                        assertEquals("Michael", properties.get("name"));
-                        assertEquals("Jordan", properties.get("surname"));
-                        assertEquals(54L, properties.get("age"));
-                        assertEquals(true, properties.get("state"));
-                    });
+        TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",\"match(p:Person {name:$nameP}) return p\", {nameP:'Michael'}, " +
+                        "{driverConfig:{logging:'WARNING', encryption: false,logLeakedSessions:true, maxIdleConnectionPoolSize:10, idleTimeBeforeConnectionTest:-1," +
+                        " routingFailureLimit: 1, routingRetryDelayMillis:500, connectionTimeoutMillis:500, maxRetryTimeMs:30000 , trustStrategy:'TRUST_ALL_CERTIFICATES'}})",
+                r -> {
+                    assertNotNull(r);
+                    Map<String, Object> row = (Map<String, Object>) r.get("row");
+                    Map<String, Object> node = (Map<String, Object>) row.get("p");
+                    assertTrue(node.containsKey("entityType"));
+                    assertEquals("NODE", node.get("entityType"));
+                    assertTrue(node.containsKey("properties"));
+                    Map<String, Object> properties = (Map<String, Object>) node.get("properties");
+                    assertEquals("Michael", properties.get("name"));
+                    assertEquals("Jordan", properties.get("surname"));
+                    assertEquals(54L, properties.get("age"));
+                    assertEquals(true, properties.get("state"));
+                });
     }
 
     @Test
     public void testLoadBigPathVirtual() throws Exception {
-            TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'MATCH path= (neo)-[r:KNOWS*3]->(other) WHERE id(neo) = $idNode return path', {idNode:3}, {virtual:true})", r -> {
-                Map<String, Object> row = (Map<String, Object>) r.get("row");
-                List<Object> path = (List<Object>) row.get("path");
-                Node start = (Node) path.get(0);
-                assertEquals(true, start.hasLabel(Label.label("Person")));
-                assertEquals("Tom", start.getProperty("name"));
-                assertEquals("Loagan", start.getProperty("surname"));
-                assertEquals(isoDuration(5, 1, 43200, 0).asIsoDuration(), start.getProperty("duration"));
-                Relationship rel = (Relationship) path.get(1);
-                assertEquals("KNOWS", rel.getType().name());
-                assertEquals(LocalTime.parse("12:50:35.556"), rel.getProperty("since"));
-                assertEquals(point(4326, 56.7, 12.78).asPoint(), rel.getProperty("born"));
-                Node end = (Node) path.get(2);
-                assertEquals(true, end.hasLabel(Label.label("Person")));
-                assertEquals("John", end.getProperty("name"));
-                assertEquals("Green", end.getProperty("surname"));
-                assertEquals(point(7203, 2.3, 4.5).asPoint(), end.getProperty("born"));
-                start = (Node) path.get(3);
-                assertEquals(true, start.hasLabel(Label.label("Person")));
-                assertEquals("John", start.getProperty("name"));
-                assertEquals("Green", start.getProperty("surname"));
-                assertEquals(point(7203, 2.3, 4.5).asPoint(), end.getProperty("born"));
-                rel = (Relationship) path.get(4);
-                assertEquals("KNOWS", rel.getType().name());
-                assertEquals(OffsetTime.parse("12:50:35.556+01:00"), rel.getProperty("since"));
-                assertEquals(point(4979, 56.7, 12.78, 100.0).asPoint(), rel.getProperty("born"));
-                end = (Node) path.get(5);
-                assertEquals(true, end.hasLabel(Label.label("Person")));
-                assertEquals("Jim", end.getProperty("name"));
-                assertEquals("Brown", end.getProperty("surname"));
-                start = (Node) path.get(6);
-                assertEquals(true, start.hasLabel(Label.label("Person")));
-                assertEquals("Jim", start.getProperty("name"));
-                assertEquals("Brown", start.getProperty("surname"));
-                rel = (Relationship) path.get(7);
-                assertEquals("KNOWS", rel.getType().name());
-                assertEquals(2013L, rel.getProperty("since"));
-                end = (Node) path.get(8);
-                assertEquals(true, end.hasLabel(Label.label("Person")));
-                assertEquals("Anne", end.getProperty("name"));
-                assertEquals("Olsson", end.getProperty("surname"));
-                assertEquals(point(9157,2.3, 4.5, 1.2).asPoint(), end.getProperty("born"));
-            });
+        TestUtil.testCall(db, "call apoc.bolt.load(" + BOLT_URL + ",'MATCH path= (neo)-[r:KNOWS*3]->(other) WHERE id(neo) = $idNode return path', {idNode:3}, {virtual:true})", r -> {
+            Map<String, Object> row = (Map<String, Object>) r.get("row");
+            List<Object> path = (List<Object>) row.get("path");
+            Node start = (Node) path.get(0);
+            assertEquals(true, start.hasLabel(Label.label("Person")));
+            assertEquals("Tom", start.getProperty("name"));
+            assertEquals("Loagan", start.getProperty("surname"));
+            assertEquals(isoDuration(5, 1, 43200, 0).asIsoDuration(), start.getProperty("duration"));
+            Relationship rel = (Relationship) path.get(1);
+            assertEquals("KNOWS", rel.getType().name());
+            assertEquals(LocalTime.parse("12:50:35.556"), rel.getProperty("since"));
+            assertEquals(point(4326, 56.7, 12.78).asPoint(), rel.getProperty("born"));
+            Node end = (Node) path.get(2);
+            assertEquals(true, end.hasLabel(Label.label("Person")));
+            assertEquals("John", end.getProperty("name"));
+            assertEquals("Green", end.getProperty("surname"));
+            assertEquals(point(7203, 2.3, 4.5).asPoint(), end.getProperty("born"));
+            start = (Node) path.get(3);
+            assertEquals(true, start.hasLabel(Label.label("Person")));
+            assertEquals("John", start.getProperty("name"));
+            assertEquals("Green", start.getProperty("surname"));
+            assertEquals(point(7203, 2.3, 4.5).asPoint(), end.getProperty("born"));
+            rel = (Relationship) path.get(4);
+            assertEquals("KNOWS", rel.getType().name());
+            assertEquals(OffsetTime.parse("12:50:35.556+01:00"), rel.getProperty("since"));
+            assertEquals(point(4979, 56.7, 12.78, 100.0).asPoint(), rel.getProperty("born"));
+            end = (Node) path.get(5);
+            assertEquals(true, end.hasLabel(Label.label("Person")));
+            assertEquals("Jim", end.getProperty("name"));
+            assertEquals("Brown", end.getProperty("surname"));
+            start = (Node) path.get(6);
+            assertEquals(true, start.hasLabel(Label.label("Person")));
+            assertEquals("Jim", start.getProperty("name"));
+            assertEquals("Brown", start.getProperty("surname"));
+            rel = (Relationship) path.get(7);
+            assertEquals("KNOWS", rel.getType().name());
+            assertEquals(2013L, rel.getProperty("since"));
+            end = (Node) path.get(8);
+            assertEquals(true, end.hasLabel(Label.label("Person")));
+            assertEquals("Anne", end.getProperty("name"));
+            assertEquals("Olsson", end.getProperty("surname"));
+            assertEquals(point(9157,2.3, 4.5, 1.2).asPoint(), end.getProperty("born"));
+        });
     }
 
-}
+    @Test
+    public void testLoadFromLocal() throws Exception {
+        final String countQuery = "MATCH p = (s:Source{id:1})-[:REL]->(t:Target{id: 2}) RETURN count(p) AS count";
+        long localCount = db.executeTransactionally(countQuery, Collections.emptyMap(),
+                result -> result.<Long>columnAs("count").next());
+        assertEquals(0L, localCount);
+        db.executeTransactionally("CREATE (s:Source{id:1})-[:REL]->(t:Target{id: 2})");
+        String localStatement = "call apoc.export.cypher.all(null, {format:'plain', stream:true}) YIELD cypherStatements\n" +
+                "UNWIND [statement IN split(cypherStatements, \";\\n\") WHERE statement STARTS WITH 'UNWIND'] AS statement\n" +
+                "RETURN statement";
+        String remoteStatement =
+                "CALL apoc.cypher.run(statement, {}) YIELD value\n" +
+                        "RETURN value";
+        final Map<String, Object> map = Util.map("url", neo4jContainer.getBoltUrl(),
+                "localStatement", localStatement,
+                "remoteStatement", remoteStatement,
+                "config", Util.map("readOnly", false));
+        db.executeTransactionally("call apoc.bolt.load.fromLocal($url, $localStatement, $remoteStatement, $config) YIELD row return row", map);
+        final long remoteCount = neo4jContainer.getSession()
+                .readTransaction(tx -> (long) tx.run("MATCH p = (s:Source{id:1})-[:REL]->(t:Target{id: 2}) RETURN count(p) AS count")
+                        .next().asMap().get("count"));
+        assertEquals(1L, remoteCount);
+        final String deleteQuery = "MATCH p = (s:Source{id:1})-[:REL]->(t:Target{id: 2}) DELETE p";
+        db.executeTransactionally(deleteQuery);
+        neo4jContainer.getSession().readTransaction(tx -> tx.run(deleteQuery));
+    }
 
+    @Test
+    public void testLoadFromLocalStream() throws Exception {
+        final String countQuery = "MATCH p = (s:Source{id:1})-[:REL]->(t:Target{id: 2}) RETURN count(p) AS count";
+        long localCount = db.executeTransactionally(countQuery, Collections.emptyMap(),
+                result -> result.<Long>columnAs("count").next());
+        assertEquals(0L, localCount);
+        db.executeTransactionally("CREATE (s:Source{id:1})-[:REL]->(t:Target{id: 2})");
+        String localStatement = "call apoc.export.cypher.all(null, {format:'plain', stream:true}) YIELD cypherStatements\n" +
+                "UNWIND split(cypherStatements, \";\\n\") AS statement\n" +
+                "RETURN statement";
+        final Map<String, Object> map = Util.map("url", neo4jContainer.getBoltUrl(),
+                "localStatement", localStatement,
+                "remoteStatement", null,
+                "config", Util.map("readOnly", false, "streamStatements", true));
+        db.executeTransactionally("call apoc.bolt.load.fromLocal($url, $localStatement, $remoteStatement, $config)", map);
+        final long remoteCount = neo4jContainer.getSession()
+                .readTransaction(tx -> (long) tx.run("MATCH p = (s:Source{id:1})-[:REL]->(t:Target{id: 2}) RETURN count(p) AS count")
+                        .next().asMap().get("count"));
+        assertEquals(1L, remoteCount);
+        final String deleteQuery = "MATCH p = (s:Source{id:1})-[:REL]->(t:Target{id: 2}) DELETE p";
+        db.executeTransactionally(deleteQuery);
+        neo4jContainer.getSession().readTransaction(tx -> tx.run(deleteQuery));
+    }
+}


### PR DESCRIPTION
Fixes #1336

- `apoc.bolt.load.fromLocal($url, $localStatement, $remoteStatement, $config)`: which allow to execute a statement into `local` Neo4j instance with the `localStatement` variable and use the result of the execution in order use them in combination with the `remoteStatement` in the `remote` Neo4j instance. **The procedure can be useful when the user needs to call `apoc.bolt.load` more than once (maybe in an unwind) because on each call we create a new Driver (& Session) instance that can slow down the performances, while into the `fromLocal` procedure we create them once**
Please look at the related tests `testLoadFromLocal` and `testLoadFromLocalStream` into the `BoltTest` class
It the `config` contains `streamStatements` as true, the procedure assumes that the output of the `localStatement` execution is a table rows of two columns:
  - `statement`: a cypher string executed into the remote statement (mandatory)
  - `params`: a map of params related to the cypher statement (optional)

I'm closing the #1361 which is related to the branch `3.5`

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Implemented the procedure
  - Added tests

