### PR TITLE
Changed apoc.load.jdbc() to READ mode instead of WRITE for 3.5.

### DIFF
--- a/src/main/java/apoc/load/Jdbc.java
+++ b/src/main/java/apoc/load/Jdbc.java
@@ -55,7 +55,7 @@ public class Jdbc {
         }
     }
 
-    @Procedure(mode = Mode.WRITE)
+    @Procedure(mode = Mode.READ)
     @Description("apoc.load.jdbc('key or url','table or statement', params, config) YIELD row - load from relational database, from a full table or a sql statement")
     public Stream<RowResult> jdbc(@Name("jdbc") String urlOrKey, @Name("tableOrSql") String tableOrSelect, @Name
             (value = "params", defaultValue = "[]") List<Object> params, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {


### PR DESCRIPTION
This fixes potential out of heap issues when using `apoc.load.jdbc()` when used in the outer driving query with `apoc.periodic.iterate()`, and mirrors the change that was applied to the 4.0 branch.

https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/1531

## Proposed Changes (Mandatory)

Changes `apoc.load.jdbc()` to READ mode instead of WRITE.