### PR TITLE
Re-add the LoadLdap procedure post-reversion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,8 @@ dependencies {
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
     compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
     compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '1.7.3'
-    compile group: 'com.novell.ldap', name: 'jldap', version: '2009-10-07'
+    compile group: 'org.apache.directory.api', name: 'api-all', version: '2.0.1'
+    testCompile group: 'org.apache.directory.server', name: 'apacheds-test-framework', version: '2.0.0.AM26', { exclude group: 'org.apache.directory.api', module: 'api-ldap-schema-data' }
 
     def withoutAntlr =  {
         exclude group: 'org.glassfish'

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,8 @@ dependencies {
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
     compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
     compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '1.7.3'
-    compile group: 'org.apache.directory.api', name: 'api-all', version: '2.0.1'
+    compileOnly group: 'org.apache.directory.api', name: 'api-all', version: '2.0.1'
+    testImplementation group: 'org.apache.directory.api', name: 'api-all', version: '2.0.1'
     testCompile group: 'org.apache.directory.server', name: 'apacheds-test-framework', version: '2.0.0.AM26', { exclude group: 'org.apache.directory.api', module: 'api-ldap-schema-data' }
 
     def withoutAntlr =  {

--- a/docs/asciidoc/database-integration/loadldap.adoc
+++ b/docs/asciidoc/database-integration/loadldap.adoc
@@ -7,21 +7,131 @@ This section describes procedures that can be used to import data from LDAP.
 --
 
 
-With 'apoc.load.ldap' you can execute queries on any LDAP v3 enabled directory, the results are turned into a streams of entries.
+With 'apoc.load.ldapurl' you can execute queries on any LDAP v3 enabled directory, the results are turned into a streams of entries.
 The entries can then be used to update or create graph structures.
 
-Note this utility requires to have the link:https://mvnrepository.com/artifact/com.novell.ldap/jldap/2009-10-07[jldap] library to be placed the plugin directory.
 
 [separator=¦,opts=header,cols="1,1m,1m,5"]
 |===
 include::../../../build/generated-documentation/apoc.load.csv[lines=1;12]
 |===
 
+
 == Parameters
+Note: you will need the following jars to be made available in the classpath or else placed alongside APOC in the plugin directory.
+  - Apache MINA Core (https://mina.apache.org/mina-core/) org.apache.mina:mi1f1aa890d52edc381e9b1c875d177d5a7baeb4a5na-core:bundle:2.1.3
+  - SLF4J API Module (http://www.slf4j.org) org.slf4j:slf4j-api:jar:1.7.26
+  - Apache ServiceMix :: Bundles :: antlr (http://servicemix.apache.org/bundles-pom/org.apache.servicemix.bundles.antlr/) org.apache.servicemix.bundles:org.apache.servicemix.bundles.antlr:bundle:2.7.7_5
+  - Apache ServiceMix :: Bundles :: dom4j (http://servicemix.apache.org/bundles-pom/org.apache.servicemix.bundles.dom4j/) org.apache.servicemix.bundles:org.apache.servicemix.bundles.dom4j:bundle:2.1.1_1
+  - Apache ServiceMix :: Bundles :: xpp3 (http://servicemix.apache.org/bundles-pom/org.apache.servicemix.bundles.xpp3/) org.apache.servicemix.bundles:org.apache.servicemix.bundles.xpp3:bundle:1.1.4c_7
+  - Apache Commons Codec (https://commons.apache.org/proper/commons-codec/) commons-codec:commons-codec:jar:1.14
+  - Apache Commons Collections (https://commons.apache.org/proper/commons-collections/) org.apache.commons:commons-collections4:jar:4.4
+  - Apache Commons Lang (http://commons.apache.org/proper/commons-lang/) org.apache.commons:commons-lang3:jar:3.9
+  - Apache Commons Pool (https://commons.apache.org/proper/commons-pool/) org.apache.commons:commons-pool2:jar:2.8.0
+  - Apache Directory API ASN.1 API (http://directory.apache.org/api-parent/api-asn1-parent/api-asn1-api/) org.apache.directory.api:api-asn1-api:bundle:2.0.1
+  - Apache Directory API ASN.1 BER (http://directory.apache.org/api-parent/api-asn1-parent/api-asn1-ber/) org.apache.directory.api:api-asn1-ber:bundle:2.0.1
+  - Apache Directory LDAP API DSML Engine (http://directory.apache.org/api-parent/api-dsml-parent/api-dsml-engine/) org.apache.directory.api:api-dsml-engine:bundle:2.0.1
+  - Apache Directory LDAP API DSML Parser (http://directory.apache.org/api-parent/api-dsml-parent/api-dsml-parser/) org.apache.directory.api:api-dsml-parser:bundle:2.0.1
+  - Apache Directory LDAP API I18n (http://directory.apache.org/api-parent/api-i18n/) org.apache.directory.api:api-i18n:bundle:2.0.1
+  - Apache Directory LDAP API Client API (http://directory.apache.org/api-parent/api-ldap-parent/api-ldap-client-parent/api-ldap-client-api/) org.apache.directory.api:api-ldap-client-api:bundle:2.0.1
+  - Apache Directory LDAP API Codec Core (http://directory.apache.org/api-parent/api-ldap-parent/api-ldap-codec-parent/api-ldap-codec-core/) org.apache.directory.api:api-ldap-codec-core:bundle:2.0.1
+  - Apache Directory LDAP API Codec Standalone (http://directory.apache.org/api-parent/api-ldap-parent/api-ldap-codec-parent/api-ldap-codec-standalone/) org.apache.directory.api:api-ldap-codec-standalone:jar:2.0.1
+  - Apache Directory LDAP API Extras ACI (http://directory.apache.org/api-parent/api-ldap-parent/api-ldap-extras-parent/api-ldap-extras-aci/) org.apache.directory.api:api-ldap-extras-aci:bundle:2.0.1
+  - Apache Directory LDAP API Extras Codec (http://directory.apache.org/api-parent/api-ldap-parent/api-ldap-extras-parent/api-ldap-extras-codec/) org.apache.directory.api:api-ldap-extras-codec:bundle:2.0.1
+  - Apache Directory LDAP API Extras Codec API (http://directory.apache.org/api-parent/api-ldap-parent/api-ldap-extras-parent/api-ldap-extras-codec-api/) org.apache.directory.api:api-ldap-extras-codec-api:bundle:2.0.1
+  - Apache Directory LDAP API Extras Stored Procedures (http://directory.apache.org/api-parent/api-ldap-parent/api-ldap-extras-parent/api-ldap-extras-sp/) org.apache.directory.api:api-ldap-extras-sp:bundle:2.0.1
+  - Apache Directory LDAP API Extras Trigger (http://directory.apache.org/api-parent/api-ldap-parent/api-ldap-extras-parent/api-ldap-extras-trigger/) org.apache.directory.api:api-ldap-extras-trigger:bundle:2.0.1
+  - Apache Directory LDAP API Extras Util (http://directory.apache.org/api-parent/api-ldap-parent/api-ldap-extras-parent/api-ldap-extras-util/) org.apache.directory.api:api-ldap-extras-util:bundle:2.0.1
+  - Apache Directory LDAP API Model (http://directory.apache.org/api-parent/api-ldap-parent/api-ldap-model/) org.apache.directory.api:api-ldap-model:bundle:2.0.1
+  - Apache Directory LDAP API Network MINA (http://directory.apache.org/api-parent/api-ldap-parent/api-ldap-net-parent/api-ldap-net-mina/) org.apache.directory.api:api-ldap-net-mina:bundle:2.0.1
+  - Apache Directory LDAP API Schema Converter (http://directory.apache.org/api-parent/api-ldap-parent/api-ldap-schema-parent/api-ldap-schema-converter/) org.apache.directory.api:api-ldap-schema-converter:bundle:2.0.1
+  - Apache Directory LDAP API Schema Data (http://directory.apache.org/api-parent/api-ldap-parent/api-ldap-schema-parent/api-ldap-schema-data/) org.apache.directory.api:api-ldap-schema-data:jar:2.0.1
+  - Apache Directory LDAP API Utilities (http://directory.apache.org/api-parent/api-util/) org.apache.directory.api:api-util:bundle:2.0.1
+
 
 [options="header",cols="a,3m,a"]
 |===
-|Parameter | Property | Description
+|Parameter      | Property  | Description
+|{connectionMap}| URL or key| See link:https://tools.ietf.org/html/rfc2255[RFC 2255] for the specifications
+|               | username  | This is the dn of the ldap server user who has read access on the ldap server
+|               | password  | This is the password used by the user
+|               | pageSize  | The number of results to return from the LDAP server at a time (default 100)
+|               | url       | Optional, if overriding the URL from the on-disk configuration
+|===
+
+Hint: Use an attribute parameter of * to return all attributes, + to return operational attributes, and no attributes will always return the distinguishedName
+
+=== Load LDAP Example
+
+.Retrieve group member information from the ldap server
+[source,cypher]
+----
+call apoc.load.ldapurl({url: "ldap://localhost:389/dc=neo4j,dc=test?uniqueMember,cn,objectClass?sub?(objectClass=groupOfUniqueNames)", username: 'uid=admin,ou=system', password: 'secret'})
+yield entry
+return entry.dn,  entry.uniqueMember
+----
+
+[options="header",cols="3m,a"]
+|===
+| entry.dn                                 | entry.uniqueMember                                                                               |
+| "cn=Machines,ou=Groups,dc=neo4j,dc=test" | ["cn=Agent Smith,ou=Machines,dc=neo4j,dc=test", "cn=The Architect,ou=Machines,dc=neo4j,dc=test"] |
+| "cn=Humans,ou=Groups,dc=neo4j,dc=test"   | ["cn=Neo,ou=Users,dc=neo4j,dc=test", "cn=Morpheus,ou=Users,dc=neo4j,dc=test"]                    |
+|===
+
+.Retrieve group member information from the ldap server and create structure in Neo4j
+[source,cypher]
+----
+call apoc.load.ldapurl({url: "ldap://localhost:389/dc=neo4j,dc=test?uniqueMember,cn,objectClass?sub?(objectClass=groupOfUniqueNames)", username: 'uid=admin,ou=system', password: 'secret'})
+yield entry
+merge (g:Group {dn : entry.dn})
+on create set g.cn = entry.cn
+foreach (member in entry.uniqueMember |
+  merge (p:Person { dn : member })
+  merge (p)-[:IS_MEMBER]->(g)
+)
+----
+
+=== Credentials
+
+To protect credentials, you can configure aliases in `conf/neo4j.conf`:
+
+.neo4j.conf Syntax
+----
+apoc.static.ldap.localhost_auth.url=ldap://localhost:389/dc=neo4j,dc=test?uniqueMember,cn,objectClass?sub?(objectClass=groupOfUniqueNames)
+apoc.static.ldap.localhost_auth.username=uid=admin,ou=system
+apoc.static.ldap.localhost_auth.password=secret
+apoc.static.ldap.localhost_auth.pageSize=250
+----
+
+Then
+
+[source,cypher]
+----
+call apoc.load.ldapurl("ldap://localhost:389/dc=neo4j,dc=test?uniqueMember,cn,objectClass?sub?(objectClass=groupOfUniqueNames)", {user: 'uid=admin,ou=system', password: 'secret'})
+yield entry
+return entry.dn,  entry
+----
+
+becomes
+
+[source,cypher]
+---------------
+with apoc.static.getAll("localhost_auth") as ldapconfig
+call apoc.load.ldapurl(ldapconfig)
+yield entry
+return entry.dn,  entry
+-----------------------
+
+== Parameters (Deprecated)
+With 'apoc.load.ldap' you can execute queries on any LDAP v3 enabled directory, the results are turned into a streams of entries.
+The entries can then be used to update or create graph structures.
+NOTE: These configuration options are considered deprecated and you are encouraged to migrate to the above format
+
+Note this utility requires to have the link:https://mvnrepository.com/artifact/com.novell.ldap/jldap/2009-10-07[jldap] library to be placed the plugin directory.
+
+[options="header",cols="a,3m,a"]
+|===
+|Parameter | Property | Description
 |{connectionMap} | ldapHost | the ldapserver:port if port is omitted the default port 389 will be used
 |  | loginDN | This is the dn of the ldap server user who has read access on the ldap server
 |  | loginPW | This is the password used by the loginDN
@@ -74,15 +184,14 @@ foreach (member in entry.uniqueMember |
 
 === Credentials
 
-To protect credentials, you can configure aliases in `conf/neo4j.conf`:
+To protect credentials, you can configure aliases in `conf/apoc.conf`:
 
-.neo4j.conf Syntax
+.apoc.conf Syntax
 ----
 apoc.loadldap.myldap.config=<host>:<port> <loginDN> <loginPW>
 ----
 
-
-.neo4j.conf:
+.apoc.conf:
 ----
 apoc.loadldap.myldap.config=ldap.forumsys.com:389 cn=read-only-admin,dc=example,dc=com password
 ----

--- a/src/main/java/apoc/load/LoadLdap.java
+++ b/src/main/java/apoc/load/LoadLdap.java
@@ -1,205 +1,171 @@
 package apoc.load;
 
-import apoc.ApocConfiguration;
-import com.novell.ldap.*;
-
-
-import org.neo4j.procedure.Description;
-import org.neo4j.procedure.Mode;
+import apoc.Description;
+import apoc.load.util.LdapUtil;
+import apoc.load.util.LoadLdapConfig;
+import org.apache.directory.api.ldap.model.cursor.SearchCursor;
+import org.apache.directory.api.ldap.model.entry.Attribute;
+import org.apache.directory.api.ldap.model.entry.Entry;
+import org.apache.directory.api.ldap.model.exception.LdapInvalidDnException;
+import org.apache.directory.api.ldap.model.message.Response;
+import org.apache.directory.api.ldap.model.message.SearchRequest;
+import org.apache.directory.api.ldap.model.message.SearchResultDone;
+import org.apache.directory.api.ldap.model.message.SearchResultEntry;
+import org.apache.directory.api.ldap.model.message.controls.PagedResults;
+import org.apache.directory.ldap.client.api.LdapConnection;
+import org.apache.directory.ldap.client.api.LdapConnectionPool;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.logging.Log;
+import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
-import java.io.UnsupportedEncodingException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static apoc.load.util.LdapUtil.buildSearch;
+import static apoc.load.util.LdapUtil.getConnectionPool;
+import static apoc.load.util.LdapUtil.rangedRetrievalEntryHandler;
+
 public class LoadLdap {
+    @Context
+    public Log log;
 
-    @Procedure(name = "apoc.load.ldap", mode = Mode.READ)
-    @Description("apoc.load.ldap(\"key\" or {connectionMap},{searchMap}) Load entries from an ldap source (yield entry)")
-    public Stream<LDAPResult> ldapQuery(@Name("connection") final Object conn, @Name("search") final Map<String,Object> search) {
+    @Context
+    public GraphDatabaseService db;
 
-        LDAPManager mgr = new LDAPManager(getConnectionMap(conn));
-
-        return mgr.executeSearch(search);
-    }
-
-    public static Map<String, Object> getConnectionMap(Object conn) {
-        if (conn instanceof String) {
-            //String value = "ldap.forumsys.com cn=read-only-admin,dc=example,dc=com password";
-            Object value = ApocConfiguration.get("loadldap").get(conn.toString() + ".config");
-            // format <ldaphost:port> <logindn> <loginpw>
-            if (value == null) throw new RuntimeException("No apoc.loadldap."+conn+".config ldap access configuration specified");
-            Map<String, Object> config = new HashMap<>();
-            String[] sConf = ((String) value).split(" ");
-            config.put("ldapHost", sConf[0]);
-            config.put("loginDN", sConf[1]);
-            config.put("loginPW", sConf[2]);
-
-            return config;
-
+    @Procedure(name = "apoc.load.ldap", deprecatedBy = "apoc.load.ldapurl")
+    @Description("apoc.load.ldap({connectionMap},{searchMap}) Load entries from an ldap source (yield entry)")
+    public Stream<LDAPResult> ldapQuery(@Name("connection") final Object conn, @Name("search") final Map<String,Object> search) throws LdapInvalidDnException {
+        LoadLdapConfig compatConfig;
+        if (conn instanceof Map) {
+            // old style config with Map of server connection parameters
+            compatConfig = LoadLdapConfig.compatConfig((Map<String, Object>) conn, search);
+        } else if (conn instanceof String) {
+            // old style config with String representing a ApocConfiguration key
+            compatConfig = LoadLdapConfig.compatConfig((String) conn, search);
         } else {
-            return (Map<String,Object> ) conn;
+            throw new RuntimeException("Cannot comprehend configuration parameters");
         }
-
+        return executePagedSearch(compatConfig);
     }
 
-    public static class LDAPManager {
-        private static final String LDAP_HOST_P = "ldapHost";
-        private static final String LDAP_LOGIN_DN_P = "loginDN";
-        private static final String LDAP_LOGIN_PW_P = "loginPW";
-        private static final String SEARCH_BASE_P = "searchBase";
-        private static final String SEARCH_SCOPE_P = "searchScope";
-        private static final String SEARCH_FILTER_P = "searchFilter";
-        private static final String SEARCH_ATTRIBUTES_P = "attributes";
+    @Procedure(name = "apoc.load.ldapurl")
+    @Description("apoc.load.ldap(config) YIELD row - run an LDAP query from an LDAP URL")
+    public Stream<LDAPResult> ldap(@Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
+        LoadLdapConfig ldapConfig = new LoadLdapConfig(config);
+        return executePagedSearch(ldapConfig);
+    }
 
-        private static final String SCOPE_BASE = "SCOPE_BASE";
-        private static final String SCOPE_ONE = "SCOPE_ONE";
-        private static final String SCOPE_SUB = "SCOPE_SUB";
+    /**
+     * Executes a paged LDAP search with a default of 100-entry page size. All of the results are
+     * collected before being passed to the EntryListIterator which does the transformations into
+     * KV pairs.
+     * To more completely handle Active Directory servers, checking for ranged retrievals of
+     * attribute values is performed. By default, AD sets this to 1500 values. If this is the
+     * case, the attribute values are also paged before being returned to the original attribute
+     * See https://ldapwiki.com/wiki/LDAP_SERVER_RANGE_OPTION_OID for more details.
+     *
+     * @param ldapConfig Parameters to pass onto the connector
+     * @return Stream of LDAPResults representing the search results
+     */
+    private Stream<LDAPResult> executePagedSearch(LoadLdapConfig ldapConfig) {
+        final String RANGE_RETRIEVAL_OID = "1.2.840.113556.1.4.802";
+        final String PAGED_SEARCH_OID = "1.2.840.113556.1.4.319";
+        List<Entry> allEntries = new ArrayList<>();
 
-        private int ldapPort;
-        private int ldapVersion = LDAPConnection.LDAP_V3;
-        private String ldapHost;
-        private String loginDN;
-        private String password;
-        private LDAPConnection lc;
-        private List<String> attributeList;
+        try {
+            // Use connection pooling to support future possible searches with range retrievals
+            LdapConnectionPool pool = getConnectionPool(ldapConfig);
+            LdapConnection connection = pool.getConnection();
+            boolean hasRangeRetrieval = connection.getSupportedControls().contains(RANGE_RETRIEVAL_OID);
+            if (log.isDebugEnabled())
+                log.debug("Server has ranged retrieval control: " + hasRangeRetrieval);
 
-        public LDAPManager(Map<String, Object> connParms) {
+            if (log.isDebugEnabled())
+                log.debug("Beginning paged LDAP search");
+            SearchRequest req = buildSearch(ldapConfig, null, log);
+            boolean hasMoreResults = true;
 
-            String sLdapHostPort = (String) connParms.get(LDAP_HOST_P);
-            if (sLdapHostPort.indexOf(":") > -1) {
-                this.ldapHost = sLdapHostPort.substring(0, sLdapHostPort.indexOf(":"));
-                this.ldapPort = Integer.parseInt(sLdapHostPort.substring(sLdapHostPort.indexOf(":") + 1));
-            } else {
-                this.ldapHost = sLdapHostPort;
-                this.ldapPort = 389; // default
-            }
-
-            this.loginDN = (String) connParms.get(LDAP_LOGIN_DN_P);
-            this.password = (String) connParms.get(LDAP_LOGIN_PW_P);
-
-        }
-
-        public Stream<LDAPResult> executeSearch(Map<String, Object> search) {
-            try {
-                Iterator<Map<String, Object>> supplier = new SearchResultsIterator(doSearch(search), attributeList);
-                Spliterator<Map<String, Object>> spliterator = Spliterators.spliteratorUnknownSize(supplier, Spliterator.ORDERED);
-                return StreamSupport.stream(spliterator, false).map(LDAPResult::new).onClose(() -> closeIt(lc));
-            } catch (Exception e) {
-                e.printStackTrace();
-                throw new RuntimeException(e);
-            }
-        }
-
-        public LDAPSearchResults doSearch(Map<String, Object> search) {
-            // parse search parameters
-            String searchBase = (String) search.get(SEARCH_BASE_P);
-            String searchFilter = (String) search.get(SEARCH_FILTER_P);
-            String sScope = (String) search.get(SEARCH_SCOPE_P);
-            attributeList = (List<String>) search.get(SEARCH_ATTRIBUTES_P);
-            if (attributeList == null) attributeList = new ArrayList<>();
-            int searchScope = LDAPConnection.SCOPE_SUB;
-            if (sScope.equals(SCOPE_BASE)) {
-                searchScope = LDAPConnection.SCOPE_BASE;
-            } else if (sScope.equals(SCOPE_ONE)) {
-                searchScope = LDAPConnection.SCOPE_ONE;
-            } else if (sScope.equals(SCOPE_SUB)) {
-                searchScope = LDAPConnection.SCOPE_SUB;
-            } else {
-                throw new RuntimeException("Invalid scope:" + sScope + ". value scopes are SCOPE_BASE, SCOPE_ONE and SCOPE_SUB");
-            }
-
-            // getting an ldap connection
-            try {
-                lc = getConnection();
-                // execute query
-                LDAPSearchConstraints cons = new LDAPSearchConstraints();
-                cons.setMaxResults(0); // no limit
-                LDAPSearchResults searchResults = null;
-                if (attributeList == null || attributeList.size() == 0) {
-                    searchResults = lc.search(searchBase, searchScope, searchFilter, null, false, cons);
-                } else {
-                    searchResults = lc.search(searchBase, searchScope, searchFilter, attributeList.toArray(new String[0]), false, cons);
+            while (hasMoreResults) {
+                try (SearchCursor searchCursor = connection.search(req)) {
+                    while (searchCursor.next()) {
+                        Response resp = searchCursor.get();
+                        if (resp instanceof SearchResultEntry) {
+                            Entry resultEntry = ((SearchResultEntry) resp).getEntry();
+                            if (hasRangeRetrieval) {
+                                LdapConnection extra = pool.getConnection();
+                                resultEntry = rangedRetrievalEntryHandler(resultEntry, extra, log);
+                                pool.releaseConnection(extra);
+                            }
+                            allEntries.add(resultEntry);
+                        }
+                    }
+                    SearchResultDone done = searchCursor.getSearchResultDone();
+                    PagedResults hasPaged = (PagedResults) done.getControl(PAGED_SEARCH_OID);
+                    if ( (null != hasPaged) && (hasPaged.getCookie().length > 0) ) {
+                        if (log.isDebugEnabled())
+                            log.debug("Iterating over the next LDAP search page");
+                        req = buildSearch(ldapConfig, hasPaged.getCookie(), log);
+                        hasMoreResults = true;
+                    } else {
+                        hasMoreResults = false;
+                    }
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
                 }
-                return searchResults;
-
-            } catch (Exception e) {
-                e.printStackTrace();
-                throw new RuntimeException(e);
             }
+            pool.releaseConnection(connection);
+            if (log.isDebugEnabled())
+                log.debug(String.format("Finished paged LDAP search: %d entries", allEntries.size()));
+
+            Iterator<Map<String, Object>> supplier = new EntryListIterator(
+                    allEntries.iterator(),
+                    ldapConfig.getLdapUrl().getAttributes(),
+                    log);
+            Spliterator<Map<String, Object>> spliterator = Spliterators.spliteratorUnknownSize(supplier, Spliterator.ORDERED);
+            return StreamSupport.stream(spliterator, false).map(LDAPResult::new).onClose(pool::close);
+
+        } catch (Exception e) {
+            throw new RuntimeException("Error connecting to server: " + e);
         }
-
-        private LDAPEntry read(String dn) throws LDAPException, UnsupportedEncodingException {
-            if (dn == null) return null;
-            LDAPEntry r = null;
-            op("read start for dn: " + dn);
-            LDAPConnection lc = getConnection();
-            r = lc.read(dn);
-            closeIt(lc);
-            // op( r.toString());
-            op("read end");
-            return r;
-
-        }
-
-        private LDAPSchema getSchema() throws LDAPException, UnsupportedEncodingException {
-            LDAPSchema r = null;
-            LDAPConnection lc = getConnection();
-            r = lc.fetchSchema(lc.getSchemaDN());
-            closeIt(lc);
-            //op( r.toString());
-
-            return r;
-        }
-
-        public static void closeIt(LDAPConnection lc) {
-            try {
-                lc.disconnect();
-            } catch (Exception e) {
-                // ignore
-                e.printStackTrace();
-            }
-        }
-
-        private LDAPConnection getConnection() throws LDAPException, UnsupportedEncodingException {
-//        LDAPSocketFactory ssf;
-//        Security.addProvider(new com.sun.net.ssl.internal.ssl.Provider());
-            // String path ="C:\\j2sdk1.4.2_09\\jre\\lib\\security\\cacerts";
-            //op("the trustStore: " + System.getProperty("javax.net.ssl.trustStore"));
-            // System.setProperty("javax.net.ssl.trustStore", path);
-//        op(" reading the strustStore: " + System.getProperty("javax.net.ssl.trustStore"));
-//        ssf = new LDAPJSSESecureSocketFactory();
-//        LDAPConnection.setSocketFactory(ssf);
-
-
-            LDAPConnection lc = new LDAPConnection();
-            lc.connect(ldapHost, ldapPort);
-
-            // bind to the server
-            lc.bind(ldapVersion, loginDN, password.getBytes("UTF8"));
-            // tbd
-            // LDAPConnection pooling here?
-            //
-
-
-            return lc;
-        }
-
-        private void op(String s) {
-            System.out.println("LDAPManager:>" + s);
-        }
-
     }
-    private static class SearchResultsIterator implements Iterator<Map<String, Object>> {
-        private final LDAPSearchResults lsr;
-        private final List<String> attributes;
-        private Map<String,Object> map;
-        public SearchResultsIterator(LDAPSearchResults lsr, List<String> attributes) {
 
-            this.lsr = lsr;
+    /**
+     * Executes a paged LDAP search with a default of 100-entry page size. All of the results are
+     * collected before being passed to the EntryListIterator which does the transformations into
+     * KV pairs.
+     * To more completely handle Active Directory servers, checking for ranged retrievals of
+     * attribute values is performed. By default, AD sets this to 1500 values. If this is the
+     * case, the attribute values are also paged before being returned to the original attribute
+     * See https://ldapwiki.com/wiki/LDAP_SERVER_RANGE_OPTION_OID for more details.
+     *
+     * @param url LDAP URL formatted according to RFC 2255
+     * @param config Parameters to pass onto the connector
+     * @return Stream of LDAPResults representing the search results
+     */
+    private Stream<LDAPResult> executePagedSearch(String url, Map<String, Object> config) {
+        LoadLdapConfig ldapConfig = new LoadLdapConfig(config, url);
+        return this.executePagedSearch(ldapConfig);
+    }
+
+    private static class EntryListIterator implements Iterator<Map<String, Object>> {
+        private final Iterator<Entry> entries;
+        private final List<String> attributes;
+        private final Log log;
+        private Map<String, Object> map;
+
+        public EntryListIterator(Iterator<Entry> entries, List<String> attributes, Log log) {
+            this.entries = entries;
             this.attributes = attributes;
+            this.log = log;
             this.map = get();
         }
 
@@ -210,61 +176,71 @@ public class LoadLdap {
 
         @Override
         public Map<String, Object> next() {
-            Map<String,Object> current = this.map;
+            Map<String, Object> current = this.map;
             this.map = get();
             return current;
         }
 
         public Map<String, Object> get() {
-            if (handleEndOfResults()) return null;
-            try {
-                Map<String, Object> entry = new LinkedHashMap<>(attributes.size() + 1);
-                LDAPEntry en = null;
-                en = lsr.next();
-                entry.put("dn", en.getDN());
-                if (attributes != null && attributes.size() > 0) {
-                    for (int col = 0; col < attributes.size(); col++) {
-                        Object val = readValue(en.getAttributeSet().getAttribute(attributes.get(col)));
-                        if (val != null) entry.put(attributes.get(col),val );
-                    }
-                } else {
-                    // make it dynamic
-                    Iterator<LDAPAttribute> iter = en.getAttributeSet().iterator();
-                    while (iter.hasNext()) {
-                        LDAPAttribute attr = iter.next();
-                        Object val = readValue(attr);
-                        if (val != null) entry.put(attr.getName(), readValue(attr));
+            if (this.log.isDebugEnabled())
+                this.log.debug("Fetching next LDAP entry");
+            if (handleEndOfResults())
+                return null;
+            Map<String, Object> entryMap = new LinkedHashMap<>(attributes.size()+1);
+            Entry ldapEntry = entries.next();
+            if (this.log.isDebugEnabled())
+                log.debug(String.format("Processing entry: %s", ldapEntry.toString()));
 
-                    }
-                    //System.out.println("entry " + entry);
-                    return entry;
-                }
-                //System.out.println("entry " + entry);
-                return entry;
-
-            } catch (LDAPException e) {
-
-                e.printStackTrace();
-                throw new RuntimeException("Error getting next ldap entry " + e.getLDAPErrorMessage());
+            // always return a distinguishedname in the result like an LDAP search would
+            entryMap.put("dn", ldapEntry.getDn().toString());
+            for (Attribute attribute : ldapEntry) {
+                String attrName = attribute.getId();
+                entryMap.put(attrName, readValue(attribute));
             }
+            if (this.log.isDebugEnabled())
+                log.debug(String.format("entryMap: %s", entryMap));
+            return entryMap;
         }
 
-        private boolean handleEndOfResults()  {
-            if (!lsr.hasMore()) {
-                return true;
-            }
-            return false;
+        private boolean handleEndOfResults() {
+            return !entries.hasNext();
         }
-        private Object readValue(LDAPAttribute att) {
-            if (att == null) return null;
-            if (att.size() == 1) {
-                // single value
-                // for now everything is string
-                return att.getStringValue();
+
+        private Object readValue(Attribute att) {
+            if (att == null)
+                return null;
+            if (this.log.isDebugEnabled())
+                this.log.debug(String.format("Processing attribute: %s", att.getId()));
+
+            // Handle uuid attributes separately since they're single valued anyway
+            String attrName = att.getId();
+            if (attrName.equals("objectguid")) {
+                return LdapUtil.getStringFromObjectGuid(att.get().getBytes());
+            }
+            if (attrName.equals("objectsid")) {
+                return LdapUtil.getStringFromObjectSid(att.get().getBytes());
+            }
+
+            // Handle datetimes specifically for formatting into Neo4j expectations for datetime
+            if (attrName.equalsIgnoreCase("createtimestamp") || attrName.equalsIgnoreCase("modifytimestamp")) {
+                return LdapUtil.formatDateTime(att.get().getString());
+            }
+
+            /*
+                It would be nice to use the schema information to return a List for all multivalued
+                attributes, but guaranteeing that the schema is available is very difficult
+                particularly when it comes to AD which doesn't supply schema information when asked
+             */
+            int numValues = att.size();
+            if (this.log.isDebugEnabled())
+                log.debug(String.format("Attribute %s has %d values", attrName, numValues));
+            if (numValues == 1) {
+                return att.get().getString();
             } else {
-                return att.getStringValueArray();
+                List<String> vals = new ArrayList<>();
+                att.forEach(val -> vals.add(val.getNormalized()));
+                return vals;
             }
         }
     }
-
 }

--- a/src/main/java/apoc/load/util/LdapUtil.java
+++ b/src/main/java/apoc/load/util/LdapUtil.java
@@ -1,0 +1,325 @@
+package apoc.load.util;
+
+import org.apache.directory.api.ldap.model.cursor.SearchCursor;
+import org.apache.directory.api.ldap.model.entry.Attribute;
+import org.apache.directory.api.ldap.model.entry.Entry;
+import org.apache.directory.api.ldap.model.entry.Value;
+import org.apache.directory.api.ldap.model.exception.LdapException;
+import org.apache.directory.api.ldap.model.exception.LdapInvalidAttributeValueException;
+import org.apache.directory.api.ldap.model.message.Response;
+import org.apache.directory.api.ldap.model.message.SearchRequest;
+import org.apache.directory.api.ldap.model.message.SearchRequestImpl;
+import org.apache.directory.api.ldap.model.message.SearchResultEntry;
+import org.apache.directory.api.ldap.model.message.SearchScope;
+import org.apache.directory.api.ldap.model.message.controls.PagedResults;
+import org.apache.directory.api.ldap.model.message.controls.PagedResultsImpl;
+import org.apache.directory.api.ldap.model.name.Dn;
+import org.apache.directory.api.ldap.model.url.LdapUrl;
+import org.apache.directory.ldap.client.api.DefaultLdapConnectionFactory;
+import org.apache.directory.ldap.client.api.DefaultPoolableLdapConnectionFactory;
+import org.apache.directory.ldap.client.api.LdapConnection;
+import org.apache.directory.ldap.client.api.LdapConnectionConfig;
+import org.apache.directory.ldap.client.api.LdapConnectionPool;
+import org.neo4j.logging.Log;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class LdapUtil {
+    public static final String LOAD_TYPE = "ldap";
+    private static final String FIRST_RANGED_PAGE_PATTERN = "(\\S+);range=(\\d)-(\\d+)";
+    private static final String REMAINING_RANGED_PAGE_PATTERN = "(\\S+);range=(\\d+)-(\\d+|\\*)";
+
+    /**
+     * Build up an LdapConnectionPool from the configuration information received from the
+     * proc constructor or config file. It will pre-authenticate connections retrieved from the
+     * pool and will already be bound.
+     * Note: Credentials are passed as-is to the LDAP server. There are a variety of binding
+     * mechanisms and we won't pretend to know what the user intends. For example, binds can be
+     * anonymous (no credentials), a bind DN and no password, or bind DN and a password. If the
+     * user has done something incorrect, we rely on the LDAP server to inform the user what has
+     * gone wrong.
+     * @param ldapConfig Configuration when the procedure was called
+     * @return a new LDAP connection pool
+     */
+    public static LdapConnectionPool getConnectionPool(LoadLdapConfig ldapConfig) {
+        LdapConnectionConfig config = new LdapConnectionConfig();
+        LdapUrl ldapUrl = ldapConfig.getLdapUrl();
+        boolean isSecure = ldapUrl.getScheme().equals(LdapUrl.LDAPS_SCHEME);
+        int port = ldapUrl.getPort();
+
+        if (isSecure && (port == -1)) {
+            port = LdapConnectionConfig.DEFAULT_LDAPS_PORT;
+        } else if (isSecure && (port != -1)) {
+            port = ldapUrl.getPort();
+        } else if (!isSecure && (port == -1)) {
+            port = LdapConnectionConfig.DEFAULT_LDAP_PORT;
+        } else {
+            port = ldapUrl.getPort();
+        }
+
+        config.setLdapHost(ldapUrl.getHost());
+        config.setLdapPort(port);
+        config.setName(ldapConfig.getCredentials().getBindDn());
+        config.setCredentials(ldapConfig.getCredentials().getBindPassword());
+        config.setUseSsl(isSecure);
+
+        DefaultLdapConnectionFactory factory = new DefaultLdapConnectionFactory(config);
+        return new LdapConnectionPool(new DefaultPoolableLdapConnectionFactory(factory));
+    }
+
+    /**
+     * Do an object-level search on the range retrieved attribute to get the next page of values
+     *
+     * @param object the attribute that was returned by the server
+     * @param attrName the original attribute name
+     * @param nextHigh the max value of the next page to retrieve
+     * @param nextLow the min value of the next page to retrieve
+     * @param connection an LdapConnection to retrieve the next page
+     * @param log Neo4j logger
+     * @return the results of the next page search
+     * @throws LdapException any search/LDAP server errors returned
+     */
+    public static Entry getRangedValues(Dn object, String attrName, int nextHigh, int nextLow, LdapConnection connection, Log log) throws LdapException {
+        Entry entry = null;
+        SearchRequest rangeRetrieval = new SearchRequestImpl();
+        String nextRange = String.format("%s;range=%d-%d", attrName, nextLow, nextHigh);
+        if (log.isDebugEnabled())
+            log.debug("Getting next range retrieval page " + nextRange);
+        rangeRetrieval.addAttributes(nextRange);
+        rangeRetrieval.setScope(SearchScope.OBJECT);
+        rangeRetrieval.setBase(object);
+        rangeRetrieval.setFilter("(objectClass=*)");
+        try (SearchCursor subCursor = connection.search(rangeRetrieval)) {
+            while (subCursor.next()) {
+                Response subResp = subCursor.get();
+                if (subResp instanceof SearchResultEntry) {
+                    entry = ((SearchResultEntry) subResp).getEntry();
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Error retrieving object: " + e);
+        }
+        return entry;
+    }
+
+    /**
+     * Process all of the possible attribute values. AD doesn't return values attached to the
+     * queried attribute. It will return a new attribute in the form of:
+     * <attribute name>;range=<low>-<high>
+     * To return results that an other LDAP server would reply with, gather all of the values to be
+     * attached to the original attribute
+     *
+     * @param rangedObject the attribute that was returned by the server
+     * @param rangedAttribute the original attribute name
+     * @param matcher the original Matcher on the attribute name
+     * @param connection an LdapConnection to retrieve the next page
+     * @param log Neo4j logger
+     * @return the complete list of values from all pages
+     */
+    public static List<Value> getAllRangedAttributeValues(Dn rangedObject,
+                                                          Attribute rangedAttribute,
+                                                          Matcher matcher,
+                                                          LdapConnection connection,
+                                                          Log log) {
+        log.info("Processing ranged attribute: " + rangedAttribute.getId());
+        List<Value> combinedValues = new ArrayList<>();
+        rangedAttribute.forEach(combinedValues::add);
+
+        String attrName = matcher.group(1);
+        int low = Integer.parseInt(matcher.group(2));
+        int high = Integer.parseInt(matcher.group(3));
+        final int step = high - low;
+        int nextLow = high + 1;
+        int nextHigh = nextLow + step;
+        boolean moreResults = true;
+
+        if (log.isDebugEnabled())
+            log.debug(String.format("Beginning first round of attribute value retrieval: %s, %d, %d", attrName, low, high));
+        while (moreResults) {
+            Entry nextPage;
+            try {
+                nextPage = getRangedValues(rangedObject, attrName, nextHigh, nextLow, connection, log);
+                for (Attribute page : nextPage) {
+                    page.forEach(combinedValues::add);
+                    Matcher nextPageMatcher = Pattern.compile(REMAINING_RANGED_PAGE_PATTERN).matcher(page.getId());
+                    if (nextPageMatcher.find()) {
+                        if (nextPageMatcher.group(3).equals("*")) {
+                            if (log.isDebugEnabled()) log.debug("Found last page of values, we are done");
+                            moreResults = false;
+                        } else {
+                            nextLow = Integer.parseInt(nextPageMatcher.group(3)) + 1;
+                            nextHigh = step + nextLow;
+                            if (log.isDebugEnabled())
+                                log.debug(String.format("Beginning next round of attribute value retrieval: %s, %d, %d", attrName, nextLow, nextHigh));
+                        }
+                    }
+                }
+            } catch (LdapException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        log.info("Finished ranged attribute: " + rangedAttribute.getId());
+        return combinedValues;
+    }
+
+    /**
+     * Starting point for handling ranged attribute values where the initial inspection occurs
+     * before spinning out any value retrieval to getAllRangedAttributeValues
+     * @param rawEntry entry as received from the LDAP server
+     * @param connection prebound connection from the pool
+     * @param log Neo4j log
+     * @return a modified Entry with complete attribute values
+     */
+    public static Entry rangedRetrievalEntryHandler(Entry rawEntry, LdapConnection connection, Log log) {
+        log.info("Beginning ranged retrieval handling for entry: " + rawEntry.getDn().toString());
+        Entry newEntry = rawEntry.clone();
+        for (Attribute attribute : newEntry) {
+            Matcher matcher = Pattern.compile(FIRST_RANGED_PAGE_PATTERN).matcher(attribute.getId());
+            if (matcher.find()) {
+                Attribute realAttribute = newEntry.get(matcher.group(1));
+                List<Value> allAttributeValues = getAllRangedAttributeValues(newEntry.getDn(), attribute, matcher, connection, log);
+                for (Value val : allAttributeValues) {
+                    try {
+                        realAttribute.add(val);
+                    } catch (LdapInvalidAttributeValueException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        }
+        log.info("Finished ranged retrieval handling for " + rawEntry.getDn().toString());
+        return newEntry;
+    }
+
+
+    /**
+     * Build the paged SearchRequest where the cookie is either null for the first run or the
+     * cookie returned from the LDAP server. In the latter instance, the cookie serves as a
+     * bookmark to inform the LDAP server which results should be returned next
+     * @param ldapConfig the config received from the procedure
+     * @param cookie the cookie returned by the LDAP server
+     * @param log Neo4j logger
+     * @return a new SearchRequest for the next page of results
+     * @throws LdapException a problem with building the search was encountered
+     */
+    public static SearchRequest buildSearch(LoadLdapConfig ldapConfig, byte[] cookie, Log log) throws LdapException {
+        if (log.isDebugEnabled())
+            log.debug("Generating new SearchRequest");
+        SearchRequest req = new SearchRequestImpl();
+        req.setScope(ldapConfig.getLdapUrl().getScope());
+        req.setSizeLimit(0);
+        req.setFilter(ldapConfig.getLdapUrl().getFilter());
+        for (String a : ldapConfig.getLdapUrl().getAttributes()) {
+            req.addAttributes(a);
+        }
+        req.setBase(ldapConfig.getLdapUrl().getDn());
+        req.followReferrals();
+
+        PagedResults pr = new PagedResultsImpl();
+        pr.setSize(ldapConfig.getPageSize());
+        if (null != cookie) {
+            pr.setCookie(cookie);
+        }
+
+        req.addControl(pr);
+        if (log.isDebugEnabled())
+            log.debug(String.format("Generated SearchRequest: %s", req.toString()));
+        return req;
+    }
+
+    /**
+     * Use the upper and lower 16 bytes to generate the UUID that would match string representations
+     * commonly found elsewhere (such as Apache Directory Studio)
+     * @param entryUuid bytes returned from the server
+     * @return string representation of the UUID
+     */
+    public static String getUuidFromEntryUuid(byte[] entryUuid) {
+        ByteBuffer bb = ByteBuffer.wrap(entryUuid);
+        long high = bb.getLong();
+        long low = bb.getLong();
+        return new UUID(high, low).toString();
+    }
+
+    /**
+     * Rearrange the bytes before generating the UUID in order ot match the form shown in all of
+     * the Active Directory tools
+     * @param objectGuid bytes returned from the server for the attribute
+     * @return a string representation of the objectGUID (which isn't a true UUID)
+     */
+    public static String getStringFromObjectGuid(byte[] objectGuid) {
+        byte[] rearranged = new byte[16];
+        rearranged[0] = objectGuid[3];
+        rearranged[1] = objectGuid[2];
+        rearranged[2] = objectGuid[1];
+        rearranged[3] = objectGuid[0];
+        rearranged[4] = objectGuid[5];
+        rearranged[5] = objectGuid[4];
+        rearranged[6] = objectGuid[7];
+        rearranged[7] = objectGuid[6];
+        System.arraycopy(objectGuid, 8, rearranged, 8, 8);
+        return getUuidFromEntryUuid(rearranged);
+    }
+
+    /**
+     * Generates a String representation of an objectSid as defined by
+     * https://docs.microsoft.com/en-us/windows/win32/secauthz/sid-components
+     * The code was adapted from https://ldapwiki.com/wiki/ObjectSID
+     * @param objectSid byte result from the LDAP server
+     * @return a String representation of the objectSid
+     */
+    public static String getStringFromObjectSid(byte[] objectSid) {
+        StringBuilder strSid = new StringBuilder("S-");
+
+        int revision = objectSid[0];
+        strSid.append(revision);
+
+        int countSubAuths = objectSid[1] & 0xFF;
+
+        long authority = 0;
+        for (int i=2; i<=7;i++) {
+            authority |= ((long) objectSid[i]) << (8 * (5 - (i - 2)));
+        }
+        strSid.append("-");
+        strSid.append(Long.toHexString(authority));
+
+        int offset = 8;
+        int size = 4;
+        for (int j=0; j<countSubAuths; j++) {
+            long subAuthority = 0;
+            for (int k=0; k<size; k++) {
+                subAuthority |= (long) (objectSid[offset+k] & 0xFF) << (8 * k);
+            }
+            strSid.append("-");
+            strSid.append(subAuthority);
+            offset += size;
+        }
+        return strSid.toString();
+    }
+
+    /**
+     * Translate an LDAP server provided timestamp into a Neo4J DateTime. AD will return a float
+     * as the milliseconds, but it's always .0. LDAP servers leave off the float
+     * @param dateTime original timestamp from the LDAP server
+     * @return a string matching what Neo4J would expect for a DateTime object
+     */
+    public static String formatDateTime(String dateTime) {
+        Pattern pattern = Pattern.compile("(\\d\\d\\d\\d)(\\d\\d)(\\d\\d)(\\d\\d)(\\d\\d)(\\d\\d)");
+        Matcher groupedDateTime = pattern.matcher(dateTime);
+        String formattedDateTime = null;
+        if (groupedDateTime.find()) {
+            formattedDateTime = String.format("%s-%s-%sT%s:%s:%sZ",
+                    groupedDateTime.group(1),
+                    groupedDateTime.group(2),
+                    groupedDateTime.group(3),
+                    groupedDateTime.group(4),
+                    groupedDateTime.group(5),
+                    groupedDateTime.group(6));
+        }
+        return formattedDateTime;
+    }
+}

--- a/src/main/java/apoc/load/util/LoadLdapConfig.java
+++ b/src/main/java/apoc/load/util/LoadLdapConfig.java
@@ -1,0 +1,150 @@
+package apoc.load.util;
+
+import apoc.ApocConfiguration;
+import org.apache.commons.lang.StringUtils;
+import org.apache.directory.api.ldap.model.exception.LdapInvalidDnException;
+import org.apache.directory.api.ldap.model.exception.LdapURLEncodingException;
+import org.apache.directory.api.ldap.model.message.SearchScope;
+import org.apache.directory.api.ldap.model.name.Dn;
+import org.apache.directory.api.ldap.model.url.LdapUrl;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class LoadLdapConfig {
+    private final Credentials credentials;
+    private int pageSize;
+    private LdapUrl ldapUrl;
+
+    public LoadLdapConfig(Map<String, Object> config, String url) {
+        config = (null != config) ? config : Collections.emptyMap();
+        this.credentials = new Credentials(
+                (String) config.getOrDefault("username", StringUtils.EMPTY),
+                (String) config.getOrDefault("password", StringUtils.EMPTY)
+        );
+        try {
+            this.ldapUrl = new LdapUrl(url);
+        } catch (LdapURLEncodingException e) {
+            throw new RuntimeException(e);
+        }
+        
+        try {
+            this.pageSize = (config.containsKey("pageSize")) ? Integer.parseInt((String) config.get("pageSize")) : 100;
+        } catch (java.lang.NumberFormatException e) {
+            this.pageSize = 100;
+        }
+    }
+
+    public LoadLdapConfig(Map<String, Object> config) {
+        this(config, (String) config.get("url"));
+    }
+
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    public int getPageSize() {
+        return this.pageSize;
+    }
+
+    public LdapUrl getLdapUrl() {
+        return this.ldapUrl;
+    }
+
+    public void setLdapUrl(String url) {
+        try {
+            this.ldapUrl = new LdapUrl(url);
+        } catch (LdapURLEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public Credentials getCredentials() {
+        return this.credentials;
+    }
+
+    public static class Credentials {
+        private final String bindDn;
+        private final String bindPassword;
+
+        public Credentials(String bindDn, String bindPassword) {
+            this.bindDn = bindDn;
+            this.bindPassword = bindPassword;
+        }
+
+        public String getBindDn() {
+            return bindDn;
+        }
+
+        public String getBindPassword() {
+            return bindPassword;
+        }
+    }
+
+    public boolean hasCredentials() {
+        return this.credentials != null;
+    }
+
+    public static LoadLdapConfig compatConfig(Map<String, Object> connMap, Map<String, Object> searchMap) throws LdapInvalidDnException {
+        LdapUrl tempUrl = new LdapUrl();
+        HashMap<String, Object> compatConfig = new HashMap<>();
+        int port = 389;
+        List<String> attributes = (List<String>) searchMap.get("attributes");
+
+        // Simple parser for hostname string which maybe includes the port number
+        String rawHost = (String) connMap.get("ldapHost");
+        String[] splitHost = rawHost.split(":");
+
+        if (!splitHost[1].equals(StringUtils.EMPTY)) {
+            try {
+                port = Integer.parseInt(splitHost[1]);
+            } catch (java.lang.NumberFormatException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        /*
+         * Since the prior plugin doesn't provide a way to specify secure connections on non-standard
+         * ports, naively assume that everything is unsecured unless 636 is given
+         */
+        boolean isSecure = (port == 636);
+        tempUrl.setHost(splitHost[0]);
+        tempUrl.setPort(port);
+        tempUrl.setScheme(isSecure ? LdapUrl.LDAPS_SCHEME : LdapUrl.LDAP_SCHEME);
+        tempUrl.setDn(new Dn((String) searchMap.get("searchBase")));
+        tempUrl.setAttributes((attributes != null) ? attributes : new ArrayList<>());
+        tempUrl.setFilter((String) searchMap.get("searchFilter"));
+        String scope = (String) searchMap.get("searchScope");
+        if (scope.equals("SCOPE_BASE")) {
+            tempUrl.setScope(SearchScope.OBJECT);
+        } else if (scope.equals("SCOPE_ONE")) {
+            tempUrl.setScope(SearchScope.ONELEVEL);
+        } else if (scope.equals("SCOPE_SUB")) {
+            tempUrl.setScope(SearchScope.SUBTREE);
+        } else {
+            throw new RuntimeException("Invalid scope:" + scope + ". value scopes are SCOPE_BASE, SCOPE_ONE and SCOPE_SUB");
+        }
+
+        compatConfig.put("url", tempUrl.toString());
+        compatConfig.put("username", connMap.get("loginDN"));
+        compatConfig.put("password", connMap.get("loginPW"));
+        return new LoadLdapConfig(compatConfig, tempUrl.toString());
+    }
+
+    public static LoadLdapConfig compatConfig(String conn, Map<String, Object> searchMap) throws LdapInvalidDnException {
+        String value = (String) ApocConfiguration.get("loadldap").get(conn + ".config");
+        // format <ldaphost:port> <logindn> <loginpw>
+        if (value == null) {
+            throw new RuntimeException("No apoc.loadldap." + conn +".config ldap access configuration specified");
+        }
+        String[] sConf = value.split(" ");
+        HashMap<String, Object> connMap = new HashMap<>();
+        connMap.put("ldapHost", sConf[0]);
+        connMap.put("loginDN", sConf[1]);
+        connMap.put("loginPW", sConf[2]);
+        return compatConfig(connMap, searchMap);
+    }
+}

--- a/src/test/java/apoc/load/LoadLdapTest.java
+++ b/src/test/java/apoc/load/LoadLdapTest.java
@@ -99,7 +99,6 @@ public class LoadLdapTest extends AbstractLdapTestUnit {
 
     @Test
     public void testLoadFromApocConfig() throws LdapURLEncodingException {
-        //LoadLdapConfig config = LdapUtil.getFromConfigFile("localhost_auth");
         LoadLdapConfig config = new LoadLdapConfig(apocStatics.getAll("localhost_auth"));
         assertEquals(config.getLdapUrl(), new LdapUrl(String.format("ldap://localhost:%d/dc=neo4j,dc=test?cn?sub?(&(objectClass=person)(cn=Agent Smith))", ldapServerPort)));
         assertEquals(config.getCredentials().getBindDn(), "uid=admin,ou=system");
@@ -108,8 +107,6 @@ public class LoadLdapTest extends AbstractLdapTestUnit {
 
     @Test
     public void testBadPageSize() {
-        //ApocConfiguration.addToConfig(map("ldap.localhost_auth.pageSize", "lah"));
-        //LoadLdapConfig config = LdapUtil.getFromConfigFile("localhost_auth");
         LoadLdapConfig config = new LoadLdapConfig(apocStatics.getAll("localhost_auth"));
         assertEquals(config.getPageSize(), 100);
 
@@ -117,8 +114,6 @@ public class LoadLdapTest extends AbstractLdapTestUnit {
 
     @Test
     public void testValidPageSize() {
-        //ApocConfiguration.addToConfig(map("ldap.localhost_auth.pageSize", "771"));
-        //LoadLdapConfig config = LdapUtil.getFromConfigFile("localhost_auth");
         apocStatics.set("localhost_auth.pageSize", "771");
         LoadLdapConfig config = new LoadLdapConfig(apocStatics.getAll("localhost_auth"));
         assertEquals(config.getPageSize(), 771);

--- a/src/test/java/apoc/load/LoadLdapTest.java
+++ b/src/test/java/apoc/load/LoadLdapTest.java
@@ -1,37 +1,210 @@
 package apoc.load;
 
+import apoc.ApocConfiguration;
+import apoc.cache.Static;
+import apoc.load.util.LoadLdapConfig;
+import apoc.util.TestUtil;
+import org.apache.directory.api.ldap.model.exception.LdapURLEncodingException;
+import org.apache.directory.api.ldap.model.url.LdapUrl;
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.core.annotations.ApplyLdifFiles;
+import org.apache.directory.server.core.annotations.CreateDS;
+import org.apache.directory.server.core.annotations.CreatePartition;
+import org.apache.directory.server.core.integ.AbstractLdapTestUnit;
+import org.apache.directory.server.core.integ.FrameworkRunner;
 
-import com.novell.ldap.LDAPEntry;
-import com.novell.ldap.LDAPSearchResults;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Result;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testResult;
+import static org.junit.Assert.*;
 
-public class LoadLdapTest {
+@RunWith(FrameworkRunner.class)
+@CreateDS(name = "testDS",
+        partitions = {
+            @CreatePartition(name = "test", suffix = "dc=neo4j,dc=test")
+        })
+@CreateLdapServer(
+        transports = {
+                @CreateTransport(protocol = "LDAP", address = "localhost")
+        },
+        allowAnonymousAccess = true
+)
+@ApplyLdifFiles({"users.ldif"})
+public class LoadLdapTest extends AbstractLdapTestUnit {
+    private GraphDatabaseService db;
+    private int ldapServerPort = ldapServer.getPort();
+
+    private final Static apocStatics = new Static();
+
+    private List<Map<String, Object>> consumeResults(Result rows) {
+        List<Map<String, Object>> results = new ArrayList<>();
+        while (rows.hasNext()) {
+            Map<String, Object> row = rows.next();
+            results.add(row);
+        }
+        return results;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        db = TestUtil.apocGraphDatabaseBuilder().newGraphDatabase();
+        ApocConfiguration.initialize((GraphDatabaseAPI) db);
+        String unsecuredUrl = String.format("ldap://localhost:%d/dc=neo4j,dc=test?cn?sub?(&(objectClass=person)(cn=Agent Smith))", ldapServerPort);
+        apocStatics.set("localhost_noauth.url", unsecuredUrl);
+        apocStatics.set("localhost_auth.url", unsecuredUrl);
+        apocStatics.set("localhost_auth.username", "uid=admin,ou=system");
+        apocStatics.set("localhost_auth.password", "secret");
+        TestUtil.registerProcedure(db, LoadLdap.class);
+        TestUtil.registerProcedure(db, Static.class);
+    }
 
     @Test
-    public void testLoadLDAP() throws Exception {
-        Map<String, Object> connParms = new HashMap<>();
-        connParms.put("ldapHost", "ldap.forumsys.com");
-        connParms.put("ldapPort", 389l);
-        connParms.put("loginDN", "cn=read-only-admin,dc=example,dc=com");
-        connParms.put("loginPW", "password");
-        LoadLdap.LDAPManager mgr = new LoadLdap.LDAPManager(LoadLdap.getConnectionMap(connParms));
-        Map<String, Object> searchParms = new HashMap<>();
-        searchParms.put("searchBase", "dc=example,dc=com");
-        searchParms.put("searchScope", "SCOPE_ONE");
-        searchParms.put("searchFilter", "(&(objectClass=*)(uid=training))");
-        ArrayList<String> ats = new ArrayList<>();
-        ats.add("uid");
-        searchParms.put("attributes", ats);
-        LDAPSearchResults results = mgr.doSearch(searchParms);
-        LDAPEntry le = results.next();
-        assertEquals("uid=training,dc=example,dc=com", le.getDN());
-        assertEquals("training", le.getAttribute("uid").getStringValue());
+    public void testConfigLoadingMap() throws LdapURLEncodingException {
+        apocStatics.set("thematrix.url", String.format("ldap://localhost:%d/dc=neo4j,dc=test?cn?sub?(&(objectClass=person)(cn=Agent Smith))", ldapServerPort));
+        apocStatics.set("thematrix.username", "TheArchitect");
+        apocStatics.set("thematrix.password", "TheOracle");
+        LoadLdapConfig ldapConfig = new LoadLdapConfig(apocStatics.getAll("thematrix"));
+        assertEquals(ldapConfig.getCredentials().getBindDn(), "TheArchitect");
+        assertEquals(ldapConfig.getCredentials().getBindPassword(), "TheOracle");
+        assertEquals(ldapConfig.getPageSize(), 100);
+        assertEquals(ldapConfig.getLdapUrl(), new LdapUrl(String.format("ldap://localhost:%d/dc=neo4j,dc=test?cn?sub?(&(objectClass=person)(cn=Agent Smith))", ldapServerPort)));
     }
-}
 
+    @Test
+    public void testConfigLoadingMapAndURL() throws LdapURLEncodingException {
+        String url = String.format("ldap://localhost:%d/dc=neo4j,dc=test?cn?sub?(&(objectClass=person)(cn=Agent Smith))", ldapServerPort);
+        apocStatics.set("thematrix.url", url);
+        apocStatics.set("thematrix.username", "TheArchitect");
+        apocStatics.set("thematrix.password", "TheOracle");
+        LoadLdapConfig ldapConfig = new LoadLdapConfig(apocStatics.getAll("thematrix"), url);
+        assertEquals(ldapConfig.getCredentials().getBindDn(), "TheArchitect");
+        assertEquals(ldapConfig.getCredentials().getBindPassword(), "TheOracle");
+        assertEquals(ldapConfig.getPageSize(), 100);
+        assertEquals(ldapConfig.getLdapUrl(), new LdapUrl(String.format("ldap://localhost:%d/dc=neo4j,dc=test?cn?sub?(&(objectClass=person)(cn=Agent Smith))", ldapServerPort)));
+    }
+
+    @Test
+    public void testLoadFromApocConfig() throws LdapURLEncodingException {
+        //LoadLdapConfig config = LdapUtil.getFromConfigFile("localhost_auth");
+        LoadLdapConfig config = new LoadLdapConfig(apocStatics.getAll("localhost_auth"));
+        assertEquals(config.getLdapUrl(), new LdapUrl(String.format("ldap://localhost:%d/dc=neo4j,dc=test?cn?sub?(&(objectClass=person)(cn=Agent Smith))", ldapServerPort)));
+        assertEquals(config.getCredentials().getBindDn(), "uid=admin,ou=system");
+        assertEquals(config.getCredentials().getBindPassword(), "secret");
+    }
+
+    @Test
+    public void testBadPageSize() {
+        //ApocConfiguration.addToConfig(map("ldap.localhost_auth.pageSize", "lah"));
+        //LoadLdapConfig config = LdapUtil.getFromConfigFile("localhost_auth");
+        LoadLdapConfig config = new LoadLdapConfig(apocStatics.getAll("localhost_auth"));
+        assertEquals(config.getPageSize(), 100);
+
+    }
+
+    @Test
+    public void testValidPageSize() {
+        //ApocConfiguration.addToConfig(map("ldap.localhost_auth.pageSize", "771"));
+        //LoadLdapConfig config = LdapUtil.getFromConfigFile("localhost_auth");
+        apocStatics.set("localhost_auth.pageSize", "771");
+        LoadLdapConfig config = new LoadLdapConfig(apocStatics.getAll("localhost_auth"));
+        assertEquals(config.getPageSize(), 771);
+
+    }
+
+    @Test
+    public void testCompatSignatureMapMap() {
+        Map<String, Object> agentSmith = new HashMap<>();
+        agentSmith.put("dn", "cn=Agent Smith,ou=Users,dc=neo4j,dc=test");
+        agentSmith.put("cn", "Agent Smith");
+        testCall(db,
+                String.format("CALL apoc.load.ldap({ldapHost: 'localhost:%d', loginDN: 'uid=admin,ou=system', loginPW: 'secret'}, ", ldapServerPort) +
+                        "{searchBase: 'dc=neo4j,dc=test', searchFilter: '(&(objectClass=person)(cn=Agent Smith))', searchScope: 'SCOPE_SUB', attributes: ['cn']})",
+                (row) -> assertEquals(row, map("entry", agentSmith)));
+    }
+
+    @Test
+    public void testCompatSignatureStringMap() {
+        ApocConfiguration.addToConfig(map("loadldap.myldap.config", String.format("localhost:%d uid=admin,ou=system secret", ldapServerPort)));
+        Map<String, Object> agentSmith = new HashMap<>();
+        agentSmith.put("dn", "cn=Agent Smith,ou=Users,dc=neo4j,dc=test");
+        agentSmith.put("cn", "Agent Smith");
+        testCall(db,
+                "CALL apoc.load.ldap('myldap', " +
+                        "{searchBase: 'dc=neo4j,dc=test', searchFilter: '(&(objectClass=person)(cn=Agent Smith))', searchScope: 'SCOPE_SUB', attributes: ['cn']})",
+                (row) -> assertEquals(row, map("entry", agentSmith)));
+    }
+
+    @Test
+    public void testLoadNoAuth() {
+        Map<String, Object> agentSmith = new HashMap<>();
+        agentSmith.put("dn", "cn=Agent Smith,ou=Users,dc=neo4j,dc=test");
+        agentSmith.put("cn", "Agent Smith");
+        String url = String.format("ldap://localhost:%d/dc=neo4j,dc=test?cn?sub?(&(objectClass=person)(cn=Agent Smith))", ldapServerPort);
+        testCall(db, String.format("CALL apoc.static.set('localhost_auth.url', '%s')", url), r -> assertEquals(url, r.get("value")));
+        testCall(db, "CALL apoc.load.ldapurl(apoc.static.getAll('localhost_auth'))", (row) -> assertEquals(row, map("entry", agentSmith)));
+    }
+
+    @Test
+    public void testLoadAuth() {
+        Map<String, Object> agentSmith = new HashMap<>();
+        agentSmith.put("dn", "cn=Agent Smith,ou=Users,dc=neo4j,dc=test");
+        agentSmith.put("cn", "Agent Smith");
+        String url = String.format("ldap://localhost:%d/dc=neo4j,dc=test?cn?sub?(&(objectClass=person)(cn=Agent Smith))", ldapServerPort);
+        testCall(db, String.format("CALL apoc.static.set('localhost_auth.url', '%s')", url), r -> assertEquals(url, r.get("value")));
+        testCall(db, "CALL apoc.load.ldapurl(apoc.static.getAll('localhost_auth'))", (row) -> assertEquals(row, map("entry", agentSmith)));
+    }
+
+    @Test
+    public void testInlineConfig() {
+        Map<String, Object> agentSmith = new HashMap<>();
+        agentSmith.put("dn", "cn=Agent Smith,ou=Users,dc=neo4j,dc=test");
+        agentSmith.put("cn", "Agent Smith");
+        testCall(db, String.format("CALL apoc.load.ldapurl({url: 'ldap://localhost:%d/dc=neo4j,dc=test?cn?sub?(&(objectClass=person)(cn=Agent Smith))', username: 'uid=admin,ou=system', password: 'secret'})", ldapServerPort),
+                (row) -> assertEquals(row, map("entry", agentSmith)));
+    }
+
+    @Test
+    public void testInlineConfigAnonymous() {
+        Map<String, Object> neo = new HashMap<>();
+        neo.put("dn", "cn=Neo,ou=Users,dc=neo4j,dc=test");
+        neo.put("cn", "Neo");
+        testCall(db,
+                String.format("CALL apoc.load.ldapurl({url: 'ldap://localhost:%d/dc=neo4j,dc=test?cn?sub?(&(objectClass=person)(cn=Neo))'})", ldapServerPort),
+                (row) -> assertEquals(row, map("entry", neo)));
+    }
+
+    @Test
+    public void testNoAttributesRequestedGotCn() {
+        Map<String, Object> neo = new HashMap<>();
+        neo.put("dn", "cn=Neo,ou=Users,dc=neo4j,dc=test");
+        neo.put("cn", "Neo");
+        testCall(db,
+                String.format("CALL apoc.load.ldapurl({url: 'ldap://localhost:%d/dc=neo4j,dc=test??sub?(&(objectClass=person)(cn=Neo))'})", ldapServerPort),
+                (row) -> assertEquals(((Map) row.get("entry")).get("uid"), "neo1"));
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
+    }
+
+    /*
+    @Test
+    public void testPagingSupport() {
+        testResult(db, "CALL apoc.load.ldap('ldaps://db.debian.org/dc=debian,dc=org?uid?sub?(objectclass=inetorgperson)')", (row)->assertTrue(consumeResults(row).size()>1000));
+    }*/
+}

--- a/src/test/resources/users.ldif
+++ b/src/test/resources/users.ldif
@@ -1,0 +1,76 @@
+version: 1
+dn: dc=neo4j,dc=test
+objectClass: domain
+objectClass: top
+dc: neo4j
+
+dn: ou=Groups,dc=neo4j,dc=test
+objectClass: organizationalUnit
+objectClass: top
+ou: Groups
+
+dn: ou=Users,dc=neo4j,dc=test
+objectClass: organizationalUnit
+objectClass: top
+ou: Users
+
+dn: cn=The Architect,ou=Users,dc=neo4j,dc=test
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: The Architect
+sn: Architect
+uid: architect1
+userPassword: ICreatedTheMatrix
+
+dn: cn=Agent Smith,ou=Users,dc=neo4j,dc=test
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Agent Smith
+sn: Smith
+givenName: Agent
+uid: agentsmith
+userPassword: IHateThisPlace
+
+dn: cn=Neo,ou=Users,dc=neo4j,dc=test
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Neo
+givenName: Thomas
+sn: Anderson
+uid: neo1
+userPassword: ThereIsNoSpoon
+
+dn: cn=Morpheus,ou=Users,dc=neo4j,dc=test
+objectClass: inetOrgPerson
+objectClass: organizationalPerson
+objectClass: person
+objectClass: top
+cn: Morpheus
+sn: Bluepill
+uid: morpheus1
+userPassword: YouThinkThatsAirYoureBreathing
+
+dn: cn=Machines,ou=Groups,dc=neo4j,dc=test
+objectClass: groupOfUniqueNames
+objectClass: top
+cn: Machines
+description: In the beginning, there was man. And for a time, it was good.
+ But humanity's so-called civil societies soon fell victim to vanity and
+ corruption. Then man made the machine in his own likeness. Thus did man
+ become the architect of his own demise.
+uniqueMember: cn=Agent Smith,ou=Machines,dc=neo4j,dc=test
+uniqueMember: cn=The Architect,ou=Machines,dc=neo4j,dc=test
+
+dn: cn=Humans,ou=Groups,dc=neo4j,dc=test
+objectClass: groupOfUniqueNames
+objectClass: top
+cn: Humans
+description: What is The Matrix?
+uniqueMember: cn=Neo,ou=Users,dc=neo4j,dc=test
+uniqueMember: cn=Morpheus,ou=Users,dc=neo4j,dc=test


### PR DESCRIPTION
Fixes #1428, improves upon #1429, and a step towards #1512 

Rewrite the LoadLdap procedure to incorporate new features and enhancements and use APOC static values to store the configurations

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

- Support a wider range of LDAP servers
- Allow looser LDAP searches from the root of a domain
- Store LDAP URLs/searches and associated credentials in APOCs configuration
- Use paged searches to avoid server-imposed search size limits
- Handle Active Directory's use of ranged attribute retrieval