### PR TITLE
fixes #1522: make fetchSize configureable for apoc.load.jdbc

### DIFF
--- a/src/main/java/apoc/load/Jdbc.java
+++ b/src/main/java/apoc/load/Jdbc.java
@@ -60,6 +60,7 @@ public class Jdbc {
     @Description("apoc.load.jdbc('key or url','table or statement', params, config) YIELD row - load from relational database, from a full table or a sql statement")
     public Stream<RowResult> jdbc(@Name("jdbc") String urlOrKey, @Name("tableOrSql") String tableOrSelect, @Name
             (value = "params", defaultValue = "[]") List<Object> params, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
+        params = params != null ? params : Collections.emptyList();
         return executeQuery(urlOrKey, tableOrSelect, config, params.toArray(new Object[params.size()]));
     }
 
@@ -67,6 +68,7 @@ public class Jdbc {
     @Deprecated
     @Description("deprecated - please use: apoc.load.jdbc('key or url','',[params]) YIELD row - load from relational database, from a sql statement with parameters")
     public Stream<RowResult> jdbcParams(@Name("jdbc") String urlOrKey, @Name("sql") String select, @Name("params") List<Object> params, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
+        params = params != null ? params : Collections.emptyList();
         return executeQuery(urlOrKey, select, config, params.toArray(new Object[params.size()]));
     }
 
@@ -77,10 +79,10 @@ public class Jdbc {
         try {
             Connection connection = getConnection(url,loadJdbcConfig);
             // see https://jdbc.postgresql.org/documentation/91/query.html#query-with-cursors
-            connection.setAutoCommit(false);
+            connection.setAutoCommit(loadJdbcConfig.isAutoCommit());
             try {
                 PreparedStatement stmt = connection.prepareStatement(query,ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
-                stmt.setFetchSize(5000);
+                stmt.setFetchSize(loadJdbcConfig.getFetchSize().intValue());
                 try {
                     for (int i = 0; i < params.length; i++) stmt.setObject(i + 1, params[i]);
                     ResultSet rs = stmt.executeQuery();

--- a/src/main/java/apoc/load/util/LoadJdbcConfig.java
+++ b/src/main/java/apoc/load/util/LoadJdbcConfig.java
@@ -1,5 +1,6 @@
 package apoc.load.util;
 
+import apoc.util.Util;
 import org.apache.commons.lang.StringUtils;
 
 import java.time.DateTimeException;
@@ -17,6 +18,10 @@ public class LoadJdbcConfig {
 
     private Credentials credentials;
 
+    private final Long fetchSize;
+
+    private final boolean autoCommit;
+
     public LoadJdbcConfig(Map<String,Object> config) {
         config = config != null ? config : Collections.emptyMap();
         try {
@@ -26,6 +31,8 @@ public class LoadJdbcConfig {
             throw new IllegalArgumentException(String.format("The timezone field contains an error: %s", e.getMessage()));
         }
         this.credentials = config.containsKey("credentials") ? createCredentials((Map<String, String>) config.get("credentials")) : null;
+        this.fetchSize = Util.toLong(config.getOrDefault("fetchSize", 5000L));
+        this.autoCommit = Util.toBoolean(config.getOrDefault("autoCommit", false));
     }
 
     public ZoneId getZoneId(){
@@ -68,4 +75,11 @@ public class LoadJdbcConfig {
         return this.credentials != null;
     }
 
+    public Long getFetchSize() {
+        return fetchSize;
+    }
+
+    public boolean isAutoCommit() {
+        return autoCommit;
+    }
 }

--- a/src/test/java/apoc/load/JdbcTest.java
+++ b/src/test/java/apoc/load/JdbcTest.java
@@ -78,6 +78,12 @@ public class JdbcTest extends AbstractJdbcTest {
     }
 
     @Test
+    public void testLoadJdbcWithFetchSize() throws Exception {
+        testCall(db, "CALL apoc.load.jdbc('jdbc:derby:derbyDB','PERSON', null, {fetchSize: 100})",
+                (row) -> assertResult(row));
+    }
+
+    @Test
     public void testLoadJdbcSelect() throws Exception {
         testCall(db, "CALL apoc.load.jdbc('jdbc:derby:derbyDB','SELECT * FROM PERSON')",
                 (row) -> assertResult(row));


### PR DESCRIPTION
Fixes #1522

make fetchSize configureable for apoc.load.jdbc

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - added `fetchSize` and `autoCommit` as configuration params
