### PR TITLE
Document Typo apoc.path.subgraph - Config parameters

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/graph-querying/expand-subgraph.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/graph-querying/expand-subgraph.adoc
@@ -43,8 +43,8 @@ See <<expand-subgraph-label-filters>>.
 If set to `true`, a `null` value is yielded whenever the expansion would normally eliminate rows due to no results.
 | endNodes | List<Node> | null | only these nodes can end returned paths, and expansion will continue past these nodes, if possible.
 | terminatorNodes | List<Node> | null | Only these nodes can end returned paths, and expansion won't continue past these nodes.
-| whiteListNodes | List<Node> | null | Only these nodes are allowed in the expansion (though endNodes and terminatorNodes will also be allowed, if present).
-| blackListNodes | List<Node> | null | None of the paths returned will include these nodes.
+| whitelistNodes | List<Node> | null | Only these nodes are allowed in the expansion (though endNodes and terminatorNodes will also be allowed, if present).
+| blacklistNodes | List<Node> | null | None of the paths returned will include these nodes.
 |===
 
 It also has the following fixed parameter:


### PR DESCRIPTION
Looks like there is a typo in the documentation.

Looking in the actual code, the "List" in "blackListNodes" should have a lower-case "L". That is, it should be "blacklistNodes" Same case for whitelistNodes

Fixes #<Replace with the number of the issue, Mandatory>

One sentence summary of the change.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Config parameters `whiteListNodes` should be `whitelistNodes`
  - Config parameters `blackListNodes` should be `blacklistNodes`
 
Check this [section in documentation](https://neo4j.com/labs/apoc/4.1/graph-querying/expand-subgraph/#expand-subgraph-config)
