### PR TITLE
Cherry-pick add a new after-async or async phase to triggers

### DIFF
--- a/core/src/main/java/apoc/CoreApocGlobalComponents.java
+++ b/core/src/main/java/apoc/CoreApocGlobalComponents.java
@@ -19,7 +19,9 @@ public class CoreApocGlobalComponents implements ApocGlobalComponents {
         return Collections.singletonMap("trigger", new TriggerHandler(db,
                 dependencies.databaseManagementService(),
                 dependencies.apocConfig(),
-                dependencies.log().getUserLog(TriggerHandler.class))
+                dependencies.log().getUserLog(TriggerHandler.class),
+                dependencies.globalProceduresRegistry(),
+                dependencies.pools())
         );
     }
 

--- a/docs/asciidoc/modules/ROOT/pages/background-operations/triggers.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/background-operations/triggers.adoc
@@ -206,7 +206,7 @@ CALL apoc.trigger.add('lowercase-by-label','UNWIND apoc.trigger.nodesByLabel($as
 
 .Trigger Phase Table
 .Helper Functions
-[cols="5m,5"]
+[cols="1m,5"]
 |===
 | Phase | Description
 | before | The trigger will be activate right `before` the commit. If no phase is specified, it's the default.


### PR DESCRIPTION
Fixes #1731 

Just cherry picked the commit from https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/1573 and resolved the conflicts

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Cherry pick the commit from https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/1573