### PR TITLE
Fix typo, clarify the difference between the load/import CSV procedures

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/import/import-csv.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/import-csv.adoc
@@ -6,7 +6,9 @@
 
 CSV files that comply with the link:https://neo4j.com/docs/operations-manual/current/tools/neo4j-admin-import/#import-tool-header-format/[Neo4j import tool's header format] can be imported using the `apoc.import.csv` procedure.
 This procedure can be used to load small- to medium-sized data sets in an online database.
-For importing larger data sets, it is recommended to perform a batch import using the (https://neo4j.com/docs/operations-manual/current/tools/import/[import tool], which loads data in bulk to an offline (initially empty) database.
+For importing larger data sets, it is recommended to perform a batch import using the link:https://neo4j.com/docs/operations-manual/current/tools/import/[import tool], which loads data in bulk to an offline (initially empty) database.
+
+This procedure should not be confused with the xref::import/load-csv.adoc[`apoc.load.csv` procedure] which loads the lines of the CSV file to lists/maps (to be used to create the entities in the database).
 
 == Usage
 


### PR DESCRIPTION
Fixes #1785

Improved documentation of `apoc.csv.import`

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - fix typo
  - clarify the difference between the load/import CSV procedures