### PR TITLE
Switch to using apoc.static for loading LDAP configurations from a file

### DIFF
--- a/src/main/java/apoc/load/LoadLdap.java
+++ b/src/main/java/apoc/load/LoadLdap.java
@@ -67,7 +67,7 @@ public class LoadLdap {
         if (url.startsWith(LdapUrl.LDAP_SCHEME) || url.startsWith(LdapUrl.LDAPS_SCHEME)) {
             return executePagedSearch(url, config);
         } else {
-            LoadLdapConfig ldapConfig = LdapUtil.getFromConfigFile(url);
+            LoadLdapConfig ldapConfig = new LoadLdapConfig(config, url);
             // allow override of config file URL with one provided from the proc call
             if (config.containsKey("url")) {
                 ldapConfig.setLdapUrl((String) config.get("url"));

--- a/src/main/java/apoc/load/util/LdapUtil.java
+++ b/src/main/java/apoc/load/util/LdapUtil.java
@@ -236,14 +236,14 @@ public class LdapUtil {
         return req;
     }
 
-    public static LoadLdapConfig getFromConfigFile(String key) {
+    /*public static LoadLdapConfig getFromConfigFile(String key) {
         Map<String, Object> temp = new HashMap<>();
         temp.put("url", Util.getLoadUrlByConfigFile(LOAD_TYPE, key, "url").orElse(StringUtils.EMPTY));
         temp.put("username", Util.getLoadUrlByConfigFile(LOAD_TYPE, key, "username").orElse(StringUtils.EMPTY));
         temp.put("password", Util.getLoadUrlByConfigFile(LOAD_TYPE, key, "password").orElse(StringUtils.EMPTY));
         temp.put("pageSize", Util.getLoadUrlByConfigFile(LOAD_TYPE, key, "pageSize").orElse("100"));
         return new LoadLdapConfig(temp);
-    }
+    }*/
 
     /**
      * Use the upper and lower 16 bytes to generate the UUID that would match string representations


### PR DESCRIPTION
Fixes #1428, improves upon #1429, and a step towards #1512 

Rewrite the LoadLdap procedure to incorporate new features and enhancements and use APOC static values to store the configurations

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

- Support a wider range of LDAP servers
- Allow looser LDAP searches from the root of a domain
- Store LDAP URLs/searches and associated credentials in APOCs configuration
- Use paged searches to avoid server-imposed search size limits
- Handle Active Directory's use of ranged attribute retrieval