### PR TITLE
Fixes #1686: graphml import doesn't create the default relationship-type anymore

### DIFF
--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
@@ -277,12 +277,13 @@ public class XmlGraphMLReader {
     private RelationshipType getRelationshipType(XMLEventReader reader) throws XMLStreamException {
         if (this.labels) {
             XMLEvent peek = reader.peek();
-            if (peek.isCharacters() && !(peek.asCharacters().isWhiteSpace())) {
+            boolean isChar = peek.isCharacters();
+            if (isChar && !(peek.asCharacters().isWhiteSpace())) {
                 String value = peek.asCharacters().getData();
                 String el = ":";
                 String typeRel = value.contains(el) ? value.replace(el, StringUtils.EMPTY) : value;
                 return RelationshipType.withName(typeRel.trim());
-            } else if (!peek.isEndDocument()) {
+            } else if (!peek.isEndDocument() && !"data".equals(isChar ? peek.asCharacters().toString() : peek.asStartElement().getName().getLocalPart()) ) {
                 reader.nextEvent();
                 return getRelationshipType(reader);
             }

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
@@ -286,8 +286,8 @@ public class XmlGraphMLReader {
             }
 
             boolean notStartElementOrContainsKeyLabel = isChar
-                    || !(peek instanceof StartElement)
-                    || peek.asStartElement().getAttributes().next().getValue().equals("label");
+                    || !peek.isStartElement()
+                    || containsLabelKey(peek);
 
             if (!peek.isEndDocument() && notStartElementOrContainsKeyLabel) {
                 reader.nextEvent();
@@ -296,6 +296,11 @@ public class XmlGraphMLReader {
         }
         reader.nextEvent(); // to prevent eventual wrong reader (f.e. self-closing tag)
         return defaultRelType;
+    }
+
+    private boolean containsLabelKey(XMLEvent peek) {
+        final Attribute keyAttribute = peek.asStartElement().getAttributeByName(new QName("key"));
+        return keyAttribute != null && keyAttribute.getValue().equals("label");
     }
 
     private void addLabels(Node node, String labels) {

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
@@ -283,11 +283,18 @@ public class XmlGraphMLReader {
                 String el = ":";
                 String typeRel = value.contains(el) ? value.replace(el, StringUtils.EMPTY) : value;
                 return RelationshipType.withName(typeRel.trim());
-            } else if (!peek.isEndDocument() && !"data".equals(isChar ? peek.asCharacters().toString() : peek.asStartElement().getName().getLocalPart()) ) {
+            }
+
+            boolean notStartElementOrContainsKeyLabel = isChar
+                    || !(peek instanceof StartElement)
+                    || peek.asStartElement().getAttributes().next().getValue().equals("label");
+
+            if (!peek.isEndDocument() && notStartElementOrContainsKeyLabel) {
                 reader.nextEvent();
                 return getRelationshipType(reader);
             }
         }
+        reader.nextEvent(); // to prevent eventual wrong reader (f.e. self-closing tag)
         return defaultRelType;
     }
 

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -221,7 +221,7 @@ public class ExportGraphMLTest {
         TestUtil.testCall(db, "MATCH ()-[r]-() RETURN Distinct type(r) as type",
                 (r) -> {
                     String label = (String) r.get("type");
-                    assertEquals(label, "RELATED");
+                    assertEquals("RELATED", label);
                 }
         );
     }

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -215,9 +215,9 @@ public class ExportGraphMLTest {
     public void testImportDefaultRelationship() throws Exception {
         db.executeTransactionally("MATCH (n) DETACH DELETE n");
         db.executeTransactionally("CALL apoc.import.graphml( " +
-                        "  'http://sonetlab.fbk.eu/data/social_networks_of_wikipedia/vecwiki_social_network_extraction/vecwiki-20091230-manual-coding.graphml', " +
-                        "  { batchSize: 5000, readLabels: true, defaultRelationshipType:'RELATED' } " +
-                        ")");
+                "  'http://sonetlab.fbk.eu/data/social_networks_of_wikipedia/vecwiki_social_network_extraction/vecwiki-20091230-manual-coding.graphml', " +
+                "  { batchSize: 5000, readLabels: true, defaultRelationshipType:'RELATED' } " +
+                ")");
         TestUtil.testCall(db, "MATCH ()-[r]-() RETURN Distinct type(r) as type",
                 (r) -> {
                     String label = (String) r.get("type");

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -214,14 +214,10 @@ public class ExportGraphMLTest {
     @Test
     public void testImportDefaultRelationship() throws Exception {
         db.executeTransactionally("MATCH (n) DETACH DELETE n");
-        TestUtil.testCall(db, "CALL apoc.import.graphml( " +
+        db.executeTransactionally("CALL apoc.import.graphml( " +
                         "  'http://sonetlab.fbk.eu/data/social_networks_of_wikipedia/vecwiki_social_network_extraction/vecwiki-20091230-manual-coding.graphml', " +
                         "  { batchSize: 5000, readLabels: true, defaultRelationshipType:'RELATED' } " +
-                        ")",
-                (r) -> {
-                    Long res = (Long) r.get("relationships");
-                    assertFalse(res<0);
-                });
+                        ")");
         TestUtil.testCall(db, "MATCH ()-[r]-() RETURN Distinct type(r) as type",
                 (r) -> {
                     String label = (String) r.get("type");

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -210,6 +210,25 @@ public class ExportGraphMLTest {
 
         TestUtil.testCall(db, "MATCH  ()-[c:RELATED]->() RETURN COUNT(c) AS c", null, (r) -> assertEquals(1L, r.get("c")));
     }
+    
+    @Test
+    public void testImportDefaultRelationship() throws Exception {
+        db.executeTransactionally("MATCH (n) DETACH DELETE n");
+        TestUtil.testCall(db, "CALL apoc.import.graphml( " +
+                        "  'http://sonetlab.fbk.eu/data/social_networks_of_wikipedia/vecwiki_social_network_extraction/vecwiki-20091230-manual-coding.graphml', " +
+                        "  { batchSize: 5000, readLabels: true, defaultRelationshipType:'RELATED' } " +
+                        ")",
+                (r) -> {
+                    Long res = (Long) r.get("relationships");
+                    assertFalse(res<0);
+                });
+        TestUtil.testCall(db, "MATCH ()-[r]-() RETURN Distinct type(r) as type",
+                (r) -> {
+                    String label = (String) r.get("type");
+                    assertEquals(label, "RELATED");
+                }
+        );
+    }
 
     @Test(expected = QueryExecutionException.class)
     public void testImportGraphMLWithNoImportConfig() throws Exception {


### PR DESCRIPTION
Fixes #1686

One sentence summary of the change.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added condition in `getRelationshipType` method in `XmlGraphReader.java` to entry in `return getRelationshipType(reader)` if an element is not a StartElement or contains key label
  - Added test to import file with `defaultRelationshipType `
