### PR TITLE
Support passive environmental service account authentication in Google Cloud

### DIFF
--- a/core/src/main/java/apoc/util/google/cloud/GCStorageURLConnection.java
+++ b/core/src/main/java/apoc/util/google/cloud/GCStorageURLConnection.java
@@ -67,7 +67,7 @@ public class GCStorageURLConnection extends URLConnection {
             if (StringUtils.isBlank(uri.getPath())) {
                 throw new RuntimeException("Please provide the file name");
             }
-            blob = getStorage(uri).get(BlobId.of(uri.getHost(), uri.getPath().substring(1)));
+            blob = getStorage(uri).get(BlobId.of(uri.getAuthority(), uri.getPath().substring(1)));
             connected = true;
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);

--- a/core/src/main/java/apoc/util/google/cloud/GCStorageURLConnection.java
+++ b/core/src/main/java/apoc/util/google/cloud/GCStorageURLConnection.java
@@ -38,7 +38,7 @@ public class GCStorageURLConnection extends URLConnection {
             case SERVICE:
                 String googleAppCredentialsEnv = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
                 if (StringUtils.isBlank(googleAppCredentialsEnv)) {
-                    throw new RuntimeException("You must set the env variable GOOGLE_APPLICATION_CREDENTIALS as described here: https://cloopenud.google.com/storage/docs/reference/libraries#client-libraries-install-java");
+                    throw new RuntimeException("You must set the env variable GOOGLE_APPLICATION_CREDENTIALS as described here: https://cloud.google.com/storage/docs/reference/libraries#client-libraries-install-java");
                 }
                 storage = StorageOptions.getDefaultInstance().getService();
                 break;

--- a/core/src/main/java/apoc/util/google/cloud/GCStorageURLConnection.java
+++ b/core/src/main/java/apoc/util/google/cloud/GCStorageURLConnection.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
 
 public class GCStorageURLConnection extends URLConnection {
 
-    enum AuthType { NONE, SERVICE }
+    enum AuthType { NONE, PRIVATE_KEY, GCP_ENVIRONMENT }
 
     private Blob blob;
     public GCStorageURLConnection(URL url) {
@@ -35,11 +35,13 @@ public class GCStorageURLConnection extends URLConnection {
         Map<String, String> queryParams = getQueryParams(uri);
         AuthType authenticationType = AuthType.valueOf(queryParams.getOrDefault("authenticationType", AuthType.NONE.toString()));
         switch (authenticationType) {
-            case SERVICE:
+            case PRIVATE_KEY:
                 String googleAppCredentialsEnv = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
                 if (StringUtils.isBlank(googleAppCredentialsEnv)) {
                     throw new RuntimeException("You must set the env variable GOOGLE_APPLICATION_CREDENTIALS as described here: https://cloud.google.com/storage/docs/reference/libraries#client-libraries-install-java");
                 }
+                // fall through
+            case GCP_ENVIRONMENT:
                 storage = StorageOptions.getDefaultInstance().getService();
                 break;
             default:

--- a/docs/asciidoc/modules/ROOT/pages/import/web-apis.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/web-apis.adoc
@@ -60,7 +60,7 @@ or
 
 == Using Google Cloud Storage
 
-In order to use https://cloud.google.com/storage/[Google Cloud Storage] you need that the following jars are included into the plugin dir:
+In order to use https://cloud.google.com/storage/[Google Cloud Storage], you need to add the following Google Cloud dependencies in the plugins directory:
 
 * api-common-1.8.1.jar
 * failureaccess-1.0.1.jar
@@ -87,21 +87,21 @@ In order to use https://cloud.google.com/storage/[Google Cloud Storage] you need
 * protobuf-java-util-3.9.1.jar
 * threetenbp-1.3.3.jar
 
-But we prepared an uber-package in order simplify the process, you can download it from http://example-data.neo4j.org/apoc/google-cloud-storage-dependencies-3.5-apoc.jar[here]
-and place it into the plugin directory
+We've prepared an uber-jar that contains the above dependencies in a single file in order simplify the process. You can download it from http://example-data.neo4j.org/apoc/google-cloud-storage-dependencies-3.5-apoc.jar[here] and copy it to your plugins directory.
 
 You can use Google Cloud storage via the following url format:
 
 `gs://<bucket_name>/<file_path>`
 
-moreover you can also define the authorization type:
+Moreover, you can also specify the authorization type via an additional `authenticationType` query parameter:
 
-* `NONE`: for public buckets (it's the default behaviour so you don't need to specify this)
-* `SERVICE`: with Service authentication by setting the env variable GOOGLE_APPLICATION_CREDENTIALS as described here: https://cloopenud.google.com/storage/docs/reference/libraries#client-libraries-install-java
+* `NONE`: for public buckets (this is the default behavior if the parameter is not specified)
+* `GCP_ENVIRONMENT`: for passive authentication as a service account when Neo4j is running in the Google Cloud
+* `PRIVATE_KEY`: for using private keys generated for service accounts (requires setting `GOOGLE_APPLICATION_CREDENTIALS` environment variable pointing to a private key json file as described here: https://cloud.google.com/docs/authentication#strategies)
 
-Ex:
+Example:
 
-`gs://andrea-bucket-1/test-privato.csv?authenticationType=SERVICE`
+`gs://andrea-bucket-1/test-privato.csv?authenticationType=GCP_ENVIRONMENT`
 
 == failOnError
 


### PR DESCRIPTION
This PR adds the ability to leverage passive authentication if Neo4j is running in Google Cloud, like in the case of running in GCE on a VM host or as a container instance. This simplifies and improves APOC's Google Cloud Storage support by:

- not requiring users to generate private key files for authenticating as a service account, which is generally [frowned upon](https://medium.com/@jryancanty/stop-downloading-google-cloud-service-account-keys-1811d44a97d9) because they do not expire and are hard to track.
- fixes a fundamental logic error causing NullPointerExceptions preventing accessing Google Storage objects (due to calling `getHost()` and not `getAuthority()` on the `URI` instance)
- updates the docs accordingly for the new `authenticationType` options (`NONE`, `PRIVATE_KEY`, `GCP_ENVIRONMENT`)
  - `PRIVATE_KEY` replaces the previous behavior used by `SERVICE`, i.e. using the `GOOGLE_APPLICATION_CREDENTIALS` approach of pointing the client libraries at the private key json on the file system
  - `GCP_ENVIRONMENT` lets the client libraries naturally identify the service account and fetch a token for authenticating with Cloud Storage

This PR supersedes #1718 (of which I will close).

Note: Ultimately this should be cherry-picked on the 4.2 branch when that's ready.