### PR TITLE
fixes #1572: mergeNodes with combine change array type

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/merge-nodes.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/merge-nodes.adoc
@@ -35,12 +35,13 @@ These config option also works for `apoc.refactor.mergeRelationships([rels],{con
 | combine | if there is only one property in list, it will be set / kept as single property otherwise create an array, tries to coerce values
 |===
 
-In addition, mergeNodes supports the following config property:
+In addition, mergeNodes supports the following config properties:
 
 [opts=header]
 |===
 | type | operations
-| mergeRels | true/false" : give the possibility to merge relationships with same type and direction.
+| mergeRels | true/false: give the possibility to merge relationships with same type and direction.
+| singleElementAsArray | false/true: if is `false` (default) and `type` is `combine` in case the merge of two arrays is a new array with size 1 it extracts the single value.
 |===
 
 Relationships properties are managed with the same nodes' method, if properties parameter isn't set relationships properties are combined.

--- a/src/main/java/apoc/refactor/util/PropertiesManager.java
+++ b/src/main/java/apoc/refactor/util/PropertiesManager.java
@@ -25,7 +25,7 @@ public class PropertiesManager {
         }
     }
 
-    private static void mergeProperty(Entity target, RefactorConfig propertyManagementMode, Map.Entry<String, Object> prop, String key, String mergeMode) {
+    private static void mergeProperty(Entity target, RefactorConfig refactorConfig, Map.Entry<String, Object> prop, String key, String mergeMode) {
         switch (mergeMode) {
             case RefactorConfig.OVERWRITE:
             case RefactorConfig.OVERRIDE:
@@ -37,12 +37,12 @@ public class PropertiesManager {
                 }
                 break;
             case RefactorConfig.COMBINE:
-                combineProperties(prop, target);
+                combineProperties(prop, target, refactorConfig);
                 break;
         }
     }
 
-    public static void combineProperties(Map.Entry<String, Object> prop, Entity target) {
+    public static void combineProperties(Map.Entry<String, Object> prop, Entity target, RefactorConfig refactorConfig) {
         if (!target.hasProperty(prop.getKey()))
             target.setProperty(prop.getKey(), prop.getValue());
         else {
@@ -55,17 +55,17 @@ public class PropertiesManager {
                 values.addAll(new ArrayBackedList(prop.getValue()));
             else
                 values.add(prop.getValue());
-            Object array = createPropertyValueFromSet(values);
+            Object array = createPropertyValueFromSet(values, refactorConfig);
             target.setProperty(prop.getKey(), array);
         }
     }
 
-    private static Object createPropertyValueFromSet(Set<Object> input) {
+    private static Object createPropertyValueFromSet(Set<Object> input, RefactorConfig refactorConfig) {
         Object array = null;
         try {
-            if (input.size() == 1)
+            if (input.size() == 1 && !refactorConfig.isSingleElementAsArray()) {
                 return input.toArray()[0];
-            else {
+            } else {
                 if (sameTypeForAllElements(input)) {
                     Class clazz = Class.forName(input.toArray()[0].getClass().getName());
                     array = Array.newInstance(clazz, input.size());

--- a/src/main/java/apoc/refactor/util/RefactorConfig.java
+++ b/src/main/java/apoc/refactor/util/RefactorConfig.java
@@ -27,6 +27,7 @@ public class RefactorConfig {
 	private boolean countMerge;
 	private boolean hasProperties;
 	private boolean collapsedLabel;
+	private boolean singleElementAsArray;
 
 	public RefactorConfig(Map<String,Object> config) {
 		Object value = config.get("properties");
@@ -42,6 +43,7 @@ public class RefactorConfig {
 		this.selfRel = toBoolean(config.get("selfRel"));
 		this.countMerge = toBoolean(config.getOrDefault("countMerge", true));
 		this.collapsedLabel = toBoolean(config.get("collapsedLabel"));
+		this.singleElementAsArray = toBoolean(config.getOrDefault("singleElementAsArray", false));
 	}
 
 	public String getMergeMode(String name){
@@ -82,5 +84,9 @@ public class RefactorConfig {
 
 	public boolean isMergeVirtualRels() {
 		return mergeVirtualRels;
+	}
+
+	public boolean isSingleElementAsArray() {
+		return singleElementAsArray;
 	}
 }


### PR DESCRIPTION
Fixes #1572

Added config property in order to prevent the behaviour

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - added `preventArrayTypeChange` with default false, so the current behaviour is mantained
  - added tests
  - updated docs
