### PR TITLE
fixes #1556: request trigger not be saved if syntactically incorrect

### DIFF
--- a/src/main/java/apoc/periodic/Periodic.java
+++ b/src/main/java/apoc/periodic/Periodic.java
@@ -159,7 +159,7 @@ public class Periodic {
     }
 
     private void validateQuery(String statement) {
-        db.executeTransactionally("EXPLAIN " + statement);
+        Util.validateQuery(db, statement);
     }
 
     @Procedure(mode = Mode.WRITE)

--- a/src/main/java/apoc/trigger/Trigger.java
+++ b/src/main/java/apoc/trigger/Trigger.java
@@ -1,6 +1,7 @@
 package apoc.trigger;
 
 import apoc.coll.SetBackedList;
+import apoc.util.Util;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -91,6 +92,7 @@ public class Trigger {
     @Procedure(mode = Mode.WRITE)
     @Description("add a trigger kernelTransaction under a name, in the kernelTransaction you can use {createdNodes}, {deletedNodes} etc., the selector is {phase:'before/after/rollback'} returns previous and new trigger information. Takes in an optional configuration.")
     public Stream<TriggerInfo> add(@Name("name") String name, @Name("kernelTransaction") String statement, @Name(value = "selector"/*, defaultValue = "{}"*/)  Map<String,Object> selector, @Name(value = "config", defaultValue = "{}") Map<String,Object> config) {
+        Util.validateQuery(db, statement);
         Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());
         Map<String, Object> removed = triggerHandler.add(name, statement, selector, params);
         if (removed != null) {

--- a/src/main/java/apoc/util/Util.java
+++ b/src/main/java/apoc/util/Util.java
@@ -896,4 +896,8 @@ public class Util {
         intersection.retainAll(b);
         return intersection;
     }
+
+    public static void validateQuery(GraphDatabaseService db, String statement) {
+        db.executeTransactionally("EXPLAIN " + statement);
+    }
 }

--- a/src/test/java/apoc/trigger/TriggerTest.java
+++ b/src/test/java/apoc/trigger/TriggerTest.java
@@ -6,6 +6,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -219,6 +220,9 @@ public class TriggerTest {
         });
     }
 
-
+    @Test(expected = QueryExecutionException.class)
+    public void showThrowAnException() throws Exception {
+        db.executeTransactionally("CALL apoc.trigger.add('test','UNWIND $createdNodes AS n SET n.txId = , n.txTime = $commitTime',{})");
+    }
 
 }


### PR DESCRIPTION
Fixes #1556

Added the validation in `add` method

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - added validation
