### PR TITLE
bumped commons-configuration2 dependency to version 2.7

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -57,8 +57,8 @@ dependencies {
     // testCompile "org.antlr:antlr4-runtime:4.7.2"
 
     compile group: 'org.roaringbitmap', name: 'RoaringBitmap', version: '0.7.17'
-    compile group: 'org.apache.commons', name: 'commons-configuration2', version: '2.5'
-    compile(group: 'org.apache.commons', name: 'commons-configuration2', version: '2.5') {
+    compile group: 'org.apache.commons', name: 'commons-configuration2', version: '2.7'
+    compile(group: 'org.apache.commons', name: 'commons-configuration2', version: '2.7') {
         exclude group: "org.yaml"
         exclude module: "snakeyaml"
     }


### PR DESCRIPTION
Updated apoc core dependency from commons-configuration2 2.5 to 2.7. 
Elsewhere in the code (and in earlier versions of apoc) 2.7 is used but it seems like updating core was missed for 4.3.
