### PR TITLE
Trying to simplify TTL tests by testing the config on its own

### DIFF
--- a/core/src/main/java/apoc/ApocConfig.java
+++ b/core/src/main/java/apoc/ApocConfig.java
@@ -290,6 +290,10 @@ public class ApocConfig extends LifecycleAdapter {
         return getConfig().getBoolean(key);
     }
 
+    public boolean getBoolean(String key, boolean defaultValue) {
+        return getConfig().getBoolean(key, defaultValue);
+    }
+
     public boolean isImportFolderConfigured() {
         // in case we're test database import path is TestDatabaseManagementServiceBuilder.EPHEMERAL_PATH
 

--- a/core/src/main/java/apoc/ApocExtensionFactory.java
+++ b/core/src/main/java/apoc/ApocExtensionFactory.java
@@ -54,6 +54,7 @@ public class ApocExtensionFactory extends ExtensionFactory<ApocExtensionFactory.
         AvailabilityGuard availabilityGuard();
         DatabaseManagementService databaseManagementService();
         ApocConfig apocConfig();
+        TTLConfig ttlConfig();
         GlobalProcedures globalProceduresRegistry();
         RegisterComponentFactory.RegisterComponentLifecycle registerComponentLifecycle();
         Pools pools();

--- a/core/src/main/java/apoc/TTLConfig.java
+++ b/core/src/main/java/apoc/TTLConfig.java
@@ -1,0 +1,57 @@
+package apoc;
+
+import org.neo4j.kernel.api.procedure.GlobalProcedures;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+public class TTLConfig extends LifecycleAdapter {
+    private final ApocConfig apocConfig;
+    public static final int DEFAULT_SCHEDULE = 60;
+
+    public TTLConfig(ApocConfig apocConfig, GlobalProcedures globalProceduresRegistry) {
+        this.apocConfig = apocConfig;
+
+        globalProceduresRegistry.registerComponent((Class<TTLConfig>) getClass(), ctx -> this, true);
+    }
+
+    public Values configFor(GraphDatabaseAPI db) {
+        String apocTTLEnabledDb = String.format(ApocConfig.APOC_TTL_ENABLED_DB, db.databaseName());
+        String apocTTLScheduleDb = String.format(ApocConfig.APOC_TTL_SCHEDULE_DB, db.databaseName());
+        String apocTTLLimitDb = String.format(ApocConfig.APOC_TTL_LIMIT_DB, db.databaseName());
+        boolean enabled = apocConfig.getBoolean(ApocConfig.APOC_TTL_ENABLED);
+        boolean dbEnabled = apocConfig.getBoolean(apocTTLEnabledDb, enabled);
+
+        if (dbEnabled) {
+            long ttlSchedule = apocConfig.getInt(ApocConfig.APOC_TTL_SCHEDULE, DEFAULT_SCHEDULE);
+            long ttlScheduleDb = apocConfig.getInt(apocTTLScheduleDb, (int) ttlSchedule);
+            long limit = apocConfig.getInt(ApocConfig.APOC_TTL_LIMIT, 1000);
+            long limitDb = apocConfig.getInt(apocTTLLimitDb, (int) limit);
+
+            return new Values(true, ttlScheduleDb, limitDb);
+        }
+
+        return new Values(false, -1, -1);
+    }
+
+
+    public static class Values {
+        public final boolean enabled;
+        public final long schedule;
+        public final long limit;
+
+        public Values(boolean enabled, long schedule, long limit) {
+            this.enabled = enabled;
+            this.schedule = schedule;
+            this.limit = limit;
+        }
+
+        @Override
+        public String toString() {
+            return "Values{" +
+                    "enabled=" + enabled +
+                    ", schedule=" + schedule +
+                    ", limit=" + limit +
+                    '}';
+        }
+    }
+}

--- a/core/src/main/java/apoc/TTLConfigExtensionFactory.java
+++ b/core/src/main/java/apoc/TTLConfigExtensionFactory.java
@@ -1,0 +1,34 @@
+package apoc;
+
+import org.neo4j.annotations.service.ServiceProvider;
+import org.neo4j.configuration.Config;
+import org.neo4j.dbms.api.DatabaseManagementService;
+import org.neo4j.kernel.api.procedure.GlobalProcedures;
+import org.neo4j.kernel.extension.ExtensionFactory;
+import org.neo4j.kernel.extension.ExtensionType;
+import org.neo4j.kernel.extension.context.ExtensionContext;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.logging.internal.LogService;
+
+/**
+ * a kernel extension for the TTL config
+ */
+@ServiceProvider
+public class TTLConfigExtensionFactory extends ExtensionFactory<TTLConfigExtensionFactory.Dependencies> {
+
+    public interface Dependencies {
+        ApocConfig config();
+        GlobalProcedures globalProceduresRegistry();
+    }
+
+    public TTLConfigExtensionFactory() {
+        super(ExtensionType.DATABASE, "TTLConfig");
+    }
+
+    @Override
+    public Lifecycle newInstance(ExtensionContext context, Dependencies dependencies) {
+        return new TTLConfig(dependencies.config(), dependencies.globalProceduresRegistry());
+    }
+
+}

--- a/core/src/test/java/apoc/TTLConfigTest.java
+++ b/core/src/test/java/apoc/TTLConfigTest.java
@@ -1,0 +1,63 @@
+package apoc;
+
+import org.junit.Test;
+import org.neo4j.kernel.api.procedure.GlobalProcedures;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+
+import static apoc.TTLConfig.DEFAULT_SCHEDULE;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TTLConfigTest {
+    @Test
+    public void ttlDisabled() {
+        ApocConfig apocConfig = mock(ApocConfig.class);
+        when(apocConfig.getBoolean(ApocConfig.APOC_TTL_ENABLED)).thenReturn(false);
+        when(apocConfig.getBoolean("apoc.ttl.enabled.foo")).thenReturn(false);
+
+        GraphDatabaseAPI db = mock(GraphDatabaseAPI.class);
+        when(db.databaseName()).thenReturn("foo");
+
+        TTLConfig ttlConfig = new TTLConfig(apocConfig, mock(GlobalProcedures.class));
+
+        assertFalse(ttlConfig.configFor(db).enabled);
+    }
+
+    @Test
+    public void ttlDisabledForOurDatabase() {
+        ApocConfig apocConfig = mock(ApocConfig.class);
+        when(apocConfig.getBoolean(ApocConfig.APOC_TTL_ENABLED)).thenReturn(true);
+        when(apocConfig.getBoolean("apoc.ttl.enabled.foo")).thenReturn(false);
+
+        GraphDatabaseAPI db = mock(GraphDatabaseAPI.class);
+        when(db.databaseName()).thenReturn("foo");
+
+        TTLConfig ttlConfig = new TTLConfig(apocConfig, mock(GlobalProcedures.class));
+
+        assertFalse(ttlConfig.configFor(db).enabled);
+    }
+
+    @Test
+    public void ttlEnabledForOurDatabaseOverridesGlobalSettings() {
+        ApocConfig apocConfig = mock(ApocConfig.class);
+        when(apocConfig.getBoolean(ApocConfig.APOC_TTL_ENABLED)).thenReturn(false);
+        when(apocConfig.getBoolean("apoc.ttl.enabled.foo", false)).thenReturn(true);
+
+        when(apocConfig.getInt(ApocConfig.APOC_TTL_SCHEDULE, DEFAULT_SCHEDULE)).thenReturn(300);
+        when(apocConfig.getInt("apoc.ttl.schedule.foo", 300)).thenReturn(500);
+
+        when(apocConfig.getInt(ApocConfig.APOC_TTL_LIMIT, 1000)).thenReturn(5000);
+        when(apocConfig.getInt("apoc.ttl.limit.foo", 5000)).thenReturn(1000);
+
+        GraphDatabaseAPI db = mock(GraphDatabaseAPI.class);
+        when(db.databaseName()).thenReturn("foo");
+
+        TTLConfig.Values values = new TTLConfig(apocConfig, mock(GlobalProcedures.class)).configFor(db);
+
+        assertTrue(values.enabled);
+        assertEquals(500, values.schedule);
+        assertEquals(1000, values.limit);
+    }
+
+}

--- a/full/src/main/java/apoc/ExtendedApocGlobalComponents.java
+++ b/full/src/main/java/apoc/ExtendedApocGlobalComponents.java
@@ -38,7 +38,7 @@ public class ExtendedApocGlobalComponents implements ApocGlobalComponents {
 
         return MapUtil.genericMap(
 
-                "ttl", new TTLLifeCycle(dependencies.scheduler(), db, dependencies.apocConfig(), dependencies.log().getUserLog(TTLLifeCycle.class)),
+                "ttl", new TTLLifeCycle(dependencies.scheduler(), db, dependencies.apocConfig(), dependencies.ttlConfig(), dependencies.log().getUserLog(TTLLifeCycle.class)),
 
                 "uuid", new UuidHandler(db,
                 dependencies.databaseManagementService(),

--- a/full/src/main/java/apoc/ttl/TTL.java
+++ b/full/src/main/java/apoc/ttl/TTL.java
@@ -1,12 +1,14 @@
 package apoc.ttl;
 
 import apoc.Extended;
+import apoc.TTLConfig;
+import apoc.util.MapUtil;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
-import org.neo4j.procedure.Description;
-import org.neo4j.procedure.Mode;
-import org.neo4j.procedure.Name;
-import org.neo4j.procedure.Procedure;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.procedure.*;
+
+import java.util.Map;
 
 import static apoc.date.Date.unit;
 
@@ -14,16 +16,32 @@ import static apoc.date.Date.unit;
 public class TTL {
 
     @Procedure(mode = Mode.WRITE)
-    @Description("CALL apoc.ttl.expireAtInstant(node,time,'time-unit') - expire node at specified time by setting :TTL label and `ttl` property")
+    @Description("CALL apoc.ttl.expire(node,time,'time-unit') - expire node at specified time by setting :TTL label and `ttl` property")
     public void expire(@Name("node") Node node, @Name("time") long time, @Name("timeUnit") String timeUnit) {
         node.addLabel(Label.label("TTL"));
         node.setProperty("ttl",unit(timeUnit).toMillis(time));
     }
 
     @Procedure(mode = Mode.WRITE)
-    @Description("CALL apoc.ttl.expireAfterTimeLength(node,timeDelta,'time-unit') - expire node after specified length of time time by setting :TTL label and `ttl` property")
+    @Description("CALL apoc.ttl.expireIn(node,timeDelta,'time-unit') - expire node after specified length of time time by setting :TTL label and `ttl` property")
     public void expireIn(@Name("node") Node node, @Name("timeDelta") long time, @Name("timeUnit") String timeUnit) {
         node.addLabel(Label.label("TTL"));
         node.setProperty("ttl",System.currentTimeMillis() + unit(timeUnit).toMillis(time));
+    }
+
+    @Context
+    public TTLConfig ttlConfig;
+
+    @Context
+    public GraphDatabaseAPI db;
+
+    @UserFunction
+    public Map<String, Object> config() {
+        TTLConfig.Values values = ttlConfig.configFor(db);
+        return MapUtil.map(
+                "enabled", values.enabled,
+                "schedule", values.schedule,
+                "limit", values.limit
+        );
     }
 }

--- a/full/src/main/java/apoc/ttl/TTLLifeCycle.java
+++ b/full/src/main/java/apoc/ttl/TTLLifeCycle.java
@@ -1,7 +1,7 @@
 package apoc.ttl;
 
 import apoc.ApocConfig;
-import apoc.Extended;
+import apoc.TTLConfig;
 import apoc.util.Util;
 import org.neo4j.graphdb.QueryStatistics;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -27,28 +27,25 @@ public class TTLLifeCycle extends LifecycleAdapter {
     private final ApocConfig apocConfig;
     private JobHandle ttlIndexJobHandle;
     private JobHandle ttlJobHandle;
+    private TTLConfig ttlConfig;
     private Log log;
 
-    public TTLLifeCycle(JobScheduler scheduler, GraphDatabaseAPI db, ApocConfig apocConfig, Log log) {
+    public TTLLifeCycle(JobScheduler scheduler, GraphDatabaseAPI db, ApocConfig apocConfig, TTLConfig ttlConfig, Log log) {
         this.scheduler = scheduler;
         this.db = db;
         this.apocConfig = apocConfig;
+        this.ttlConfig = ttlConfig;
         this.log = log;
     }
 
     @Override
     public void start() {
-        String apocTTLEnabledDb = String.format(ApocConfig.APOC_TTL_ENABLED_DB, this.db.databaseName());
-        String apocTTLScheduleDb = String.format(ApocConfig.APOC_TTL_SCHEDULE_DB, this.db.databaseName());
-        String apocTTLLimitDb = String.format(ApocConfig.APOC_TTL_LIMIT_DB, this.db.databaseName());
-        boolean enabled = apocConfig.getBoolean(ApocConfig.APOC_TTL_ENABLED);
-        boolean dbEnabled = apocConfig.getConfig().getBoolean(apocTTLEnabledDb, enabled);
-        if (dbEnabled) {
-            long ttlSchedule = apocConfig.getConfig().getInt(ApocConfig.APOC_TTL_SCHEDULE, DEFAULT_SCHEDULE);
-            long ttlScheduleDb = apocConfig.getConfig().getInt(apocTTLScheduleDb, (int) ttlSchedule);
+        TTLConfig.Values configValues = ttlConfig.configFor(db);
+        System.out.println("configValues = " + configValues);
+        if(configValues.enabled) {
+            long ttlScheduleDb = configValues.schedule;
             ttlIndexJobHandle = scheduler.schedule(TTL_GROUP, this::createTTLIndex, (int)(ttlScheduleDb*0.8), TimeUnit.SECONDS);
-            long limit = apocConfig.getInt(ApocConfig.APOC_TTL_LIMIT, 1000);
-            long limitDb = apocConfig.getInt(apocTTLLimitDb, (int) limit);
+            long limitDb = configValues.limit;
             ttlJobHandle = scheduler.scheduleRecurring(TTL_GROUP, () -> expireNodes(limitDb), ttlScheduleDb, ttlScheduleDb, TimeUnit.SECONDS);
         }
     }

--- a/full/src/main/java/apoc/ttl/TTLLifeCycle.java
+++ b/full/src/main/java/apoc/ttl/TTLLifeCycle.java
@@ -41,7 +41,6 @@ public class TTLLifeCycle extends LifecycleAdapter {
     @Override
     public void start() {
         TTLConfig.Values configValues = ttlConfig.configFor(db);
-        System.out.println("configValues = " + configValues);
         if(configValues.enabled) {
             long ttlScheduleDb = configValues.schedule;
             ttlIndexJobHandle = scheduler.schedule(TTL_GROUP, this::createTTLIndex, (int)(ttlScheduleDb*0.8), TimeUnit.SECONDS);

--- a/full/src/test/java/apoc/date/TTLTest.java
+++ b/full/src/test/java/apoc/date/TTLTest.java
@@ -1,5 +1,7 @@
 package apoc.date;
 
+import apoc.ttl.TTL;
+import apoc.util.MapUtil;
 import apoc.util.TestUtil;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -8,14 +10,19 @@ import org.junit.contrib.java.lang.system.ProvideSystemProperty;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.ResultTransformer;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
+import java.util.Map;
+
 import static apoc.ApocConfig.APOC_TTL_ENABLED;
 import static apoc.ApocConfig.APOC_TTL_SCHEDULE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author mh
@@ -26,8 +33,10 @@ public class TTLTest {
     public static DbmsRule db = new ImpermanentDbmsRule();
 
     public static ProvideSystemProperty systemPropertyRule
-            = new ProvideSystemProperty(APOC_TTL_ENABLED, "true")
-            .and(APOC_TTL_SCHEDULE, "5");
+            = new ProvideSystemProperty(
+                    APOC_TTL_ENABLED, "true")
+            .and(APOC_TTL_SCHEDULE, "5")
+            .and("apoc.ttl.limit", "200");
 
     @ClassRule
     public static TestRule chain = RuleChain.outerRule(systemPropertyRule).around(db);
@@ -35,6 +44,7 @@ public class TTLTest {
     @BeforeClass
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, DateExpiry.class);
+        TestUtil.registerProcedure(db, TTL.class);
         db.executeTransactionally("CREATE (n:Foo:TTL) SET n.ttl = timestamp() + 100");
         db.executeTransactionally("CREATE (n:Bar) WITH n CALL apoc.date.expireIn(n,500,'ms') RETURN count(*)");
         testNodes(1,1);
@@ -44,6 +54,21 @@ public class TTLTest {
     public void testExpire() throws Exception {
         Thread.sleep(10*1000);
         testNodes(0,0);
+    }
+
+    @Test
+    public void testConfig() throws Exception {
+        db.executeTransactionally("RETURN apoc.ttl.config() AS value", MapUtil.map(), new ResultTransformer<Object>() {
+            @Override
+            public Object apply(Result result) {
+                Map<String, Object> row = result.next();
+                Map<String, Object> value = (Map<String, Object>) row.get("value");
+                assertTrue((Boolean) value.get("enabled"));
+                assertEquals(5L, value.get("schedule"));
+                assertEquals(200L, value.get("limit"));
+                return null;
+            }
+        });
     }
 
     private static void testNodes(int foo, int bar) {


### PR DESCRIPTION
The current tests in TTLMultiDbTest are super flaky. I think a better way to test this functionality is to check that the config used for scheduling is correct.

So I've pulled out the config and created a function that exposes the config for the current database. This makes the tests more deterministic, which will stop them failing almost every build!