### PR TITLE
fixes #1661: Add lead/lag function for collections

### DIFF
--- a/core/src/test/java/apoc/coll/CollTest.java
+++ b/core/src/test/java/apoc/coll/CollTest.java
@@ -900,5 +900,33 @@ public class CollTest {
                 (row) -> assertEquals(asList("Гусак", "Єльська"), row.get("value")));
     }
 
+    @Test
+    public void testPairWithOffsetFn() throws Exception {
+        testCall(db, "RETURN apoc.coll.pairWithOffset([1,2,3,4], 2) AS value",
+                (row) -> assertEquals(asList(asList(1L, 3L), asList(2L, 4L), asList(3L, null), asList(4L, null)), row.get("value")));
+        testCall(db, "RETURN apoc.coll.pairWithOffset([1,2,3,4], -2) AS value",
+                (row) -> assertEquals(asList(asList(1L, null), asList(2L, null), asList(3L, 1L), asList(4L, 2L)), row.get("value")));
+    }
+
+    @Test
+    public void testPairWithOffset() throws Exception {
+        testResult(db, "CALL apoc.coll.pairWithOffset([1,2,3,4], 2)",
+                (result) -> {
+                    assertEquals(asList(1L, 3L), result.next().get("value"));
+                    assertEquals(asList(2L, 4L), result.next().get("value"));
+                    assertEquals(asList(3L, null), result.next().get("value"));
+                    assertEquals(asList(4L, null), result.next().get("value"));
+                    assertFalse(result.hasNext());
+                });
+        testResult(db, "CALL apoc.coll.pairWithOffset([1,2,3,4], -2)",
+                (result) -> {
+                    assertEquals(asList(1L, null), result.next().get("value"));
+                    assertEquals(asList(2L, null), result.next().get("value"));
+                    assertEquals(asList(3L, 1L), result.next().get("value"));
+                    assertEquals(asList(4L, 2L), result.next().get("value"));
+                    assertFalse(result.hasNext());
+                });
+    }
+
 }
 

--- a/docs/asciidoc/modules/ROOT/pages/data-structures/collection-list-functions.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/data-structures/collection-list-functions.adoc
@@ -61,6 +61,7 @@ endif::[]
 | apoc.coll.different(values) | returns true if value are different
 | apoc.coll.fill(item, count) | returns a list with the given count of items
 | apoc.coll.sortText(coll, conf) | sort on string based collections
+| apoc.coll.pairWithOffset(values, offset) | returns a list of pairs defined by the offset
 |===
 
 .The following computes the sum of values in a list:
@@ -689,5 +690,34 @@ RETURN apoc.coll.sortText(['Єльська', 'Гусак'], {locale: 'ru'}) as O
 | Output
 | Гусак
 | Єльська
+|===
+
+.The following returns a list of pairs defined by the offset:
+[source,cypher]
+----
+RETURN apoc.coll.pairWithOffset([1,2,3,4], 2) AS value
+----
+
+.Results
+[opts="header",cols="1"]
+|===
+| value
+| [[1,3],[2,4],[3,null],[4,null]]
+|===
+
+It works also as procedure:
+
+----
+CALL apoc.coll.pairWithOffset([1,2,3,4], 2)
+----
+
+.Results
+[opts="header",cols="1"]
+|===
+| value
+| [1,3]
+| [2,4]
+| [3,null]
+| [4,null]
 |===
 


### PR DESCRIPTION
Fixes #1661

Added `apoc.coll.pairWithOffset` procedure and function

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added the procedure
  - Added the function
  - Added test
  - Updated docs
