### PR TITLE
Using apoc schema assert to ensure TTL index is present

### DIFF
--- a/full/src/main/java/apoc/ttl/TTLLifeCycle.java
+++ b/full/src/main/java/apoc/ttl/TTLLifeCycle.java
@@ -66,7 +66,7 @@ public class TTLLifeCycle extends LifecycleAdapter {
 
     public void createTTLIndex() {
         try {
-            db.executeTransactionally("CREATE INDEX ON :TTL(ttl)");
+            db.executeTransactionally("call apoc.schema.assert({ TTL: ['ttl'] }, null, false)");
         } catch (Exception e) {
             log.error("TTL: Error creating index", e);
         }


### PR DESCRIPTION
The previus way of always trying to create the TTL index
created unneccessary errors in the logs.

Fixes #1587

Using apoc schema assert to ensure TTL index is present

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - CREATE INDEX ON :TTL(ttl) replaced with call apoc.schema.assert({ TTL: ['ttl'] }, null, false) to prevent error being logged on startup
