### PR TITLE
fixes #1705: Quote identifiers starting with a dollar character

### DIFF
--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -668,7 +668,7 @@ public class Util {
     }
 
     public static String quote(String var) {
-        return SourceVersion.isIdentifier(var) ? var : '`' + var + '`';
+        return SourceVersion.isIdentifier(var) && !var.startsWith("$") ? var : '`' + var + '`';
     }
 
     public static String sanitizeAndQuote(String var) {

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -650,6 +650,24 @@ public class ExportCypherTest {
                 });
     }
 
+    @Test
+    public void shouldQuotePropertyNameStartingWithDollarCharacter() {
+        db.executeTransactionally("CREATE (n:Bar:Baz{name: 'A', `$lock`: true})");
+        String query = "MATCH (n:Baz) RETURN n";
+        final String expected = "UNWIND [{name:\"A\", properties:{`$lock`:true}}] AS row\n" +
+                "CREATE (n:Bar{name: row.name}) SET n += row.properties SET n:Baz";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.query($query, $file, $config)",
+                map("file", null, "query", query, "config", map("format", "plain", "stream", true)), (r) -> {
+                    final String cypherStatements = (String) r.get("cypherStatements");
+                    String unwind = Stream.of(cypherStatements.split(";"))
+                            .map(String::trim)
+                            .filter(s -> s.startsWith("UNWIND"))
+                            .findFirst()
+                            .orElse(null);
+                    assertEquals(expected, unwind);
+                });
+    }
+
     private void assertResultsOptimized(String fileName, Map<String, Object> r) {
         assertEquals(7L, r.get("nodes"));
         assertEquals(2L, r.get("relationships"));

--- a/core/src/test/java/apoc/util/UtilQuoteTest.java
+++ b/core/src/test/java/apoc/util/UtilQuoteTest.java
@@ -1,0 +1,64 @@
+package apoc.util;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+@RunWith(Parameterized.class)
+public class UtilQuoteTest {
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule();
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> parameters() {
+        return Arrays.asList(new Object[][] {
+                { "abc", true },
+                { "_id", true },
+                { "some_var", true },
+                { "$lock", false },
+                { "has$inside", true },
+                { "ähhh", true },
+                { "rübe", true },
+                { "rådhuset", true },
+                { "1first", false },
+                { "first1", true },
+                { "a weird identifier", false },
+                { "^n", false },
+                { "$$n", false },
+                { " var ", false },
+                { "foo.bar.baz", false },
+        });
+    }
+
+    private final String identifier;
+    private final boolean shouldAvoidQuote;
+
+    public UtilQuoteTest(String identifier, boolean shouldAvoidQuote) {
+        this.identifier = identifier;
+        this.shouldAvoidQuote = shouldAvoidQuote;
+    }
+
+    @Test
+    public void shouldQuoteIfNeededForUsageAsParameterName() {
+        db.executeTransactionally(String.format("CREATE (n:TestNode) SET n.%s = true", Util.quote(identifier)));
+        // If the query did not fail entirely, did it create the expected property?
+        TestUtil.testCallCount(db, String.format("MATCH (n:TestNode) WHERE n.`%s` RETURN id(n)", identifier), 1);
+    }
+
+    @Test
+    public void shouldNotQuoteWhenAvoidQuoteIsTrue() {
+        assumeTrue(shouldAvoidQuote);
+        assertEquals(Util.quote(identifier), identifier);
+    }
+
+}


### PR DESCRIPTION
Fixes #1705 

Checking the [documentation for Cypher](https://neo4j.com/docs/cypher-manual/current/syntax/naming/) the `$` character seems to be forbidden at the start of a Neo4j identifier as opposed to a Java identifier. This causes the issue from #1705.

## Proposed Changes

1. Check in `Util.quote` whether the passed identifier starts with a `$` character and then quote it, even if it is a valid Java identifier
2. Add test cases for the identifier `$lock` and others mentioned in the [documentation for Cypher](https://neo4j.com/docs/cypher-manual/current/syntax/naming/)
3. Ensure that quotes are not applied in cases which previously where not quoted and which do work without quotes. This helps to avoid many test failures e.g. in [`ExportCypherTest`](https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/4.1/core/src/test/java/apoc/export/cypher/ExportCypherTest.java)

### Reasoning

Neo4j Browser for example quotes defensively (i.e. more than absolutely necessary). The rule Neo4j Browser seems to use is to quote every identifier containing non-alphabetic characters (e.g. even `some_var` or `_id`).

If `Util.quote` similarly where to use defensive quoting, identifiers such as `_id` would have also been quoted causing the aforementioned test failures from 3.
