### PR TITLE
added fingerprint strategy

### DIFF
--- a/docs/asciidoc/utilities/hashing.adoc
+++ b/docs/asciidoc/utilities/hashing.adoc
@@ -42,6 +42,15 @@ This is useful if you store properties (like `created=timestamp()`) that should 
 | `allRelsAllowList` | List | empty | a List used for properties common to all Relationships that you need to include in the fingerprint
 | `allNodesDisallowList` | List | empty | a List used for properties common to all Nodes that you need to exclude from the fingerprint
 | `allRelsDisallowList` | List | empty | a List used for properties common to all Relationships that you need to exclude from the fingerprint
+| `strategy` | Enum[EAGER, LAZY] | LAZY | define the behaviour in case the properties are not present for the specific node/relationship, see the `Fingerprinting strategy` paragraph
 |===
 
 .n.b you cannot combine allow & disallow list for the same entity type, this means that for nodes/rels/maps you can specify allow or disallow with lists
+
+== Fingerprinting strategy
+
+In case the properties defined in the configuration are not present in the node and/or relationship you can define how
+the fingerprinting procedure must proceed with the process:
+
+* `EAGER`: it evaluates the whole node properties in order to create the fingerprint of the node/relationship
+* `LAZY`: it evaluates only the nodes/relationships provided in the configuration

--- a/src/main/java/apoc/hashing/Fingerprinting.java
+++ b/src/main/java/apoc/hashing/Fingerprinting.java
@@ -1,6 +1,8 @@
 package apoc.hashing;
 
+import apoc.util.Util;
 import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
@@ -14,19 +16,17 @@ import org.neo4j.procedure.UserFunction;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Formatter;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 public class Fingerprinting {
-
-    public static final String DIGEST_ALGORITHM = "MD5";
 
     @Context
     public Transaction tx;
@@ -37,7 +37,9 @@ public class Fingerprinting {
     @UserFunction
     @Description("calculate a checksum (md5) over a node or a relationship. This deals gracefully with array properties. Two identical entities do share the same hash.")
     public String fingerprint(@Name("some object") Object thing, @Name(value = "propertyExcludes", defaultValue = "[]") List<String> excludedPropertyKeys) {
-        FingerprintingConfig config = new FingerprintingConfig(Collections.singletonMap("propertyExcludes", excludedPropertyKeys));
+        FingerprintingConfig config = new FingerprintingConfig(Util.map("allNodesDisallowList", excludedPropertyKeys,
+                "allRelsDisallowList", excludedPropertyKeys, "mapDisallowList", excludedPropertyKeys,
+                "strategy", FingerprintingConfig.FingerprintStrategy.EAGER.toString()));
         return fingerprint(thing, config);
     }
 
@@ -58,37 +60,49 @@ public class Fingerprinting {
         } else if (thing instanceof Relationship) {
             fingerprintRelationship(md, (Relationship) thing, conf);
         } else if (thing instanceof Path) {
-            StreamSupport.stream(((Path) thing).nodes().spliterator(), false)
-                    .forEach(o -> fingerprint(md, o, conf));
-            StreamSupport.stream(((Path) thing).relationships().spliterator(), false)
-                    .forEach(o -> fingerprint(md, o, conf));
+            fingerprintPath(md, (Path) thing, conf);
         } else if (thing instanceof Map) {
-            Map<String, Object> map = (Map<String, Object>) thing;
-            map.entrySet().stream()
-                    .filter(e -> {
-                        if (!conf.getMapAllowList().isEmpty()) {
-                            return conf.getMapAllowList().contains(e.getKey());
-                        } else {
-                            return !conf.getMapDisallowList().contains(e.getKey());
-                        }
-                    })
-                    .sorted(Map.Entry.comparingByKey())
-                    .forEachOrdered(entry -> {
-                        md.update(entry.getKey().getBytes());
-                        md.update(fingerprint(entry.getValue(), conf).getBytes());
-                    });
+            fingerprintMap(md, conf, (Map<String, Object>) thing);
         } else if (thing instanceof List) {
-            List list = (List) thing;
-            list.stream().forEach(o -> fingerprint(md, o, conf));
+            fingerprintList(md, conf, (List) thing);
         } else {
             md.update(convertValueToString(thing).getBytes());
         }
     }
 
+    private void fingerprintList(DiagnosingMessageDigestDecorator md, FingerprintingConfig conf, List list) {
+        list.stream().forEach(o -> fingerprint(md, o, conf));
+    }
+
+    private void fingerprintPath(DiagnosingMessageDigestDecorator md, Path thing, FingerprintingConfig conf) {
+        StreamSupport.stream(thing.nodes().spliterator(), false)
+                .forEach(o -> fingerprint(md, o, conf));
+        StreamSupport.stream(thing.relationships().spliterator(), false)
+                .forEach(o -> fingerprint(md, o, conf));
+    }
+
+    private void fingerprintMap(DiagnosingMessageDigestDecorator md, FingerprintingConfig conf, Map<String, Object> map) {
+        map.entrySet().stream()
+                .filter(e -> {
+                    if (!conf.getMapAllowList().isEmpty()) {
+                        return conf.getMapAllowList().contains(e.getKey());
+                    } else {
+                        return !conf.getMapDisallowList().contains(e.getKey());
+                    }
+                })
+                .sorted(Map.Entry.comparingByKey())
+                .forEachOrdered(entry -> {
+                    md.update(entry.getKey().getBytes());
+                    md.update(fingerprint(entry.getValue(), conf).getBytes());
+                });
+    }
+
     @UserFunction
     @Description("calculate a checksum (md5) over a the full graph. Be aware that this function does use in-memomry datastructures depending on the size of your graph.")
     public String fingerprintGraph(@Name(value = "propertyExcludes", defaultValue = "[]") List<String> excludedPropertyKeys) {
-        FingerprintingConfig config = new FingerprintingConfig(Collections.singletonMap("propertyExcludes", excludedPropertyKeys));
+        FingerprintingConfig config = new FingerprintingConfig(Util.map("allNodesDisallowList", excludedPropertyKeys,
+                "allRelsDisallowList", excludedPropertyKeys, "mapDisallowList", excludedPropertyKeys,
+                "strategy", FingerprintingConfig.FingerprintStrategy.EAGER.toString()));
         return withMessageDigest(config, messageDigest -> {
             // step 1: load all nodes, calc their hash and map them to id
             Map<Long, String> idToNodeHash = tx.getAllNodes().stream().collect(Collectors.toMap(
@@ -179,69 +193,88 @@ public class Fingerprinting {
     }
 
     private void fingerprintNode(DiagnosingMessageDigestDecorator md, Node node, FingerprintingConfig config) {
-        StreamSupport.stream(node.getLabels().spliterator(), false)
+        switch (config.getStrategy()) {
+            case EAGER:
+                StreamSupport.stream(node.getLabels().spliterator(), false)
+                        .map(Label::name)
+                        .sorted()
+                        .map(String::getBytes)
+                        .forEach(md::update);
+                break;
+            case LAZY:
+                StreamSupport.stream(node.getLabels().spliterator(), false)
+                        .map(Label::name)
+                        .filter(name -> config.getAllLabels().contains(name))
+                        .sorted()
+                        .map(String::getBytes)
+                        .forEach(md::update);
+        }
+
+        final List<String> keysToRetain = new ArrayList<>(config.getAllNodesAllowList());
+        keysToRetain.addAll(StreamSupport.stream(node.getLabels().spliterator(), false)
                 .map(Label::name)
-                .sorted()
-                .map(String::getBytes)
-                .forEach(md::update);
-        final Map<String, Object> allProperties;
-        if (!config.getNodeAllowMap().isEmpty()) {
-            final String[] keys = StreamSupport.stream(node.getLabels().spliterator(), false)
-                    .map(Label::name)
-                    .flatMap(label -> config.getNodeAllowMap().getOrDefault(label, Collections.emptyList()).stream())
-                    .toArray(String[]::new);
-            allProperties = keys.length > 0 ? node.getProperties(keys) : node.getAllProperties();
-        } else if (!config.getNodeDisallowMap().isEmpty()) {
-            allProperties = node.getAllProperties();
-            final Set<String> keysToRemove = StreamSupport.stream(node.getLabels().spliterator(), false)
-                    .map(Label::name)
-                    .flatMap(label -> config.getNodeDisallowMap().getOrDefault(label, Collections.emptyList()).stream())
-                    .collect(Collectors.toSet());
-            allProperties.keySet().removeAll(keysToRemove);
-        } else if (!config.getMapDisallowList().isEmpty()) {
-            allProperties = node.getAllProperties();
-            allProperties.keySet().removeAll(config.getMapDisallowList());
-        } else {
-            allProperties = node.getAllProperties();
-        }
-        if (!config.getAllNodesAllowList().isEmpty()) {
-            allProperties.keySet().retainAll(config.getAllNodesAllowList());
-        }
-        if (!config.getAllNodesDisallowList().isEmpty()) {
-            allProperties.keySet().removeAll(config.getAllNodesDisallowList());
-        }
+                .flatMap(label -> config.getNodeAllowMap().getOrDefault(label, Collections.emptyList()).stream())
+                .collect(Collectors.toSet()));
+
+        final List<String> keysToRemove = new ArrayList<>(config.getAllNodesDisallowList());
+        keysToRemove.addAll(StreamSupport.stream(node.getLabels().spliterator(), false)
+                .map(Label::name)
+                .flatMap(label -> config.getNodeDisallowMap().getOrDefault(label, Collections.emptyList()).stream())
+                .collect(Collectors.toSet()));
+        keysToRemove.addAll(config.getMapDisallowList()); // just to backwards compatibility remove it
+
+        final Map<String, Object> allProperties = getEntityProperties(node, config, keysToRetain, keysToRemove);
         fingerprint(md, allProperties, config);
     }
 
     private void fingerprintRelationship(DiagnosingMessageDigestDecorator md, Relationship rel, FingerprintingConfig config) {
-        md.update(rel.getType().name().getBytes());
-        md.update(fingerprint(rel.getStartNode(), config).getBytes());
-        md.update(fingerprint(rel.getEndNode(), config).getBytes());
+        switch (config.getStrategy()) {
+            case EAGER:
+                md.update(rel.getType().name().getBytes());
+                md.update(fingerprint(rel.getStartNode(), config).getBytes());
+                md.update(fingerprint(rel.getEndNode(), config).getBytes());
+                break;
+            case LAZY:
+                if (config.getAllTypes().contains(rel.getType().name())) {
+                    md.update(rel.getType().name().getBytes());
+                    md.update(fingerprint(rel.getStartNode(), config).getBytes());
+                    md.update(fingerprint(rel.getEndNode(), config).getBytes());
+                }
+        }
 
-        final Map<String, Object> allProperties;
-        if (!config.getRelAllowMap().isEmpty()) {
-            final String[] keys = config.getRelAllowMap()
-                    .getOrDefault(rel.getType().name(), Collections.emptyList())
-                    .toArray(String[]::new);
-            allProperties = keys.length > 0 ? rel.getProperties(keys) : rel.getAllProperties();
-        } else if (!config.getRelDisallowMap().isEmpty()) {
-            allProperties = rel.getAllProperties();
-            final List<String> keysToRemove = config.getRelDisallowMap()
-                    .getOrDefault(rel.getType().name(), Collections.emptyList());
-            allProperties.keySet().removeAll(keysToRemove);
-        } else if (!config.getMapDisallowList().isEmpty()) {
-            allProperties = rel.getAllProperties();
-            allProperties.keySet().removeAll(config.getMapDisallowList());
-        } else {
-            allProperties = rel.getAllProperties();
-        }
-        if (!config.getAllRelsAllowList().isEmpty()) {
-            allProperties.keySet().retainAll(config.getAllRelsAllowList());
-        }
-        if (!config.getAllRelsDisallowList().isEmpty()) {
-            allProperties.keySet().removeAll(config.getAllRelsAllowList());
-        }
+        final List<String> keysToRetain = new ArrayList<>(config.getAllRelsAllowList());
+        keysToRetain.addAll(config.getRelAllowMap()
+                .getOrDefault(rel.getType().name(), Collections.emptyList()));
+
+        final List<String> keysToRemove = new ArrayList<>(config.getAllRelsDisallowList());
+        keysToRemove.addAll(config.getRelDisallowMap()
+                .getOrDefault(rel.getType().name(), Collections.emptyList()));
+        keysToRemove.addAll(config.getMapDisallowList()); // just to backwards compatibility remove it
+
+        final Map<String, Object> allProperties = getEntityProperties(rel, config, keysToRetain, keysToRemove);
         fingerprint(md, allProperties, config);
+    }
+
+    private Map<String, Object> getEntityProperties(Entity entity, FingerprintingConfig config, List<String> keysToRetain, List<String> keysToRemove) {
+        final Map<String, Object> allProperties;
+        if (keysToRetain.isEmpty() && keysToRemove.isEmpty()) {
+            switch (config.getStrategy()) {
+                case LAZY:
+                    allProperties = Collections.emptyMap();
+                    break;
+                default:
+                    allProperties = entity.getAllProperties();
+            }
+        } else {
+            allProperties = entity.getAllProperties();
+            if (!keysToRetain.isEmpty()) {
+                allProperties.keySet().retainAll(keysToRetain);
+            }
+            if (!keysToRemove.isEmpty()) {
+                allProperties.keySet().removeAll(keysToRemove);
+            }
+        }
+        return allProperties;
     }
 
     private String withMessageDigest(FingerprintingConfig conf, Consumer<DiagnosingMessageDigestDecorator> consumer) {
@@ -264,6 +297,9 @@ public class Fingerprinting {
     }
 
     private String convertValueToString(Object value) {
+        if (value == null) {
+            return "";
+        }
         if (value.getClass().isArray()) {
             return nativeArrayToString(value);
         } else {

--- a/src/main/java/apoc/util/Util.java
+++ b/src/main/java/apoc/util/Util.java
@@ -49,6 +49,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -885,5 +886,14 @@ public class Util {
             }
         }
         return node;
+    }
+
+    public static <T> Set<T> intersection(Collection<T> a, Collection<T> b) {
+        if (a == null || b == null) {
+            return Collections.emptySet();
+        }
+        Set<T> intersection = new HashSet<>(a);
+        intersection.retainAll(b);
+        return intersection;
     }
 }

--- a/src/test/java/apoc/hashing/FingerprintingTest.java
+++ b/src/test/java/apoc/hashing/FingerprintingTest.java
@@ -4,9 +4,11 @@ import apoc.coll.Coll;
 import apoc.graph.Graphs;
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -48,6 +50,9 @@ public class FingerprintingTest  {
 
         String hashOfABoolean = TestUtil.singleResultFirstColumn(db, "return apoc.hashing.fingerprint(true);");
         assertEquals("B326B5062B2F0E69046810717534CB09", hashOfABoolean);
+
+        String hashOfNull = TestUtil.singleResultFirstColumn(db, "return apoc.hashing.fingerprint(null);");
+        assertEquals("D41D8CD98F00B204E9800998ECF8427E", hashOfNull);
     }
 
     @Test
@@ -125,50 +130,55 @@ public class FingerprintingTest  {
     @Test
     public void testFingerprintingMapConf() {
         db.executeTransactionally("CREATE (p1:Person{name:'Andrea', surname:'Santurbano'}), (p2:Person{name:'Stefan', surname:'Armbruster'}), " +
-                "(p1)-[:KNOWS{since: 2014}]->(p2), (p2)-[:KNOWS{since: 2018}]->(p1)");
+                "(pr:Product{sku: 'Nintendo Switch'}), " +
+                "(p1)-[:KNOWS{since: 2014}]->(p2), (p2)-[:KNOWS{since: 2018}]->(p1), " +
+                "(p1)-[:BOUGHT{when: 2017}]->(pr)");
         String all = TestUtil.singleResultFirstColumn(db, "MATCH p = (n)-[r]->(m) " +
                         "WITH collect(p) AS paths " +
                         "CALL apoc.graph.fromPaths(paths, '', {}) yield graph AS g " +
                         "WITH {nodes: apoc.coll.toSet(g.nodes), rels: apoc.coll.toSet(g.relationships)} AS map " +
                         "RETURN apoc.hashing.fingerprinting(map, $conf) as hash ",
                 Collections.singletonMap("conf", Collections.emptyMap()));
-        String personName = TestUtil.singleResultFirstColumn(db, "MATCH p = (n)-[r]->(m) " +
+    }
+
+    @Test
+    public void testFingerprintingWithLazyEvaluation() {
+        db.executeTransactionally("CREATE (p1:Person{name:'Andrea', surname:'Santurbano'}), (p2:Person{name:'Stefan', surname:'Armbruster'}), " +
+                "(pr:Product{sku: 'Nintendo Switch'}), " +
+                "(p1)-[:KNOWS{since: 2014}]->(p2), (p2)-[:KNOWS{since: 2018}]->(p1), " +
+                "(p1)-[:BOUGHT{when: 2017}]->(pr)");
+        String all = TestUtil.singleResultFirstColumn(db, "MATCH p = (n)-[r]->(m) " +
                         "WITH collect(p) AS paths " +
                         "CALL apoc.graph.fromPaths(paths, '', {}) yield graph AS g " +
                         "WITH {nodes: apoc.coll.toSet(g.nodes), rels: apoc.coll.toSet(g.relationships)} AS map " +
                         "RETURN apoc.hashing.fingerprinting(map, $conf) as hash ",
-                Collections.singletonMap("conf",
-                        Util.map("nodeAllowMap", Util.map("Person", Arrays.asList("name")))));
-        String personNameByDisallowMap = TestUtil.singleResultFirstColumn(db, "MATCH p = (n)-[r]->(m) " +
-                        "WITH collect(p) AS paths " +
-                        "CALL apoc.graph.fromPaths(paths, '', {}) yield graph AS g " +
-                        "WITH {nodes: apoc.coll.toSet(g.nodes), rels: apoc.coll.toSet(g.relationships)} AS map " +
-                        "RETURN apoc.hashing.fingerprinting(map, $conf) as hash ",
-                Collections.singletonMap("conf",
-                        Util.map("nodeDisallowMap", Util.map("Person", Arrays.asList("surname")))));
-        String personNameByAllNodesAllowList = TestUtil.singleResultFirstColumn(db, "MATCH p = (n)-[r]->(m) " +
-                        "WITH collect(p) AS paths " +
-                        "CALL apoc.graph.fromPaths(paths, '', {}) yield graph AS g " +
-                        "WITH {nodes: apoc.coll.toSet(g.nodes), rels: apoc.coll.toSet(g.relationships)} AS map " +
-                        "RETURN apoc.hashing.fingerprinting(map, $conf) as hash ",
-                Collections.singletonMap("conf", Util.map("allNodesAllowList", Arrays.asList("name"))));
-        String personNameByAllNodesDisallowList = TestUtil.singleResultFirstColumn(db, "MATCH p = (n)-[r]->(m) " +
-                        "WITH collect(p) AS paths " +
-                        "CALL apoc.graph.fromPaths(paths, '', {}) yield graph AS g " +
-                        "WITH {nodes: apoc.coll.toSet(g.nodes), rels: apoc.coll.toSet(g.relationships)} AS map " +
-                        "RETURN apoc.hashing.fingerprinting(map, $conf) as hash ",
-                Collections.singletonMap("conf", Util.map("allNodesDisallowList", Arrays.asList("surname"))));
-        String rel = TestUtil.singleResultFirstColumn(db, "MATCH p = (n)-[r]->(m) " +
-                        "WITH collect(p) AS paths " +
-                        "CALL apoc.graph.fromPaths(paths, '', {}) yield graph AS g " +
-                        "WITH {nodes: apoc.coll.toSet(g.nodes), rels: apoc.coll.toSet(g.relationships)} AS map " +
-                        "RETURN apoc.hashing.fingerprinting(map, $conf) as hash ",
-                Collections.singletonMap("conf",
-                        Util.map("relDisallowMap", Util.map("KNOWS", Arrays.asList("since")))));
-        Set<String> hashes = new HashSet<>(Arrays.asList(all, personName,
-                personNameByDisallowMap, personNameByAllNodesAllowList,
-                personNameByAllNodesDisallowList, rel));
-        assertEquals(3, hashes.size()); // 3 because personName = personNameByDisallowMap = personNameByAllNodesAllowMap = personNameByAllNodesDisallowMap
+                Collections.singletonMap("conf", Util.map("nodeAllowMap", Util.map("Person", Collections.singletonList("name")))));
+        String filtered = TestUtil.singleResultFirstColumn(db, "MATCH (p:Person) " +
+                        "RETURN apoc.hashing.fingerprinting({nodes: collect(p), rels: []}, $conf) as hash ",
+                Collections.singletonMap("conf", Util.map("nodeAllowMap", Util.map("Person", Collections.singletonList("name")))));
+        assertEquals(all, filtered);
+    }
+
+    @Test(expected = QueryExecutionException.class)
+    public void testConfigExceptionOnTheSameLabels() {
+        db.executeTransactionally("CREATE (p1:Person{name:'Andrea', surname:'Santurbano'}), (p2:Person{name:'Stefan', surname:'Armbruster'}), " +
+                "(pr:Product{sku: 'Nintendo Switch'}), " +
+                "(p1)-[:KNOWS{since: 2014}]->(p2), (p2)-[:KNOWS{since: 2018}]->(p1), " +
+                "(p1)-[:BOUGHT{when: 2017}]->(pr)");
+        final Map<String, Object> conf = Util.map("nodeAllowMap", Util.map("Person", Arrays.asList("name")),
+                "nodeDisallowMap", Util.map("Person", Arrays.asList("surname")));
+        try {
+            TestUtil.singleResultFirstColumn(db, "MATCH p = (n)-[r]->(m) " +
+                            "WITH collect(p) AS paths " +
+                            "CALL apoc.graph.fromPaths(paths, '', {}) yield graph AS g " +
+                            "WITH {nodes: apoc.coll.toSet(g.nodes), rels: apoc.coll.toSet(g.relationships)} AS map " +
+                            "RETURN apoc.hashing.fingerprinting(map, $conf) as hash ",
+                    Collections.singletonMap("conf", conf));
+        } catch (Exception e) {
+            String expected = "You can't set the same labels for allow and disallow lists for nodes";
+            assertEquals(expected, ExceptionUtils.getRootCause(e).getMessage());
+            throw e;
+        }
     }
 
     private void compareGraph(String cypher, List<String> excludes, boolean shouldBeEqual) {


### PR DESCRIPTION
Added fingerprinting strategy. Now we have two values:

* `EAGER` is as it behaves the old procedure, it evaluates every graph entity.
* `LAZY` is the new one and processed the data only if the graph entity is present into the configuration in `allow` or `disallow` lists

Now we support both allow and disallow configurations, but the user cannot define allow&disallow for the same graph entity

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added the strategies
  - Improved the configuration management
  - Updated the documentation
  - Updated tests
