### PR TITLE
fix docker tests on Team City

### DIFF
--- a/src/test/java/apoc/couchbase/CouchbaseTestUtils.java
+++ b/src/test/java/apoc/couchbase/CouchbaseTestUtils.java
@@ -61,7 +61,7 @@ public class CouchbaseTestUtils {
     }
 
     public static String getUrl(CouchbaseContainer couchbaseContainer) {
-        return String.format("couchbase://%s:%s@localhost:%s", USERNAME, PASSWORD, couchbaseContainer.getMappedPort(8091));
+        return String.format("couchbase://%s:%s@%s:%s", USERNAME, PASSWORD, couchbaseContainer.getContainerIpAddress(), couchbaseContainer.getMappedPort(8091));
     }
     
     @SuppressWarnings("unchecked")

--- a/src/test/java/apoc/export/cypher/ExportCypherEnterpriseFeaturesTest.java
+++ b/src/test/java/apoc/export/cypher/ExportCypherEnterpriseFeaturesTest.java
@@ -36,7 +36,6 @@ public class ExportCypherEnterpriseFeaturesTest {
         assumeFalse(isTravis());
         TestUtil.ignoreException(() -> {
             // We build the project, the artifact will be placed into ./build/libs
-            executeGradleTasks("shadow");
             neo4jContainer = createEnterpriseDB(!TestUtil.isTravis())
                     .withInitScript("init_neo4j_export_csv.cypher");
             neo4jContainer.start();

--- a/src/test/java/apoc/load/LoadCsvTest.java
+++ b/src/test/java/apoc/load/LoadCsvTest.java
@@ -335,8 +335,9 @@ RETURN m.col_1,m.col_2,m.col_3
             httpServer.start();
         }, Exception.class);
         Assume.assumeNotNull(httpServer);
+        String url = String.format("http://%s:%s", httpServer.getContainerIpAddress(), httpServer.getMappedPort(8000));
         try {
-            testResult(db, "CALL apoc.load.csv($url)", map("url", "http://localhost:" + httpServer.getMappedPort(8000)),
+            testResult(db, "CALL apoc.load.csv($url)", map("url", url),
                     (r) -> r.hasNext());
         } catch (QueryExecutionException e) {
             assertTrue(e.getMessage().contains("The redirect URI has a different protocol: file:/etc/passwd"));

--- a/src/test/java/apoc/util/TestContainerUtil.java
+++ b/src/test/java/apoc/util/TestContainerUtil.java
@@ -2,6 +2,7 @@ package apoc.util;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.ProjectConnection;
 import org.neo4j.driver.Record;
@@ -79,6 +80,7 @@ public class TestContainerUtil {
                         p.destroy();
                         cmd.withUser(s);
                     } catch (Exception e) {
+                        System.out.println("Exception while assign cmd user to docker container:\n" + ExceptionUtils.getStackTrace(e));
                         // ignore since it may fail depending on operating system
                     }
                 });

--- a/src/test/java/apoc/util/UtilIT.java
+++ b/src/test/java/apoc/util/UtilIT.java
@@ -72,6 +72,6 @@ public class UtilIT {
 
     @NotNull
     private String getServerUrl() {
-        return "http://localhost:" + httpServer.getMappedPort(8000);
+        return String.format("http://%s:%s", httpServer.getContainerIpAddress(), httpServer.getMappedPort(8000));
     }
 }


### PR DESCRIPTION
## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:
 - Added reference to container IP address instead of `localhost`
 - improved logging while we fail to assign the host user to the container
