### PR TITLE
follow-up fingerprint

### DIFF
--- a/docs/asciidoc/utilities/hashing.adoc
+++ b/docs/asciidoc/utilities/hashing.adoc
@@ -36,8 +36,12 @@ This is useful if you store properties (like `created=timestamp()`) that should 
 | `relAllowMap` | Map<K,V> | empty | a map where the key is the rel type and the value is a lists properties allowed
 | `nodeDisallowMap` | Map<K,V> | empty | a DisallowMap map where the key is the node Label and the value is a lists properties disallowed
 | `relDisallowMap` | Map<K,V> | empty | a DisallowMap map where the key is the rel type and the value is a lists properties disallowed
-| `mapAllowList` | List | empty | a Map used in case the input to the procedure is a map allowed
-| `mapDisallowList` | List | empty | a used in case the input to the procedure is a map disallowed
+| `mapAllowList` | List | empty | a List used in case the input to the procedure is a map allowed
+| `mapDisallowList` | List | empty | a List used in case the input to the procedure is a map disallowed
+| `allNodesAllowList` | List | empty | a List used for properties common to all Nodes that you need to include in the fingerprint
+| `allRelsAllowList` | List | empty | a List used for properties common to all Relationships that you need to include in the fingerprint
+| `allNodesDisallowList` | List | empty | a List used for properties common to all Nodes that you need to exclude from the fingerprint
+| `allRelsDisallowList` | List | empty | a List used for properties common to all Relationships that you need to exclude from the fingerprint
 |===
 
 .n.b you cannot combine allow & disallow list for the same entity type, this means that for nodes/rels/maps you can specify allow or disallow with lists

--- a/src/main/java/apoc/hashing/FingerprintingConfig.java
+++ b/src/main/java/apoc/hashing/FingerprintingConfig.java
@@ -14,6 +14,10 @@ public class FingerprintingConfig {
 
     private final List<String> mapAllowList;
     private final List<String> mapDisallowList;
+    private final List<String> allNodesAllowList;
+    private final List<String> allRelsAllowList;
+    private final List<String> allNodesDisallowList;
+    private final List<String> allRelsDisallowList;
 
 
     public FingerprintingConfig(Map<String, Object> config) {
@@ -26,6 +30,10 @@ public class FingerprintingConfig {
         this.relDisallowMap = (Map<String, List<String>>) config.getOrDefault("relDisallowMap", Collections.emptyMap());
         this.mapAllowList = (List<String>) config.getOrDefault("mapAllowList", Collections.emptyList());
         this.mapDisallowList = (List<String>) config.getOrDefault("mapDisallowList", config.getOrDefault("propertyExcludes", Collections.emptyList()));
+        this.allNodesAllowList = (List<String>) config.getOrDefault("allNodesAllowList", Collections.emptyList());
+        this.allRelsAllowList = (List<String>) config.getOrDefault("allRelsAllowList", Collections.emptyList());
+        this.allNodesDisallowList = (List<String>) config.getOrDefault("allNodesDisallowList", Collections.emptyList());
+        this.allRelsDisallowList = (List<String>) config.getOrDefault("allRelsDisallowList", Collections.emptyList());
 
         validateConfig();
     }
@@ -40,6 +48,12 @@ public class FingerprintingConfig {
         }
         if (!mapAllowList.isEmpty() && !mapDisallowList.isEmpty()) {
             throw new RuntimeException(message + "maps");
+        }
+        if (!allNodesAllowList.isEmpty() && !allNodesDisallowList.isEmpty()) {
+            throw new RuntimeException(message + "all nodes");
+        }
+        if (!allRelsAllowList.isEmpty() && !allRelsDisallowList.isEmpty()) {
+            throw new RuntimeException(message + "all rels");
         }
     }
 
@@ -69,5 +83,21 @@ public class FingerprintingConfig {
 
     public List<String> getMapDisallowList() {
         return mapDisallowList;
+    }
+
+    public List<String> getAllNodesAllowList() {
+        return allNodesAllowList;
+    }
+
+    public List<String> getAllRelsAllowList() {
+        return allRelsAllowList;
+    }
+
+    public List<String> getAllNodesDisallowList() {
+        return allNodesDisallowList;
+    }
+
+    public List<String> getAllRelsDisallowList() {
+        return allRelsDisallowList;
     }
 }

--- a/src/test/java/apoc/hashing/FingerprintingTest.java
+++ b/src/test/java/apoc/hashing/FingerprintingTest.java
@@ -146,6 +146,18 @@ public class FingerprintingTest  {
                         "RETURN apoc.hashing.fingerprinting(map, $conf) as hash ",
                 Collections.singletonMap("conf",
                         Util.map("nodeDisallowMap", Util.map("Person", Arrays.asList("surname")))));
+        String personNameByAllNodesAllowList = TestUtil.singleResultFirstColumn(db, "MATCH p = (n)-[r]->(m) " +
+                        "WITH collect(p) AS paths " +
+                        "CALL apoc.graph.fromPaths(paths, '', {}) yield graph AS g " +
+                        "WITH {nodes: apoc.coll.toSet(g.nodes), rels: apoc.coll.toSet(g.relationships)} AS map " +
+                        "RETURN apoc.hashing.fingerprinting(map, $conf) as hash ",
+                Collections.singletonMap("conf", Util.map("allNodesAllowList", Arrays.asList("name"))));
+        String personNameByAllNodesDisallowList = TestUtil.singleResultFirstColumn(db, "MATCH p = (n)-[r]->(m) " +
+                        "WITH collect(p) AS paths " +
+                        "CALL apoc.graph.fromPaths(paths, '', {}) yield graph AS g " +
+                        "WITH {nodes: apoc.coll.toSet(g.nodes), rels: apoc.coll.toSet(g.relationships)} AS map " +
+                        "RETURN apoc.hashing.fingerprinting(map, $conf) as hash ",
+                Collections.singletonMap("conf", Util.map("allNodesDisallowList", Arrays.asList("surname"))));
         String rel = TestUtil.singleResultFirstColumn(db, "MATCH p = (n)-[r]->(m) " +
                         "WITH collect(p) AS paths " +
                         "CALL apoc.graph.fromPaths(paths, '', {}) yield graph AS g " +
@@ -153,8 +165,10 @@ public class FingerprintingTest  {
                         "RETURN apoc.hashing.fingerprinting(map, $conf) as hash ",
                 Collections.singletonMap("conf",
                         Util.map("relDisallowMap", Util.map("KNOWS", Arrays.asList("since")))));
-        Set<String> hashes = new HashSet<>(Arrays.asList(all, personName, personNameByDisallowMap, rel));
-        assertEquals(3, hashes.size()); // 3 because personName = personNameByDisallowMap
+        Set<String> hashes = new HashSet<>(Arrays.asList(all, personName,
+                personNameByDisallowMap, personNameByAllNodesAllowList,
+                personNameByAllNodesDisallowList, rel));
+        assertEquals(3, hashes.size()); // 3 because personName = personNameByDisallowMap = personNameByAllNodesAllowMap = personNameByAllNodesDisallowMap
     }
 
     private void compareGraph(String cypher, List<String> excludes, boolean shouldBeEqual) {


### PR DESCRIPTION
Followup for fingerprinting:

- added 4 new properties:
  - `allNodesAllowList/allNodesDisallowList` for properties common to all Nodes
  - `allRelsAllowList/allRelsDisallowList` for properties common to all Relationships
- Fixed a bug in case the `keys` to include in the fingerprint is empty.
- added fingerprint for type `Path`