### PR TITLE
Fixes #1448: apoc.custom.asProcedure is broken for procedure names with '.' in them.

### DIFF
--- a/core/src/main/java/apoc/SystemPropertyKeys.java
+++ b/core/src/main/java/apoc/SystemPropertyKeys.java
@@ -13,6 +13,7 @@ public enum SystemPropertyKeys  {
     outputs,
     output,
     forceSingle,
+    prefix,
 
     // triggers
     selector,

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -159,13 +159,14 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
         String name = (String) node.getProperty(SystemPropertyKeys.name.name());
         String description = (String) node.getProperty(SystemPropertyKeys.description.name(), null);
+        String[] prefix = (String[]) node.getProperty(SystemPropertyKeys.prefix.name(), new String[]{PREFIX});
 
         String property = (String) node.getProperty(SystemPropertyKeys.inputs.name());
         List<FieldSignature> inputs = deserializeSignatures(property);
 
         List<FieldSignature> outputSignature = deserializeSignatures((String) node.getProperty(SystemPropertyKeys.outputs.name()));
         return new ProcedureDescriptor(Signatures.createProcedureSignature(
-                new QualifiedName(new String[]{PREFIX}, name),
+                new QualifiedName(prefix, name),
                 inputs,
                 outputSignature,
                 Mode.valueOf((String) node.getProperty(SystemPropertyKeys.mode.name())),
@@ -186,13 +187,14 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
         String name = (String) node.getProperty(SystemPropertyKeys.name.name());
         String description = (String) node.getProperty(SystemPropertyKeys.description.name(), null);
+        String[] prefix = (String[]) node.getProperty(SystemPropertyKeys.prefix.name(), new String[]{PREFIX});
 
         String property = (String) node.getProperty(SystemPropertyKeys.inputs.name());
         List<FieldSignature> inputs = deserializeSignatures(property);
 
         boolean forceSingle = (boolean) node.getProperty(SystemPropertyKeys.forceSingle.name(), false);
         return new UserFunctionDescriptor(new UserFunctionSignature(
-                new QualifiedName(new String[]{PREFIX}, name),
+                new QualifiedName(prefix, name),
                 inputs,
                 typeof((String) node.getProperty(SystemPropertyKeys.output.name())),
                 null,
@@ -244,7 +246,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                     Pair.of(SystemPropertyKeys.database.name(), api.databaseName()),
                     Pair.of(SystemPropertyKeys.name.name(), signature.name().name())
             );
-
+            node.setProperty(SystemPropertyKeys.prefix.name(),  signature.name().namespace());
             node.setProperty(SystemPropertyKeys.description.name(), signature.description().orElse(null));
             node.setProperty(SystemPropertyKeys.statement.name(), statement);
             node.setProperty(SystemPropertyKeys.inputs.name(), serializeSignatures(signature.inputSignature()));
@@ -263,6 +265,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                     Pair.of(SystemPropertyKeys.database.name(), api.databaseName()),
                     Pair.of(SystemPropertyKeys.name.name(), signature.name().name())
             );
+            node.setProperty(SystemPropertyKeys.prefix.name(),  signature.name().namespace());
             node.setProperty(SystemPropertyKeys.description.name(), signature.description().orElse(null));
             node.setProperty(SystemPropertyKeys.statement.name(), statement);
             node.setProperty(SystemPropertyKeys.inputs.name(), serializeSignatures(signature.inputSignature()));

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -246,6 +246,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                     Pair.of(SystemPropertyKeys.database.name(), api.databaseName()),
                     Pair.of(SystemPropertyKeys.name.name(), signature.name().name())
             );
+
             node.setProperty(SystemPropertyKeys.prefix.name(),  signature.name().namespace());
             node.setProperty(SystemPropertyKeys.description.name(), signature.description().orElse(null));
             node.setProperty(SystemPropertyKeys.statement.name(), statement);

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -247,7 +247,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                     Pair.of(SystemPropertyKeys.name.name(), signature.name().name())
             );
 
-            node.setProperty(SystemPropertyKeys.prefix.name(),  signature.name().namespace());
+            node.setProperty(SystemPropertyKeys.prefix.name(), signature.name().namespace());
             node.setProperty(SystemPropertyKeys.description.name(), signature.description().orElse(null));
             node.setProperty(SystemPropertyKeys.statement.name(), statement);
             node.setProperty(SystemPropertyKeys.inputs.name(), serializeSignatures(signature.inputSignature()));
@@ -266,7 +266,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                     Pair.of(SystemPropertyKeys.database.name(), api.databaseName()),
                     Pair.of(SystemPropertyKeys.name.name(), signature.name().name())
             );
-            node.setProperty(SystemPropertyKeys.prefix.name(),  signature.name().namespace());
+            node.setProperty(SystemPropertyKeys.prefix.name(), signature.name().namespace());
             node.setProperty(SystemPropertyKeys.description.name(), signature.description().orElse(null));
             node.setProperty(SystemPropertyKeys.statement.name(), statement);
             node.setProperty(SystemPropertyKeys.inputs.name(), serializeSignatures(signature.inputSignature()));

--- a/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -50,6 +50,14 @@ public class CypherProceduresStorageTest {
     }
 
     @Test
+    public void registerSimpleStatementWithDotInName() throws Exception {
+        db.executeTransactionally("call apoc.custom.asProcedure('foo.bar','RETURN 42 as answer')");
+        TestUtil.testCall(db, "call custom.foo.bar()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
+        restartDb();
+        TestUtil.testCall(db, "call custom.foo.bar()", (row) -> assertEquals(42L, ((Map)row.get("row")).get("answer")));
+    }
+
+    @Test
     public void registerSimpleStatementConcreteResults() throws Exception {
         db.executeTransactionally("call apoc.custom.asProcedure('answer','RETURN 42 as answer','read',[['answer','long']])");
         restartDb();
@@ -91,6 +99,14 @@ public class CypherProceduresStorageTest {
         TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
         restartDb();
         TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+    }
+
+    @Test
+    public void registerSimpleStatementFunctionWithDotInName() throws Exception {
+        db.executeTransactionally("call apoc.custom.asFunction('foo.bar','RETURN 42 as answer')");
+        TestUtil.testCall(db, "return custom.foo.bar() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        restartDb();
+        TestUtil.testCall(db, "return custom.foo.bar() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
     }
 
     @Test


### PR DESCRIPTION
Fixes #1448 

One sentence summary of the change.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - added "prefix" property to `SystemPropertyKeys.java` to save custom procedures and functions with dot in name
- added tests save procedure and function with dot in name
