### PR TITLE
fixes #1546: Sorting for international strings

### DIFF
--- a/docs/asciidoc/utilities/collection.adoc
+++ b/docs/asciidoc/utilities/collection.adoc
@@ -62,6 +62,7 @@ endif::[]
 | apoc.coll.remove(coll, index, [length=1]) | remove range of values from index to length
 | apoc.coll.different(values) | returns true if value are different
 | apoc.coll.fill(item, count) | returns a list with the given count of items
+| apoc.coll.sortText(coll, conf) | sort on string based collections
 |===
 
 .The following computes the sum of values in a list:
@@ -675,5 +676,20 @@ RETURN apoc.coll.different([1,3,5,7,9]) AS output
 |===
 | Output
 | true
+|===
+
+.The following sort a list of strings:
+[source,cypher]
+----
+// n.b. if no locale is provided it takes the default of the machine where neo4j is running on
+RETURN apoc.coll.sortText(['Єльська', 'Гусак'], {locale: 'ru'}) as Output
+----
+
+.Results
+[opts="header",cols="1"]
+|===
+| Output
+| Гусак
+| Єльська
 |===
 

--- a/src/main/java/apoc/coll/Coll.java
+++ b/src/main/java/apoc/coll/Coll.java
@@ -3,12 +3,35 @@ package apoc.coll;
 import apoc.result.ListResult;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.apache.commons.math3.util.Combinations;
-import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.helpers.collection.Pair;
-import org.neo4j.procedure.*;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.UserFunction;
 
 import java.lang.reflect.Array;
-import java.util.*;
+import java.text.Collator;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.RandomAccess;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -901,5 +924,18 @@ public class Coll {
     @Description("apoc.coll.fill(item, count) - returns a list with the given count of items")
     public List<Object> fill(@Name("item") String item, @Name("count") long count) {
         return Collections.nCopies((int) count, item);
+    }
+
+    @UserFunction
+    @Description("apoc.coll.sortText(coll) sort on string based collections")
+    public List<String> sortText(@Name("coll") List<String> coll, @Name(value = "conf", defaultValue = "{}") Map<String, Object> conf) {
+        if (conf == null) conf = Collections.emptyMap();
+        if (coll == null || coll.isEmpty()) return Collections.emptyList();
+        List<String> sorted = new ArrayList<>(coll);
+        String localeAsStr = conf.getOrDefault("locale", "").toString();
+        final Locale locale = !localeAsStr.isBlank() ? Locale.forLanguageTag(localeAsStr) : null;
+        Collator collator = locale != null ? Collator.getInstance(locale) : Collator.getInstance();
+        Collections.sort(sorted, collator);
+        return sorted;
     }
 }

--- a/src/test/java/apoc/coll/CollTest.java
+++ b/src/test/java/apoc/coll/CollTest.java
@@ -892,5 +892,13 @@ public class CollTest {
                 });
     }
 
+    @Test
+    public void testSortText() throws Exception {
+        testCall(db, "RETURN apoc.coll.sortText(['b', 'a']) as value",
+                (row) -> assertEquals(asList("a", "b"), row.get("value")));
+        testCall(db, "RETURN apoc.coll.sortText(['Єльська', 'Гусак'], {locale: 'ru'}) as value",
+                (row) -> assertEquals(asList("Гусак", "Єльська"), row.get("value")));
+    }
+
 }
 


### PR DESCRIPTION
Fixes #1546

Created the new procedure that sorts lists of strings

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - created `apoc.coll.sortText`
  - added text
  - updated documentation
