### PR TITLE
db specific initializers

### DIFF
--- a/core/src/main/java/apoc/ApocConfig.java
+++ b/core/src/main/java/apoc/ApocConfig.java
@@ -58,6 +58,12 @@ public class ApocConfig extends LifecycleAdapter {
     public static final String APOC_CONFIG_JOBS_POOL_NUM_THREADS = "apoc.jobs.pool.num_threads";
     public static final String APOC_CONFIG_JOBS_QUEUE_SIZE = "apoc.jobs.queue.size";
     public static final String APOC_CONFIG_INITIALIZER = "apoc.initializer";
+
+    /**
+     * @deprecated
+     * This has been replaced by database-specific initialisers.
+     * Use apoc.initializer.<database name> instead.
+     */
     @Deprecated
     public static final String APOC_CONFIG_INITIALIZER_CYPHER = APOC_CONFIG_INITIALIZER + ".cypher";
 

--- a/core/src/main/java/apoc/ApocConfig.java
+++ b/core/src/main/java/apoc/ApocConfig.java
@@ -57,7 +57,9 @@ public class ApocConfig extends LifecycleAdapter {
     public static final String APOC_CONFIG_JOBS_SCHEDULED_NUM_THREADS = "apoc.jobs.scheduled.num_threads";
     public static final String APOC_CONFIG_JOBS_POOL_NUM_THREADS = "apoc.jobs.pool.num_threads";
     public static final String APOC_CONFIG_JOBS_QUEUE_SIZE = "apoc.jobs.queue.size";
-    public static final String APOC_CONFIG_INITIALIZER_CYPHER = "apoc.initializer.cypher";
+    public static final String APOC_CONFIG_INITIALIZER = "apoc.initializer";
+    @Deprecated
+    public static final String APOC_CONFIG_INITIALIZER_CYPHER = APOC_CONFIG_INITIALIZER + ".cypher";
 
     private static final List<Setting> NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES = new ArrayList<>(Arrays.asList(
             data_directory,

--- a/core/src/main/java/apoc/ApocExtensionFactory.java
+++ b/core/src/main/java/apoc/ApocExtensionFactory.java
@@ -121,13 +121,14 @@ public class ApocExtensionFactory extends ExtensionFactory<ApocExtensionFactory.
                     }
                 });
 
-                AvailabilityGuard availabilityGuard = dependencies.availabilityGuard();
-                for (ApocGlobalComponents c: apocGlobalComponents) {
-                    for (AvailabilityListener listener: c.getListeners(db, dependencies)) {
-                        availabilityGuard.addListener(listener);
-                    }
-                }
             });
+
+            AvailabilityGuard availabilityGuard = dependencies.availabilityGuard();
+            for (ApocGlobalComponents c: apocGlobalComponents) {
+                for (AvailabilityListener listener: c.getListeners(db, dependencies)) {
+                    availabilityGuard.addListener(listener);
+                }
+            }
         }
 
         @Override

--- a/core/src/main/java/apoc/ApocSettings.java
+++ b/core/src/main/java/apoc/ApocSettings.java
@@ -39,6 +39,7 @@ public class ApocSettings implements SettingsDeclaration {
 
     public static final Setting<Boolean> apoc_uuid_enabled = newBuilder(APOC_UUID_ENABLED, BOOL, false ).build();
 
+    @Deprecated
     public static final Setting<String> apoc_initializer_cypher = newBuilder(APOC_CONFIG_INITIALIZER_CYPHER, STRING, null).build();
 
     public static final Setting<Long> apoc_jobs_queue_size = newBuilder(APOC_CONFIG_JOBS_QUEUE_SIZE, LONG, null).build();

--- a/core/src/main/java/apoc/CoreApocGlobalComponents.java
+++ b/core/src/main/java/apoc/CoreApocGlobalComponents.java
@@ -33,6 +33,5 @@ public class CoreApocGlobalComponents implements ApocGlobalComponents {
     @Override
     public Iterable<AvailabilityListener> getListeners(GraphDatabaseAPI db, ApocExtensionFactory.Dependencies dependencies) {
         return Collections.singleton(new CypherInitializer(db, dependencies.log().getUserLog(CypherInitializer.class)));
-
     }
 }

--- a/core/src/main/java/apoc/cypher/CypherInitializer.java
+++ b/core/src/main/java/apoc/cypher/CypherInitializer.java
@@ -11,10 +11,10 @@ import org.neo4j.kernel.availability.AvailabilityListener;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.Log;
 
-import java.util.Collections;
+import java.util.Collection;
 import java.util.ConcurrentModificationException;
+import java.util.Map;
 import java.util.TreeMap;
-import java.util.stream.Collectors;
 
 public class CypherInitializer implements AvailabilityListener {
 
@@ -50,7 +50,6 @@ public class CypherInitializer implements AvailabilityListener {
         // we need to wait until apoc procs are registered
         // unfortunately an AvailabilityListener is triggered before that
         Util.newDaemonThread(() -> {
-
             try {
                 final boolean isSystemDatabase = db.databaseName().equals(GraphDatabaseSettings.SYSTEM_DATABASE_NAME);
                 if (!isSystemDatabase) {
@@ -58,25 +57,14 @@ public class CypherInitializer implements AvailabilityListener {
                 }
                 Configuration config = dependencyResolver.resolveDependency(ApocConfig.class).getConfig();
 
-                TreeMap<String, String> initializers = new TreeMap<>();
-
-                config.getKeys(ApocConfig.APOC_CONFIG_INITIALIZER + "." + db.databaseName()).forEachRemaining(key -> initializers.put(key, config.getString(key)));
-
-                if (!isSystemDatabase) {
-                    config.getKeys(ApocConfig.APOC_CONFIG_INITIALIZER_CYPHER).forEachRemaining(key -> initializers.put(key, config.getString(key)));
-                }
-
-                for (Object initializer : initializers.values()) {
-                    String query = initializer.toString();
-                    if (!query.isEmpty()) {
-                        try {
-                            // we need to apply a retry strategy here since in systemdb we potentially conflict with
-                            // creating contraints which could cause our query to fail with a transient error.
-                            Util.retryInTx(userLog, db, tx -> Iterators.count(tx.execute(query)), 0, 5, retries -> {});
-                            userLog.info("successfully initialized: " + query);
-                        } catch (Exception e) {
-                            userLog.error("error upon initialization, running: " + query, e);
-                        }
+                for (String query : collectInitializers(isSystemDatabase, config)) {
+                    try {
+                        // we need to apply a retry strategy here since in systemdb we potentially conflict with
+                        // creating constraints which could cause our query to fail with a transient error.
+                        Util.retryInTx(userLog, db, tx -> Iterators.count(tx.execute(query)), 0, 5, retries -> { });
+                        userLog.info("successfully initialized: " + query);
+                    } catch (Exception e) {
+                        userLog.error("error upon initialization, running: " + query, e);
                     }
                 }
             } finally {
@@ -85,13 +73,30 @@ public class CypherInitializer implements AvailabilityListener {
         }).start();
     }
 
+    private Collection<String> collectInitializers(boolean isSystemDatabase, Configuration config) {
+        Map<String, String> initializers = new TreeMap<>();
+
+        config.getKeys(ApocConfig.APOC_CONFIG_INITIALIZER + "." + db.databaseName())
+                .forEachRemaining(key -> putIfNotBlank(initializers, key, config.getString(key)));
+
+        // add legacy style initializers
+        if (!isSystemDatabase) {
+            config.getKeys(ApocConfig.APOC_CONFIG_INITIALIZER_CYPHER)
+                    .forEachRemaining(key -> initializers.put(key, config.getString(key)));
+        }
+
+        return initializers.values();
+    }
+
+    private void putIfNotBlank(Map<String,String> map, String key, String value) {
+        if ((value!=null) && (!value.isBlank())) {
+            map.put(key, value);
+        }
+    }
+
     private void awaitApocProceduresRegistered() {
         while (!areApocProceduresRegistered()) {
-            try {
-                Thread.sleep(100);
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
+            Util.sleep(100);
         }
     }
 

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -205,7 +205,7 @@ public class Util {
         return relTypes;
     }
 
-    private static <T> T retryInTx(Log log, GraphDatabaseService db, Function<Transaction, T> function, long retry, long maxRetries, Consumer<Long> callbackForRetry) {
+    public static <T> T retryInTx(Log log, GraphDatabaseService db, Function<Transaction, T> function, long retry, long maxRetries, Consumer<Long> callbackForRetry) {
         try (Transaction tx = db.beginTx()) {
             T result = function.apply(tx);
             tx.commit();

--- a/core/src/test/java/apoc/cypher/CypherInitializerTest.java
+++ b/core/src/test/java/apoc/cypher/CypherInitializerTest.java
@@ -1,49 +1,51 @@
 package apoc.cypher;
 
-import apoc.ApocConfig;
+import apoc.test.EnvSettingRule;
+import apoc.test.annotations.Env;
+import apoc.test.annotations.EnvSetting;
 import apoc.util.TestUtil;
 import apoc.util.Utils;
-import org.apache.commons.configuration2.Configuration;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.internal.helpers.Listeners;
 import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.kernel.availability.AvailabilityGuard;
 import org.neo4j.kernel.availability.AvailabilityListener;
 import org.neo4j.kernel.availability.DatabaseAvailabilityGuard;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.ReflectionUtil;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
-import static apoc.util.TestUtil.testResult;
+import java.util.Collections;
+
+import static apoc.ApocConfig.APOC_CONFIG_INITIALIZER;
+import static apoc.ApocConfig.APOC_CONFIG_INITIALIZER_CYPHER;
 import static org.junit.Assert.assertEquals;
+import static org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAME;
+import static org.neo4j.configuration.GraphDatabaseSettings.SYSTEM_DATABASE_NAME;
 
 public class CypherInitializerTest {
 
+    public DbmsRule dbmsRule = new ImpermanentDbmsRule();
+
     @Rule
-    public DbmsRule db = new ImpermanentDbmsRule();
+    public RuleChain ruleChain = new EnvSettingRule().around(dbmsRule);
 
-    public void init(String... initializers) {
+    @Before
+    public void waitForInitializerBeingFinished() {
+        // we need at least on APOC proc being registered in finished CypherInitializers
+        TestUtil.registerProcedure(dbmsRule, Utils.class);
 
-        Configuration config = db.resolveDependency(ApocConfig.class).getConfig();
-        Iterators.stream(config.getKeys(ApocConfig.APOC_CONFIG_INITIALIZER_CYPHER)).forEach(k -> config.clearProperty(k));
-
-        if (initializers.length == 1) {
-            config.setProperty(ApocConfig.APOC_CONFIG_INITIALIZER_CYPHER, initializers[0]);
-        } else {
-            int index = 1;
-            for (String initializer : initializers) {
-                config.setProperty(ApocConfig.APOC_CONFIG_INITIALIZER_CYPHER + "." + index++, initializer);
-            }
-        }
-
-        // NB we need to register at least one procedure with name "apoc", otherwise initializer will not get called
-        TestUtil.registerProcedure(db, Utils.class);
-        waitForInitializerBeingFinished();
+        waitForInitializerBeingFinished(SYSTEM_DATABASE_NAME);
+        waitForInitializerBeingFinished(DEFAULT_DATABASE_NAME);
     }
 
-    private void waitForInitializerBeingFinished() {
-        CypherInitializer initializer = getInitializer();
+    private void waitForInitializerBeingFinished(String dbName) {
+        CypherInitializer initializer = getInitializer(dbName);
         while (!initializer.isFinished()) {
             try {
                 Thread.sleep(10);
@@ -58,14 +60,14 @@ public class CypherInitializerTest {
      * get a reference to CypherInitializer for diagnosis. This needs to use reflection.
      * @return
      */
-    private CypherInitializer getInitializer() {
-        DatabaseAvailabilityGuard availabilityGuard = (DatabaseAvailabilityGuard) db.getDependencyResolver().resolveDependency(AvailabilityGuard.class);
+    private CypherInitializer getInitializer(String dbName) {
+        GraphDatabaseAPI api = ((GraphDatabaseAPI) (dbmsRule.getManagementService().database(dbName)));
+        DatabaseAvailabilityGuard availabilityGuard = (DatabaseAvailabilityGuard) api.getDependencyResolver().resolveDependency(AvailabilityGuard.class);;
         try {
             Listeners<AvailabilityListener> listeners = ReflectionUtil.getPrivateField(availabilityGuard, "listeners", Listeners.class);
-
             for (AvailabilityListener listener: listeners) {
                 if (listener instanceof CypherInitializer) {
-                    return (CypherInitializer) listener;
+                     return (CypherInitializer) listener;
                 }
             }
             throw new IllegalStateException("found no cypher initializer");
@@ -76,36 +78,56 @@ public class CypherInitializerTest {
     }
 
     @Test
+    @Env
     public void noInitializerWorks() {
-        init();
         expectNodeCount(0);
     }
 
     @Test
+    @Env({
+            @EnvSetting(key= APOC_CONFIG_INITIALIZER_CYPHER, value="")
+    })
     public void emptyInitializerWorks() {
-        init("");
         expectNodeCount(0);
     }
 
     @Test
+    @Env({
+            @EnvSetting(key= APOC_CONFIG_INITIALIZER_CYPHER, value="create()")
+    })
     public void singleInitializerWorks() {
-        init("create()");
         expectNodeCount(1);
     }
 
     @Test
+    @Env({  // this only creates 2 nodes if the statements run in same order
+            @EnvSetting(key= APOC_CONFIG_INITIALIZER_CYPHER + ".0", value="create()"),
+            @EnvSetting(key= APOC_CONFIG_INITIALIZER_CYPHER + ".1", value="match (n) create ()")
+    })
     public void multipleInitializersWorks() {
-        init("create ()", "match (n) create ()");  // this only creates 2 nodes if the statements run in same order
         expectNodeCount(2);
     }
 
     @Test
+    @Env({  // this only creates 1 node since the first statement doesn't do anything
+            @EnvSetting(key= APOC_CONFIG_INITIALIZER_CYPHER + ".0", value="match (n) create ()"),
+            @EnvSetting(key= APOC_CONFIG_INITIALIZER_CYPHER + ".1", value="create()")
+    })
     public void multipleInitializersWorks2() {
-        init("match (n) create ()", "create ()");
         expectNodeCount(1);
     }
 
-    private void expectNodeCount(int i) {
-        testResult(db, "match (n) return n", result -> assertEquals(i, Iterators.count(result)));
+    @Test
+    @Env({  // this only creates 2 nodes if the statements run in same order
+            @EnvSetting(key= APOC_CONFIG_INITIALIZER + "." + SYSTEM_DATABASE_NAME, value="create user dummy set password 'abc'")
+    })
+    public void databaseSpecificInitializersForSystem() {
+        GraphDatabaseService systemDb = dbmsRule.getManagementService().database(SYSTEM_DATABASE_NAME);
+        long numberOfUsers = systemDb.executeTransactionally("show users", Collections.emptyMap(), Iterators::count);
+        assertEquals(2l, numberOfUsers);
+    }
+
+    private void expectNodeCount(long i) {
+        assertEquals(i, TestUtil.count(dbmsRule, "match (n) return n"));
     }
 }

--- a/core/src/test/java/apoc/test/EnvSettingRule.java
+++ b/core/src/test/java/apoc/test/EnvSettingRule.java
@@ -1,0 +1,42 @@
+package apoc.test;
+
+import apoc.test.annotations.Env;
+import apoc.test.annotations.EnvSetting;
+import org.jetbrains.annotations.NotNull;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.lang.reflect.Method;
+
+public class EnvSettingRule implements TestRule {
+
+    private final EnvironmentVariables env = new EnvironmentVariables();
+    private final RuleChain delegate = RuleChain.outerRule((base, description) -> new Statement() {
+                @Override
+                public void evaluate() throws Throwable {
+                    Class<?> testClass = description.getTestClass();
+                    String methodName = description.getMethodName();
+                    Method method = testClass.getMethod(methodName);
+                    Env annotation = method.getAnnotation(Env.class);
+                    for (EnvSetting envSetting : annotation.value()) {
+                        env.set(envSetting.key(), envSetting.value());
+                    }
+                    base.evaluate();
+                }
+            })
+            .around(env);
+
+    @NotNull
+    @Override
+    public Statement apply(@NotNull Statement base, @NotNull Description description) {
+        return delegate.apply(base, description);
+    }
+
+    public RuleChain around(TestRule enclosedRule) {
+        return delegate.around(enclosedRule);
+    }
+
+}

--- a/core/src/test/java/apoc/test/annotations/Env.java
+++ b/core/src/test/java/apoc/test/annotations/Env.java
@@ -1,0 +1,12 @@
+package apoc.test.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Env {
+    EnvSetting[] value() default {};
+}

--- a/core/src/test/java/apoc/test/annotations/EnvSetting.java
+++ b/core/src/test/java/apoc/test/annotations/EnvSetting.java
@@ -1,0 +1,10 @@
+package apoc.test.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+public @interface EnvSetting {
+    String key();
+    String value();
+}

--- a/docs/asciidoc/modules/ROOT/pages/operational/init-script.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/operational/init-script.adoc
@@ -2,12 +2,35 @@
 = Cypher init script
 :description: This section describes a hook to run Cypher commands after database initialization.
 
-
-
-Apoc optionally allows you to run a cypher command after database initialization is finished.
+Apoc optionally allows you to run cypher commands after database initialization is finished.
 This can e.g. be used to ensure indexes/constraints are created up front.
 
-To use this feature use a config option:
+The initializers are defined by xref::config/index.adoc[] using the following naming convention:
+
+[source,config]
+----
+apoc.initializer.<database_name>.<identifier> = <some cypher string>
+----
+
+For each database all initializer strings are ordered by `<identifier>` and each of them is executed in a separate transaction. If you only have one single initializer for a given database you can omit `<identifier>`.
+
+As an example we want to
+
+* create another db user in system db
+* create a index for `:Person` in default db `neo4j`
+* add two person nodes in default db `neo4j`
+
+This is achieved by
+
+[source,config]
+----
+apoc.initializer.system=create user dummy set password 'abc'
+apoc.initializer.neo4j.0=create index person_index for (p:Person) on (p.name)
+apoc.initializer.neo4j.1=create (:Person{name:'foo'})
+apoc.initializer.neo4j.2=create (:Person{name:'bar'})
+----
+
+WARNING: There's deprecated syntax originating back from the 3.x days - see below. This old style syntax will be removed in future. Note that the initializers in old syntax are applied to *all* databases (except `system`)
 
 [source,config]
 ----

--- a/full/src/main/java/apoc/ExtendedApocGlobalComponents.java
+++ b/full/src/main/java/apoc/ExtendedApocGlobalComponents.java
@@ -6,6 +6,7 @@ import apoc.ttl.TTLLifeCycle;
 import apoc.uuid.Uuid;
 import apoc.uuid.UuidHandler;
 import org.neo4j.annotations.service.ServiceProvider;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.internal.helpers.collection.MapUtil;
 import org.neo4j.kernel.availability.AvailabilityListener;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -15,22 +16,25 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 @ServiceProvider
 public class ExtendedApocGlobalComponents implements ApocGlobalComponents {
 
-    private CypherProceduresHandler cypherProcedureHandler;
+    private final Map<GraphDatabaseService,CypherProceduresHandler> cypherProcedureHandlers = new ConcurrentHashMap<>();
 
     @Override
     public Map<String, Lifecycle> getServices(GraphDatabaseAPI db, ApocExtensionFactory.Dependencies dependencies) {
 
-        this.cypherProcedureHandler = new CypherProceduresHandler(
+
+        CypherProceduresHandler cypherProcedureHandler = new CypherProceduresHandler(
                 db,
                 dependencies.scheduler(),
                 dependencies.apocConfig(),
                 dependencies.log().getUserLog(CypherProcedures.class),
                 dependencies.globalProceduresRegistry()
         );
+        cypherProcedureHandlers.put(db, cypherProcedureHandler);
 
         return MapUtil.genericMap(
 
@@ -53,6 +57,7 @@ public class ExtendedApocGlobalComponents implements ApocGlobalComponents {
 
     @Override
     public Iterable<AvailabilityListener> getListeners(GraphDatabaseAPI db, ApocExtensionFactory.Dependencies dependencies) {
-        return Collections.singleton(cypherProcedureHandler);
+        CypherProceduresHandler cypherProceduresHandler = cypherProcedureHandlers.get(db);
+        return cypherProceduresHandler==null ? Collections.emptyList() : Collections.singleton(cypherProceduresHandler);
     }
 }


### PR DESCRIPTION
Adding support for db specific cypher initializers.

Side note: also added a custom TestRule that allows for test-method specific env settings via annotations.

Please cherry pick this one for 4.2 as well.