### PR TITLE
Fixes #1555: apoc.custom.asProcedure doesn't overwrite existing procedure by same name

### DIFF
--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -867,7 +867,7 @@ public class Util {
 
     public static Node mergeNode(Transaction tx, Label primaryLabel, Label addtionalLabel,
                                  Pair<String, Object>... pairs ) {
-        Node node = Iterators.singleOrNull(tx.findNodes(primaryLabel, pairs[0].first(), pairs[1].other()).stream()
+        Node node = Iterators.singleOrNull(tx.findNodes(primaryLabel, pairs[0].first(), pairs[0].other()).stream()
                 .filter(n -> addtionalLabel!=null && n.hasLabel(addtionalLabel))
                 .filter( n -> {
                     for (int i=1; i<pairs.length; i++) {

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -601,30 +601,32 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
     public void removeProcedure(String name) {
         withSystemDb(tx -> {
-            Node node = Iterators.single(tx.findNodes(SystemLabels.ApocCypherProcedures,
+            tx.findNodes(SystemLabels.ApocCypherProcedures,
                     SystemPropertyKeys.database.name(), api.databaseName(),
                     SystemPropertyKeys.name.name(), name
-            ).stream().filter(n -> n.hasLabel(SystemLabels.Procedure)).iterator());
-            ProcedureDescriptor descriptor = procedureDescriptor(node);
-            registerProcedure(descriptor.getSignature(), null);
-            registeredProcedureSignatures.remove(descriptor.getSignature());
-            node.delete();
-            setLastUpdate(tx);
+            ).stream().filter(n -> n.hasLabel(SystemLabels.Procedure)).forEach(node -> {
+                ProcedureDescriptor descriptor = procedureDescriptor(node);
+                registerProcedure(descriptor.getSignature(), null);
+                registeredProcedureSignatures.remove(descriptor.getSignature());
+                node.delete();
+                setLastUpdate(tx);
+            });
             return null;
         });
     }
 
     public void removeFunction(String name) {
         withSystemDb(tx -> {
-            Node node = Iterators.single(tx.findNodes(SystemLabels.ApocCypherProcedures,
+            tx.findNodes(SystemLabels.ApocCypherProcedures,
                     SystemPropertyKeys.database.name(), api.databaseName(),
                     SystemPropertyKeys.name.name(), name
-            ).stream().filter(n -> n.hasLabel(SystemLabels.Function)).iterator());
-            UserFunctionDescriptor descriptor = userFunctionDescriptor(node);
-            registerFunction(descriptor.getSignature(), null, false);
-            registeredUserFunctionSignatures.remove(descriptor.getSignature());
-            node.delete();
-            setLastUpdate(tx);
+            ).stream().filter(n -> n.hasLabel(SystemLabels.Function)).forEach(node -> {
+                UserFunctionDescriptor descriptor = userFunctionDescriptor(node);
+                registerFunction(descriptor.getSignature(), null, false);
+                registeredUserFunctionSignatures.remove(descriptor.getSignature());
+                node.delete();
+                setLastUpdate(tx);
+            });
             return null;
         });
 

--- a/full/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -259,6 +259,22 @@ public class CypherProceduresTest  {
     }
 
     @Test
+    public void shouldOverwriteAndRemoveCustomProcedure() throws Exception {
+        db.executeTransactionally("call apoc.custom.asProcedure('answer','RETURN 42')");
+        db.executeTransactionally("call apoc.custom.asProcedure('answer','RETURN 42')");
+        assertEquals("Expecting one procedure listed", 1, TestUtil.count(db, "call apoc.custom.list()"));
+        db.executeTransactionally("call apoc.custom.removeProcedure('answer')");
+    }
+
+    @Test
+    public void shouldOverwriteAndRemoveCustomFunction() throws Exception {
+        db.executeTransactionally("call apoc.custom.asFunction('answer','RETURN 42','long')");
+        db.executeTransactionally("call apoc.custom.asFunction('answer','RETURN 42','long')");
+        assertEquals("Expecting one function listed", 1, TestUtil.count(db, "call apoc.custom.list()"));
+        db.executeTransactionally("call apoc.custom.removeFunction('answer')");
+    }
+
+    @Test
     public void shouldRemovalOfProcedureNodeDeactivate() {
         thrown.expect(QueryExecutionException.class);
         thrown.expectMessage("There is no procedure with the name `custom.answer` registered for this database instance. " +


### PR DESCRIPTION
Fixes #1555 

The pr #1559 has fixed this issue, however this pr was merged in `4.0` but the bug is still present in `4.1` branch.
