### PR TITLE
Fix #1758 by updating neo4j-java-driver and Neo4j versions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "4.2.0"
+    neo4jVersion = "4.2.2"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.15.1'

--- a/docs/asciidoc/antora.yml
+++ b/docs/asciidoc/antora.yml
@@ -8,4 +8,4 @@ asciidoc:
     docs-version: "4.2"
     branch: "4.2"
     apoc-release-absolute: "4.2"
-    apoc-release: "4.2.0.0"
+    apoc-release: "4.2.0.1"

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 //    compile group: 'commons-codec', name: 'commons-codec', version: '1.14'
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
     compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
-    compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.0.0'
+    compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.2.0'
     compile group: 'com.novell.ldap', name: 'jldap', version: '2009-10-07'
 
     antlr "org.antlr:antlr4:4.7.2", {

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,8 +1,8 @@
 :readme:
 :branch: 4.2
 :docs: https://neo4j.com/docs/labs/apoc/current
-:apoc-release: 4.2.0.0
-:neo4j-version: 4.2.0
+:apoc-release: 4.2.0.1
+:neo4j-version: 4.2.2
 :img: https://raw.githubusercontent.com/neo4j-contrib/neo4j-apoc-procedures/{branch}/docs/images
 
 = Awesome Procedures for Neo4j {branch}.x
@@ -187,6 +187,8 @@ The trailing `<apoc>` part of the version number will be incremented with every 
 [opts=header]
 |===
 |apoc version | neo4j version
+| http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.2.0.1[4.2.0.1#^] | 4.2.2 (4.2.x)
+| http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.1.0.4[4.1.0.4^] | 4.1.1 (4.1.x)
 | http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.0.0.16[4.0.0.16#^] | 4.0.6 (4.0.x)
 | http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/3.5.0.11[3.5.0.11^] | 3.5.16 (3.5.x)
 | http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/3.4.0.4[3.4.0.6^] | 3.4.12 (3.4.x)

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     // there is a compatibility problem between the Guava Library used by HDFS, Google Cloud Storage and Reflections; the only version that fits for all is the following
     compile group: 'com.google.guava', name: 'guava', version: '20.0'
 
-    compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.0.0'
+    compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.2.0'
 
     compile group: 'org.gradle', name: 'gradle-tooling-api', version: '6.0.1'
 
@@ -27,7 +27,7 @@ dependencies {
     compile group: 'org.apache.hadoop', name: 'hadoop-common', version: '2.7.5', withoutServers
     compile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '2.7.5', withoutServers
 
-    compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.0.0'
+    compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.2.0'
     compile group: 'org.jetbrains', name: 'annotations', version: "17.0.0"
 
     // Test Containers

--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -46,7 +46,7 @@ public class TestContainerUtil {
         importFolder.mkdirs();
 
         // read neo4j version from build.gradle and use this as default
-        String neo4jDockerImageVersion = System.getProperty("neo4jDockerImage", "neo4j:4.2.1-enterprise");
+        String neo4jDockerImageVersion = System.getProperty("neo4jDockerImage", "neo4j:4.2.2-enterprise");
 
         // use a separate folder for mounting plugins jar - build/libs might contain other jars as well.
         File pluginsFolder = new File("build/plugins");


### PR DESCRIPTION
Fixes #1758

Version for neo4j-java-driver has been bumped to 4.2.0. Neo4j version has been updated to 4.2.2, too as requested in #1759.
Note: This is the same topic as #1759 which I accidentally closed. I also incorporated the requested changes from #1759 and polished the readme.