### PR TITLE
Fix #1570

### DIFF
--- a/docs/asciidoc/graph-updates/uuid.adoc
+++ b/docs/asciidoc/graph-updates/uuid.adoc
@@ -7,6 +7,9 @@ This section describes procedures that can be used to add UUID properties to nod
 --
 
 The library supports manual and automation generation of UUIDs, which can be stored as properties on nodes.
+
+UUIDs are generated using the https://docs.oracle.com/javase/7/docs/api/java/util/UUID.html#randomUUID()[java randomUUID utility method], which generates a https://www.ietf.org/rfc/rfc4122.txt[v4UUID].
+
 This section includes:
 
 * <<manual-uuids>>


### PR DESCRIPTION
Fixes #1570

Adds clarity into how UUID's are generated by `apoc.create.uuid`

## Proposed Changes

A brief list of proposed changes in order to fix the issue:

  - Adds a one sentence paragraph that:
    - Explains how UUID's are generated under the hood
    - Provides links to the java method used to generated UUIDs and UUID RFC4122

## Additional Information:
I built the plugin from source after my changes and realized the documentation changes wouldn't be there. Let me know if there is a good way for me to test this locally - my IDE provides a great adoc editor so I can see the changes look fine.

I also ran tests locally and everything passed. Since it's just a text change I don't know if I should add a test for this change, but if I should let me know.
