### PR TITLE
Fixes #1783: Removed double escape of identProps in apoc.merge

### DIFF
--- a/core/src/main/java/apoc/merge/Merge.java
+++ b/core/src/main/java/apoc/merge/Merge.java
@@ -83,7 +83,7 @@ public class Merge {
     private String buildIdentPropsString(Map<String, Object> identProps) {
         if (identProps == null) return "";
         return identProps.keySet().stream().map(Util::quote)
-                .map(s -> "`"+s+"`:$identProps.`" + s+"`")
+                .map(s -> s + ":$identProps." + s)
                 .collect(Collectors.joining(","));
     }
 }

--- a/core/src/test/java/apoc/merge/MergeTest.java
+++ b/core/src/test/java/apoc/merge/MergeTest.java
@@ -94,7 +94,22 @@ public class MergeTest {
             }
         }
     }
-
+    
+    @Test
+    public void testEscapeIdentityPropertiesWithSpecialCharactersShouldWork() {
+        for (String key: new String[]{"normal", "i:d", "i-d", "i d"}) {
+            Map<String, String> identProps = MapUtil.map(key, "value");
+            Map<String, Object> params = MapUtil.map("identProps", identProps);
+            
+            testCall(db, "CALL apoc.merge.node(['Person'], $identProps) YIELD node RETURN node", params,
+                        (row) -> {
+                            assertTrue(row.get("node") instanceof Node);
+                            assertTrue(node.hasProperty(key));
+                            assertEquals("value", node.getProperty(key));
+                        });
+        }
+    }
+    
     @Test
     public void testLabelsWithSpecialCharactersShouldWork() {
         for (String label: new String[]{"Label with spaces", ":LabelWithColon", "label-with-dash", "LabelWithUmlautsÄÖÜ"}) {

--- a/core/src/test/java/apoc/merge/MergeTest.java
+++ b/core/src/test/java/apoc/merge/MergeTest.java
@@ -98,12 +98,13 @@ public class MergeTest {
     @Test
     public void testEscapeIdentityPropertiesWithSpecialCharactersShouldWork() {
         for (String key: new String[]{"normal", "i:d", "i-d", "i d"}) {
-            Map<String, String> identProps = MapUtil.map(key, "value");
+            Map<String, Object> identProps = MapUtil.map(key, "value");
             Map<String, Object> params = MapUtil.map("identProps", identProps);
             
             testCall(db, "CALL apoc.merge.node(['Person'], $identProps) YIELD node RETURN node", params,
                         (row) -> {
-                            assertTrue(row.get("node") instanceof Node);
+                            Node node = (Node) row.get("node");
+                            assertTrue(node instanceof Node);
                             assertTrue(node.hasProperty(key));
                             assertEquals("value", node.getProperty(key));
                         });


### PR DESCRIPTION
Fixes neo4j-contrib/neo4j-apoc-procedures#1783

Removed double escaping of keys in identPropsString

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Removed double escaping of keys in identPropsString (already done once by Util.quote)
  - Created test case