### PR TITLE
fixes #1387: Failed batches with no error msg from apoc.refactor.rename.type

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/rename-label-type-property.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/rename-label-type-property.adoc
@@ -11,11 +11,35 @@ The available procedures are described in the table below:
 
 [cols="5m,5"]
 |===
-| call apoc.refactor.rename.label(oldLabel, newLabel, [nodes]) | rename a label from 'oldLabel' to 'newLabel' for all nodes. If 'nodes' is provided renaming is applied to this set only
-| call apoc.refactor.rename.type(oldType, newType, [rels]) | rename all relationships with type 'oldType' to 'newType'. If 'rels' is provided renaming is applied to this set only
-| call apoc.refactor.rename.nodeProperty(oldName, newName, [nodes]) | rename all node's property from 'oldName' to 'newName'. If 'nodes' is provided renaming is applied to this set only
-| call apoc.refactor.rename.typeProperty(oldName, newName, [rels]) | rename all relationship's property from 'oldName' to 'newName'. If 'rels' is provided renaming is applied to this set only
+| call apoc.refactor.rename.label(oldLabel, newLabel, [nodes], config) | rename a label from 'oldLabel' to 'newLabel' for all nodes. If 'nodes' is provided renaming is applied to this set only
+| call apoc.refactor.rename.type(oldType, newType, [rels], config) | rename all relationships with type 'oldType' to 'newType'. If 'rels' is provided renaming is applied to this set only
+| call apoc.refactor.rename.nodeProperty(oldName, newName, [nodes], config) | rename all node's property from 'oldName' to 'newName'. If 'nodes' is provided renaming is applied to this set only
+| call apoc.refactor.rename.typeProperty(oldName, newName, [rels], config) | rename all relationship's property from 'oldName' to 'newName'. If 'rels' is provided renaming is applied to this set only
 |===
+
+As the collection of data is processed in batch via `apoc.periodic.iterate` these procedures support the following config parameters:
+
+.Config
+[options=header]
+|===
+| name | type | default | description
+| batchSize | Long | 10000 | run the specified number of operation statements in a single tx - params: {_count, _batch}
+| parallel | boolean | true | run operation statements in parallel (note that statements might deadlock if conflicting)
+| retries | Long | 0 | if the operation statement fails with an error, sleep 100ms and retry until retries-count is reached - param {_retry}
+| batchMode | String | "BATCH" | how data-driven statements should be processed by operation statement. Valid values are:
+
+* "BATCH" - execute operation statement once per batchSize. Operation statement is prefixed with the following, which extracts each field returned in the data-driven statement from the `$_batch` parameter:
+[source,cypher]
+----
+UNWIND $_batch AS _batch
+WITH _batch.field1 AS field1, _batch.field2 AS field2
+----
+* "SINGLE" - execute operation statement one at a time
+* "BATCH_SINGLE" - execute operation statement once per batchSize, but leaves unpacking of batch to the operation statement.
+The operation query can access the batched values via the `$_batch` parameter.
+| concurrency | Long | 50 | number of concurrent tasks are generated when using `parallel:true`
+|===
+
 
 == Example Usage
 


### PR DESCRIPTION
Fixes #1387

Improved returned fields and added configuration params.

As the procedures under the hood leverage `apoc.periodic.iterate` I added configuration params in order to allow fine-tuning on this procedure

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added config params 
  - Improved returned messages
  - Updated documentation
