### PR TITLE
Handle Optional.empty() function descriptions

### DIFF
--- a/src/main/java/apoc/custom/CypherProcedures.java
+++ b/src/main/java/apoc/custom/CypherProcedures.java
@@ -575,7 +575,7 @@ public class CypherProcedures {
                 }
                 return (String)rawDescription;
             }
-            return "";
+            return null;
         }
 
         @Override
@@ -593,7 +593,7 @@ public class CypherProcedures {
         }
 
         public static Map<String, Object> storeProcedure(GraphDatabaseAPI api, ProcedureSignature signature, String statement) {
-            Map<String, Object> data = map("statement", statement, "mode", signature.mode().toString(), "signature", signature.toString(), "description", signature.description().orElse(""));
+            Map<String, Object> data = map("statement", statement, "mode", signature.mode().toString(), "signature", signature.toString(), "description", signature.description().orElse(null));
             return updateCustomData(getProperties(api), signature.name().toString(), PROCEDURES, data);
         }
         public static Map<String, Object> storeFunction(GraphDatabaseAPI api, String name, String statement, String output, List<List<String>> inputs, boolean forceSingle, String description) {
@@ -602,7 +602,7 @@ public class CypherProcedures {
         }
 
         public static Map<String, Object> storeFunction(GraphDatabaseAPI api, UserFunctionSignature signature, String statement, boolean forceSingle) {
-            Map<String, Object> data = map("statement", statement, "forceSingle", forceSingle, "signature", signature.toString(), "description", signature.description().orElse(""));
+            Map<String, Object> data = map("statement", statement, "forceSingle", forceSingle, "signature", signature.toString(), "description", signature.description().orElse(null));
             return updateCustomData(getProperties(api), signature.name().toString(), FUNCTIONS, data);
         }
 

--- a/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -4,14 +4,22 @@ import apoc.util.TestUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
+import org.neo4j.internal.kernel.api.procs.Neo4jTypes;
+import org.neo4j.internal.kernel.api.procs.QualifiedName;
+import org.neo4j.internal.kernel.api.procs.UserFunctionSignature;
 import org.neo4j.io.fs.FileUtils;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.logging.Log;
+import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -127,5 +135,28 @@ public class CypherProceduresStorageTest {
                 "[['int','int'],['float','float'],['string','string'],['map','map'],['list int','list int'],['bool','bool'],['date','date'],['datetime','datetime'],['point','point']], true)");
         restartDb();
         TestUtil.testCall(db, "return custom.answer(42,3.14,'foo',{a:1},[1],true,date(),datetime(),point({x:1,y:2})) as data", (row) -> assertEquals(9, ((List)row.get("data")).size()));
+    }
+
+    @Test
+    public void handleFunctionsWithNoneDescriptions() throws Exception {
+        // Anyone that knows the right knobs can store whatever they like in the graph properties store;
+        // hence we should make sure we handle the case of someone having modified our JSON blob
+        JobScheduler fakeScheduler = Mockito.mock(JobScheduler.class);
+        Log fakeLog = Mockito.mock(Log.class);
+        GraphDatabaseAPI gds = (GraphDatabaseAPI) this.db;
+
+        // Given I've stored a function with no description..
+        CypherProcedures.CustomProcedureStorage.storeFunction(gds, new UserFunctionSignature( new QualifiedName(new String[]{"apoc"}, "nodescription"),
+                Collections.emptyList(), Neo4jTypes.NTBoolean, "", new String[]{}, null, false), "my query", false);
+
+        // When I load the stored state..
+        CypherProcedures.CustomProcedureStorage store = new CypherProcedures.CustomProcedureStorage(fakeScheduler, gds, fakeLog);
+        store.available();
+
+        // Then its ok
+        List<CypherProcedures.CustomProcedureInfo> result = store.list();
+        assertEquals(1, result.size());
+        CypherProcedures.CustomProcedureInfo myFuncInfo = result.get(0);
+        assertEquals("", myFuncInfo.description);
     }
 }

--- a/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -1,17 +1,21 @@
 package apoc.custom;
 
+import apoc.util.JsonUtil;
+import apoc.util.MapUtil;
 import apoc.util.TestUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.procs.Neo4jTypes;
 import org.neo4j.internal.kernel.api.procs.QualifiedName;
 import org.neo4j.internal.kernel.api.procs.UserFunctionSignature;
 import org.neo4j.io.fs.FileUtils;
+import org.neo4j.kernel.impl.core.GraphPropertiesProxy;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.Log;
 import org.neo4j.scheduler.JobScheduler;
@@ -23,7 +27,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static apoc.util.Util.map;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * @author mh
@@ -157,6 +163,43 @@ public class CypherProceduresStorageTest {
         List<CypherProcedures.CustomProcedureInfo> result = store.list();
         assertEquals(1, result.size());
         CypherProcedures.CustomProcedureInfo myFuncInfo = result.get(0);
-        assertEquals("", myFuncInfo.description);
+        assertNull(myFuncInfo.description);
+    }
+
+    @Test
+    public void handlePersistedStateWithMapAsFunctionDescription() throws Exception {
+        // Anyone that knows the right knobs can store whatever they like in the graph properties store;
+        // hence we should make sure we handle the case of someone having modified our JSON blob
+        JobScheduler fakeScheduler = Mockito.mock(JobScheduler.class);
+        Log fakeLog = Mockito.mock(Log.class);
+        GraphDatabaseAPI gds = (GraphDatabaseAPI) this.db;
+
+        // Given the database contains an old state blob with a map in the `description` field of a function..
+        UserFunctionSignature signature = new UserFunctionSignature(new QualifiedName(new String[]{"apoc"}, "nodescription"),
+                Collections.emptyList(), Neo4jTypes.NTBoolean, "", new String[]{}, null, false);
+        try(Transaction tx = gds.beginTx()) {
+            GraphPropertiesProxy props = CypherProcedures.CustomProcedureStorage.getProperties(gds);
+            props.setProperty(CypherProcedures.CustomProcedureStorage.APOC_CUSTOM, JsonUtil.writeValueAsString(MapUtil.map(
+                "procedures", MapUtil.map(),
+                    "functions", MapUtil.map(
+                            "myfunc", MapUtil.map(
+                                    "statement", "..",
+                                    "forceSingle", false,
+                                    "signature", signature.toString(),
+                                    "description", MapUtil.map("present", false))
+                    )
+            )));
+            tx.success();
+        }
+
+        // When I load the stored state..
+        CypherProcedures.CustomProcedureStorage store = new CypherProcedures.CustomProcedureStorage(fakeScheduler, gds, fakeLog);
+        store.available();
+
+        // Then its ok
+        List<CypherProcedures.CustomProcedureInfo> result = store.list();
+        assertEquals(1, result.size());
+        CypherProcedures.CustomProcedureInfo myFuncInfo = result.get(0);
+        assertNull(myFuncInfo.description);
     }
 }


### PR DESCRIPTION
This handles loading a stored APOC custom state where
a function or procedure had an Optional.empty() description.

Jackson serialized those to {"present::false}, which then broke
Apocs assumptions about the schema here.

This makes it so we handle any in-the-wild incarnations of this,
and modifies our write path to always ensure the value is a string

Fixes #<Replace with the number of the issue, Mandatory>

One sentence summary of the change.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

When APOC serializes custom function/procedure state, it does this:

```
Map<String, Object> data = map("statement", statement, "mode", signature.mode().toString(), "signature", signature.toString(), "description", signature.description());
```

Which assumes `signature.description()` won't be `Optional.empty()` (it seems that's been changed to be Optional since the original apoc code was written). In cases where it *is* empty, the end-result JSON will be `{"present":false}`, rather than a string, which then breaks APOC loading the state back again.

This changes the serialization behavior to always result in a string, and also modifies the deserialization behavior to handle existing in-the-wild stores that have ran into this issue.