### PR TITLE
Add documentation for date section

### DIFF
--- a/docs/asciidoc/temporal/datetime.adoc
+++ b/docs/asciidoc/temporal/datetime.adoc
@@ -6,101 +6,33 @@
 This section describes functions for working with dates and times.
 --
 
-== Conversion between formatted dates and timestamps
+Dates and times can show up in a variety of formats and configurations, often requiring translations or conversions for data storage systems, reports, web pages, and more.
+The APOC date functions allow users to take these Long or String values and manipulate them for different types of format requirements.
 
-[cols="1m,5"]
-|===
-| apoc.date.parse('2015/03/25 03:15:59',['ms'/'s'], ['yyyy/MM/dd HH:mm:ss']) | same as previous, but accepts custom datetime format
-| apoc.date.format(12345, ['ms'/'s'], ['yyyy/MM/dd HH:mm:ss']) | the same as previous, but accepts custom datetime format
-| apoc.date.systemTimezone() | return the system timezone display format string
-| apoc.date.currentTimestamp() | provides current time millis with changing values over a transaction
-|===
+[NOTE]
+====
+If you need to manipulate Date object types into other formats, please see the APOC section for https://neo4j.com/docs/labs/apoc/current/temporal/temporal-conversions/[temporal funtions].
+====
 
-* possible unit values: `ms,s,m,h,d` and their long forms `millis,milliseconds,seconds,minutes,hours,days`.
-* possible time zone values: Either an abbreviation such as `PST`, a full name such as `America/Los_Angeles`, or a custom ID such as `GMT-8:00`. Full names are recommended. You can view a list of full names in https://en.wikipedia.org/wiki/List_of_tz_database_time_zones[this Wikipedia page].
+This section includes:
+* <<datetime-format-notes>>
+* <<datetime-available-procedures>>
+    ** <<datetime-available-procedures-apoc.date.add>>
+    ** <<datetime-available-procedures-apoc.date.convert>>
+    ** <<datetime-available-procedures-apoc.date.convertFormat>>
+    ** <<datetime-available-procedures-apoc.date.currentTimestamp>>
+    ** <<datetime-available-procedures-apoc.date.field>>
+    ** <<datetime-available-procedures-apoc.date.fields>>
+    ** <<datetime-available-procedures-apoc.date.format>>
+    ** <<datetime-available-procedures-apoc.date.fromISO8601>>
+    ** <<datetime-available-procedures-apoc.date.parse>>
+    ** <<datetime-available-procedures-apoc.date.parseAsZonedDateTime>>
+    ** <<datetime-available-procedures-apoc.date.systemTimezone>>
+    ** <<datetime-available-procedures-apoc.date.toISO8601>>
+    ** <<datetime-available-procedures-apoc.date.toYears>>
 
-== Current timestamp
-
-`apoc.date.currentTimestamp()` provides the System.currentTimeMillis which is current throughout transaction execution compared to Cypher's timestamp() function which does not update within a transaction
-
-.The following captures the current timestamp, sleeps for 1 second, and then captures the current timestamp again:
-[source,cypher]
-----
-WITH apoc.date.currentTimestamp() as start
-CALL apoc.util.sleep(1000)
-RETURN start, apoc.date.currentTimestamp() AS end;
-----
-
-.Results
-[opts="header",cols="1, 1"]
-|===
-| Start | End
-| 1561386222609 | 1561386223612
-|===
-
-== Conversion of timestamps between different time units
-
-* `apoc.date.convert(12345, 'ms', 'd')` convert a timestamp in one time unit into one of a different time unit
-
-* possible unit values: `ms,s,m,h,d` and their long forms.
-
-== Adding/subtracting time unit values to timestamps
-
-* `apoc.date.add(12345, 'ms', -365, 'd')` given a timestamp in one time unit, adds a value of the specified time unit
-
-* possible unit values: `ms,s,m,h,d` and their long forms.
-
-== Reading separate datetime fields:
-
-Splits date (optionally, using given custom format) into fields returning a map from field name to its value.
-
-[source,cypher]
-----
-RETURN apoc.date.fields('2015-03-25 03:15:59')
-----
-
-.The following returns the fields in a date and time:
-[source,cypher]
-----
-RETURN apoc.date.fields('2015-01-02 03:04:05 EET', 'yyyy-MM-dd HH:mm:ss zzz') AS output;
-----
-
-.Results
-[opts="header",cols="1"]
-|===
-| Output
-|  {
-    'weekdays': 5,
-    'years': 2015,
-    'seconds': 5,
-    'zoneid': 'EET',
-    'minutes': 4,
-    'hours': 3,
-    'months': 1,
-    'days': 2
-  }
-|===
-
-.The following returns the fields in a date:
-[source,cypher]
-----
-RETURN apoc.date.fields('2015/01/02_EET', 'yyyy/MM/dd_z') AS output;
-----
-
-.Results
-[opts="header",cols="1"]
-|===
-| Output
-|  {
-    'weekdays': 5,
-    'years': 2015,
-    'zoneid': 'EET',
-    'months': 1,
-    'days': 2
-  }
-|===
-
-== Notes on formats:
+[[datetime-format-notes]]
+== Notes on formats for dates and times:
 
 * the default format is `yyyy-MM-dd HH:mm:ss`
 * if the format pattern doesn't specify timezone, formatter considers dates to belong to the UTC timezone
@@ -108,51 +40,296 @@ RETURN apoc.date.fields('2015/01/02_EET', 'yyyy/MM/dd_z') AS output;
 * the `to/fromSeconds` timestamp values are in POSIX (Unix time) system, i.e. timestamps represent the number of seconds elapsed since https://en.wikipedia.org/wiki/Unix_time[00:00:00 UTC, Thursday, 1 January 1970]
 * the full list of supported formats is described in https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html[SimpleDateFormat JavaDoc]
 
-== Reading single datetime field from UTC Epoch:
+[[datetime-available-procedures]]
+== Procedure Overview
 
-Extracts the value of one field from a datetime epoch.
+The table below describes the available procedures:
 
-[source,cypher]
-----
-RETURN apoc.date.field(12345)
-----
-
-Following fields are supported:
-
-[options="header"]
-|===============================================================================================================
-| Result field	| Represents
-| 'years'		| year
-| 'months' 		| month of year
-| 'days' 		| day of month (default)
-| 'hours' 		| hour of day
-| 'minutes' 	| minute of hour
-| 'seconds'		| second of minute
-| 'millis'		| milliseconds of a second
-|===============================================================================================================
-
-.The following returns the day of the month of the timestamp:
-[source,cypher]
-----
-RETURN apoc.date.field(12345) AS output;
-----
-
-.Results
-[opts="header",cols="1"]
+[separator=¦,opts=header,cols="1,1m,1m,5"]
 |===
-| Output
-| 1
+include::../../../build/generated-documentation/apoc.date.add.csv[]
+include::../../../build/generated-documentation/apoc.date.convert.csv[lines=2:]
+include::../../../build/generated-documentation/apoc.date.convertFormat.csv[lines=2:]
+include::../../../build/generated-documentation/apoc.date.currentTimestamp.csv[lines=2:]
+include::../../../build/generated-documentation/apoc.date.field.csv[lines=2:]
+include::../../../build/generated-documentation/apoc.date.fields.csv[lines=2:]
+include::../../../build/generated-documentation/apoc.date.format.csv[lines=2:]
+include::../../../build/generated-documentation/apoc.date.fromISO8601.csv[lines=2:]
+include::../../../build/generated-documentation/apoc.date.parse.csv[lines=2:]
+include::../../../build/generated-documentation/apoc.date.parseAsZonedDateTime.csv[lines=2:]
+include::../../../build/generated-documentation/apoc.date.systemTimezone.csv[lines=2:]
+include::../../../build/generated-documentation/apoc.date.toISO8601.csv[lines=2:]
+include::../../../build/generated-documentation/apoc.date.toYears.csv[lines=2:]
 |===
 
-.The following returns the year of the timestamp:
-[source,cypher]
-----
-RETURN apoc.date.field(12345, 'years') AS output;
-----
+[[datetime-available-procedures-apoc.date.add]]
+=== `apoc.date.add`
 
-.Results
-[opts="header",cols="1"]
+This function can add or subtract time unit values to or from dates in the epoch format.
+
+[separator=¦,opts=header,cols="1m"]
 |===
-| Output
-| 1970
+include::../../../build/generated-documentation/apoc.date.add-lite.csv[]
+|===
+
+It accepts the following parameters:
+
+.Config
+[opts=header]
+|===
+| name | type | description | potential values
+| time | Integer | the date value (in epoch integer format) to operate upon |
+| unit | String | the specificity of the input value | `ms,s,m,h,d` or long forms (`millis,seconds,minutes,hours,days`)
+| addValue | Integer | the number to add or subtract from the time |
+| addUnit | String | the unit type to add or subtract | `ms,s,m,h,d` or long forms
+|===
+
+[[datetime-available-procedures-apoc.date.convert]]
+=== `apoc.date.convert`
+
+This function converts date values of one time unit to date values of a different time unit.
+
+[separator=¦,opts=header,cols="1m"]
+|===
+include::../../../build/generated-documentation/apoc.date.convert-lite.csv[]
+|===
+
+It accepts the following parameters:
+
+.Config
+[opts=header]
+|===
+| name | type | description | potential values
+| time | Integer | the date value (in epoch integer format) to operate upon |
+| unit | String | the specificity of the input value | `ms,s,m,h,d` or long forms (`millis,seconds,minutes,hours,days`)
+| toUnit | String | the unit type for the output value | `ms,s,m,h,d` or long forms
+|===
+
+[[datetime-available-procedures-apoc.date.convertFormat]]
+=== `apoc.date.convertFormat`
+
+This function converts date strings of one format to date strings of a different format.
+
+[separator=¦,opts=header,cols="1m"]
+|===
+include::../../../build/generated-documentation/apoc.date.convertFormat-lite.csv[]
+|===
+
+It accepts the following parameters:
+
+.Config
+[opts=header]
+|===
+| name | type | description | potential values
+| temporal | String | the date string that needs converted |
+| currentFormat | String | the format of the input date string | see the Java documentation for https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/format/DateTimeFormatter.html[full list] (under Patterns for Formatting and Parsing)
+| convertTo | String | the format for the output temporal type | can be specified manually with https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html[Java formats^] or as https://www.elastic.co/guide/en/elasticsearch/reference/5.5/mapping-date-format.html#built-in-date-formats[built-in formats^]
+|===
+
+[[datetime-available-procedures-apoc.date.currentTimestamp]]
+=== `apoc.date.currentTimestamp`
+
+This function returns the current timestamp from the system at the time it is called.
+It provides the `System.currentTimeMillis()`, which is current throughout transaction execution, and is different from Cypher's `timestamp()` function, which does not update within a transaction.
+
+[separator=¦,opts=header,cols="1m"]
+|===
+include::../../../build/generated-documentation/apoc.date.currentTimestamp-lite.csv[]
+|===
+
+It accepts no parameters.
+
+[[datetime-available-procedures-apoc.date.field]]
+=== `apoc.date.field`
+
+This function extracts the value of one field from a date in epoch format.
+
+[separator=¦,opts=header,cols="1m"]
+|===
+include::../../../build/generated-documentation/apoc.date.field-lite.csv[]
+|===
+
+[NOTE]
+====
+With Neo4j v3.4+, the database supports temporal data types.
+While this APOC is still operational, we recommend storing dates using the Neo4j native date types and retrieving a field with Cypher's instant.field - e.g. datetime({epochMillis: dateInteger}).year (https://neo4j.com/docs/cypher-manual/current/syntax/temporal/#cypher-temporal-accessing-components-temporal-instants[Cypher documentation] shows this syntax).
+However, if you still need to convert timestamp formats, this procedure will provide that.
+====
+
+It accepts the following parameters:
+
+.Config
+[opts=header]
+|===
+| name | type | description | potential values
+| time | Integer | the date value (in epoch integer format) to operate upon |
+| unit | String | the specificity of the input value | `ms,s,m,h,d` or long forms (`millis,seconds,minutes,hours,days`)
+| timezone | String | the timezone of the resulting date string | can be specified with GMT or database (text) name, as listed for https://en.wikipedia.org/wiki/List_of_tz_database_time_zones[timezones]
+|===
+
+[[datetime-available-procedures-apoc.date.fields]]
+=== `apoc.date.fields`
+
+This function extracts values of all fields from a date in epoch format and returns the columns and a map representation.
+
+[separator=¦,opts=header,cols="1m"]
+|===
+include::../../../build/generated-documentation/apoc.date.fields-lite.csv[]
+|===
+
+[NOTE]
+====
+With Neo4j v3.4+, the database supports temporal data types.
+While this APOC is still operational, we recommend storing dates using the Neo4j native date types and retrieving a field with Cypher's instant.field - e.g. datetime({epochMillis: dateInteger}).year (https://neo4j.com/docs/cypher-manual/current/syntax/temporal/#cypher-temporal-accessing-components-temporal-instants[Cypher documentation] shows this syntax).
+However, if you still need to convert timestamp formats, this procedure will provide that.
+====
+
+It accepts the following parameters:
+
+.Config
+[opts=header]
+|===
+| name | type | description | potential values
+| date | String | the date string that needs formatted | date string in an https://en.wikipedia.org/wiki/ISO_8601[ISO8601] standard format
+| pattern | String | the format of the input date string | see the Java documentation for https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/format/DateTimeFormatter.html[full list] (under Patterns for Formatting and Parsing)
+|===
+
+[[datetime-available-procedures-apoc.date.format]]
+=== `apoc.date.format`
+
+This function converts dates in epoch format to date strings with a specified format.
+
+[separator=¦,opts=header,cols="1m"]
+|===
+include::../../../build/generated-documentation/apoc.date.format-lite.csv[]
+|===
+
+It accepts the following parameters:
+
+.Config
+[opts=header]
+|===
+| name | type | description | potential values
+| time | Integer | the date value (in epoch integer format) to operate upon |
+| unit | String | the specificity of the input value | `ms,s,m,h,d` or long forms (`millis,seconds,minutes,hours,days`)
+| format | String | the format for the output date string | can be specified manually with https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html[Java formats^] or as https://www.elastic.co/guide/en/elasticsearch/reference/5.5/mapping-date-format.html#built-in-date-formats[built-in formats^]
+| timezone | String | the timezone of the resulting date string | can be specified with GMT or database (text) name, as listed for https://en.wikipedia.org/wiki/List_of_tz_database_time_zones[timezones]
+|===
+
+[[datetime-available-procedures-apoc.date.fromISO8601]]
+=== `apoc.date.fromISO8601`
+
+This function converts date strings in an ISO8601 standard format to dates in epoch format.
+
+[separator=¦,opts=header,cols="1m"]
+|===
+include::../../../build/generated-documentation/apoc.date.format-lite.csv[]
+|===
+
+It accepts the following parameters:
+
+.Config
+[opts=header]
+|===
+| name | type | description | potential values
+| time | String | the date string that needs formatted | date string in an https://en.wikipedia.org/wiki/ISO_8601[ISO8601] standard format
+|===
+
+[NOTE]
+====
+The date string timezone expects only a GMT+00:00 format of `Z` as the timezone specifier. Other timezone specifications are not supported in this procedure.
+====
+
+[[datetime-available-procedures-apoc.date.parse]]
+=== `apoc.date.parse`
+
+This function parses a date string in one format and converts it to a date of the specified time unit in Epoch format.
+
+[separator=¦,opts=header,cols="1m"]
+|===
+include::../../../build/generated-documentation/apoc.date.parse-lite.csv[]
+|===
+
+It accepts the following parameters:
+
+.Config
+[opts=header]
+|===
+| name | type | description | potential values
+| time | String | the date string that needs formatted | date string in an https://en.wikipedia.org/wiki/ISO_8601[ISO8601] standard format
+| unit | String | the specificity desired for the output date value | `ms,s,m,h,d` or long forms (`millis,seconds,minutes,hours,days`)
+| format | String | the format of the date string to convert | see the Java documentation for https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/format/DateTimeFormatter.html[full list] (under Patterns for Formatting and Parsing)
+| timezone | String | the timezone of the resulting date string | can be specified with GMT or database (text) name, as listed for https://en.wikipedia.org/wiki/List_of_tz_database_time_zones[timezones]
+|===
+
+[[datetime-available-procedures-apoc.date.parseAsZonedDateTime]]
+=== `apoc.date.parseAsZonedDateTime`
+
+This function parses a date string in a specified format and converts it to a Neo4j-supported temporal type with date, time, and timezone.
+
+[NOTE]
+====
+This function has been moved to the temporal section and renamed to `apoc.temporal.toZonedDateTime`.
+====
+
+[[datetime-available-procedures-apoc.date.systemTimezone]]
+=== `apoc.date.systemTimezone`
+
+This function returns the timezone display name of the system.
+
+[separator=¦,opts=header,cols="1m"]
+|===
+include::../../../build/generated-documentation/apoc.date.systemTimezone-lite.csv[]
+|===
+
+It accepts no parameters.
+
+[[datetime-available-procedures-apoc.date.toISO8601]]
+=== `apoc.date.toISO8601`
+
+This function converts dates in epoch format to date strings in ISO8601 standard format.
+
+[separator=¦,opts=header,cols="1m"]
+|===
+include::../../../build/generated-documentation/apoc.date.toISO8601-lite.csv[]
+|===
+
+It accepts the following parameters:
+
+.Config
+[opts=header]
+|===
+| name | type | description | potential values
+| time | Integer | the date value (in epoch integer format) to operate upon |
+| unit | String | the specificity of the input value | `ms,s,m,h,d` or long forms (`millis,seconds,minutes,hours,days`)
+|===
+
+[[datetime-available-procedures-apoc.date.toYears]]
+=== `apoc.date.toYears`
+
+This function can make a couple of different conversions.
+
+1. Convert dates in epoch millisecond format to the number of years that have passed since the Unix epoch time of `January 1, 1970`.
+2. Convert date strings in specified formats to the number of years that have passed since the year `0`.
+
+[separator=¦,opts=header,cols="1m"]
+|===
+include::../../../build/generated-documentation/apoc.date.toISO8601-lite.csv[]
+|===
+
+It accepts the following parameters for each conversion:
+
+.Config - epoch to years
+[opts=header]
+|===
+| name | type | description | potential values
+| value | Integer | the date value (in epoch millisecond integer format) to operate upon | NOTE: the timestamp must be in `ms` format!
+|===
+
+.Config - string date to years
+[opts=header]
+|===
+| name | type | description | potential values
+| value | String | the date string that needs formatted | date string in an https://en.wikipedia.org/wiki/ISO_8601[ISO8601] standard format
+| format | String | the format of the date string to convert | see the Java documentation for https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/format/DateTimeFormatter.html[full list] (under Patterns for Formatting and Parsing)
 |===

--- a/src/main/java/apoc/date/Date.java
+++ b/src/main/java/apoc/date/Date.java
@@ -52,7 +52,7 @@ public class Date {
 	);
 
 	@UserFunction
-	@Description("toYears(timestap) or toYears(date[,format]) converts timestamp into floating point years")
+	@Description("toYears(timestamp) or toYears(date[,format]) converts timestamp into floating point years")
 	public double toYears(@Name("value") Object value, @Name(value = "format", defaultValue = DEFAULT_FORMAT) String format) {
 		if (value instanceof Number) {
 			long time = ((Number) value).longValue();
@@ -79,9 +79,8 @@ public class Date {
 		node.setProperty("ttl",System.currentTimeMillis() + unit(timeUnit).toMillis(time));
 	}
 
-	@UserFunction(deprecatedBy = "Neo4j native datetime using instant.field")
+	@UserFunction
 	@Description("apoc.date.fields('2012-12-23',('yyyy-MM-dd')) - return columns and a map representation of date parsed with the given format with entries for years,months,weekdays,days,hours,minutes,seconds,zoneid")
-	@Deprecated
 	public Map<String,Object> fields(final @Name("date") String date, final @Name(value = "pattern", defaultValue = DEFAULT_FORMAT) String pattern) {
 		if (date == null) {
 			return Util.map();
@@ -97,9 +96,8 @@ public class Date {
 		return result.asMap();
 	}
 
-	@UserFunction(deprecatedBy = "Neo4j native datetime using instant.field - e.g. datetime({epochMillis: dateInteger}).year")
+	@UserFunction
 	@Description("apoc.date.field(12345,('ms|s|m|h|d|month|year'),('TZ')")
-	@Deprecated
 	public Long field(final @Name("time") Long time,  @Name(value = "unit", defaultValue = "d") String unit, @Name(value = "timezone",defaultValue = "UTC") String timezone) {
 		return (time == null)
 				? null
@@ -184,8 +182,9 @@ public class Date {
 		return value == null ? null : unit(unit).convert(value, TimeUnit.MILLISECONDS);
 	}
 
-	@UserFunction
-	@Description("apoc.date.parseAsZonedDateTime('2012-12-23 23:59:59','yyyy-MM-dd HH:mm:ss', 'UTC') parse date string using the specified format at the specified timezone")
+	@UserFunction(deprecatedBy = "apoc.temporal.toZonedTemporal")
+	@Description("apoc.date.parseAsZonedDateTime('2012-12-23 23:59:59','yyyy-MM-dd HH:mm:ss', 'UTC-hour-offset') parse date string using the specified format to specified timezone")
+	@Deprecated
 	public ZonedDateTime parseAsZonedDateTime(@Name("time") String time, @Name(value = "format", defaultValue = DEFAULT_FORMAT) String format, final @Name(value = "timezone", defaultValue = "UTC") String timezone) {
 		Long value = parseOrThrow(time, getFormat(format, timezone));
 		return value == null ? null : Instant.ofEpochMilli(value).atZone(ZoneId.of(timezone));

--- a/src/main/java/apoc/temporal/TemporalProcedures.java
+++ b/src/main/java/apoc/temporal/TemporalProcedures.java
@@ -79,5 +79,11 @@ public class TemporalProcedures
         }
     }
 
+    @UserFunction
+	@Description("apoc.temporal.toZonedTemporal('2012-12-23 23:59:59','yyyy-MM-dd HH:mm:ss', 'UTC-hour-offset') parse date string using the specified format to specified timezone")
+	public ZonedDateTime toZonedTemporal(@Name("time") String time, @Name(value = "format", defaultValue = DEFAULT_FORMAT) String format, final @Name(value = "timezone", defaultValue = "UTC") String timezone) {
+		Long value = parseOrThrow(time, getFormat(format, timezone));
+		return value == null ? null : Instant.ofEpochMilli(value).atZone(ZoneId.of(timezone));
+	}
 
 }


### PR DESCRIPTION
Make following updates:
- move apoc.date.parseAsZonedDateTime to temporal section, mark deprecated in date section
- create overview sections in docs for each date procedure and list params
