### PR TITLE
fixes #1537: Make Pools queue size configurable

### DIFF
--- a/docs/asciidoc/config.adoc
+++ b/docs/asciidoc/config.adoc
@@ -43,6 +43,7 @@ procedures
 | apoc.jobs.scheduled.num_threads=number-of-threads (default: number of CPU cores / 4) | Many periodic procedures rely on a scheduled executor that has
 a pool of threads with a default fixed size. You can configure the pool size using this configuration property
 | apoc.jobs.pool.num_threads=number-of-threads (default: number of CPU cores * 2) | Number of threads in the default APOC thread pool used for background executions.
+| apoc.jobs.queue.size=size of the queue (default: value of `apoc.jobs.pool.num_threads` * 5) | Size of the queue ThreadPoolExecutor working queue
 | apoc.mongodb.<key>.uri=mongodb-url-with-credentials | store mongodb-urls under a key to be used by mongodb procedures
 | apoc.spatial.geocode.provider=<providername>
 apoc.spatial.geocode.<providerName>.<key>=<value>

--- a/src/main/java/apoc/ApocConfig.java
+++ b/src/main/java/apoc/ApocConfig.java
@@ -57,6 +57,7 @@ public class ApocConfig extends LifecycleAdapter {
     public static final String APOC_IMPORT_FILE_ALLOW__READ__FROM__FILESYSTEM = "apoc.import.file.allow_read_from_filesystem";
     public static final String APOC_CONFIG_JOBS_SCHEDULED_NUM_THREADS = "apoc.jobs.scheduled.num_threads";
     public static final String APOC_CONFIG_JOBS_POOL_NUM_THREADS = "apoc.jobs.pool.num_threads";
+    public static final String APOC_CONFIG_JOBS_QUEUE_SIZE = "apoc.jobs.queue.size";
     public static final String APOC_CONFIG_INITIALIZER_CYPHER = "apoc.initializer.cypher";
 
     private static final List<Setting> NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES = new ArrayList<>(Arrays.asList(

--- a/src/main/java/apoc/Pools.java
+++ b/src/main/java/apoc/Pools.java
@@ -45,7 +45,8 @@ public class Pools extends LifecycleAdapter {
 
         int threads = Math.max(1, apocConfig.getInt(ApocConfig.APOC_CONFIG_JOBS_POOL_NUM_THREADS, DEFAULT_POOL_THREADS));
 
-        int queueSize = threads * 25;
+        int queueSize = Math.max(1, apocConfig.getInt(ApocConfig.APOC_CONFIG_JOBS_QUEUE_SIZE, threads * 5));
+
         this.defaultExecutorService = new ThreadPoolExecutor(threads / 2, threads, 30L, TimeUnit.SECONDS, new ArrayBlockingQueue<>(queueSize),
                 new CallerBlocksPolicy());
 


### PR DESCRIPTION
Fixes #1537

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

- made it configurable via `apoc.jobs.queue.size` property
- reduced the default to threads * 5
