### PR TITLE
Added apoc.uuid.enabled.db_name=false/true key to apoc.conf

### DIFF
--- a/core/src/main/java/apoc/ApocConfig.java
+++ b/core/src/main/java/apoc/ApocConfig.java
@@ -51,6 +51,7 @@ public class ApocConfig extends LifecycleAdapter {
     public static final String APOC_TTL_LIMIT = "apoc.ttl.limit";
     public static final String APOC_TRIGGER_ENABLED = "apoc.trigger.enabled";
     public static final String APOC_UUID_ENABLED = "apoc.uuid.enabled";
+    public static final String APOC_UUID_ENABLED_DB = "apoc.uuid.enabled.%s";
     public static final String APOC_JSON_ZIP_URL = "apoc.json.zip.url";  // TODO: check if really needed
     public static final String APOC_JSON_SIMPLE_JSON_URL = "apoc.json.simpleJson.url"; // TODO: check if really needed
     public static final String APOC_IMPORT_FILE_ALLOW__READ__FROM__FILESYSTEM = "apoc.import.file.allow_read_from_filesystem";

--- a/docs/asciidoc/modules/ROOT/pages/config/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/config/index.adoc
@@ -58,6 +58,7 @@ apoc.spatial.geocode.<providerName>.<key>=<value>
 | apoc.ttl.schedule=<secs> (default `60`) | Set frequency in seconds to run ttl background task
 | apoc.ttl.limit=<number> (default 1000) | Maximum number of nodes being deleted in one background transaction
 | apoc.uuid.enabled=false/true (default false) | global switch to enable uuid handlers
+| apoc.uuid.enabled.<name_db>=false/true (default true) | Enable/disable uuid handlers for a specific db. Please note that this key has to be set necessarily in `apoc.conf`. If is true UUID is enabled for the db even if apoc.uuid.enabled is false, instead if is false is disabled for the db even if apoc.uuid.enabled is true
 
 
 //public static final String APOC_JSON_ZIP_URL = "apoc.json.zip.url";

--- a/docs/asciidoc/modules/ROOT/pages/graph-updates/uuid.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/graph-updates/uuid.adoc
@@ -55,7 +55,7 @@ There are also procedures that handle automatic adding of UUID properties, via t
 The UUID handler is a transaction event handler that automatically adds the UUID property to a provided label and for the provided property name.
 Please check the following documentation to an in-depth description.
 
-Enable `apoc.uuid.enabled=true` in `$NEO4J_HOME/config/apoc.conf` first.
+Enable `apoc.uuid.enabled=true` or `apoc.uuid.enabled.[DATABASE_NAME]=true` in `$NEO4J_HOME/config/apoc.conf` first.
 
 [cols="5m,5"]
 |===

--- a/full/src/main/java/apoc/uuid/UuidHandler.java
+++ b/full/src/main/java/apoc/uuid/UuidHandler.java
@@ -38,8 +38,8 @@ public class UuidHandler extends LifecycleAdapter implements TransactionEventLis
     private final ApocConfig apocConfig;
     private final ConcurrentHashMap<String, String> configuredLabelAndPropertyNames = new ConcurrentHashMap<>();
 
-    private static final String NOT_ENABLED_ERROR = "UUID have not been enabled." +
-            " Set 'apoc.uuid.enabled=true' in your apoc.conf file located in the $NEO4J_HOME/conf/ directory.";
+    public static final String NOT_ENABLED_ERROR = "UUID have not been enabled." +
+            " Set 'apoc.uuid.enabled=true' or 'apoc.uuid.enabled.%s=true' in your apoc.conf file located in the $NEO4J_HOME/conf/ directory.";
 
     public UuidHandler(GraphDatabaseAPI db, DatabaseManagementService databaseManagementService, Log log, ApocConfig apocConfig, GlobalProcedures globalProceduresRegistry) {
         this.db = db;
@@ -57,7 +57,8 @@ public class UuidHandler extends LifecycleAdapter implements TransactionEventLis
     }
 
     private boolean isEnabled() {
-        return apocConfig.getBoolean(APOC_UUID_ENABLED);
+        String apocUUIDEnabledDb = String.format(ApocConfig.APOC_UUID_ENABLED_DB, this.db.databaseName());
+        return apocConfig.getConfig().getBoolean(apocUUIDEnabledDb, apocConfig.getBoolean(APOC_UUID_ENABLED));
     }
 
     @Override
@@ -127,7 +128,7 @@ public class UuidHandler extends LifecycleAdapter implements TransactionEventLis
 
     private void checkEnabled() {
         if (!isEnabled()) {
-            throw new RuntimeException(NOT_ENABLED_ERROR);
+            throw new RuntimeException(String.format(NOT_ENABLED_ERROR, this.db.databaseName()) );
         }
     }
 

--- a/full/src/test/java/apoc/uuid/UUIDMultiDbTest.java
+++ b/full/src/test/java/apoc/uuid/UUIDMultiDbTest.java
@@ -1,0 +1,97 @@
+package apoc.uuid;
+import apoc.util.*;
+import org.junit.*;
+import org.neo4j.driver.*;
+
+import java.util.Map;
+
+import static apoc.ApocConfig.APOC_UUID_ENABLED;
+import static apoc.ApocConfig.APOC_UUID_ENABLED_DB;
+import static apoc.util.TestContainerUtil.createEnterpriseDB;
+import static apoc.util.TestContainerUtil.testResult;
+import static apoc.util.TestUtil.isTravis;
+import static apoc.uuid.UuidHandler.NOT_ENABLED_ERROR;
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeNotNull;
+
+public class UUIDMultiDbTest {
+
+    private static Neo4jContainerExtension neo4jContainer;
+    private static Driver driver;
+    private static String dbTest = "dbtest";
+
+    @BeforeClass
+    public static void setupContainer() {
+        assumeFalse(isTravis());
+        TestUtil.ignoreException(() -> {
+            neo4jContainer = createEnterpriseDB(!TestUtil.isTravis())
+                    .withEnv(Map.of(String.format(APOC_UUID_ENABLED_DB, dbTest), "false",
+                            APOC_UUID_ENABLED, "true"));
+            neo4jContainer.start();
+        }, Exception.class);
+        assumeNotNull(neo4jContainer);
+
+        driver = GraphDatabase.driver(neo4jContainer.getBoltUrl(), AuthTokens.basic("neo4j", "apoc"));
+
+        try (Session session = driver.session()) {
+            session.writeTransaction(tx -> tx.run(String.format("CREATE DATABASE %s;", dbTest)));
+        }
+    }
+
+    @AfterClass
+    public static void bringDownContainer() {
+        if (neo4jContainer != null) {
+            neo4jContainer.close();
+        }
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testWithSpecificDatabaseWithUUIDDisabled() throws Exception {
+
+        Session session = driver.session(SessionConfig.forDatabase(dbTest));
+        try{
+            session.writeTransaction(tx -> tx.run(
+                    "CREATE (d:Foo {name:'Test'})-[:WORK]->(l:Bar {name:'Baz'})")
+            );
+
+            session.writeTransaction(tx -> tx.run(
+                    "CREATE CONSTRAINT ON (foo:Foo) ASSERT foo.uuid IS UNIQUE")
+            );
+
+            session.writeTransaction(tx -> tx.run(
+                    "CALL apoc.uuid.install('Foo') YIELD label RETURN label")
+            );
+
+        } catch (RuntimeException e) {
+            String expectedMessage = "Failed to invoke procedure `apoc.uuid.install`: " +
+                    "Caused by: java.lang.RuntimeException: " + String.format(NOT_ENABLED_ERROR, dbTest);
+            assertEquals(expectedMessage, e.getMessage());
+            throw e;
+        }
+    }
+
+    @Test
+    public void testWithDefaultDatabaseWithUUIDEnabled() {
+
+        try (Session session = driver.session(SessionConfig.forDatabase("neo4j"))) {
+            session.writeTransaction(tx -> tx.run(
+                    "CREATE (d:Foo {name:'Test'})-[:WORK]->(l:Bar {name:'Baz'})")
+            );
+
+            session.writeTransaction(tx -> tx.run(
+                    "CREATE CONSTRAINT ON (foo:Foo) ASSERT foo.uuid IS UNIQUE")
+            );
+
+            session.writeTransaction(tx -> tx.run(
+                    "CALL apoc.uuid.install('Foo') YIELD label RETURN label")
+            );
+
+            testResult(session, "MATCH (n:Foo) RETURN n.uuid as uuid", (result) -> {
+                Map<String, Object> r = result.next();
+                assertNotNull(r.get("uuid")  );
+            });
+
+        }
+    }
+}


### PR DESCRIPTION
Added `apoc.uuid.enabled.db_name=false/true` key to `apoc.conf`.

- With `apoc.uuid.enabled=false` and `apoc.uuid.enabled.<db_name>=true`, 
UUID is disabled for all databases except for database with name `db_name`.

- With `apoc.uuid.enabled=true` and `apoc.uuid.enabled.<db_name>=false`, 
UUID is enabled for all databases except for database with name `db_name`.