### PR TITLE
fixes #1671: apoc.export.cypher.all() causes integer is too large error

### DIFF
--- a/core/src/main/java/apoc/export/util/FormatUtils.java
+++ b/core/src/main/java/apoc/export/util/FormatUtils.java
@@ -3,11 +3,13 @@ package apoc.export.util;
 import apoc.util.JsonUtil;
 import apoc.util.Util;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.spatial.Point;
 
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -23,20 +25,9 @@ import static apoc.util.Util.map;
  */
 public class FormatUtils {
 
-    private static DecimalFormat decimalFormat = new DecimalFormat() {
-        {
-            setMaximumFractionDigits(340);
-            setGroupingUsed(false);
-            setDecimalSeparatorAlwaysShown(false);
-            DecimalFormatSymbols symbols = getDecimalFormatSymbols();
-            symbols.setDecimalSeparator('.');
-            setDecimalFormatSymbols(symbols);
-        }
-    };
-
     public static String formatNumber(Number value) {
         if (value == null) return null;
-        return decimalFormat.format(value);
+        return value.toString();
     }
 
     public static String formatString(Object value) {

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -630,7 +630,24 @@ public class ExportCypherTest {
                             .orElse(null);
                     assertEquals(expected, unwind);
                 });
+    }
 
+    @Test
+    public void shouldManageBigNumbersCorrectly() {
+        db.executeTransactionally("MATCH (n) DETACH DELETE n");
+        db.executeTransactionally("CREATE (:bug {var1:1.416785E32, var2:12E4});");
+        final String expected = "UNWIND [{_id:3, properties:{var1:1.416785E32, var2:120000}}] AS row\n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:bug";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($file, $config)",
+                map("file", null, "config", map("format", "plain", "stream", true)), (r) -> {
+                    final String cypherStatements = (String) r.get("cypherStatements");
+                    String unwind = Stream.of(cypherStatements.split(";"))
+                            .map(String::trim)
+                            .filter(s -> s.startsWith("UNWIND"))
+                            .findFirst()
+                            .orElse(null);
+                    assertEquals(expected, unwind);
+                });
     }
 
     private void assertResultsOptimized(String fileName, Map<String, Object> r) {


### PR DESCRIPTION
Fixes #1671

Remove number formatting leaving the original representation for Cypher export

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Fixed the bug
  - Added test
