### PR TITLE
Fixes #1689

### DIFF
--- a/core/src/main/java/apoc/export/cypher/ExportFileManager.java
+++ b/core/src/main/java/apoc/export/cypher/ExportFileManager.java
@@ -11,4 +11,6 @@ public interface ExportFileManager {
     String drain(String type);
 
     String getFileName();
+
+    Boolean separatedFiles();
 }

--- a/core/src/main/java/apoc/export/cypher/FileManagerFactory.java
+++ b/core/src/main/java/apoc/export/cypher/FileManagerFactory.java
@@ -67,6 +67,11 @@ public class FileManagerFactory {
         public String getFileName() {
             return this.fileName;
         }
+
+        @Override
+        public Boolean separatedFiles() {
+            return this.separatedFiles;
+        }
     }
 
     private static class StringExportCypherFileManager implements ExportFileManager {
@@ -114,6 +119,11 @@ public class FileManagerFactory {
         @Override
         public String getFileName() {
             return null;
+        }
+
+        @Override
+        public Boolean separatedFiles() {
+            return this.separatedFiles;
         }
     }
 

--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -95,26 +95,38 @@ public class MultiStatementCypherSubGraphExporter {
         int batchSize = config.getBatchSize();
         ExportConfig.OptimizationType useOptimizations = config.getOptimizationType();
 
+        PrintWriter schemaWriter = cypherFileManager.getPrintWriter("schema");
+        PrintWriter nodesWriter = cypherFileManager.getPrintWriter("nodes");
+        PrintWriter relationshipsWriter = cypherFileManager.getPrintWriter("relationships");
+        PrintWriter cleanupWriter = cypherFileManager.getPrintWriter("cleanup");
+
         switch (useOptimizations) {
             case NONE:
-                exportNodes(cypherFileManager.getPrintWriter("nodes"), reporter, batchSize);
-                exportSchema(cypherFileManager.getPrintWriter("schema"));
-                exportRelationships(cypherFileManager.getPrintWriter("relationships"), reporter, batchSize);
+                exportNodes(nodesWriter, reporter, batchSize);
+                exportSchema(schemaWriter);
+                exportRelationships(relationshipsWriter, reporter, batchSize);
                 break;
             default:
                 artificialUniques += countArtificialUniques(graph.getNodes());
-                exportSchema(cypherFileManager.getPrintWriter("schema"));
-                PrintWriter nodeWrite = cypherFileManager.getPrintWriter("nodes");
-                exportNodesUnwindBatch(nodeWrite, reporter);
-                PrintWriter relWrite = cypherFileManager.getPrintWriter("relationships");
-                exportRelationshipsUnwindBatch(relWrite, reporter);
+                exportSchema(schemaWriter);
+                exportNodesUnwindBatch(nodesWriter, reporter);
+                exportRelationshipsUnwindBatch(relationshipsWriter, reporter);
+                break;
         }
-        exportCleanUp(cypherFileManager.getPrintWriter("cleanup"), batchSize);
+        if (cypherFileManager.separatedFiles()) {
+            nodesWriter.close();
+            schemaWriter.close();
+            relationshipsWriter.close();
+        }
+        exportCleanUp(cleanupWriter, batchSize);
+        cleanupWriter.close();
         reporter.done();
     }
 
     public void exportOnlySchema(ExportFileManager cypherFileManager) {
-        exportSchema(cypherFileManager.getPrintWriter("schema"));
+        PrintWriter schemaWriter = cypherFileManager.getPrintWriter("schema");
+        exportSchema(schemaWriter);
+        schemaWriter.close();
     }
 
     // ---- Nodes ----

--- a/core/src/main/java/apoc/util/FileUtils.java
+++ b/core/src/main/java/apoc/util/FileUtils.java
@@ -5,6 +5,7 @@ import apoc.export.util.CountingInputStream;
 import apoc.export.util.CountingReader;
 import apoc.util.hdfs.HDFSUtils;
 import apoc.util.s3.S3URLConnection;
+import apoc.util.s3.S3UploadUtils;
 import org.apache.commons.io.output.WriterOutputStream;
 import org.neo4j.configuration.GraphDatabaseSettings;
 
@@ -37,6 +38,7 @@ public class FileUtils {
     static final String HDFS_PROTOCOL = "hdfs";
     static final boolean HDFS_ENABLED = Util.classExists("org.apache.hadoop.fs.FileSystem");
     public static final Pattern HDFS_PATTERN = Pattern.compile("^(hdfs:\\/\\/)(?:[^@\\/\\n]+@)?([^\\/\\n]+)");
+    public static final Pattern S3_PATTERN = Pattern.compile("^(s3:\\/\\/)(?:[^@\\/\\n]+@)?([^\\/\\n]+)");
 
     private static final List<String> NON_FILE_PROTOCOLS = Arrays.asList(HTTP_PROTOCOL, S3_PROTOCOL, GCS_PROTOCOL, HDFS_PROTOCOL);
 
@@ -147,7 +149,14 @@ public class FileUtils {
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
-        } else {
+        } else if (isS3(fileName)) {
+            try {
+                outputStream = S3UploadUtils.writeFile(fileName);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        else {
             outputStream = getOrCreateOutputStream(fileName, out);
 //            outputStream = fileName.equals("-") ? out : new FileOutputStream(fileName);
         }
@@ -208,6 +217,11 @@ public class FileUtils {
                     "\nSee the documentation: https://neo4j-contrib.github.io/neo4j-apoc-procedures/#_loading_data_from_web_apis_json_xml_csv");
         }
         return HDFSUtils.readFile(url);
+    }
+
+    public static boolean isS3(String fileName) {
+        Matcher matcher = S3_PATTERN.matcher(fileName);
+        return matcher.find();
     }
 
     public static boolean isHdfs(String fileName) {

--- a/core/src/main/java/apoc/util/s3/S3Aws.java
+++ b/core/src/main/java/apoc/util/s3/S3Aws.java
@@ -1,37 +1,57 @@
 package apoc.util.s3;
 
 import apoc.util.StreamConnection;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.S3Object;
 
-import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 
 public class S3Aws {
 
     AmazonS3 s3Client;
 
-    public S3Aws(S3Params s3Params, String region){
-        s3Client = AmazonS3ClientBuilder.standard()
-                .withCredentials(new AWSStaticCredentialsProvider(new BasicAWSCredentials(s3Params.getAccessKey(), s3Params.getSecretKey())))
+    public S3Aws(S3Params s3Params, String region) {
+
+        AWSCredentialsProvider credentialsProvider = getCredentialsProvider(
+                s3Params.getAccessKey(), s3Params.getSecretKey(), s3Params.getSessionToken());
+
+        AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard();
+        builder.withCredentials(credentialsProvider)
                 .withClientConfiguration(S3URLConnection.buildClientConfig())
-                .withPathStyleAccessEnabled(true)
-                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(s3Params.getEndpoint(), region))
-                .build();
+                .withPathStyleAccessEnabled(true);
+
+        region = Objects.nonNull(region) ? region : s3Params.getRegion();
+        String endpoint = s3Params.getEndpoint();
+        if (Objects.nonNull(endpoint)) {
+            builder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(s3Params.getEndpoint(), region));
+        } else if (Objects.nonNull(region)) {
+            builder.withRegion(region);
+        }
+
+        s3Client = builder.build();
     }
 
-    public StreamConnection getS3AwsInputStream(S3Params s3Params){
+    public AmazonS3 getClient() {
+        return s3Client;
+    }
+
+    public StreamConnection getS3AwsInputStream(S3Params s3Params) {
 
         S3Object s3Object = s3Client.getObject(s3Params.getBucket(), s3Params.getKey());
         ObjectMetadata metadata = s3Object.getObjectMetadata();
         return new StreamConnection() {
             @Override
-            public InputStream getInputStream() throws IOException {
+            public InputStream getInputStream() {
                 return s3Object.getObjectContent();
             }
 
@@ -45,5 +65,21 @@ public class S3Aws {
                 return metadata.getContentLength();
             }
         };
+    }
+
+    private static AWSCredentialsProvider getCredentialsProvider(
+            final String accessKey, final String secretKey, final String sessionToken) {
+
+        if (Objects.nonNull(accessKey) && !accessKey.isEmpty()
+                && Objects.nonNull(secretKey) && !secretKey.isEmpty()) {
+            final AWSCredentials credentials;
+            if (Objects.isNull(sessionToken) || sessionToken.isEmpty()) {
+                credentials = new BasicAWSCredentials(accessKey, secretKey);
+            } else {
+                credentials = new BasicSessionCredentials(accessKey, secretKey, sessionToken);
+            }
+            return new AWSStaticCredentialsProvider(credentials);
+        }
+        return new DefaultAWSCredentialsProviderChain();
     }
 }

--- a/core/src/main/java/apoc/util/s3/S3OutputStream.java
+++ b/core/src/main/java/apoc/util/s3/S3OutputStream.java
@@ -1,0 +1,284 @@
+package apoc.util.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import javax.annotation.Nonnull;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.InvalidParameterException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+public class S3OutputStream extends OutputStream {
+    private volatile boolean isDone = false;
+    private volatile long totalMemory = 0L;
+    private long transferred = 0;
+    private int buffSize = 0;
+    private final Object totalMemoryLock = new Object();
+    private final Future<?> managerFuture;
+    private byte[] buffer;
+    private final String bucketName;
+    private final String keyName;
+    private final BlockingQueue<S3UploadData> queue = new LinkedBlockingQueue<>();
+    private int maxWaitTimeMinutes = S3UploadConstants.MAX_WAIT_TIME_MINUTES;
+
+    // Extra constructor to allow user to overwrite maxWaitTimeMinutes.
+    S3OutputStream(@Nonnull AmazonS3 s3Client, @Nonnull String bucketName, @Nonnull String keyName, int maxWaitTimeMinutes) throws IOException {
+        this(s3Client, bucketName, keyName);
+        this.maxWaitTimeMinutes = maxWaitTimeMinutes;
+    }
+
+    S3OutputStream(@Nonnull AmazonS3 s3Client, @Nonnull String bucketName, @Nonnull String keyName) throws IOException {
+        if (bucketName.isEmpty() || keyName.isEmpty()) {
+            throw new InvalidParameterException("Bucket and/or key pass to S3OutputStream is empty.");
+        }
+        this.bucketName = bucketName;
+        this.keyName = keyName;
+        allocateMemory(AllocationSize.MB_5);
+        ExecutorService executorService = Executors.newSingleThreadExecutor(
+                new ThreadFactoryBuilder().setNameFormat("S3-Upload-Manager-Thread-%d").setDaemon(true).build());
+        managerFuture = executorService.submit(new S3UploadManager(s3Client, queue));
+    }
+
+    private void allocateMemory(final AllocationSize allocationSize) throws IOException {
+        long incomingSize = allocationSize.getAllocationSize();
+        synchronized (totalMemoryLock) {
+            if (incomingSize > S3UploadConstants.TOTAL_MEMORY_ALLOWED) {
+                throw new IOException(String.format("A total of %d bytes of memory were provided for all buffers, but a buffer of %d bytes was requested.",
+                        S3UploadConstants.TOTAL_MEMORY_ALLOWED, incomingSize));
+            }
+            // Only allow defined amount of memory to be used at one time.
+            while ((totalMemory + incomingSize) > S3UploadConstants.TOTAL_MEMORY_ALLOWED) {
+                try {
+                    // Wait for signal that the amount of memory in use has gone down before allocating more.
+                    totalMemoryLock.wait();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+
+        // We have enough free memory to continue.
+        synchronized (totalMemoryLock) {
+            totalMemory += incomingSize;
+        }
+        buffer = new byte[(int)incomingSize];
+    }
+
+    private void transmitBuffer() throws IOException {
+        queue.add(new S3UploadData(new ByteArrayInputStream(buffer), false, buffSize));
+        transferred += buffSize;
+        buffSize = 0;
+
+        /*
+            Memory allocation here scales with the amount of memory transferred. From the documentation, S3 multipart
+            upload has a 5 MB minimum part size (with the exception of the last part), with a maximum of 10,000 parts
+            and a maximum file size of 5 TB. To allow up to 5 TB to be transferred and allow multipart streaming of
+            smaller files, the amount of memory allocated scales with the amount of data transferred.
+            See https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
+         */
+        if (transferred < S3UploadConstants.TRANSFERRED_2p5GB) {
+            allocateMemory(AllocationSize.MB_5);
+        } else if (transferred < S3UploadConstants.TRANSFERRED_25GB) {
+            allocateMemory(AllocationSize.MB_50);
+        } else if (transferred < S3UploadConstants.TRANSFERRED_2TB) {
+            allocateMemory(AllocationSize.MB_500);
+        } else {
+            allocateMemory(AllocationSize.MB_750);
+        }
+    }
+
+    @Override
+    public void write(final int i) throws IOException {
+        write(new byte[] { (byte)i }, 0, 1);
+    }
+
+    @Override
+    public void write(@Nonnull final byte[] b) throws IOException {
+        write(b, 0, b.length);
+    }
+
+    // This function call is used directly by OutputStream writer, so it's best that everything routes to it.
+    @Override
+    public void write(@Nonnull final byte[] b, final int offset, final int length) throws IOException {
+        int rdPtr = offset;
+        do {
+            // If the amount of data left to consume from the input is less than the amount of space in the
+            // buffer, fill the remaining space of the buffer with the input, otherwise fully consume the
+            // remaining input.
+            final int wrAmount = Math.min(buffer.length - buffSize, length - (rdPtr - offset));
+            System.arraycopy(b, rdPtr, buffer, buffSize, wrAmount);
+            buffSize += wrAmount;
+            rdPtr += wrAmount;
+
+            // If the buffer is full, transmit it
+            if (buffer.length == buffSize) {
+                transmitBuffer();
+            }
+        } while ((rdPtr - offset) < length);
+    }
+
+    @Override
+    public void close() {
+        // Do not reorder operations, setting done to true first defeats a race condition with the queue being blocked.
+        isDone = true;
+
+        // Based on the requirements of multipart upload, the last piece can disobey the sizing requirements
+        // See https://docs.aws.amazon.com/AmazonS3/latest/dev/qfacts.html
+        queue.add(new S3UploadData(new ByteArrayInputStream(buffer), true, buffSize));
+        buffer = null;
+        try {
+            // Wait for manager's future to complete before exiting.
+            synchronized (managerFuture) {
+                managerFuture.get();
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    private static class S3UploadData {
+        private final InputStream stream;
+        private final boolean isLast;
+        private final int size;
+
+        S3UploadData(@Nonnull InputStream stream, final boolean isLast, final int size) {
+            this.stream = stream;
+            this.isLast = isLast;
+            this.size = size;
+        }
+
+        InputStream getStream() {
+            return stream;
+        }
+
+        boolean getIsLast() {
+            return isLast;
+        }
+
+        int getSize() {
+            return size;
+        }
+    }
+
+    public class S3UploadManager implements Runnable {
+        private final AmazonS3 s3Client;
+        private final String uploadId;
+        private final BlockingQueue<S3UploadData> queue;
+        private final List<PartETag> partETags = new ArrayList<>();
+        private final InitiateMultipartUploadResult initResponse;
+        private final ExecutorService executorService = Executors.newFixedThreadPool(
+                S3UploadConstants.MAX_THREAD_COUNT,
+                new ThreadFactoryBuilder().setNameFormat("S3-Upload-Thread-%d").setDaemon(true).build());
+
+        S3UploadManager(@Nonnull final AmazonS3 s3Client, @Nonnull final BlockingQueue<S3UploadData> queue) {
+            this.s3Client = s3Client;
+            this.queue = queue;
+            initResponse = s3Client.initiateMultipartUpload(new InitiateMultipartUploadRequest(bucketName, keyName));
+            uploadId = initResponse.getUploadId();
+        }
+
+        @Override
+        public void run() {
+            int partNumber = 1;
+
+            // If the OutputStream is done and the queue is empty, exit the loop.
+            while (!isDone || !queue.isEmpty()) {
+                try {
+                    // Grab item from blocking queue and pass it to executor service.
+                    final S3UploadData data = queue.take();
+                    executorService.submit(new Uploader(partNumber++, data));
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            // Uploading is complete, finish off remaining parts.
+            executorService.shutdown();
+            try {
+                executorService.awaitTermination(maxWaitTimeMinutes, TimeUnit.MINUTES);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            s3Client.completeMultipartUpload(
+                    new CompleteMultipartUploadRequest(bucketName, keyName, initResponse.getUploadId(), partETags));
+        }
+
+        public class Uploader implements Runnable {
+            private final int partNumber;
+            private final S3UploadData s3UploadData;
+
+            Uploader(final int partNumber, @Nonnull final S3UploadData s3UploadData) {
+                this.partNumber = partNumber;
+                this.s3UploadData = s3UploadData;
+            }
+
+            @Override
+            public void run() {
+                // Upload the part and add the part to the tags.
+                final UploadPartRequest uploadPartRequest = new UploadPartRequest()
+                        .withBucketName(bucketName)
+                        .withKey(keyName)
+                        .withUploadId(uploadId)
+                        .withPartNumber(partNumber)
+                        .withInputStream(s3UploadData.getStream())
+                        .withPartSize(s3UploadData.getSize())
+                        .withLastPart(s3UploadData.getIsLast());
+                final UploadPartResult result = s3Client.uploadPart(uploadPartRequest);
+                partETags.add(result.getPartETag());
+
+                // Notify main thread that memory that was given is no longer in use.
+                synchronized (totalMemoryLock) {
+                    totalMemory -= s3UploadData.getSize();
+                    totalMemoryLock.notifyAll();
+                }
+            }
+        }
+    }
+
+    public enum AllocationSize {
+        MB_5 (5 * S3UploadConstants.MB),
+        MB_50 (50 * S3UploadConstants.MB),
+        MB_500 (500 * S3UploadConstants.MB),
+        MB_750 (750 * S3UploadConstants.MB);
+
+        private final int allocationSize;
+
+        AllocationSize(final int allocationSize) {
+            this.allocationSize = allocationSize;
+        }
+
+        int getAllocationSize() {
+            return allocationSize;
+        }
+    }
+
+    private static class S3UploadConstants {
+        private final static int MB = 1024 * 1024;
+        private static final long TRANSFERRED_2p5GB = AllocationSize.MB_5.getAllocationSize() * 500L;
+        private static final long TRANSFERRED_25GB = AllocationSize.MB_50.getAllocationSize() * 500L;
+        private static final long TRANSFERRED_2TB = AllocationSize.MB_500.getAllocationSize() * 4000L;
+        private static final long TOTAL_MEMORY_ALLOWED = AllocationSize.MB_750.getAllocationSize() * 3L; // 2.25 GB
+        private static final int MAX_THREAD_COUNT = 8;
+        // A max of 5 TB could take a very long time, so give a lot of time for this.
+        private static final int MAX_WAIT_TIME_MINUTES = 65536;
+    }
+}

--- a/core/src/main/java/apoc/util/s3/S3Params.java
+++ b/core/src/main/java/apoc/util/s3/S3Params.java
@@ -4,14 +4,17 @@ public class S3Params {
 
     private final String accessKey;
     private final String secretKey;
+    private final String sessionToken;
     private final String endpoint;
     private final String bucket;
     private final String key;
     private final String region;
 
-    public S3Params(String accessKey, String secretKey, String endpoint, String bucket, String key, String region) {
+    public S3Params(String accessKey, String secretKey, String sessionToken,
+                    String endpoint, String bucket, String key, String region) {
         this.accessKey = accessKey;
         this.secretKey = secretKey;
+        this.sessionToken = sessionToken;
         this.endpoint = endpoint;
         this.bucket = bucket;
         this.key = key;
@@ -24,6 +27,10 @@ public class S3Params {
 
     public String getSecretKey() {
         return secretKey;
+    }
+
+    public String getSessionToken() {
+        return sessionToken;
     }
 
     public String getEndpoint() {

--- a/core/src/main/java/apoc/util/s3/S3UploadUtils.java
+++ b/core/src/main/java/apoc/util/s3/S3UploadUtils.java
@@ -1,0 +1,19 @@
+package apoc.util.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URL;
+
+public class S3UploadUtils {
+
+    private S3UploadUtils() {}
+
+    public static OutputStream writeFile(String s3Url) throws IOException {
+        S3Params s3Params = S3ParamsExtractor.extract(new URL(s3Url));
+        S3Aws s3Aws = new S3Aws(s3Params, s3Params.getRegion());
+        AmazonS3 s3 = s3Aws.getClient();
+        return new S3OutputStream(s3, s3Params.getBucket(), s3Params.getKey());
+    }
+}

--- a/core/src/test/java/apoc/export/ExportS3PerformanceTest.java
+++ b/core/src/test/java/apoc/export/ExportS3PerformanceTest.java
@@ -1,0 +1,102 @@
+package apoc.export;
+
+import apoc.ApocSettings;
+import apoc.export.csv.ExportCSV;
+import apoc.graph.Graphs;
+import apoc.util.TestUtil;
+import apoc.util.s3.S3Aws;
+import apoc.util.s3.S3Params;
+import apoc.util.s3.S3ParamsExtractor;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.io.IOException;
+import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import static apoc.util.MapUtil.map;
+import static junit.framework.TestCase.assertTrue;
+
+@Disabled("To use this test, you need to set the S3 bucket and region to a valid endpoint " +
+        "and have your access key and secret key setup in your environment.")
+public class ExportS3PerformanceTest {
+    private static String S3_BUCKET_NAME = null;
+    private static int REPEAT_TEST = 3;
+
+    private static String getEnvVar(String envVarKey) throws Exception {
+        return Optional.ofNullable(System.getenv(envVarKey)).orElseThrow(
+                () -> new Exception(String.format("%s is not set in the environment", envVarKey))
+        );
+    }
+
+    private static String getS3Url(String key) {
+        return String.format("s3://:/%s/%s", S3_BUCKET_NAME, key);
+    }
+
+    private void verifyFileUploaded(String s3Url, String fileName) throws IOException {
+        S3Params s3Params = S3ParamsExtractor.extract(new URL(s3Url));
+        S3Aws s3Aws = new S3Aws(s3Params, s3Params.getRegion());
+        AmazonS3 s3Client = s3Aws.getClient();
+
+        boolean fileUploaded = false;
+        ObjectListing objectListing = s3Client.listObjects(s3Params.getBucket());
+        for(S3ObjectSummary os : objectListing.getObjectSummaries()) {
+            if (os.getKey().equals(fileName)) {
+                fileUploaded = true;
+                break;
+            }
+        }
+        assertTrue(fileUploaded);
+    }
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(ApocSettings.apoc_export_file_enabled, true);
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        if (S3_BUCKET_NAME == null) {
+            S3_BUCKET_NAME = getEnvVar("S3_BUCKET_NAME");
+        }
+        TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class);
+    }
+
+    @Test
+    public void testExportAllCsvS3() throws Exception {
+        System.out.println("Data creation started.");
+        // create large data (> 100 MB)
+        for (int i=0; i<555000; i++) {
+            String query = String.format("CREATE (f:User1:User {name:'foo%d',age:%d,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar%d',age:%d}),(c:User {age:12})", i, i, i, i );
+            db.executeTransactionally(query);
+        }
+        System.out.println("Data creation finished.");
+
+        System.out.println("Test started.");
+        for (int repeat=1; repeat<=REPEAT_TEST; repeat++) {
+            String fileName = String.format("performanceTest_%d.csv", repeat);
+            String s3Url = getS3Url(fileName);
+
+            // Run the performance testing
+            final Instant start = Instant.now();
+            TestUtil.testCall(db, "CALL apoc.export.csv.all($s3,null)",
+                    map("s3", s3Url),
+                    (r) -> {});
+            final Instant end = Instant.now();
+            final Duration diff = Duration.between(start, end);
+            System.out.println("Time to upload" + ": " + diff.toMillis() + " ms.");
+
+            // Verify the file was successfully uploaded.
+            verifyFileUploaded(s3Url, fileName);
+        }
+        System.out.println("Test finished.");
+    }
+}

--- a/core/src/test/java/apoc/export/ExportS3PerformanceTest.java
+++ b/core/src/test/java/apoc/export/ExportS3PerformanceTest.java
@@ -13,7 +13,7 @@ import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.jupiter.api.Disabled;
+import org.junit.Ignore;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -26,7 +26,7 @@ import java.util.Optional;
 import static apoc.util.MapUtil.map;
 import static junit.framework.TestCase.assertTrue;
 
-@Disabled("To use this test, you need to set the S3 bucket and region to a valid endpoint " +
+@Ignore("To use this test, you need to set the S3 bucket and region to a valid endpoint " +
         "and have your access key and secret key setup in your environment.")
 public class ExportS3PerformanceTest {
     private static String S3_BUCKET_NAME = null;

--- a/core/src/test/java/apoc/export/csv/ExportCsvS3Test.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvS3Test.java
@@ -1,0 +1,264 @@
+package apoc.export.csv;
+
+import apoc.ApocSettings;
+import apoc.graph.Graphs;
+import apoc.util.TestUtil;
+import apoc.util.s3.S3TestUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Optional;
+
+import static apoc.util.MapUtil.map;
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+@Disabled("To use this test, you need to set the S3 bucket and region to a valid endpoint " +
+        "and have your access key and secret key setup in your environment.")
+public class ExportCsvS3Test {
+    private static String S3_BUCKET_NAME = null;
+
+    private static final String EXPECTED_QUERY_NODES = String.format("\"u\"%n" +
+            "\"{\"\"id\"\":0,\"\"labels\"\":[\"\"User\"\",\"\"User1\"\"],\"\"properties\"\":{\"\"name\"\":\"\"foo\"\",\"\"age\"\":42,\"\"male\"\":true,\"\"kids\"\":[\"\"a\"\",\"\"b\"\",\"\"c\"\"]}}\"%n" +
+            "\"{\"\"id\"\":1,\"\"labels\"\":[\"\"User\"\"],\"\"properties\"\":{\"\"name\"\":\"\"bar\"\",\"\"age\"\":42}}\"%n" +
+            "\"{\"\"id\"\":2,\"\"labels\"\":[\"\"User\"\"],\"\"properties\"\":{\"\"age\"\":12}}\"%n");
+    private static final String EXPECTED_QUERY = String.format("\"u.age\",\"u.name\",\"u.male\",\"u.kids\",\"labels(u)\"%n" +
+            "\"42\",\"foo\",\"true\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"[\"\"User1\"\",\"\"User\"\"]\"%n" +
+            "\"42\",\"bar\",\"\",\"\",\"[\"\"User\"\"]\"%n" +
+            "\"12\",\"\",\"\",\"\",\"[\"\"User\"\"]\"%n");
+    private static final String EXPECTED_QUERY_WITHOUT_QUOTES = String.format("u.age,u.name,u.male,u.kids,labels(u)%n" +
+            "42,foo,true,[\"a\",\"b\",\"c\"],[\"User1\",\"User\"]%n" +
+            "42,bar,,,[\"User\"]%n" +
+            "12,,,,[\"User\"]%n");
+    private static final String EXPECTED_QUERY_QUOTES_NONE = String.format("a.name,a.city,a.street,labels(a)%n" +
+            "Andrea,Milano,Via Garibaldi, 7,[\"Address1\",\"Address\"]%n" +
+            "Bar Sport,,,[\"Address\"]%n" +
+            ",,via Benni,[\"Address\"]%n");
+    private static final String EXPECTED_QUERY_QUOTES_ALWAYS = String.format("\"a.name\",\"a.city\",\"a.street\",\"labels(a)\"%n" +
+            "\"Andrea\",\"Milano\",\"Via Garibaldi, 7\",\"[\"\"Address1\"\",\"\"Address\"\"]\"%n" +
+            "\"Bar Sport\",\"\",\"\",\"[\"\"Address\"\"]\"%n" +
+            "\"\",\"\",\"via Benni\",\"[\"\"Address\"\"]\"%n");
+    private static final String EXPECTED_QUERY_QUOTES_NEEDED = String.format("a.name,a.city,a.street,labels(a)%n" +
+            "Andrea,Milano,\"Via Garibaldi, 7\",\"[\"Address1\",\"Address\"]\"%n" +
+            "Bar Sport,,,\"[\"Address\"]\"%n" +
+            ",,via Benni,\"[\"Address\"]\"%n");
+    private static final String EXPECTED = String.format("\"_id\",\"_labels\",\"age\",\"city\",\"kids\",\"male\",\"name\",\"street\",\"_start\",\"_end\",\"_type\"%n" +
+            "\"0\",\":User:User1\",\"42\",\"\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"true\",\"foo\",\"\",,,%n" +
+            "\"1\",\":User\",\"42\",\"\",\"\",\"\",\"bar\",\"\",,,%n" +
+            "\"2\",\":User\",\"12\",\"\",\"\",\"\",\"\",\"\",,,%n" +
+            "\"3\",\":Address:Address1\",\"\",\"Milano\",\"\",\"\",\"Andrea\",\"Via Garibaldi, 7\",,,%n" +
+            "\"4\",\":Address\",\"\",\"\",\"\",\"\",\"Bar Sport\",\"\",,,%n" +
+            "\"5\",\":Address\",\"\",\"\",\"\",\"\",\"\",\"via Benni\",,,%n" +
+            ",,,,,,,,\"0\",\"1\",\"KNOWS\"%n" +
+            ",,,,,,,,\"3\",\"4\",\"NEXT_DELIVERY\"%n");
+
+    private static final String EXPECTED_NONE_QUOTES = String.format("_id,_labels,age,city,kids,male,name,street,_start,_end,_type%n" +
+            "0,:User:User1,42,,[\"a\",\"b\",\"c\"],true,foo,,,,%n" +
+            "1,:User,42,,,,bar,,,,%n" +
+            "2,:User,12,,,,,,,,%n" +
+            "3,:Address:Address1,,Milano,,,Andrea,Via Garibaldi, 7,,,%n" +
+            "4,:Address,,,,,Bar Sport,,,,%n" +
+            "5,:Address,,,,,,via Benni,,,%n" +
+            ",,,,,,,,0,1,KNOWS%n" +
+            ",,,,,,,,3,4,NEXT_DELIVERY%n");
+    private static final String EXPECTED_NEEDED_QUOTES = String.format("_id,_labels,age,city,kids,male,name,street,_start,_end,_type%n" +
+            "0,:User:User1,42,,\"[\"a\",\"b\",\"c\"]\",true,foo,,,,%n" +
+            "1,:User,42,,,,bar,,,,%n" +
+            "2,:User,12,,,,,,,,%n" +
+            "3,:Address:Address1,,Milano,,,Andrea,\"Via Garibaldi, 7\",,,%n" +
+            "4,:Address,,,,,Bar Sport,,,,%n" +
+            "5,:Address,,,,,,via Benni,,,%n" +
+            ",,,,,,,,0,1,KNOWS%n" +
+            ",,,,,,,,3,4,NEXT_DELIVERY%n");
+
+    private static File directory = new File("target/import");
+    static { //noinspection ResultOfMethodCallIgnored
+        directory.mkdirs();
+    }
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath())
+            .withSetting(ApocSettings.apoc_export_file_enabled, true);
+
+    private static String getEnvVar(String envVarKey) throws Exception {
+        return Optional.ofNullable(System.getenv(envVarKey)).orElseThrow(
+                () -> new Exception(String.format("%s is not set in the environment", envVarKey))
+        );
+    }
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        if (S3_BUCKET_NAME == null) {
+            S3_BUCKET_NAME = getEnvVar("S3_BUCKET_NAME");
+        }
+        TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class);
+        db.executeTransactionally("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})");
+        db.executeTransactionally("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+    }
+
+    private static String getS3Url(String key) {
+        return String.format("s3://:@/%s/%s", S3_BUCKET_NAME, key);
+    }
+
+    private String readFile(String fileName) {
+        return TestUtil.readFileToString(new File(directory, fileName));
+    }
+
+    private void verifyUpload(String s3Url, String fileName, String expected) throws IOException {
+        S3TestUtil.readFile(s3Url, Paths.get(directory.toString(), fileName).toString());
+        assertEquals(expected, readFile(fileName));
+    }
+
+    @Test
+    public void testExportAllCsvS3() throws Exception {
+        String fileName = "all.csv";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.csv.all($s3,null)",
+                map("s3", s3Url),
+                (r) -> assertResults(s3Url, r, "database"));
+        verifyUpload(s3Url, fileName, EXPECTED);
+    }
+
+    @Test
+    public void testExportAllCsvS3WithQuotes() throws Exception {
+        String fileName = "all.csv";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.csv.all($s3,{quotes: true})",
+                map("s3", s3Url),
+                (r) -> assertResults(s3Url, r, "database"));
+        verifyUpload(s3Url, fileName, EXPECTED);
+    }
+
+    @Test
+    public void testExportAllCsvS3WithoutQuotes() throws Exception {
+        String fileName = "all1.csv";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.csv.all($s3,{quotes: 'none'})",
+                map("s3", s3Url),
+                (r) -> assertResults(s3Url, r, "database"));
+        verifyUpload(s3Url, fileName, EXPECTED_NONE_QUOTES);
+    }
+
+    @Test
+    public void testExportAllCsvS3NeededQuotes() throws Exception {
+        String fileName = "all2.csv";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.csv.all($s3,{quotes: 'ifNeeded'})",
+                map("s3", s3Url),
+                (r) -> assertResults(s3Url, r, "database"));
+        verifyUpload(s3Url, fileName, EXPECTED_NEEDED_QUOTES);
+    }
+
+    @Test
+    public void testExportGraphCsv() throws Exception {
+        String fileName = "graph.csv";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.csv.graph(graph, $s3,{quotes: 'none'}) " +
+                        "YIELD nodes, relationships, properties, file, source,format, time " +
+                        "RETURN *", map("s3", s3Url),
+                (r) -> assertResults(s3Url, r, "graph"));
+        verifyUpload(s3Url, fileName, EXPECTED_NONE_QUOTES);
+    }
+
+    @Test
+    public void testExportGraphCsvWithoutQuotes() throws Exception {
+        String fileName = "graph1.csv";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.csv.graph(graph, $s3,null) " +
+                        "YIELD nodes, relationships, properties, file, source,format, time " +
+                        "RETURN *", map("s3", s3Url),
+                (r) -> assertResults(s3Url, r, "graph"));
+        verifyUpload(s3Url, fileName, EXPECTED);
+    }
+
+    @Test
+    public void testExportQueryCsv() throws Exception {
+        String fileName = "query.csv";
+        String s3Url = getS3Url(fileName);
+        String query = "MATCH (u:User) return u.age, u.name, u.male, u.kids, labels(u)";
+        TestUtil.testCall(db, "CALL apoc.export.csv.query($query,$s3,null)",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(5)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("csv", r.get("format"));
+
+                });
+        verifyUpload(s3Url, fileName, EXPECTED_QUERY);
+    }
+
+    @Test
+    public void testExportQueryCsvWithoutQuotes() throws Exception {
+        String fileName = "query1.csv";
+        String s3Url = getS3Url(fileName);
+        String query = "MATCH (u:User) return u.age, u.name, u.male, u.kids, labels(u)";
+        TestUtil.testCall(db, "CALL apoc.export.csv.query($query,$s3,{quotes: false})",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(5)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("csv", r.get("format"));
+
+                });
+        verifyUpload(s3Url, fileName, EXPECTED_QUERY_WITHOUT_QUOTES);
+    }
+
+    @Test
+    public void testExportQueryNodesCsv() throws Exception {
+        String fileName = "query_nodes.csv";
+        String s3Url = getS3Url(fileName);
+        String query = "MATCH (u:User) return u";
+        TestUtil.testCall(db, "CALL apoc.export.csv.query($query,$s3,null)",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("csv", r.get("format"));
+
+                });
+        verifyUpload(s3Url, fileName, EXPECTED_QUERY_NODES);
+    }
+
+    @Test
+    public void testExportQueryNodesCsvParams() throws Exception {
+        String fileName = "query_nodes1.csv";
+        String s3Url = getS3Url(fileName);
+        String query = "MATCH (u:User) WHERE u.age > $age return u";
+        TestUtil.testCall(db, "CALL apoc.export.csv.query($query,$s3,{params:{age:10}})", map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should s3 statement", r.get("source").toString().contains("statement: cols(1)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("csv", r.get("format"));
+
+                });
+        verifyUpload(s3Url, fileName, EXPECTED_QUERY_NODES);
+    }
+
+    private void assertResults(String fileName, Map<String, Object> r, final String source) {
+        assertEquals(6L, r.get("nodes"));
+        assertEquals(2L, r.get("relationships"));
+        assertEquals(12L, r.get("properties"));
+        assertEquals(source + ": nodes(6), rels(2)", r.get("source"));
+        assertEquals(fileName, r.get("file"));
+        assertEquals("csv", r.get("format"));
+        assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
+    }
+
+}

--- a/core/src/test/java/apoc/export/csv/ExportCsvS3Test.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvS3Test.java
@@ -8,7 +8,7 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.jupiter.api.Disabled;
+import org.junit.Ignore;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -23,7 +23,7 @@ import static apoc.util.MapUtil.map;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
-@Disabled("To use this test, you need to set the S3 bucket and region to a valid endpoint " +
+@Ignore("To use this test, you need to set the S3 bucket and region to a valid endpoint " +
         "and have your access key and secret key setup in your environment.")
 public class ExportCsvS3Test {
     private static String S3_BUCKET_NAME = null;

--- a/core/src/test/java/apoc/export/cypher/ExportCypherS3Test.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherS3Test.java
@@ -1,0 +1,1019 @@
+package apoc.export.cypher;
+
+import apoc.graph.Graphs;
+import apoc.util.TestUtil;
+import apoc.util.s3.S3TestUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.rules.TestName;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Optional;
+
+import static apoc.ApocConfig.APOC_EXPORT_FILE_ENABLED;
+import static apoc.ApocConfig.apocConfig;
+import static apoc.export.cypher.ExportCypherTest.ExportCypherResults.*;
+import static apoc.export.util.ExportFormat.*;
+import static apoc.util.Util.map;
+import static org.junit.Assert.*;
+
+@Disabled("To use this test, you need to set the S3 bucket and region to a valid endpoint " +
+        "and have your access key and secret key setup in your environment.")
+public class ExportCypherS3Test {
+    private static String S3_BUCKET_NAME = null;
+
+    private static final Map<String, Object> exportConfig = map("useOptimizations", map("type", "none"), "separateFiles", true, "format", "neo4j-admin");
+
+    private static File directory = new File("target/import");
+
+    static { //noinspection ResultOfMethodCallIgnored
+        directory.mkdirs();
+    }
+
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath());
+
+    @Rule
+    public TestName testName = new TestName();
+
+    private static final String OPTIMIZED = "Optimized";
+    private static final String ODD = "OddDataset";
+
+    private static String getS3Url(String key) {
+        return String.format("s3://:@/%s/%s", S3_BUCKET_NAME, key);
+    }
+
+    private void verifyUpload(String fileName, String expected) throws IOException {
+        String s3Url = getS3Url(fileName);
+        S3TestUtil.readFile(s3Url, Paths.get(directory.toString(), fileName).toString());
+        assertEquals(expected, readFile(fileName));
+    }
+
+    private static String readFile(String fileName) {
+        return TestUtil.readFileToString(new File(directory, fileName));
+    }
+
+    private static String getEnvVar(String envVarKey) throws Exception {
+        return Optional.ofNullable(System.getenv(envVarKey)).orElseThrow(
+                () -> new Exception(String.format("%s is not set in the environment", envVarKey))
+        );
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        if (S3_BUCKET_NAME == null) {
+            S3_BUCKET_NAME = getEnvVar("S3_BUCKET_NAME");
+        }
+        apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
+        TestUtil.registerProcedure(db, ExportCypher.class, Graphs.class);
+        db.executeTransactionally("CREATE INDEX ON :Bar(first_name, last_name)");
+        db.executeTransactionally("CREATE INDEX ON :Foo(name)");
+        db.executeTransactionally("CREATE CONSTRAINT ON (b:Bar) ASSERT b.name IS UNIQUE");
+        if (testName.getMethodName().endsWith(OPTIMIZED)) {
+            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})-[:KNOWS {since:2016}]->(b:Bar {name:'bar',age:42}),(c:Bar:Person {age:12}),(d:Bar {age:12})," +
+                    " (t:Foo {name:'foo2', born:date('2017-09-29')})-[:KNOWS {since:2015}]->(e:Bar {name:'bar2',age:44}),({age:99})");
+        } else if(testName.getMethodName().endsWith(ODD)) {
+            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})," +
+                    "(t:Foo {name:'foo2', born:date('2017-09-29')})," +
+                    "(g:Foo {name:'foo3', born:date('2016-03-12')})," +
+                    "(b:Bar {name:'bar',age:42})," +
+                    "(c:Bar {age:12})," +
+                    "(d:Bar {age:4})," +
+                    "(e:Bar {name:'bar2',age:44})," +
+                    "(f)-[:KNOWS {since:2016}]->(b)");
+        } else {
+            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})-[:KNOWS {since:2016}]->(b:Bar {name:'bar',age:42}),(c:Bar {age:12})");
+        }
+    }
+
+    // -- Whole file test -- //
+    @Test
+    public void testExportAllCypherDefault() throws Exception {
+        String fileName = "all.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,{useOptimizations: { type: 'none'}, format: 'neo4j-shell'})",
+                map("s3", s3Url),
+                (r) -> assertResults(s3Url, r, "database"));
+        verifyUpload(fileName, EXPECTED_NEO4J_SHELL);
+    }
+
+    @Test
+    public void testExportAllCypherForCypherShell() throws Exception {
+        String fileName = "all.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,$config)",
+                map("s3", s3Url, "config", map("useOptimizations", map("type", "none"), "format", "cypher-shell")),
+                (r) -> assertResults(s3Url, r, "database"));
+        verifyUpload(fileName, EXPECTED_CYPHER_SHELL);
+    }
+
+    @Test
+    public void testExportQueryCypherForNeo4j() throws Exception {
+        String fileName = "all.cypher";
+        String s3Url = getS3Url(fileName);
+        String query = "MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.query($query,$s3,$config)",
+                map("s3", s3Url, "query", query, "config", map("useOptimizations", map("type", "none"), "format", "neo4j-shell")), (r) -> {
+                });
+        verifyUpload(fileName, EXPECTED_NEO4J_SHELL);
+    }
+
+    @Test
+    public void testExportGraphCypher() throws Exception {
+        String fileName = "graph.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.cypher.graph(graph, $s3,$exportConfig) " +
+                        "YIELD nodes, relationships, properties, file, source,format, time " +
+                        "RETURN *",
+                map("s3", s3Url, "exportConfig", map("useOptimizations", map("type", "none"), "format", "neo4j-shell")),
+                (r) -> assertResults(s3Url, r, "graph"));
+        verifyUpload(fileName, EXPECTED_NEO4J_SHELL);
+    }
+
+    // -- Separate files tests -- //
+    @Test
+    public void testExportAllCypherNodes() throws Exception {
+        String fileName = "all.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,$exportConfig)",
+                map("s3", s3Url, "exportConfig", exportConfig),
+                (r) -> assertResults(s3Url, r, "database"));
+        verifyUpload("all.nodes.cypher", EXPECTED_NODES);
+    }
+
+    @Test
+    public void testExportAllCypherRelationships() throws Exception {
+        String fileName = "all.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,$exportConfig)",
+                map("s3", s3Url, "exportConfig", exportConfig),
+                (r) -> assertResults(s3Url, r, "database"));
+        verifyUpload("all.relationships.cypher", EXPECTED_RELATIONSHIPS);
+    }
+
+    @Test
+    public void testExportAllCypherSchema() throws Exception {
+        String fileName = "all.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,$exportConfig)",
+                map("s3", s3Url, "exportConfig", exportConfig),
+                (r) -> assertResults(s3Url, r, "database"));
+        verifyUpload("all.schema.cypher", EXPECTED_SCHEMA);
+    }
+
+    @Test
+    public void testExportAllCypherCleanUp() throws Exception {
+        String fileName = "all.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,$exportConfig)",
+                map("s3", s3Url, "exportConfig", exportConfig),
+                (r) -> assertResults(s3Url, r, "database"));
+        verifyUpload("all.cleanup.cypher", EXPECTED_CLEAN_UP);
+    }
+
+    @Test
+    public void testExportGraphCypherNodes() throws Exception {
+        String fileName = "graph.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                "CALL apoc.export.cypher.graph(graph, $s3,$exportConfig) " +
+                "YIELD nodes, relationships, properties, file, source,format, time " +
+                "RETURN *",
+                map("s3", s3Url, "exportConfig", exportConfig),
+                (r) -> assertResults(s3Url, r, "graph"));
+        verifyUpload("graph.nodes.cypher", EXPECTED_NODES);
+    }
+
+    @Test
+    public void testExportGraphCypherRelationships() throws Exception {
+        String fileName = "graph.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.cypher.graph(graph, $s3,$exportConfig) " +
+                        "YIELD nodes, relationships, properties, file, source, format, time " +
+                        "RETURN *",
+                map("s3", s3Url, "exportConfig", exportConfig),
+                (r) -> assertResults(s3Url, r, "graph"));
+        verifyUpload("graph.relationships.cypher", EXPECTED_RELATIONSHIPS);
+    }
+
+    @Test
+    public void testExportGraphCypherSchema() throws Exception {
+        String fileName = "graph.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.cypher.graph(graph, $s3,$exportConfig) " +
+                        "YIELD nodes, relationships, properties, file, source,format, time " +
+                        "RETURN *",
+                map("s3", s3Url, "exportConfig", exportConfig),
+                (r) -> assertResults(s3Url, r, "graph"));
+        verifyUpload("graph.schema.cypher", EXPECTED_SCHEMA);
+    }
+
+    @Test
+    public void testExportGraphCypherCleanUp() throws Exception {
+        String fileName = "graph.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.cypher.graph(graph, $s3,$exportConfig) " +
+                        "YIELD nodes, relationships, properties, file, source,format, time " +
+                        "RETURN *",
+                map("s3", s3Url, "exportConfig", exportConfig),
+                (r) -> assertResults(s3Url, r, "graph"));
+        verifyUpload("graph.cleanup.cypher", EXPECTED_CLEAN_UP);
+    }
+
+    private void assertResults(String fileName, Map<String, Object> r, final String source) {
+        assertEquals(3L, r.get("nodes"));
+        assertEquals(1L, r.get("relationships"));
+        assertEquals(6L, r.get("properties"));
+        assertEquals(fileName, r.get("file"));
+        assertEquals(source + ": nodes(3), rels(1)", r.get("source"));
+        assertEquals("cypher", r.get("format"));
+        assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
+    }
+
+    @Test
+    public void testExportQueryCypherPlainFormat() throws Exception {
+        String fileName = "all.cypher";
+        String s3Url = getS3Url(fileName);
+        String query = "MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.query($query,$s3,$config)",
+                map("s3", s3Url, "query", query, "config", map("useOptimizations", map("type", "none"), "format", "plain")), (r) -> {
+                });
+        verifyUpload(fileName, EXPECTED_PLAIN);
+    }
+
+    @Test
+    public void testExportQueryCypherFormatUpdateAll() throws Exception {
+        String fileName = "all.cypher";
+        String s3Url = getS3Url(fileName);
+        String query = "MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.query($query,$s3,$config)",
+                map("s3", s3Url, "query", query, "config", map("useOptimizations", map("type", "none"), "format", "neo4j-shell", "cypherFormat", "updateAll")), (r) -> {
+                });
+        verifyUpload(fileName, EXPECTED_NEO4J_MERGE);
+    }
+
+    @Test
+    public void testExportQueryCypherFormatAddStructure() throws Exception {
+        String fileName = "all.cypher";
+        String s3Url = getS3Url(fileName);
+        String query = "MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.query($query,$s3,$config)",
+                map("s3", s3Url, "query", query, "config", map("useOptimizations", map("type", "none"), "format", "neo4j-shell", "cypherFormat", "addStructure")), (r) -> {
+                });
+        verifyUpload(fileName, EXPECTED_NODES_MERGE_ON_CREATE_SET + EXPECTED_SCHEMA_EMPTY + EXPECTED_RELATIONSHIPS + EXPECTED_CLEAN_UP_EMPTY);
+    }
+
+    @Test
+    public void testExportQueryCypherFormatUpdateStructure() throws Exception {
+        String fileName = "all.cypher";
+        String s3Url = getS3Url(fileName);
+        String query = "MATCH (n) OPTIONAL MATCH p = (n)-[r]-(m) RETURN n,r,m";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.query($query,$s3,$config)",
+                map("s3", s3Url, "query", query, "config", map("useOptimizations", map("type", "none"), "format", "neo4j-shell", "cypherFormat", "updateStructure")), (r) -> {
+                });
+        verifyUpload(fileName, EXPECTED_NODES_EMPTY + EXPECTED_SCHEMA_EMPTY + EXPECTED_RELATIONSHIPS_MERGE_ON_CREATE_SET + EXPECTED_CLEAN_UP_EMPTY);
+    }
+
+    @Test
+    public void testExportSchemaCypher() throws Exception {
+        String fileName = "onlySchema.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.schema($s3,$exportConfig)", map("s3", s3Url, "exportConfig", exportConfig), (r) -> {
+        });
+        verifyUpload(fileName, EXPECTED_ONLY_SCHEMA_NEO4J_SHELL);
+    }
+
+    @Test
+    public void testExportSchemaCypherShell() throws Exception {
+        String fileName = "onlySchema.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.schema($s3,$exportConfig)",
+                map("s3", s3Url, "exportConfig", map("useOptimizations", map("type", "none"), "format", "cypher-shell")),
+                (r) -> {});
+        verifyUpload(fileName, EXPECTED_ONLY_SCHEMA_CYPHER_SHELL);
+    }
+
+    @Test
+    public void testExportCypherNodePoint() throws IOException {
+        db.executeTransactionally("CREATE (f:Test {name:'foo'," +
+                "place2d:point({ x: 2.3, y: 4.5 })," +
+                "place3d1:point({ x: 2.3, y: 4.5 , z: 1.2})})" +
+                "-[:FRIEND_OF {place2d:point({ longitude: 56.7, latitude: 12.78 })}]->" +
+                "(:Bar {place3d:point({ longitude: 12.78, latitude: 56.7, height: 100 })})");
+        String fileName = "temporalPoint.cypher";
+        String s3Url = getS3Url(fileName);
+        String query = "MATCH (n:Test)-[r]-(m) RETURN n,r,m";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.query($query,$s3,$config)",
+                map("s3", s3Url, "query", query, "config", map("useOptimizations", map("type", "none"),"format", "neo4j-shell")),
+                (r) -> {});
+        verifyUpload(fileName, EXPECTED_CYPHER_POINT);
+    }
+
+    @Test
+    public void testExportCypherNodeDate() throws IOException {
+        db.executeTransactionally("CREATE (f:Test {name:'foo', " +
+                "date:date('2018-10-30'), " +
+                "datetime:datetime('2018-10-30T12:50:35.556+0100'), " +
+                "localTime:localdatetime('20181030T19:32:24')})" +
+                "-[:FRIEND_OF {date:date('2018-10-30')}]->" +
+                "(:Bar {datetime:datetime('2018-10-30T12:50:35.556')})");
+        String fileName = "temporalDate.cypher";
+        String s3Url = getS3Url(fileName);
+        String query = "MATCH (n:Test)-[r]-(m) RETURN n,r,m";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.query($query,$s3,$config)",
+                map("s3", s3Url, "query", query, "config", map("useOptimizations", map("type", "none"),"format", "neo4j-shell")),
+                (r) -> {});
+        verifyUpload(fileName, EXPECTED_CYPHER_DATE);
+    }
+
+    @Test
+    public void testExportCypherNodeTime() throws IOException {
+        db.executeTransactionally("CREATE (f:Test {name:'foo', " +
+                "local:localtime('12:50:35.556')," +
+                "t:time('125035.556+0100')})" +
+                "-[:FRIEND_OF {t:time('125035.556+0100')}]->" +
+                "(:Bar {datetime:datetime('2018-10-30T12:50:35.556+0100')})");
+        String fileName = "temporalTime.cypher";
+        String s3Url = getS3Url(fileName);
+        String query = "MATCH (n:Test)-[r]-(m) RETURN n,r,m";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.query($query,$s3,$config)",
+                map("s3", s3Url, "query", query, "config", map("useOptimizations", map("type", "none"),"format", "neo4j-shell")),
+                (r) -> {});
+        verifyUpload(fileName, EXPECTED_CYPHER_TIME);
+    }
+
+    @Test
+    public void testExportCypherNodeDuration() throws IOException {
+        db.executeTransactionally("CREATE (f:Test {name:'foo', " +
+                "duration:duration('P5M1.5D')})" +
+                "-[:FRIEND_OF {duration:duration('P5M1.5D')}]->" +
+                "(:Bar {duration:duration('P5M1.5D')})");
+        String fileName = "temporalDuration.cypher";
+        String s3Url = getS3Url(fileName);
+        String query = "MATCH (n:Test)-[r]-(m) RETURN n,r,m";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.query($query,$s3,$config)",
+                map("s3", s3Url, "query", query, "config", map("useOptimizations", map("type", "none"),"format", "neo4j-shell")),
+                (r) -> {});
+        verifyUpload(fileName, EXPECTED_CYPHER_DURATION);
+    }
+
+    @Test
+    public void testExportWithAscendingLabels() throws IOException {
+        db.executeTransactionally("CREATE (f:User:User1:User0:User12 {name:'Alan'})");
+        String fileName = "ascendingLabels.cypher";
+        String s3Url = getS3Url(fileName);
+        String query = "MATCH (f:User) WHERE f.name='Alan' RETURN f";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.query($query,$s3,$config)",
+                map("s3", s3Url, "query", query, "config", map("useOptimizations", map("type", "none"),"format", "neo4j-shell")),
+                (r) -> {});
+        verifyUpload(fileName, EXPECTED_CYPHER_LABELS_ASCENDEND);
+    }
+
+    @Test
+    public void testExportAllCypherDefaultWithUnwindBatchSizeOptimized() throws Exception {
+        String fileName = "allDefaultOptimized.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,{useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}, format: 'neo4j-shell'})", map("s3", s3Url),
+                (r) -> assertResultsOptimized(s3Url, r));
+        verifyUpload(fileName, EXPECTED_NEO4J_OPTIMIZED_BATCH_SIZE);
+    }
+
+    @Test
+    public void testExportAllCypherDefaultOptimized() throws Exception {
+        String fileName = "allDefaultOptimized.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3, $exportConfig)", map("s3", s3Url, "exportConfig", map("format", "neo4j-shell")),
+                (r) -> assertResultsOptimized(s3Url, r));
+        verifyUpload(fileName, EXPECTED_NEO4J_OPTIMIZED);
+    }
+
+    @Test
+    public void testExportAllCypherDefaultSeparatedFilesOptimized() throws Exception {
+        String fileName = "allDefaultOptimized.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3, $exportConfig)",
+                map("s3", s3Url, "exportConfig", map("separateFiles", true, "format", "neo4j-shell")),
+                (r) -> assertResultsOptimized(s3Url, r));
+        verifyUpload("allDefaultOptimized.nodes.cypher", EXPECTED_NODES_OPTIMIZED);
+        verifyUpload("allDefaultOptimized.relationships.cypher", EXPECTED_RELATIONSHIPS_OPTIMIZED);
+        verifyUpload("allDefaultOptimized.schema.cypher", EXPECTED_SCHEMA_OPTIMIZED);
+        verifyUpload("allDefaultOptimized.cleanup.cypher", EXPECTED_CLEAN_UP);
+    }
+
+    @Test
+    public void testExportAllCypherCypherShellWithUnwindBatchSizeOptimized() throws Exception {
+        String fileName = "allCypherShellOptimized.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,{format:'cypher-shell', useOptimizations: {type: 'unwind_batch'}})",
+                map("s3", s3Url),
+                (r) -> assertResultsOptimized(s3Url, r));
+        verifyUpload(fileName, EXPECTED_CYPHER_SHELL_OPTIMIZED_BATCH_SIZE);
+    }
+
+    @Test
+    public void testExportAllCypherCypherShellOptimized() throws Exception {
+        String fileName = "allCypherShellOptimized.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,{format:'cypher-shell'})",
+                map("s3", s3Url),
+                (r) -> assertResultsOptimized(s3Url, r));
+        verifyUpload(fileName, EXPECTED_CYPHER_SHELL_OPTIMIZED);
+    }
+
+    @Test
+    public void testExportAllCypherPlainWithUnwindBatchSizeOptimized() throws Exception {
+        String fileName = "allPlainOptimized.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,{format:'plain', useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}})",
+                map("s3", s3Url),
+                (r) -> assertResultsOptimized(s3Url, r));
+        verifyUpload(fileName, EXPECTED_PLAIN_OPTIMIZED_BATCH_SIZE);
+    }
+
+    @Test
+    public void testExportAllCypherPlainAddStructureWithUnwindBatchSizeOptimized() throws Exception {
+        String fileName = "allPlainAddStructureOptimized.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,{format:'plain', cypherFormat: 'addStructure', useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}})",
+                map("s3", s3Url), (r) -> assertResultsOptimized(s3Url, r));
+        verifyUpload(fileName, EXPECTED_PLAIN_ADD_STRUCTURE_UNWIND);
+    }
+
+    @Test
+    public void testExportAllCypherPlainUpdateStructureWithUnwindBatchSizeOptimized() throws Exception {
+        String fileName = "allPlainUpdateStructureOptimized.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,{format:'plain', cypherFormat: 'updateStructure', useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}})",
+                map("s3", s3Url), (r) -> {
+                    assertEquals(0L, r.get("nodes"));
+                    assertEquals(2L, r.get("relationships"));
+                    assertEquals(2L, r.get("properties"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("cypher", r.get("format"));
+                    assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
+                });
+        verifyUpload(fileName, EXPECTED_PLAIN_UPDATE_STRUCTURE_UNWIND);
+    }
+
+    @Test
+    public void testExportAllCypherPlainUpdateAllWithUnwindBatchSizeOptimized() throws Exception {
+        String fileName = "allPlainUpdateAllOptimized.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,{format:'plain', cypherFormat: 'updateAll', useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}})",
+                map("s3", s3Url), (r) -> assertResultsOptimized(s3Url, r));
+        verifyUpload(fileName, EXPECTED_UPDATE_ALL_UNWIND);
+    }
+
+    @Test
+    public void testExportQueryCypherShellWithUnwindBatchSizeWithBatchSizeOptimized() throws Exception {
+        String fileName = "allPlainOptimized.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,{format:'cypher-shell', useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}, batchSize: 2})",
+                map("s3", s3Url),
+                (r) -> assertResultsOptimized(s3Url, r));
+        verifyUpload(fileName, EXPECTED_QUERY_CYPHER_SHELL_OPTIMIZED_UNWIND);
+    }
+
+    @Test
+    public void testExportQueryCypherShellWithUnwindBatchSizeWithBatchSizeOddDataset() throws Exception {
+        String fileName = "allPlainOdd.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,{format:'cypher-shell', useOptimizations: { type: 'unwind_batch', unwindBatchSize: 2}, batchSize: 2})",
+                map("s3", s3Url), (r) -> assertResultsOdd(s3Url, r));
+        verifyUpload(fileName, EXPECTED_QUERY_CYPHER_SHELL_OPTIMIZED_ODD);
+    }
+
+    @Test
+    public void testExportQueryCypherShellUnwindBatchParamsWithOddDataset() throws Exception {
+        String fileName = "allPlainOdd.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,{format:'cypher-shell', useOptimizations: { type: 'unwind_batch_params', unwindBatchSize: 2}, batchSize:2})",
+                map("s3", s3Url),
+                (r) -> assertResultsOdd(s3Url, r));
+        verifyUpload(fileName, EXPECTED_QUERY_CYPHER_SHELL_PARAMS_OPTIMIZED_ODD);
+    }
+
+    @Test
+    public void testExportQueryCypherShellUnwindBatchParamsWithOddBatchSizeOddDataset() throws Exception {
+        db.executeTransactionally("CREATE (:Bar {name:'bar3',age:35}), (:Bar {name:'bar4',age:36})");
+        String fileName = "allPlainOddNew.cypher";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($s3,{format:'cypher-shell', useOptimizations: { type: 'unwind_batch_params', unwindBatchSize: 2}, batchSize:3})",
+                map("s3", s3Url),
+                (r) -> {});
+        db.executeTransactionally("MATCH (n:Bar {name:'bar3',age:35}), (n1:Bar {name:'bar4',age:36}) DELETE n, n1");
+        String expectedNodes = String.format(":begin%n" +
+                ":param rows => [{_id:4, properties:{age:12}}, {_id:5, properties:{age:4}}]%n" +
+                "UNWIND $rows AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar;%n" +
+                ":param rows => [{_id:0, properties:{born:date('2018-10-31'), name:\"foo\"}}]%n" +
+                "UNWIND $rows AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;%n" +
+                ":commit%n" +
+                ":begin%n" +
+                ":param rows => [{_id:1, properties:{born:date('2017-09-29'), name:\"foo2\"}}, {_id:2, properties:{born:date('2016-03-12'), name:\"foo3\"}}]%n" +
+                "UNWIND $rows AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;%n" +
+                ":param rows => [{name:\"bar\", properties:{age:42}}]%n" +
+                "UNWIND $rows AS row%n" +
+                "CREATE (n:Bar{name: row.name}) SET n += row.properties;%n" +
+                ":commit%n" +
+                ":begin%n" +
+                ":param rows => [{name:\"bar2\", properties:{age:44}}, {name:\"bar3\", properties:{age:35}}]%n" +
+                "UNWIND $rows AS row%n" +
+                "CREATE (n:Bar{name: row.name}) SET n += row.properties;%n" +
+                ":param rows => [{name:\"bar4\", properties:{age:36}}]%n" +
+                "UNWIND $rows AS row%n" +
+                "CREATE (n:Bar{name: row.name}) SET n += row.properties;%n" +
+                ":commit%n");
+        int expectedDropNum = 3;
+        String expectedDrop = String.format(":begin%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT %d REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                ":commit%n" +
+                ":begin%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT %d REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                ":commit%n" +
+                ":begin%n" +
+                "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                ":commit%n", expectedDropNum, expectedDropNum);
+        String expected = (EXPECTED_SCHEMA_OPTIMIZED + expectedNodes + EXPECTED_RELATIONSHIPS_PARAMS_ODD + expectedDrop)
+                .replace(NEO4J_SHELL.begin(), CYPHER_SHELL.begin())
+                .replace(NEO4J_SHELL.commit(), CYPHER_SHELL.commit())
+                .replace(NEO4J_SHELL.schemaAwait(), EXPECTED_INDEXES_AWAIT)
+                .replace(NEO4J_SHELL.schemaAwait(), CYPHER_SHELL.schemaAwait());
+        verifyUpload(fileName, expected);
+    }
+
+    private void assertResultsOptimized(String fileName, Map<String, Object> r) {
+        assertEquals(7L, r.get("nodes"));
+        assertEquals(2L, r.get("relationships"));
+        assertEquals(13L, r.get("properties"));
+        assertEquals(fileName, r.get("file"));
+        assertEquals("database" + ": nodes(7), rels(2)", r.get("source"));
+        assertEquals("cypher", r.get("format"));
+        assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
+    }
+
+    private void assertResultsOdd(String fileName, Map<String, Object> r) {
+        assertEquals(7L, r.get("nodes"));
+        assertEquals(1L, r.get("relationships"));
+        assertEquals(13L, r.get("properties"));
+        assertEquals(fileName, r.get("file"));
+        assertEquals("database" + ": nodes(7), rels(1)", r.get("source"));
+        assertEquals("cypher", r.get("format"));
+        assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
+    }
+
+    static class ExportCypherResults {
+
+        static final String EXPECTED_NODES = String.format("BEGIN%n" +
+                "CREATE (:Foo:`UNIQUE IMPORT LABEL` {born:date('2018-10-31'), name:\"foo\", `UNIQUE IMPORT ID`:0});%n" +
+                "CREATE (:Bar {age:42, name:\"bar\"});%n" +
+                "CREATE (:Bar:`UNIQUE IMPORT LABEL` {age:12, `UNIQUE IMPORT ID`:2});%n" +
+                "COMMIT%n");
+
+        private static final String EXPECTED_NODES_MERGE = String.format("BEGIN%n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}) SET n.name=\"foo\", n.born=date('2018-10-31'), n:Foo;%n" +
+                "MERGE (n:Bar{name:\"bar\"}) SET n.age=42;%n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) SET n.age=12, n:Bar;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_NODES_MERGE_ON_CREATE_SET =
+                EXPECTED_NODES_MERGE.replaceAll(" SET ", " ON CREATE SET ");
+
+        static final String EXPECTED_NODES_EMPTY = String.format("BEGIN%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_SCHEMA = String.format("BEGIN%n" +
+                "CREATE INDEX ON :Bar(first_name,last_name);%n" +
+                "CREATE INDEX ON :Foo(name);%n" +
+                "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n" +
+                "SCHEMA AWAIT%n");
+
+        static final String EXPECTED_SCHEMA_EMPTY = String.format("BEGIN%n" +
+                "COMMIT%n" +
+                "SCHEMA AWAIT%n");
+
+        public static final String EXPECTED_INDEXES_AWAIT = String.format("CALL db.awaitIndexes(300);%n");
+
+        private static final String EXPECTED_INDEXES_AWAIT_QUERY = String.format("CALL db.awaitIndex(300);%n");
+
+        static final String EXPECTED_RELATIONSHIPS = String.format("BEGIN%n" +
+                "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:Bar{name:\"bar\"}) CREATE (n1)-[r:KNOWS {since:2016}]->(n2);%n" +
+                "COMMIT%n");
+
+        private static final String EXPECTED_RELATIONSHIPS_MERGE = String.format("BEGIN%n" +
+                "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:Bar{name:\"bar\"}) MERGE (n1)-[r:KNOWS]->(n2) SET r.since=2016;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_RELATIONSHIPS_MERGE_ON_CREATE_SET =
+                EXPECTED_RELATIONSHIPS_MERGE.replaceAll(" SET ", " ON CREATE SET ");
+
+        static final String EXPECTED_CLEAN_UP = String.format("BEGIN%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_CLEAN_UP_EMPTY = String.format("BEGIN%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_ONLY_SCHEMA_NEO4J_SHELL = String.format("BEGIN%n" +
+                "CREATE INDEX ON :Bar(first_name,last_name);%n" +
+                "CREATE INDEX ON :Foo(name);%n" +
+                "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
+                "COMMIT%n" +
+                "SCHEMA AWAIT%n");
+
+        static final String EXPECTED_CYPHER_POINT = String.format("BEGIN%n" +
+                "CREATE (:Test:`UNIQUE IMPORT LABEL` {name:\"foo\", place2d:point({x: 2.3, y: 4.5, crs: 'cartesian'}), place3d1:point({x: 2.3, y: 4.5, z: 1.2, crs: 'cartesian-3d'}), `UNIQUE IMPORT ID`:3});%n" +
+                "CREATE (:Bar:`UNIQUE IMPORT LABEL` {place3d:point({x: 12.78, y: 56.7, z: 100.0, crs: 'wgs-84-3d'}), `UNIQUE IMPORT ID`:4});%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "CREATE INDEX ON :Bar(first_name,last_name);%n" +
+                "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n" +
+                "SCHEMA AWAIT%n" +
+                "BEGIN%n" +
+                "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:4}) CREATE (n1)-[r:FRIEND_OF {place2d:point({x: 56.7, y: 12.78, crs: 'wgs-84'})}]->(n2);%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_CYPHER_DATE = String.format("BEGIN%n" +
+                "CREATE (:Test:`UNIQUE IMPORT LABEL` {date:date('2018-10-30'), datetime:datetime('2018-10-30T12:50:35.556+01:00'), localTime:localdatetime('2018-10-30T19:32:24'), name:\"foo\", `UNIQUE IMPORT ID`:3});%n" +
+                "CREATE (:Bar:`UNIQUE IMPORT LABEL` {datetime:datetime('2018-10-30T12:50:35.556Z'), `UNIQUE IMPORT ID`:4});%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "CREATE INDEX ON :Bar(first_name,last_name);%n" +
+                "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n" +
+                "SCHEMA AWAIT%n" +
+                "BEGIN%n" +
+                "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:4}) CREATE (n1)-[r:FRIEND_OF {date:date('2018-10-30')}]->(n2);%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_CYPHER_TIME = String.format("BEGIN%n" +
+                "CREATE (:Test:`UNIQUE IMPORT LABEL` {local:localtime('12:50:35.556'), name:\"foo\", t:time('12:50:35.556+01:00'), `UNIQUE IMPORT ID`:3});%n" +
+                "CREATE (:Bar:`UNIQUE IMPORT LABEL` {datetime:datetime('2018-10-30T12:50:35.556+01:00'), `UNIQUE IMPORT ID`:4});%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "CREATE INDEX ON :Bar(first_name,last_name);%n" +
+                "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n" +
+                "SCHEMA AWAIT%n" +
+                "BEGIN%n" +
+                "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:4}) CREATE (n1)-[r:FRIEND_OF {t:time('12:50:35.556+01:00')}]->(n2);%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_CYPHER_DURATION = String.format("BEGIN%n" +
+                "CREATE (:Test:`UNIQUE IMPORT LABEL` {duration:duration('P5M1DT12H'), name:\"foo\", `UNIQUE IMPORT ID`:3});%n" +
+                "CREATE (:Bar:`UNIQUE IMPORT LABEL` {duration:duration('P5M1DT12H'), `UNIQUE IMPORT ID`:4});%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "CREATE INDEX ON :Bar(first_name,last_name);%n" +
+                "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n" +
+                "SCHEMA AWAIT%n" +
+                "BEGIN%n" +
+                "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:4}) CREATE (n1)-[r:FRIEND_OF {duration:duration('P5M1DT12H')}]->(n2);%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_CYPHER_LABELS_ASCENDEND = String.format("BEGIN%n" +
+                "CREATE (:User:User0:User1:User12:`UNIQUE IMPORT LABEL` {name:\"Alan\", `UNIQUE IMPORT ID`:3});%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n" +
+                "SCHEMA AWAIT%n" +
+                "BEGIN%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_SCHEMA_OPTIMIZED = String.format("BEGIN%n" +
+                "CREATE INDEX ON :Bar(first_name,last_name);%n" +
+                "CREATE INDEX ON :Foo(name);%n" +
+                "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n" +
+                "SCHEMA AWAIT%n");
+
+        static final String EXPECTED_NODES_OPTIMIZED_BATCH_SIZE = String.format("BEGIN%n" +
+                "UNWIND [{_id:3, properties:{age:12}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar;%n" +
+                "UNWIND [{_id:2, properties:{age:12}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar:Person;%n" +
+                "UNWIND [{_id:0, properties:{born:date('2018-10-31'), name:\"foo\"}}, {_id:4, properties:{born:date('2017-09-29'), name:\"foo2\"}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;%n" +
+                "UNWIND [{name:\"bar\", properties:{age:42}}, {name:\"bar2\", properties:{age:44}}] AS row%n" +
+                "CREATE (n:Bar{name: row.name}) SET n += row.properties;%n" +
+                "UNWIND [{_id:6, properties:{age:99}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_NODES_OPTIMIZED = String.format("BEGIN%n" +
+                "UNWIND [{_id:3, properties:{age:12}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar;%n" +
+                "UNWIND [{_id:2, properties:{age:12}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar:Person;%n" +
+                "UNWIND [{_id:0, properties:{born:date('2018-10-31'), name:\"foo\"}}, {_id:4, properties:{born:date('2017-09-29'), name:\"foo2\"}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;%n" +
+                "UNWIND [{name:\"bar\", properties:{age:42}}, {name:\"bar2\", properties:{age:44}}] AS row%n" +
+                "CREATE (n:Bar{name: row.name}) SET n += row.properties;%n" +
+                "UNWIND [{_id:6, properties:{age:99}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_QUERY_NODES_OPTIMIZED = String.format("BEGIN%n" +
+                "UNWIND [{_id:0, properties:{born:date('2018-10-31'), name:\"foo\"}}, {_id:4, properties:{born:date('2017-09-29'), name:\"foo2\"}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;%n" +
+                "UNWIND [{name:\"bar\", properties:{age:42}}, {name:\"bar2\", properties:{age:44}}] AS row%n" +
+                "CREATE (n:Bar{name: row.name}) SET n += row.properties;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_QUERY_NODES_OPTIMIZED2 = String.format("BEGIN%n" +
+                "UNWIND [{_id:4, properties:{born:date('2017-09-29'), name:\"foo2\"}}, {_id:0, properties:{born:date('2018-10-31'), name:\"foo\"}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;%n" +
+                "UNWIND [{name:\"bar\", properties:{age:42}}, {name:\"bar2\", properties:{age:44}}] AS row%n" +
+                "CREATE (n:Bar{name: row.name}) SET n += row.properties;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_RELATIONSHIPS_OPTIMIZED = String.format("BEGIN%n" +
+                "UNWIND [{start: {_id:0}, end: {name:\"bar\"}, properties:{since:2016}}, {start: {_id:4}, end: {name:\"bar2\"}, properties:{since:2015}}] AS row%n" +
+                "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})%n" +
+                "MATCH (end:Bar{name: row.end.name})%n" +
+                "CREATE (start)-[r:KNOWS]->(end) SET r += row.properties;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_RELATIONSHIPS_ODD = String.format("BEGIN%n" +
+                "UNWIND [{start: {_id:0}, end: {name:\"bar\"}, properties:{since:2016}}] AS row%n" +
+                "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})%n" +
+                "MATCH (end:Bar{name: row.end.name})%n" +
+                "CREATE (start)-[r:KNOWS]->(end) SET r += row.properties;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_RELATIONSHIPS_PARAMS_ODD = String.format(
+                "BEGIN%n" +
+                        ":param rows => [{start: {_id:0}, end: {name:\"bar\"}, properties:{since:2016}}]%n" +
+                        "UNWIND $rows AS row%n" +
+                        "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})%n" +
+                        "MATCH (end:Bar{name: row.end.name})%n" +
+                        "CREATE (start)-[r:KNOWS]->(end) SET r += row.properties;%n" +
+                        "COMMIT%n");
+
+        static final String DROP_UNIQUE_OPTIMIZED = String.format("BEGIN%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n");
+
+        static final String DROP_UNIQUE_OPTIMIZED_BATCH = String.format("BEGIN%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 2 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 2 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 2 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_NODES_OPTIMIZED_BATCH_SIZE_UNWIND = String.format("BEGIN%n" +
+                "UNWIND [{_id:3, properties:{age:12}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar;%n" +
+                "UNWIND [{_id:2, properties:{age:12}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar:Person;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "UNWIND [{_id:0, properties:{born:date('2018-10-31'), name:\"foo\"}}, {_id:4, properties:{born:date('2017-09-29'), name:\"foo2\"}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "UNWIND [{name:\"bar\", properties:{age:42}}, {name:\"bar2\", properties:{age:44}}] AS row%n" +
+                "CREATE (n:Bar{name: row.name}) SET n += row.properties;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "UNWIND [{_id:6, properties:{age:99}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_NODES_OPTIMIZED_BATCH_SIZE_ODD = String.format("BEGIN%n" +
+                "UNWIND [{_id:4, properties:{age:12}}, {_id:5, properties:{age:4}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "UNWIND [{_id:0, properties:{born:date('2018-10-31'), name:\"foo\"}}, {_id:1, properties:{born:date('2017-09-29'), name:\"foo2\"}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "UNWIND [{_id:2, properties:{born:date('2016-03-12'), name:\"foo3\"}}] AS row%n" +
+                "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;%n" +
+                "UNWIND [{name:\"bar\", properties:{age:42}}] AS row%n" +
+                "CREATE (n:Bar{name: row.name}) SET n += row.properties;%n" +
+                "COMMIT%n" +
+                "BEGIN%n" +
+                "UNWIND [{name:\"bar2\", properties:{age:44}}] AS row%n" +
+                "CREATE (n:Bar{name: row.name}) SET n += row.properties;%n" +
+                "COMMIT%n");
+
+        static final String EXPECTED_NODES_OPTIMIZED_PARAMS_BATCH_SIZE_ODD = String.format(
+                ":begin%n" +
+                        ":param rows => [{_id:4, properties:{age:12}}, {_id:5, properties:{age:4}}]%n" +
+                        "UNWIND $rows AS row%n" +
+                        "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar;%n" +
+                        ":commit%n" +
+                        ":begin%n" +
+                        ":param rows => [{_id:0, properties:{born:date('2018-10-31'), name:\"foo\"}}, {_id:1, properties:{born:date('2017-09-29'), name:\"foo2\"}}]%n" +
+                        "UNWIND $rows AS row%n" +
+                        "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;%n" +
+                        ":commit%n" +
+                        ":begin%n" +
+                        ":param rows => [{_id:2, properties:{born:date('2016-03-12'), name:\"foo3\"}}]%n" +
+                        "UNWIND $rows AS row%n" +
+                        "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;%n" +
+                        ":param rows => [{name:\"bar\", properties:{age:42}}]%n" +
+                        "UNWIND $rows AS row%n" +
+                        "CREATE (n:Bar{name: row.name}) SET n += row.properties;%n" +
+                        ":commit%n" +
+                        ":begin%n" +
+                        ":param rows => [{name:\"bar2\", properties:{age:44}}]%n" +
+                        "UNWIND $rows AS row%n" +
+                        "CREATE (n:Bar{name: row.name}) SET n += row.properties;%n" +
+                        ":commit%n");
+
+        static final String EXPECTED_PLAIN_ADD_STRUCTURE_UNWIND = String.format("UNWIND [{_id:3, properties:{age:12}}] AS row%n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) ON CREATE SET n += row.properties SET n:Bar;%n" +
+                "UNWIND [{_id:2, properties:{age:12}}] AS row%n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) ON CREATE SET n += row.properties SET n:Bar:Person;%n" +
+                "UNWIND [{_id:0, properties:{born:date('2018-10-31'), name:\"foo\"}}, {_id:4, properties:{born:date('2017-09-29'), name:\"foo2\"}}] AS row%n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) ON CREATE SET n += row.properties SET n:Foo;%n" +
+                "UNWIND [{name:\"bar\", properties:{age:42}}, {name:\"bar2\", properties:{age:44}}] AS row%n" +
+                "MERGE (n:Bar{name: row.name}) ON CREATE SET n += row.properties;%n" +
+                "UNWIND [{_id:6, properties:{age:99}}] AS row%n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) ON CREATE SET n += row.properties;%n" +
+                "UNWIND [{start: {_id:0}, end: {name:\"bar\"}, properties:{since:2016}}, {start: {_id:4}, end: {name:\"bar2\"}, properties:{since:2015}}] AS row%n" +
+                "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})%n" +
+                "MATCH (end:Bar{name: row.end.name})%n" +
+                "CREATE (start)-[r:KNOWS]->(end)  SET r += row.properties;%n");
+
+        static final String EXPECTED_UPDATE_ALL_UNWIND = String.format("CREATE INDEX ON :Bar(first_name,last_name);%n" +
+                "CREATE INDEX ON :Foo(name);%n" +
+                "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "UNWIND [{_id:3, properties:{age:12}}] AS row%n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar;%n" +
+                "UNWIND [{_id:2, properties:{age:12}}] AS row%n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar:Person;%n" +
+                "UNWIND [{_id:0, properties:{born:date('2018-10-31'), name:\"foo\"}}, {_id:4, properties:{born:date('2017-09-29'), name:\"foo2\"}}] AS row%n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;%n" +
+                "UNWIND [{name:\"bar\", properties:{age:42}}, {name:\"bar2\", properties:{age:44}}] AS row%n" +
+                "MERGE (n:Bar{name: row.name}) SET n += row.properties;%n" +
+                "UNWIND [{_id:6, properties:{age:99}}] AS row%n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties;%n" +
+                "UNWIND [{start: {_id:0}, end: {name:\"bar\"}, properties:{since:2016}}, {start: {_id:4}, end: {name:\"bar2\"}, properties:{since:2015}}] AS row%n" +
+                "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})%n" +
+                "MATCH (end:Bar{name: row.end.name})%n" +
+                "MERGE (start)-[r:KNOWS]->(end) SET r += row.properties;%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n");
+
+        static final String EXPECTED_PLAIN_UPDATE_STRUCTURE_UNWIND = String.format("UNWIND [{start: {_id:0}, end: {name:\"bar\"}, properties:{since:2016}}, {start: {_id:4}, end: {name:\"bar2\"}, properties:{since:2015}}] AS row%n" +
+                "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})%n" +
+                "MATCH (end:Bar{name: row.end.name})%n" +
+                "MERGE (start)-[r:KNOWS]->(end) SET r += row.properties;%n");
+
+        static final String EXPECTED_NEO4J_OPTIMIZED = EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_NODES_OPTIMIZED + EXPECTED_RELATIONSHIPS_OPTIMIZED + DROP_UNIQUE_OPTIMIZED;
+
+        static final String EXPECTED_NEO4J_OPTIMIZED_BATCH_SIZE = EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_NODES_OPTIMIZED_BATCH_SIZE + EXPECTED_RELATIONSHIPS_OPTIMIZED + DROP_UNIQUE_OPTIMIZED;
+
+        static final String EXPECTED_NEO4J_SHELL_OPTIMIZED = EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_NODES_OPTIMIZED + EXPECTED_RELATIONSHIPS_OPTIMIZED + DROP_UNIQUE_OPTIMIZED;
+
+        static final String EXPECTED_NEO4J_SHELL_OPTIMIZED_BATCH_SIZE = EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_NODES_OPTIMIZED_BATCH_SIZE + EXPECTED_RELATIONSHIPS_OPTIMIZED + DROP_UNIQUE_OPTIMIZED;
+
+        static final String EXPECTED_QUERY_NODES =  EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_QUERY_NODES_OPTIMIZED + EXPECTED_RELATIONSHIPS_OPTIMIZED + DROP_UNIQUE_OPTIMIZED;
+        static final String EXPECTED_QUERY_NODES2 =  EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_QUERY_NODES_OPTIMIZED2 + EXPECTED_RELATIONSHIPS_OPTIMIZED + DROP_UNIQUE_OPTIMIZED;
+
+        static final String EXPECTED_CYPHER_OPTIMIZED_BATCH_SIZE_UNWIND = EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_NODES_OPTIMIZED_BATCH_SIZE_UNWIND + EXPECTED_RELATIONSHIPS_OPTIMIZED + DROP_UNIQUE_OPTIMIZED_BATCH;
+
+        static final String EXPECTED_CYPHER_OPTIMIZED_BATCH_SIZE_ODD = EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_NODES_OPTIMIZED_BATCH_SIZE_ODD + EXPECTED_RELATIONSHIPS_ODD + DROP_UNIQUE_OPTIMIZED_BATCH;
+
+        static final String EXPECTED_CYPHER_SHELL_PARAMS_OPTIMIZED_ODD = EXPECTED_SCHEMA_OPTIMIZED + EXPECTED_NODES_OPTIMIZED_PARAMS_BATCH_SIZE_ODD + EXPECTED_RELATIONSHIPS_PARAMS_ODD + DROP_UNIQUE_OPTIMIZED_BATCH;
+
+
+        static final String EXPECTED_QUERY_CYPHER_SHELL_OPTIMIZED_UNWIND = EXPECTED_CYPHER_OPTIMIZED_BATCH_SIZE_UNWIND
+                .replace(NEO4J_SHELL.begin(), CYPHER_SHELL.begin())
+                .replace(NEO4J_SHELL.commit(), CYPHER_SHELL.commit())
+                .replace(NEO4J_SHELL.schemaAwait(), EXPECTED_INDEXES_AWAIT)
+                .replace(NEO4J_SHELL.schemaAwait(), CYPHER_SHELL.schemaAwait());
+
+
+        static final String EXPECTED_QUERY_CYPHER_SHELL_OPTIMIZED_ODD = EXPECTED_CYPHER_OPTIMIZED_BATCH_SIZE_ODD
+                .replace(NEO4J_SHELL.begin(), CYPHER_SHELL.begin())
+                .replace(NEO4J_SHELL.commit(), CYPHER_SHELL.commit())
+                .replace(NEO4J_SHELL.schemaAwait(), EXPECTED_INDEXES_AWAIT)
+                .replace(NEO4J_SHELL.schemaAwait(), CYPHER_SHELL.schemaAwait());
+
+        static final String EXPECTED_QUERY_CYPHER_SHELL_PARAMS_OPTIMIZED_ODD = EXPECTED_CYPHER_SHELL_PARAMS_OPTIMIZED_ODD
+                .replace(NEO4J_SHELL.begin(), CYPHER_SHELL.begin())
+                .replace(NEO4J_SHELL.commit(), CYPHER_SHELL.commit())
+                .replace(NEO4J_SHELL.schemaAwait(), EXPECTED_INDEXES_AWAIT)
+                .replace(NEO4J_SHELL.schemaAwait(), CYPHER_SHELL.schemaAwait());
+
+        static final String EXPECTED_QUERY_CYPHER_SHELL_OPTIMIZED = EXPECTED_QUERY_NODES
+                .replace(NEO4J_SHELL.begin(), CYPHER_SHELL.begin())
+                .replace(NEO4J_SHELL.commit(), CYPHER_SHELL.commit())
+                .replace(NEO4J_SHELL.schemaAwait(), EXPECTED_INDEXES_AWAIT_QUERY)
+                .replace(NEO4J_SHELL.schemaAwait(), CYPHER_SHELL.schemaAwait());
+
+        static final String EXPECTED_QUERY_CYPHER_SHELL_OPTIMIZED2 = EXPECTED_QUERY_NODES2
+                .replace(NEO4J_SHELL.begin(), CYPHER_SHELL.begin())
+                .replace(NEO4J_SHELL.commit(), CYPHER_SHELL.commit())
+                .replace(NEO4J_SHELL.schemaAwait(), EXPECTED_INDEXES_AWAIT_QUERY)
+                .replace(NEO4J_SHELL.schemaAwait(), CYPHER_SHELL.schemaAwait());
+
+        static final String EXPECTED_CYPHER_SHELL_OPTIMIZED = EXPECTED_NEO4J_SHELL_OPTIMIZED
+                .replace(NEO4J_SHELL.begin(), CYPHER_SHELL.begin())
+                .replace(NEO4J_SHELL.commit(), CYPHER_SHELL.commit())
+                .replace(NEO4J_SHELL.schemaAwait(), EXPECTED_INDEXES_AWAIT)
+                .replace(NEO4J_SHELL.schemaAwait(), CYPHER_SHELL.schemaAwait());
+
+        static final String EXPECTED_CYPHER_SHELL_OPTIMIZED_BATCH_SIZE = EXPECTED_NEO4J_SHELL_OPTIMIZED_BATCH_SIZE
+                .replace(NEO4J_SHELL.begin(), CYPHER_SHELL.begin())
+                .replace(NEO4J_SHELL.commit(), CYPHER_SHELL.commit())
+                .replace(NEO4J_SHELL.schemaAwait(), EXPECTED_INDEXES_AWAIT)
+                .replace(NEO4J_SHELL.schemaAwait(), CYPHER_SHELL.schemaAwait());
+
+        static final String EXPECTED_PLAIN_OPTIMIZED_BATCH_SIZE = EXPECTED_NEO4J_SHELL_OPTIMIZED_BATCH_SIZE
+                .replace(NEO4J_SHELL.begin(), PLAIN_FORMAT.begin())
+                .replace(NEO4J_SHELL.commit(), PLAIN_FORMAT.commit())
+                .replace(NEO4J_SHELL.schemaAwait(), PLAIN_FORMAT.schemaAwait());
+
+        static final String EXPECTED_NEO4J_SHELL = EXPECTED_NODES + EXPECTED_SCHEMA + EXPECTED_RELATIONSHIPS + EXPECTED_CLEAN_UP;
+
+        static final String EXPECTED_CYPHER_SHELL = EXPECTED_NEO4J_SHELL
+                .replace(NEO4J_SHELL.begin(), CYPHER_SHELL.begin())
+                .replace(NEO4J_SHELL.commit(), CYPHER_SHELL.commit())
+                .replace(NEO4J_SHELL.schemaAwait(), EXPECTED_INDEXES_AWAIT)
+                .replace(NEO4J_SHELL.schemaAwait(), CYPHER_SHELL.schemaAwait());
+
+        static final String EXPECTED_PLAIN = EXPECTED_NEO4J_SHELL
+                .replace(NEO4J_SHELL.begin(), PLAIN_FORMAT.begin()).replace(NEO4J_SHELL.commit(), PLAIN_FORMAT.commit())
+                .replace(NEO4J_SHELL.schemaAwait(), PLAIN_FORMAT.schemaAwait());
+
+        static final String EXPECTED_NEO4J_MERGE = EXPECTED_NODES_MERGE + EXPECTED_SCHEMA + EXPECTED_RELATIONSHIPS_MERGE + EXPECTED_CLEAN_UP;
+
+        static final String EXPECTED_ONLY_SCHEMA_CYPHER_SHELL = EXPECTED_ONLY_SCHEMA_NEO4J_SHELL.replace(NEO4J_SHELL.begin(), CYPHER_SHELL.begin())
+                .replace(NEO4J_SHELL.commit(), CYPHER_SHELL.commit()).replace(NEO4J_SHELL.schemaAwait(), CYPHER_SHELL.schemaAwait()) + EXPECTED_INDEXES_AWAIT;
+    }
+
+}

--- a/core/src/test/java/apoc/export/cypher/ExportCypherS3Test.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherS3Test.java
@@ -6,7 +6,7 @@ import apoc.util.s3.S3TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.Disabled;
+import org.junit.Ignore;
 import org.junit.rules.TestName;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.test.rule.DbmsRule;
@@ -25,7 +25,7 @@ import static apoc.export.util.ExportFormat.*;
 import static apoc.util.Util.map;
 import static org.junit.Assert.*;
 
-@Disabled("To use this test, you need to set the S3 bucket and region to a valid endpoint " +
+@Ignore("To use this test, you need to set the S3 bucket and region to a valid endpoint " +
         "and have your access key and secret key setup in your environment.")
 public class ExportCypherS3Test {
     private static String S3_BUCKET_NAME = null;

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLS3Test.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLS3Test.java
@@ -1,0 +1,324 @@
+package apoc.export.graphml;
+
+import apoc.ApocSettings;
+import apoc.graph.Graphs;
+import apoc.util.TestUtil;
+import apoc.util.s3.S3TestUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.rules.TestName;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.DefaultNodeMatcher;
+import org.xmlunit.diff.Diff;
+import org.xmlunit.diff.ElementSelector;
+import org.xmlunit.util.Nodes;
+
+import javax.xml.namespace.QName;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static apoc.ApocConfig.*;
+import static apoc.util.MapUtil.map;
+import static org.junit.Assert.*;
+import static org.xmlunit.diff.ElementSelectors.byName;
+
+@Disabled("To use this test, you need to set the S3 bucket and region to a valid endpoint " +
+        "and have your access key and secret key setup in your environment.")
+public class ExportGraphMLS3Test {
+    private static String S3_BUCKET_NAME = null;
+
+    public static final List<String> ATTRIBUTES_CONTAINING_NODE_IDS = Arrays.asList("id", "source", "target");
+
+    public static final String GRAPH = "<graph id=\"G\" edgedefault=\"directed\">%n";
+    public static final String HEADER = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>%n" +
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">%n";
+    public static final String KEY_TYPES_FALSE = "<key id=\"born\" for=\"node\" attr.name=\"born\"/>%n" +
+            "<key id=\"values\" for=\"node\" attr.name=\"values\"/>%n" +
+            "<key id=\"name\" for=\"node\" attr.name=\"name\"/>%n" +
+            "<key id=\"label\" for=\"node\" attr.name=\"label\"/>%n"+
+            "<key id=\"place\" for=\"node\" attr.name=\"place\"/>%n" +
+            "<key id=\"age\" for=\"node\" attr.name=\"age\"/>%n" +
+            "<key id=\"label\" for=\"edge\" attr.name=\"label\"/>%n";
+    public static final String KEY_TYPES = "<key id=\"born\" for=\"node\" attr.name=\"born\" attr.type=\"string\"/>%n" +
+            "<key id=\"values\" for=\"node\" attr.name=\"values\" attr.type=\"string\" attr.list=\"long\"/>%n" +
+            "<key id=\"name\" for=\"node\" attr.name=\"name\" attr.type=\"string\"/>%n" +
+            "<key id=\"label\" for=\"node\" attr.name=\"label\" attr.type=\"string\"/>%n"+
+            "<key id=\"place\" for=\"node\" attr.name=\"place\" attr.type=\"string\"/>%n" +
+            "<key id=\"age\" for=\"node\" attr.name=\"age\" attr.type=\"long\"/>%n" +
+            "<key id=\"label\" for=\"edge\" attr.name=\"label\" attr.type=\"string\"/>%n";
+    public static final String KEY_TYPES_PATH = "<key id=\"born\" for=\"node\" attr.name=\"born\" attr.type=\"string\"/>%n" +
+            "<key id=\"name\" for=\"node\" attr.name=\"name\" attr.type=\"string\"/>%n" +
+            "<key id=\"label\" for=\"node\" attr.name=\"label\" attr.type=\"string\"/>%n"+
+            "<key id=\"place\" for=\"node\" attr.name=\"place\" attr.type=\"string\"/>%n" +
+            "<key id=\"TYPE\" for=\"node\" attr.name=\"TYPE\" attr.type=\"string\"/>%n" +
+            "<key id=\"age\" for=\"node\" attr.name=\"age\" attr.type=\"long\"/>%n" +
+            "<key id=\"label\" for=\"edge\" attr.name=\"label\" attr.type=\"string\"/>%n" +
+            "<key id=\"TYPE\" for=\"edge\" attr.name=\"TYPE\" attr.type=\"string\"/>%n";
+    public static final String KEY_TYPES_CAMEL_CASE = "<key id=\"firstName\" for=\"node\" attr.name=\"firstName\" attr.type=\"string\"/>%n" +
+            "<key id=\"ageNow\" for=\"node\" attr.name=\"ageNow\" attr.type=\"long\"/>%n" +
+            "<key id=\"name\" for=\"node\" attr.name=\"name\" attr.type=\"string\"/>%n" +
+            "<key id=\"label\" for=\"node\" attr.name=\"label\" attr.type=\"string\"/>%n" +
+            "<key id=\"TYPE\" for=\"node\" attr.name=\"TYPE\" attr.type=\"string\"/>%n" +
+            "<key id=\"label\" for=\"edge\" attr.name=\"label\" attr.type=\"string\"/>%n" +
+            "<key id=\"TYPE\" for=\"edge\" attr.name=\"TYPE\" attr.type=\"string\"/>%n";
+    public static final String DATA = "<node id=\"n0\" labels=\":Foo:Foo0:Foo2\"><data key=\"labels\">:Foo:Foo0:Foo2</data><data key=\"place\">{\"crs\":\"wgs-84-3d\",\"latitude\":56.7,\"longitude\":12.78,\"height\":100.0}</data><data key=\"name\">foo</data><data key=\"born\">2018-10-10</data></node>%n" +
+            "<node id=\"n1\" labels=\":Bar\"><data key=\"labels\">:Bar</data><data key=\"age\">42</data><data key=\"name\">bar</data><data key=\"place\">{\"crs\":\"wgs-84\",\"latitude\":56.7,\"longitude\":12.78,\"height\":null}</data></node>%n" +
+            "<node id=\"n2\" labels=\":Bar\"><data key=\"labels\">:Bar</data><data key=\"age\">12</data><data key=\"values\">[1,2,3]</data></node>%n" +
+            "<edge id=\"e0\" source=\"n0\" target=\"n1\" label=\"KNOWS\"><data key=\"label\">KNOWS</data></edge>%n";
+    public static final String DATA_CAMEL_CASE =
+            "<node id=\"n0\" labels=\":Foo:Foo0:Foo2\"><data key=\"TYPE\">:Foo:Foo0:Foo2</data><data key=\"label\">foo</data><data key=\"firstName\">foo</data></node>%n" +
+                    "<node id=\"n1\" labels=\":Bar\"><data key=\"TYPE\">:Bar</data><data key=\"label\">bar</data><data key=\"name\">bar</data><data key=\"ageNow\">42</data></node>%n" +
+                    "<edge id=\"e0\" source=\"n0\" target=\"n1\" label=\"KNOWS\"><data key=\"label\">KNOWS</data><data key=\"TYPE\">KNOWS</data></edge>%n";
+
+    public static final String FOOTER = "</graph>%n" +
+            "</graphml>";
+
+    public static final String DATA_PATH = "<node id=\"n0\" labels=\":Foo:Foo0:Foo2\"><data key=\"TYPE\">:Foo:Foo0:Foo2</data><data key=\"label\">foo</data><data key=\"place\">{\"crs\":\"wgs-84-3d\",\"latitude\":56.7,\"longitude\":12.78,\"height\":100.0}</data><data key=\"name\">foo</data><data key=\"born\">2018-10-10</data></node>%n" +
+            "<node id=\"n1\" labels=\":Bar\"><data key=\"TYPE\">:Bar</data><data key=\"label\">bar</data><data key=\"age\">42</data><data key=\"name\">bar</data><data key=\"place\">{\"crs\":\"wgs-84\",\"latitude\":56.7,\"longitude\":12.78,\"height\":null}</data></node>%n" +
+            "<edge id=\"e0\" source=\"n0\" target=\"n1\" label=\"KNOWS\"><data key=\"label\">KNOWS</data><data key=\"TYPE\">KNOWS</data></edge>%n";
+
+    public static final String DATA_PATH_CAPTION = "<node id=\"n0\" labels=\":Foo:Foo0:Foo2\"><data key=\"TYPE\">:Foo:Foo0:Foo2</data><data key=\"label\">foo</data><data key=\"place\">{\"crs\":\"wgs-84-3d\",\"latitude\":56.7,\"longitude\":12.78,\"height\":100.0}</data><data key=\"name\">foo</data><data key=\"born\">2018-10-10</data></node>%n" +
+            "<node id=\"n1\" labels=\":Bar\"><data key=\"TYPE\">:Bar</data><data key=\"label\">bar</data><data key=\"age\">42</data><data key=\"name\">bar</data><data key=\"place\">{\"crs\":\"wgs-84\",\"latitude\":56.7,\"longitude\":12.78,\"height\":null}</data></node>%n" +
+            "<edge id=\"e0\" source=\"n0\" target=\"n1\" label=\"KNOWS\"><data key=\"label\">KNOWS</data><data key=\"TYPE\">KNOWS</data></edge>%n";
+
+    public static final String DATA_PATH_CAPTION_DEFAULT = "<node id=\"n0\" labels=\":Foo:Foo0:Foo2\"><data key=\"TYPE\">:Foo:Foo0:Foo2</data><data key=\"label\">point({x: 56.7, y: 12.78, z: 100.0, crs: 'wgs-84-3d'})</data><data key=\"place\">{\"crs\":\"wgs-84-3d\",\"latitude\":56.7,\"longitude\":12.78,\"height\":100.0}</data><data key=\"name\">foo</data><data key=\"born\">2018-10-10</data></node>%n" +
+            "<node id=\"n1\" labels=\":Bar\"><data key=\"TYPE\">:Bar</data><data key=\"label\">42</data><data key=\"age\">42</data><data key=\"name\">bar</data><data key=\"place\">{\"crs\":\"wgs-84\",\"latitude\":56.7,\"longitude\":12.78,\"height\":null}</data></node>%n" +
+            "<edge id=\"e0\" source=\"n0\" target=\"n1\" label=\"KNOWS\"><data key=\"label\">KNOWS</data><data key=\"TYPE\">KNOWS</data></edge>%n";
+
+    private static final String EXPECTED_TYPES_PATH = String.format(HEADER + KEY_TYPES_PATH + GRAPH + DATA_PATH + FOOTER);
+    private static final String EXPECTED_TYPES_PATH_CAPTION = String.format(HEADER + KEY_TYPES_PATH + GRAPH + DATA_PATH_CAPTION + FOOTER);
+    private static final String EXPECTED_TYPES_PATH_WRONG_CAPTION = String.format(HEADER + KEY_TYPES_PATH + GRAPH + DATA_PATH_CAPTION_DEFAULT + FOOTER);
+    private static final String EXPECTED_TYPES = String.format(HEADER + KEY_TYPES + GRAPH + DATA + FOOTER);
+    private static final String EXPECTED_FALSE = String.format(HEADER + KEY_TYPES_FALSE + GRAPH + DATA + FOOTER);
+    private static final String EXPECTED_TYPES_PATH_CAMEL_CASE = String.format(HEADER + KEY_TYPES_CAMEL_CASE + GRAPH + DATA_CAMEL_CASE + FOOTER);
+
+    @Rule
+    public TestName testName = new TestName();
+
+    private static final String TEST_WITH_NO_IMPORT = "WithNoImportConfig";
+    private static final String TEST_WITH_NO_EXPORT = "WithNoExportConfig";
+
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(ApocSettings.apoc_import_file_use__neo4j__config, false)
+            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath());
+
+    private static File directory = new File("target/import");
+
+    static { //noinspection ResultOfMethodCallIgnored
+        directory.mkdirs();
+    }
+
+    private static String getS3Url(String key) {
+        return String.format("s3://:@/%s/%s", S3_BUCKET_NAME, key);
+    }
+
+    private static String readFile(String fileName) {
+        return TestUtil.readFileToString(new File(directory, fileName));
+    }
+
+    private  void verifyUpload(String s3Url, String fileName, String expected) throws IOException {
+        S3TestUtil.readFile(s3Url, Paths.get(directory.toString(), fileName).toString());
+        assertXMLEquals(expected, readFile(fileName));
+    }
+
+    private static String getEnvVar(String envVarKey) throws Exception {
+        return Optional.ofNullable(System.getenv(envVarKey)).orElseThrow(
+                () -> new Exception(String.format("%s is not set in the environment", envVarKey))
+            );
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        if (S3_BUCKET_NAME == null) {
+            S3_BUCKET_NAME = getEnvVar("S3_BUCKET_NAME");
+        }
+
+        TestUtil.registerProcedure(db, ExportGraphML.class, Graphs.class);
+
+        apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, Boolean.toString(!testName.getMethodName().endsWith(TEST_WITH_NO_EXPORT)));
+        apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, Boolean.toString(!testName.getMethodName().endsWith(TEST_WITH_NO_IMPORT)));
+
+        db.executeTransactionally("CREATE (f:Foo:Foo2:Foo0 {name:'foo', born:Date('2018-10-10'), place:point({ longitude: 56.7, latitude: 12.78, height: 100 })})-[:KNOWS]->(b:Bar {name:'bar',age:42, place:point({ longitude: 56.7, latitude: 12.78})}),(c:Bar {age:12,values:[1,2,3]})");
+    }
+
+    @Test
+    public void testExportAllGraphML() throws Exception {
+        String fileName = "all.graphml";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.export.graphml.all($s3, null)",
+                map("s3", s3Url),
+                (r) -> assertResults(s3Url, r, "database"));
+        verifyUpload(s3Url, fileName, EXPECTED_FALSE);
+    }
+
+    @Test
+    public void testExportGraphGraphML() throws Exception {
+        String fileName = "graph.graphml";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.graphml.graph(graph, $s3, null) " +
+                        "YIELD nodes, relationships, properties, file, source, format, time " +
+                        "RETURN *",
+                map("s3", s3Url),
+                (r) -> assertResults(s3Url, r, "graph"));
+        verifyUpload(s3Url, fileName, EXPECTED_FALSE);
+    }
+
+    private void assertXMLEquals(Object output, String xmlString) {
+        Diff myDiff = DiffBuilder.compare(xmlString)
+                .withTest(output)
+                .checkForSimilar()
+                .ignoreWhitespace()
+                .withAttributeFilter(attr -> !ATTRIBUTES_CONTAINING_NODE_IDS.contains(attr.getLocalName())) // ignore id properties
+                .withNodeMatcher(new DefaultNodeMatcher((ElementSelector) (controlElement, testElement) -> {
+                    if (!byName.canBeCompared(controlElement, testElement)) {
+                        return false;
+                    }
+                    Map<QName, String> cAttrs = Nodes.getAttributes(controlElement);
+                    Map<QName, String> tAttrs = Nodes.getAttributes(testElement);
+                    if (cAttrs.size() != tAttrs.size()) {
+                        return false;
+                    }
+                    for (Map.Entry<QName, String> e: cAttrs.entrySet()) {
+                        if ((!ATTRIBUTES_CONTAINING_NODE_IDS.contains(e.getKey().getLocalPart()))
+                                && (!e.getValue().equals(tAttrs.get(e.getKey())))) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }))
+                .build();
+
+        assertFalse(myDiff.toString(), myDiff.hasDifferences());
+    }
+
+    @Test
+    public void testExportGraphGraphMLTypes() throws Exception {
+        String fileName = "graph.graphml";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.graphml.graph(graph, $s3,{useTypes:true}) " +
+                        "YIELD nodes, relationships, properties, file, source,format, time " +
+                        "RETURN *",
+                map("s3", s3Url),
+                (r) -> assertResults(s3Url, r, "graph"));
+        verifyUpload(s3Url, fileName, EXPECTED_TYPES);
+    }
+
+    @Test
+    public void testExportGraphGraphMLQueryGephi() throws Exception {
+        String fileName = "query.graphml";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "call apoc.export.graphml.query('MATCH p=()-[r]->() RETURN p limit 1000',$s3,{useTypes:true, format: 'gephi'}) ",
+                map("s3", s3Url),
+                (r) -> {
+                    assertEquals(2L, r.get("nodes"));
+                    assertEquals(1L, r.get("relationships"));
+                    assertEquals(6L, r.get("properties"));
+                    assertEquals(s3Url, r.get("file"));
+                    if (r.get("source").toString().contains(":"))
+                        assertEquals("statement" + ": nodes(2), rels(1)", r.get("source"));
+                    else
+                        assertEquals("file", r.get("source"));
+                    assertEquals("graphml", r.get("format"));
+                    assertTrue("Should get time greater than 0",((long) r.get("time")) > 0);
+                });
+        verifyUpload(s3Url, fileName, EXPECTED_TYPES_PATH);
+    }
+
+    @Test
+    public void testExportGraphGraphMLQueryGephiWithArrayCaption() throws Exception {
+        String fileName = "query.graphml";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "call apoc.export.graphml.query('MATCH p=()-[r]->() RETURN p limit 1000',$s3,{useTypes:true, format: 'gephi', caption: ['bar','name','foo']}) ",
+                map("s3", s3Url),
+                (r) -> {
+                    assertEquals(2L, r.get("nodes"));
+                    assertEquals(1L, r.get("relationships"));
+                    assertEquals(6L, r.get("properties"));
+                    assertEquals(s3Url, r.get("file"));
+                    if (r.get("source").toString().contains(":"))
+                        assertEquals("statement" + ": nodes(2), rels(1)", r.get("source"));
+                    else
+                        assertEquals("file", r.get("source"));
+                    assertEquals("graphml", r.get("format"));
+                    assertTrue("Should get time greater than 0",((long) r.get("time")) > 0);
+                });
+        verifyUpload(s3Url, fileName, EXPECTED_TYPES_PATH_CAPTION);
+    }
+
+    @Test
+    public void testExportGraphGraphMLQueryGephiWithArrayCaptionWrong() throws Exception {
+        String fileName = "query.graphml";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "call apoc.export.graphml.query('MATCH p=()-[r]->() RETURN p limit 1000',$s3,{useTypes:true, format: 'gephi', caption: ['a','b','c']}) ",
+                map("s3", s3Url),
+                (r) -> {
+                    assertEquals(2L, r.get("nodes"));
+                    assertEquals(1L, r.get("relationships"));
+                    assertEquals(6L, r.get("properties"));
+                    assertEquals(s3Url, r.get("file"));
+                    if (r.get("source").toString().contains(":"))
+                        assertEquals("statement" + ": nodes(2), rels(1)", r.get("source"));
+                    else
+                        assertEquals("file", r.get("source"));
+                    assertEquals("graphml", r.get("format"));
+                    assertTrue("Should get time greater than 0",((long) r.get("time")) > 0);
+                });
+        verifyUpload(s3Url, fileName, EXPECTED_TYPES_PATH_WRONG_CAPTION);
+    }
+
+    @Test
+    public void testExportGraphmlQueryWithStringCaptionCamelCase() throws FileNotFoundException, Exception {
+        db.executeTransactionally("MATCH (n) detach delete (n)");
+        db.executeTransactionally("CREATE (f:Foo:Foo2:Foo0 {firstName:'foo'})-[:KNOWS]->(b:Bar {name:'bar',ageNow:42}),(c:Bar {age:12,values:[1,2,3]})");
+        String fileName = "query.graphml";
+        String s3Url = getS3Url(fileName);
+        TestUtil.testCall(db, "call apoc.export.graphml.query('MATCH p=()-[r]->() RETURN p limit 1000',$s3,{useTypes:true, format: 'gephi'}) ",
+                map("s3", s3Url),
+                (r) -> {
+                    assertEquals(2L, r.get("nodes"));
+                    assertEquals(1L, r.get("relationships"));
+                    assertEquals(3L, r.get("properties"));
+                    assertEquals(s3Url, r.get("file"));
+                    if (r.get("source").toString().contains(":"))
+                        assertEquals("statement" + ": nodes(2), rels(1)", r.get("source"));
+                    else
+                        assertEquals("file", r.get("source"));
+                    assertEquals("graphml", r.get("format"));
+                    assertTrue("Should get time greater than 0",((long) r.get("time")) > 0);
+                });
+        verifyUpload(s3Url, fileName, EXPECTED_TYPES_PATH_CAMEL_CASE);
+    }
+
+    private void assertResults(String fileName, Map<String, Object> r, final String source) {
+        assertCommons(r);
+        assertEquals(fileName, r.get("file"));
+        if (r.get("source").toString().contains(":"))
+            assertEquals(source + ": nodes(3), rels(1)", r.get("source"));
+        else
+            assertEquals("file", r.get("source"));
+        assertNull("data should be null", r.get("data"));
+    }
+
+    private void assertCommons(Map<String, Object> r) {
+        assertEquals(3L, r.get("nodes"));
+        assertEquals(1L, r.get("relationships"));
+        assertEquals(8L, r.get("properties"));
+        assertEquals("graphml", r.get("format"));
+        assertTrue("Should get time greater than 0",((long) r.get("time")) > 0);
+    }
+
+}

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLS3Test.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLS3Test.java
@@ -7,7 +7,7 @@ import apoc.util.s3.S3TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.Disabled;
+import org.junit.Ignore;
 import org.junit.rules.TestName;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.test.rule.DbmsRule;
@@ -33,7 +33,7 @@ import static apoc.util.MapUtil.map;
 import static org.junit.Assert.*;
 import static org.xmlunit.diff.ElementSelectors.byName;
 
-@Disabled("To use this test, you need to set the S3 bucket and region to a valid endpoint " +
+@Ignore("To use this test, you need to set the S3 bucket and region to a valid endpoint " +
         "and have your access key and secret key setup in your environment.")
 public class ExportGraphMLS3Test {
     private static String S3_BUCKET_NAME = null;

--- a/core/src/test/java/apoc/export/json/ExportJsonS3Test.java
+++ b/core/src/test/java/apoc/export/json/ExportJsonS3Test.java
@@ -1,0 +1,406 @@
+package apoc.export.json;
+
+import apoc.ApocSettings;
+import apoc.graph.Graphs;
+import apoc.util.JsonUtil;
+import apoc.util.TestUtil;
+import apoc.util.s3.S3TestUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Optional;
+
+import static apoc.util.MapUtil.map;
+import static org.junit.Assert.*;
+
+@Disabled("To use this test, you need to set the S3 bucket and region to a valid endpoint " +
+        "and have your access key and secret key setup in your environment.")
+public class ExportJsonS3Test {
+    private static String S3_BUCKET_NAME = null;
+
+    private static File directory = new File("target/import");
+    private static File directoryExpected = new File("../docs/asciidoc/modules/ROOT/examples/data/exportJSON");
+
+    static { //noinspection ResultOfMethodCallIgnored
+        directory.mkdirs();
+    }
+
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath())
+            .withSetting(ApocSettings.apoc_export_file_enabled, true);
+
+    private static String getS3Url(String key) {
+        return String.format("s3://:@/%s/%s", S3_BUCKET_NAME, key);
+    }
+
+    private String readFile(String fileName) {
+        return TestUtil.readFileToString(new File(directory, fileName));
+    }
+
+    private void verifyUpload(String s3Url, String fileName) throws IOException {
+        S3TestUtil.readFile(s3Url, Paths.get(directory.toString(), fileName).toString());
+        assertFileEquals(fileName);
+    }
+
+    private static String getEnvVar(String envVarKey) throws Exception {
+        return Optional.ofNullable(System.getenv(envVarKey)).orElseThrow(
+                () -> new Exception(String.format("%s is not set in the environment", envVarKey))
+        );
+    }
+
+    @Before
+    public void setup() throws Exception {
+        if (S3_BUCKET_NAME == null) {
+            S3_BUCKET_NAME = getEnvVar("S3_BUCKET_NAME");
+        }
+
+        TestUtil.registerProcedure(db, ExportJson.class, Graphs.class);
+        db.executeTransactionally("CREATE (f:User {name:'Adam',age:42,male:true,kids:['Sam','Anna','Grace'], born:localdatetime('2015185T19:32:24'), place:point({latitude: 13.1, longitude: 33.46789})})-[:KNOWS {since: 1993, bffSince: duration('P5M1.5D')}]->(b:User {name:'Jim',age:42}),(c:User {age:12})");
+    }
+
+    @Test
+    public void testExportAllJson() throws Exception {
+        String filename = "all.json";
+        String s3Url = getS3Url(filename);
+
+        TestUtil.testCall(db, "CALL apoc.export.json.all($s3,null)",
+                map("s3", s3Url),
+                (r) -> {
+                    assertResults(s3Url, r, "database");
+                }
+        );
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportPointMapDatetimeJson() throws Exception {
+        String filename = "mapPointDatetime.json";
+        String s3Url = getS3Url(filename);
+        String query = "return {data: 1, value: {age: 12, name:'Mike', data: {number: [1,3,5], born: date('2018-10-29'), place: point({latitude: 13.1, longitude: 33.46789})}}} as map, " +
+                "datetime('2015-06-24T12:50:35.556+0100') AS theDateTime, " +
+                "localdatetime('2015185T19:32:24') AS theLocalDateTime," +
+                "point({latitude: 13.1, longitude: 33.46789}) as point," +
+                "date('+2015-W13-4') as date," +
+                "time('125035.556+0100') as time," +
+                "localTime('12:50:35.556') as localTime";
+
+        TestUtil.testCall(db, "CALL apoc.export.json.query($query,$s3)",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(7)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                    assertFileEquals(filename);
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportListNode() throws Exception {
+        String filename = "listNode.json";
+        String s3Url = getS3Url(filename);
+        String query = "MATCH (u:User) RETURN COLLECT(u) as list";
+
+        TestUtil.testCall(db, "CALL apoc.export.json.query($query,$s3)",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportListRel() throws Exception {
+        String filename = "listRel.json";
+        String s3Url = getS3Url(filename);
+        String query = "MATCH (u:User)-[rel:KNOWS]->(u2:User) RETURN COLLECT(rel) as list";
+
+        TestUtil.testCall(db, "CALL apoc.export.json.query($query,$s3)",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportListPath() throws Exception {
+        String filename = "listPath.json";
+        String s3Url = getS3Url(filename);
+        String query = "MATCH p = (u:User)-[rel]->(u2:User) RETURN COLLECT(p) as list";
+
+        TestUtil.testCall(db, "CALL apoc.export.json.query($query,$s3)",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportMap() throws Exception {
+        String filename = "MapNode.json";
+        String s3Url = getS3Url(filename);
+        String query = "MATCH (u:User)-[r:KNOWS]->(d:User) RETURN u {.*}, d {.*}, r {.*}";
+
+        TestUtil.testCall(db, "CALL apoc.export.json.query($query,$s3)",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(3)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportMapPath() throws Exception {
+        db.executeTransactionally("CREATE (f:User {name:'Mike',age:78,male:true})-[:KNOWS {since: 1850}]->(b:User {name:'John',age:18}),(c:User {age:39})");
+        String filename = "MapPath.json";
+        String s3Url = getS3Url(filename);
+        String query = "MATCH path = (u:User)-[rel:KNOWS]->(u2:User) RETURN {key:path} as map, 'Kate' as name";
+
+        TestUtil.testCall(db, "CALL apoc.export.json.query($query,$s3)",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(2)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportMapRel() throws Exception {
+        String filename = "MapRel.json";
+        String s3Url = getS3Url(filename);
+        String query = "MATCH p = (u:User)-[rel:KNOWS]->(u2:User) RETURN rel {.*}";
+
+        TestUtil.testCall(db, "CALL apoc.export.json.query($query,$s3)",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportMapComplex() throws Exception {
+        String filename = "MapComplex.json";
+        String s3Url = getS3Url(filename);
+        String query = "RETURN {value:1, data:[10,'car',null, point({ longitude: 56.7, latitude: 12.78 }), point({ longitude: 56.7, latitude: 12.78, height: 8 }), point({ x: 2.3, y: 4.5 }), point({ x: 2.3, y: 4.5, z: 2 }),date('2018-10-10'), datetime('2018-10-18T14:21:40.004Z'), localdatetime({ year:1984, week:10, dayOfWeek:3, hour:12, minute:31, second:14, millisecond: 645 }), {x:1, y:[1,2,3,{age:10}]}]} as key";
+
+        TestUtil.testCall(db, "CALL apoc.export.json.query($query,$s3)",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportGraphJson() throws Exception {
+        String filename = "graph.json";
+        String s3Url = getS3Url(filename);
+
+        TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
+                        "CALL apoc.export.json.graph(graph, $s3) " +
+                        "YIELD nodes, relationships, properties, file, source,format, time " +
+                        "RETURN *",
+                map("s3", s3Url),
+                (r) -> assertResults(s3Url, r, "graph"));
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportQueryJson() throws Exception {
+        String filename = "query.json";
+        String s3Url = getS3Url(filename);
+        String query = "MATCH (u:User) return u.age, u.name, u.male, u.kids, labels(u)";
+
+        TestUtil.testCall(db, "CALL apoc.export.json.query($query,$s3)",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(5)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportQueryNodesJson() throws Exception {
+        String filename = "query_nodes.json";
+        String s3Url = getS3Url(filename);
+        String query = "MATCH (u:User) return u";
+
+        TestUtil.testCall(db, "CALL apoc.export.json.query($query,$s3)",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportQueryTwoNodesJson() throws Exception {
+        String filename = "query_two_nodes.json";
+        String s3Url = getS3Url(filename);
+        String query = "MATCH (u:User{name:'Adam'}), (l:User{name:'Jim'}) return u, l";
+
+        TestUtil.testCall(db, "CALL apoc.export.json.query($query,$s3)",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(2)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportQueryNodesJsonParams() throws Exception {
+        String filename = "query_nodes_param.json";
+        String s3Url = getS3Url(filename);
+        String query = "MATCH (u:User) WHERE u.age > $age return u";
+
+        TestUtil.testCall(db, "CALL apoc.export.json.query($query,$s3,{params:{age:10}})",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportQueryNodesJsonCount() throws Exception {
+        String filename = "query_nodes_count.json";
+        String s3Url = getS3Url(filename);
+        String query = "MATCH (n) return count(n)";
+
+        TestUtil.testCall(db, "CALL apoc.export.json.query($query,$s3)",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportData() throws Exception {
+        String filename = "data.json";
+        String s3Url = getS3Url(filename);
+
+        TestUtil.testCall(db, "MATCH (nod:User) " +
+                        "MATCH ()-[reels:KNOWS]->() " +
+                        "WITH collect(nod) as node, collect(reels) as rels "+
+                        "CALL apoc.export.json.data(node, rels, $s3, null) " +
+                        "YIELD nodes, relationships, properties, file, source,format, time " +
+                        "RETURN *",
+                map("s3", s3Url),
+                (r) -> {
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportDataPath() throws Exception {
+        String filename = "query_nodes_path.json";
+        String s3Url = getS3Url(filename);
+        String query = "MATCH p = (u:User)-[rel]->(u2:User) return u, rel, u2, p, u.name";
+
+        TestUtil.testCall(db, "CALL apoc.export.json.query($query,$s3)",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportAllWithWriteNodePropertiesJson() throws Exception {
+        String filename = "writeNodeProperties.json";
+        String s3Url = getS3Url(filename);
+        String query = "MATCH p = (u:User)-[rel:KNOWS]->(u2:User) RETURN rel";
+
+        TestUtil.testCall(db, "CALL apoc.export.json.query($query,$s3,{writeNodeProperties:true})",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    @Test
+    public void testExportQueryOrderJson() throws Exception {
+        db.executeTransactionally("CREATE (f:User12:User1:User0:User {name:'Alan'})");
+        String filename = "query_node_labels.json";
+        String s3Url = getS3Url(filename);
+        String query = "MATCH (u:User) WHERE u.name='Alan' RETURN u";
+
+        TestUtil.testCall(db, "CALL apoc.export.json.query($query,$s3)",
+                map("s3", s3Url, "query", query),
+                (r) -> {
+                    assertTrue("Should get statement",r.get("source").toString().contains("statement: cols(1)"));
+                    assertEquals(s3Url, r.get("file"));
+                    assertEquals("json", r.get("format"));
+                });
+        verifyUpload(s3Url, filename);
+    }
+
+    private void assertResults(String filename, Map<String, Object> r, final String source) {
+        assertEquals(3L, r.get("nodes"));
+        assertEquals(1L, r.get("relationships"));
+        assertEquals(11L, r.get("properties"));
+        assertEquals(source + ": nodes(3), rels(1)", r.get("source"));
+        assertEquals(filename, r.get("file"));
+        assertEquals("json", r.get("format"));
+        assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);
+    }
+
+    private void assertFileEquals(String fileName) {
+        String actualText = TestUtil.readFileToString(new File(directory, fileName));
+        assertStreamEquals(fileName, actualText);
+    }
+
+    private void assertStreamEquals(String fileName, String actualText) {
+        String expectedText = TestUtil.readFileToString(new File(directoryExpected, fileName));
+        String[] actualArray = actualText.split("\n");
+        String[] expectArray = expectedText.split("\n");
+        assertEquals(expectArray.length, actualArray.length);
+        for (int i = 0; i < actualArray.length; i++) {
+            assertEquals(JsonUtil.parse(expectArray[i],null, Object.class), JsonUtil.parse(actualArray[i],null, Object.class));
+        }
+    }
+}

--- a/core/src/test/java/apoc/export/json/ExportJsonS3Test.java
+++ b/core/src/test/java/apoc/export/json/ExportJsonS3Test.java
@@ -8,7 +8,7 @@ import apoc.util.s3.S3TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.Disabled;
+import org.junit.Ignore;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -22,7 +22,7 @@ import java.util.Optional;
 import static apoc.util.MapUtil.map;
 import static org.junit.Assert.*;
 
-@Disabled("To use this test, you need to set the S3 bucket and region to a valid endpoint " +
+@Ignore("To use this test, you need to set the S3 bucket and region to a valid endpoint " +
         "and have your access key and secret key setup in your environment.")
 public class ExportJsonS3Test {
     private static String S3_BUCKET_NAME = null;

--- a/core/src/test/java/apoc/util/s3/S3TestUtil.java
+++ b/core/src/test/java/apoc/util/s3/S3TestUtil.java
@@ -1,0 +1,32 @@
+package apoc.util.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * Utility class for testing Amazon S3 related functionality.
+ */
+public class S3TestUtil {
+
+    /**
+     * Read object from S3 bucket and save it as a file. This code expects valid AWS credentials are set up.
+     * @param s3Url String containing url to S3 bucket.
+     * @param pathname Local pathname where the file will be stored.
+     * @throws IOException Exception thrown if copying stream to file fails.
+     */
+    public static void readFile(String s3Url, String pathname) throws IOException {
+        S3Params s3Params = S3ParamsExtractor.extract(new URL(s3Url));
+        S3Aws s3Aws = new S3Aws(s3Params, s3Params.getRegion());
+        AmazonS3 s3Client = s3Aws.getClient();
+
+        S3Object s3object = s3Client.getObject(s3Params.getBucket(), s3Params.getKey());
+        S3ObjectInputStream inputStream = s3object.getObjectContent();
+        FileUtils.copyInputStreamToFile(inputStream, new File(pathname));
+    }
+}

--- a/docs/asciidoc/modules/ROOT/pages/export/csv.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/export/csv.adoc
@@ -35,6 +35,11 @@ include::example$generated-documentation/apoc.export.csv.csv[]
 
 include::partial$enableFileExport.adoc[]
 
+[[export-csv-s3-export]]
+== Exporting to S3
+
+include::partial$enableS3Export.adoc[]
+
 [[export-csv-stream-export]]
 == Exporting a stream
 

--- a/docs/asciidoc/modules/ROOT/pages/export/cypher.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/export/cypher.adoc
@@ -65,6 +65,11 @@ The procedures support the following config parameters:
 
 include::partial$enableFileExport.adoc[]
 
+[[export-csv-s3-export]]
+== Exporting to S3
+
+include::partial$enableS3Export.adoc[]
+
 [[export-cypher-stream-export]]
 == Exporting a stream
 

--- a/docs/asciidoc/modules/ROOT/pages/export/graphml.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/export/graphml.adoc
@@ -63,6 +63,11 @@ The procedures support the following config parameters:
 
 include::partial$enableFileExport.adoc[]
 
+[[export-csv-s3-export]]
+== Exporting to S3
+
+include::partial$enableS3Export.adoc[]
+
 [[export-graphml-stream-export]]
 == Exporting a stream
 

--- a/docs/asciidoc/modules/ROOT/pages/export/json.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/export/json.adoc
@@ -42,6 +42,11 @@ The output of `labels()` function is not sorted, use it in combination with `apo
 
 include::partial$enableFileExport.adoc[]
 
+[[export-csv-s3-export]]
+== Exporting to S3
+
+include::partial$enableS3Export.adoc[]
+
 [[export-json-stream-export]]
 == Exporting a stream
 

--- a/docs/asciidoc/modules/ROOT/pages/import/web-apis.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/web-apis.adoc
@@ -53,10 +53,12 @@ Once those files have been copied we'll need to restart the database.
 
 The S3 URL must be in the following format:
 
-* `s3://accessKey:secretKey@endpoint:port/bucket/key`
-or
-* `s3://endpoint:port/bucket/key?accessKey=accessKey&secretKey=secretKey`
-
+* `s3://accessKey:secretKey[:sessionToken]@endpoint:port/bucket/key`
+(sessionToken is optional) or
+* `s3://endpoint:port/bucket/key?accessKey=accessKey&secretKey=secretKey[&sessionToken=sessionToken]`
+(sessionToken is optional) or
+* `s3://endpoint:port/bucket/key`
+if the accessKey, secretKey, and the optional sessionToken are provided in the environment variables
 
 == Using Google Cloud Storage
 

--- a/docs/asciidoc/modules/ROOT/partials/enableS3Export.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/enableS3Export.adoc
@@ -1,0 +1,39 @@
+By default exporting to S3 is disabled.
+We can enable it by setting the following property in `apoc.conf`:
+
+.apoc.conf
+[source,properties]
+----
+apoc.export.file.enabled=true
+----
+
+If we try to use any of the export procedures without having first set this property, we'll get the following error message:
+
+|===
+| Failed to invoke procedure: Caused by: java.lang.RuntimeException: Export to files not enabled, please set apoc.export.file.enabled=true in your neo4j.conf
+|===
+
+== Using S3 protocol
+
+When using the S3 protocol we need to download and copy the following jars into the plugins directory:
+
+* aws-java-sdk-core-1.11.250.jar (https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-core/1.11.250)
+* aws-java-sdk-s3-1.11.250.jar (https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-s3/1.11.250)
+* httpclient-4.4.8.jar (https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient/4.5.4)
+* httpcore-4.5.4.jar (https://mvnrepository.com/artifact/org.apache.httpcomponents/httpcore/4.4.8)
+* joda-time-2.9.9.jar (https://mvnrepository.com/artifact/joda-time/joda-time/2.9.9)
+
+Once those files have been copied we'll need to restart the database.
+
+Exporting to S3 can be done by simply replacing the file output with an S3 endpoint. The S3 URL must be in the following format:
+
+* `s3://accessKey:secretKey[:sessionToken]@endpoint:port/bucket/key`
+(where the sessionToken is optional) or
+* `s3://endpoint:port/bucket/key?accessKey=accessKey&secretKey=secretKey[&sessionToken=sessionToken]`
+(where the sessionToken is optional) or
+* `s3://endpoint:port/bucket/key`
+if the accessKey, secretKey, and the optional sessionToken are provided in the environment variables
+
+== Memory Requirements
+
+To support large uploads, the S3 uploading utility may use up to 2.25 GB of memory at a time. The actual usage will depend on the size of the upload, but will use a maximum of 2.25 GB.


### PR DESCRIPTION
Adds support for S3 as an export destination

Adds the ability to use an S3 location as an export destination for csv, graphml, json, and cypher script.

Includes test coverage.

https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/1689

