### PR TITLE
fixes #1584: apoc.custom.asProcedure() doesn't work when there is input parameters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ jar {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "4.0.4"
+    neo4jVersion = "4.0.6"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.12.2'

--- a/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -162,7 +162,7 @@ public class CypherProceduresHandler implements AvailabilityListener {
         List<FieldSignature> inputs = deserializeSignatures(property);
 
         List<FieldSignature> outputSignature = deserializeSignatures((String) node.getProperty(SystemPropertyKeys.outputs.name()));
-        return new ProcedureDescriptor(new ProcedureSignature(
+        return new ProcedureDescriptor(Signatures.createProcedureSignature(
                 new QualifiedName(new String[]{PREFIX}, name),
                 inputs,
                 outputSignature,
@@ -172,6 +172,7 @@ public class CypherProceduresHandler implements AvailabilityListener {
                 new String[0],
                 description,
                 null,
+                false,
                 false,
                 false,
                 false
@@ -317,7 +318,7 @@ public class CypherProceduresHandler implements AvailabilityListener {
     public ProcedureSignature procedureSignature(String name, String mode, List<List<String>> outputs, List<List<String>> inputs, String description) {
         boolean admin = false; // TODO
         return new ProcedureSignature(qualifiedName(name), inputSignatures(inputs), outputSignatures(outputs),
-                Mode.valueOf(mode.toUpperCase()), admin, null, new String[0], description, null, false, false, true
+                Mode.valueOf(mode.toUpperCase()), admin, null, new String[0], description, null, false, false, true, false
         );
     }
 

--- a/src/main/java/apoc/custom/Signatures.java
+++ b/src/main/java/apoc/custom/Signatures.java
@@ -5,6 +5,7 @@ import org.antlr.v4.runtime.*;
 import org.neo4j.internal.kernel.api.procs.*;
 import org.neo4j.procedure.Mode;
 
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -72,7 +73,7 @@ public class Signatures {
         String warning = null; // "todo warning";
         boolean eager = false;
         boolean caseInsensitive = true;
-        return new ProcedureSignature(name, inputSignatures, outputSignature, mode, admin, deprecated, allowed, description, warning, eager, caseInsensitive, false);
+        return createProcedureSignature(name, inputSignatures, outputSignature, mode, admin, deprecated, allowed, description, warning, eager, caseInsensitive, false, false);
     }
 
     public List<String> namespace(SignatureParser.NamespaceContext namespaceContext) {
@@ -212,5 +213,63 @@ public class Signatures {
     public ProcedureSignature asProcedureSignature(String signature, String description, Mode mode) {
         SignatureParser.ProcedureContext ctx = parseProcedure(signature);
         return toProcedureSignature(ctx, description, mode);
+    }
+
+    public static ProcedureSignature createProcedureSignature(QualifiedName name,
+                                                              List<FieldSignature> inputSignature,
+                                                              List<FieldSignature> outputSignature,
+                                                              Mode mode,
+                                                              boolean admin,
+                                                              String deprecated,
+                                                              String[] allowed,
+                                                              String description,
+                                                              String warning,
+                                                              boolean eager,
+                                                              boolean caseInsensitive,
+                                                              boolean systemProcedure,
+                                                              boolean internal) {
+        try {
+            // in Neo4j 4.0.5 org.neo4j.internal.kernel.api.procs.ProcedureSignature
+            // changed the signature adding a boolean at the end and without leaving the old signature
+            // in order to maintain the backwards compatibility with version prior to 4.0.5 we use the
+            // reflection to create a new instance of the class
+            final Class<?> clazz = Class.forName("org.neo4j.internal.kernel.api.procs.ProcedureSignature");
+            final Constructor<?>[] constructors = clazz.getConstructors();
+            for (int i = 0; i < constructors.length; i++) {
+                final Constructor<?> constructor = constructors[i];
+                switch (constructor.getParameterCount()) {
+                    case 13:
+                        return (ProcedureSignature) constructor.newInstance(name,
+                                inputSignature,
+                                outputSignature,
+                                mode,
+                                admin,
+                                deprecated,
+                                allowed,
+                                description,
+                                warning,
+                                eager,
+                                caseInsensitive,
+                                systemProcedure,
+                                internal);
+                    case 12:
+                        return (ProcedureSignature) constructor.newInstance(name,
+                                inputSignature,
+                                outputSignature,
+                                mode,
+                                admin,
+                                deprecated,
+                                allowed,
+                                description,
+                                warning,
+                                eager,
+                                caseInsensitive,
+                                systemProcedure);
+                }
+            }
+            throw new RuntimeException("Constructor of org.neo4j.internal.kernel.api.procs.ProcedureSignature not found");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1584 

In Neo4j 4.0.5 `org.neo4j.internal.kernel.api.procs.ProcedureSignature` changed the signature adding a boolean at the end and without leaving the old signature in order to maintain the backwards compatibility with version prior to 4.0.5 we use the reflection to create a new instance of the class.