### PR TITLE
fixes #1695: Apoc.cypher.runFile not closing file handle

### DIFF
--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -736,12 +736,19 @@ public class Util {
         }
     }
 
-    public static void close(Closeable closeable) {
+    public static void close(Closeable closeable, Consumer<Exception> onErrror) {
         try {
             if (closeable!=null) closeable.close();
-        } catch (IOException e) {
+        } catch (Exception e) {
             // ignore
+            if (onErrror != null) {
+                onErrror.accept(e);
+            }
         }
+    }
+
+    public static void close(Closeable closeable) {
+        close(closeable, null);
     }
 
     public static boolean isNotNullOrEmpty(String s) {


### PR DESCRIPTION
Fixes #1695

Changed the `runFiles` internals in order to close `Reader` and `Scanner` when the stream ends

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - fixed the bug