### PR TITLE
Passing database name as argument to dmbs.cluster.role

### DIFF
--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -700,7 +700,7 @@ public class Util {
                 /* ignore */
             }
 
-            String role = db.executeTransactionally("CALL dbms.cluster.role()", Collections.emptyMap(),
+            String role = db.executeTransactionally("CALL dbms.cluster.role($dbname)", MapUtil.map("dbname", db.databaseName()),
                     result -> Iterators.single(result.columnAs("role")));
             return role.equalsIgnoreCase("LEADER");
         } catch(QueryExecutionException e) {


### PR DESCRIPTION
Fixes #1550

Passing database name as argument to dmbs.cluster.role

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Passing database name as argument to dmbs.cluster.role

