### PR TITLE
Fixes #1657: apoc.schema.assert nodekey throws EquivalentSchemaRuleAlreadyExistsException

### DIFF
--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -116,9 +116,9 @@ public class Schemas {
                 if (item instanceof String) {
                     return item.equals(info.key);
                 } else {
-                    Collections.sort(info.keys);
-                    Collections.sort((List) item);
-                    return info.keys.equals(item);
+                    TreeSet<String> keys = new TreeSet<>(info.keys);
+                    TreeSet<String> items = new TreeSet<>((List<String>) item);
+                    return keys.equals(items);
                 }
             });
         }

--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -85,20 +85,55 @@ public class Schemas {
         Map<String, List<Object>> constraints = copyMapOfObjects(constraints0);
         List<AssertSchemaResult> result = new ArrayList<>(constraints.size());
         Schema schema = tx.schema();
+//        System.out.println("schema.getConstraints()");
+//        System.out.println(constraints + "| constraints");
+//        System.out.println(schema.getConstraints());
 
         for (ConstraintDefinition definition : schema.getConstraints()) {
             String label = definition.isConstraintType(ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE) ? definition.getRelationshipType().name() : definition.getLabel().name();
             AssertSchemaResult info = new AssertSchemaResult(label, Iterables.asList(definition.getPropertyKeys())).unique();
-            if (!constraints.containsKey(label) || !constraints.get(label).remove(info.key)) {
+//            System.out.println("info ! " + info.key);
+//            System.out.println("info ! " + info.keys);
+//            System.out.println("info ! " + info.keys);
+//            System.out.println("label ! " + label);
+//            System.out.println("constraints.get(label) ! " + constraints.get(label));
+//            System.out.println("constraints.get(label) ! " + constraints.get(label));
+//            ArrayList<String> listOne = new ArrayList<>(Arrays.asList("a", "b"));
+
+
+
+//            if (constraints.get(label) != null) {
+//                constraints.get(label).removeIf(item -> {
+//                    if (item instanceof String) {
+//                        return item.equals(info.key);
+//                    } else {
+//                        Collections.sort(info.keys);
+//                        Collections.sort((List) item);
+//                        return info.keys.equals(item);
+//                    }
+//                });
+//            }
+
+
+
+//            if (!constraints.containsKey(label) /*|| !constraints.get(label).remove(info.key)  || !constraints.get(label).remove(info.keys) */) {
+//            if (!constraints.containsKey(label) /*|| !constraints.get(label).remove(info.key)*/) {
+            if (checkConstraint(label, constraints, info) /*|| !constraints.get(label).remove(info.key)*/) {
                 if (dropExisting) {
+                    System.out.println("dropExisting"); // todo - se c'è già la constraint "a mano" fa il dropExisting...
+                    System.out.println(definition);
+                    System.out.println(label);
                     definition.drop();
                     info.dropped();
                 }
             }
             result.add(info);
+            System.out.println("constraints0 = " + constraints0 + ", dropExisting = " + dropExisting);
         }
-
+        System.out.println(constraints + "| constraints 2");
         for (Map.Entry<String, List<Object>> constraint : constraints.entrySet()) {
+            System.out.println("constraints0 = " + constraints0 + ", dropExisting = " + dropExisting);
+            System.out.println(constraint + " - constraint");
             for (Object key : constraint.getValue()) {
                 if (key instanceof String) {
                     result.add(createUniqueConstraint(schema, constraint.getKey(), key.toString()));
@@ -107,10 +142,34 @@ public class Schemas {
                 }
             }
         }
+        System.out.println(result);
         return result;
     }
 
+    private boolean checkConstraint(String label, Map<String, List<Object>> constraints, AssertSchemaResult info) {
+        if (constraints.containsKey(label) ) {
+//            System.out.println("bbb");
+            boolean bbb = !constraints.get(label).removeIf(item -> {
+                if (item instanceof String) {
+                    return item.equals(info.key);
+                } else {
+                    Collections.sort(info.keys);
+                    Collections.sort((List) item);
+                    return info.keys.equals(item);
+                }
+            });
+            System.out.println(bbb);
+            return bbb;
+
+        } else {
+            System.out.println("aaa");
+            return true;
+        }
+//        return true;
+    }
+
     private AssertSchemaResult createNodeKeyConstraint(String lbl, List<Object> keys) {
+        System.out.println("lbl = " + lbl + ", keys = " + keys);
         String keyProperties = keys.stream()
                 .map( property -> String.format("n.`%s`", property))
                 .collect( Collectors.joining( "," ) );
@@ -120,6 +179,7 @@ public class Schemas {
     }
 
     private AssertSchemaResult createUniqueConstraint(Schema schema, String lbl, String key) {
+        System.out.println("schema = " + schema + ", lbl = " + lbl + ", key = " + key);
         schema.constraintFor(label(lbl)).assertPropertyIsUnique(key).create();
         return new AssertSchemaResult(lbl, key).unique().created();
     }

--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -116,9 +116,7 @@ public class Schemas {
                 if (item instanceof String) {
                     return item.equals(info.key);
                 } else {
-                    TreeSet<String> keys = new TreeSet<>(info.keys);
-                    TreeSet<String> items = new TreeSet<>((List<String>) item);
-                    return keys.equals(items);
+                    return info.keys.equals(item);
                 }
             });
         }

--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -89,7 +89,7 @@ public class Schemas {
         for (ConstraintDefinition definition : schema.getConstraints()) {
             String label = definition.isConstraintType(ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE) ? definition.getRelationshipType().name() : definition.getLabel().name();
             AssertSchemaResult info = new AssertSchemaResult(label, Iterables.asList(definition.getPropertyKeys())).unique();
-            if (!checkIfConstraintNotExists(label, constraints, info)) {
+            if (!checkIfConstraintExists(label, constraints, info)) {
                 if (dropExisting) {
                     definition.drop();
                     info.dropped();
@@ -110,7 +110,7 @@ public class Schemas {
         return result;
     }
 
-    private boolean checkIfConstraintNotExists(String label, Map<String, List<Object>> constraints, AssertSchemaResult info) {
+    private boolean checkIfConstraintExists(String label, Map<String, List<Object>> constraints, AssertSchemaResult info) {
         if (constraints.containsKey(label)) {
             return constraints.get(label).removeIf(item -> {
                 // when there is a constraint IS UNIQUE

--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -89,7 +89,7 @@ public class Schemas {
         for (ConstraintDefinition definition : schema.getConstraints()) {
             String label = definition.isConstraintType(ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE) ? definition.getRelationshipType().name() : definition.getLabel().name();
             AssertSchemaResult info = new AssertSchemaResult(label, Iterables.asList(definition.getPropertyKeys())).unique();
-            if (checkIfConstraintNotExists(label, constraints, info)) {
+            if (!checkIfConstraintNotExists(label, constraints, info)) {
                 if (dropExisting) {
                     definition.drop();
                     info.dropped();
@@ -112,15 +112,17 @@ public class Schemas {
 
     private boolean checkIfConstraintNotExists(String label, Map<String, List<Object>> constraints, AssertSchemaResult info) {
         if (constraints.containsKey(label)) {
-            return !constraints.get(label).removeIf(item -> {
+            return constraints.get(label).removeIf(item -> {
+                // when there is a constraint IS UNIQUE
                 if (item instanceof String) {
                     return item.equals(info.key);
+                // when there is a constraint IS NODE KEY
                 } else {
                     return info.keys.equals(item);
                 }
             });
         }
-        return true;
+        return false;
     }
 
     private AssertSchemaResult createNodeKeyConstraint(String lbl, List<Object> keys) {

--- a/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
+++ b/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
@@ -50,6 +50,112 @@ public class SchemasEnterpriseFeaturesTest {
     }
 
     @Test
+    public void testDropNodeKeyConstraintAndCreateNodeKeyConstraintWhenUsingDropExisting12() {
+        testResult(session, "CALL apoc.schema.assert(null,{Foo:['bar']}, false)", (result) -> {
+            Map<String, Object> r = result.next();
+//            assertEquals("Foo", r.get("label"));
+//            assertEquals(expectedKeys("bar","foo"), r.get("keys"));
+//            assertEquals(true, r.get("unique"));
+//            assertEquals("DROPPED", r.get("action"));
+//
+//            r = result.next();
+            assertEquals("Foo", r.get("label"));
+//            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
+//            assertEquals(true, r.get("unique"));
+//            assertEquals("CREATED", r.get("action"));
+        });
+
+        testResult(session, "CALL apoc.schema.assert(null,{Foo:['bar']}, false)", (result) -> {
+            Map<String, Object> r = result.next();
+//            assertEquals("Foo", r.get("label"));
+//            assertEquals(expectedKeys("bar","foo"), r.get("keys"));
+//            assertEquals(true, r.get("unique"));
+//            assertEquals("DROPPED", r.get("action"));
+//
+//            r = result.next();
+//            assertEquals("Foo", r.get("label"));
+//            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
+//            assertEquals(true, r.get("unique"));
+//            assertEquals("CREATED", r.get("action"));
+
+            assertNotNull(r);
+        });
+
+        testResult(session, "CALL apoc.schema.assert(null,{Foo:['bar']}, false)", (result) -> {
+            Map<String, Object> r = result.next();
+//            assertEquals("Foo", r.get("label"));
+//            assertEquals(expectedKeys("bar","foo"), r.get("keys"));
+//            assertEquals(true, r.get("unique"));
+//            assertEquals("DROPPED", r.get("action"));
+//
+//            r = result.next();
+//            assertEquals("Foo", r.get("label"));
+//            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
+//            assertEquals(true, r.get("unique"));
+//            assertEquals("CREATED", r.get("action"));
+
+            assertNotNull(r);
+        });
+
+        session.readTransaction(tx -> {
+            List<Record> result = tx.run("CALL db.constraints").list();
+            assertEquals(1, result.size());
+            tx.commit();
+            return null;
+        });
+
+//        session.writeTransaction(tx -> {
+//            tx.run("DROP CONSTRAINT ON (f:Foo) ASSERT (f.bar,f.foo) IS NODE KEY").list();
+//            tx.commit();
+//            return null;
+//        });
+    }
+
+    @Test
+    public void testDropNodeKeyConstraintAndCreateNodeKeyConstraintWhenUsingDropExisting1() {
+        testResult(session, "CALL apoc.schema.assert(null,{Foo:[['foo','bar']]}, false)", (result) -> {
+            Map<String, Object> r = result.next();
+//            assertEquals("Foo", r.get("label"));
+//            assertEquals(expectedKeys("bar","foo"), r.get("keys"));
+//            assertEquals(true, r.get("unique"));
+//            assertEquals("DROPPED", r.get("action"));
+//
+//            r = result.next();
+//            assertEquals("Foo", r.get("label"));
+//            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
+//            assertEquals(true, r.get("unique"));
+//            assertEquals("CREATED", r.get("action"));
+        });
+
+        testResult(session, "CALL apoc.schema.assert(null,{Foo:[['foo','bar']]}, false)", (result) -> {
+            Map<String, Object> r = result.next();
+//            assertEquals("Foo", r.get("label"));
+//            assertEquals(expectedKeys("bar","foo"), r.get("keys"));
+//            assertEquals(true, r.get("unique"));
+//            assertEquals("DROPPED", r.get("action"));
+//
+//            r = result.next();
+//            assertEquals("Foo", r.get("label"));
+//            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
+//            assertEquals(true, r.get("unique"));
+//            assertEquals("CREATED", r.get("action"));
+        });
+
+        session.readTransaction(tx -> {
+            List<Record> result = tx.run("CALL db.constraints").list();
+            assertEquals(1, result.size());
+            tx.commit();
+            return null;
+        });
+
+//        session.writeTransaction(tx -> {
+//            tx.run("DROP CONSTRAINT ON (f:Foo) ASSERT (f.bar,f.foo) IS NODE KEY").list();
+//            tx.commit();
+//            return null;
+//        });
+    }
+
+    @Test
     public void testDropNodeKeyConstraintAndCreateNodeKeyConstraintWhenUsingDropExisting() {
         session.writeTransaction(tx -> {
             tx.run("CREATE CONSTRAINT ON (f:Foo) ASSERT (f.bar,f.foo) IS NODE KEY");
@@ -61,13 +167,13 @@ public class SchemasEnterpriseFeaturesTest {
             assertEquals("Foo", r.get("label"));
             assertEquals(expectedKeys("bar","foo"), r.get("keys"));
             assertEquals(true, r.get("unique"));
-            assertEquals("DROPPED", r.get("action"));
+            assertEquals("KEPT", r.get("action"));
 
-            r = result.next();
-            assertEquals("Foo", r.get("label"));
-            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
-            assertEquals(true, r.get("unique"));
-            assertEquals("CREATED", r.get("action"));
+//            r = result.next();
+//            assertEquals("Foo", r.get("label"));
+//            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
+//            assertEquals(true, r.get("unique"));
+//            assertEquals("CREATED", r.get("action"));
         });
 
         session.readTransaction(tx -> {

--- a/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
+++ b/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
@@ -50,7 +50,7 @@ public class SchemasEnterpriseFeaturesTest {
     }
 
     @Test
-    public void testDropNodeKeyConstraintAndCreateNodeKeyConstraintWhenUsingDropExisting1() {
+    public void testKeptNodeKeyAndUniqueConstraintIfExistsAndDropExistingIsFalse() {
 
         String query = "CALL apoc.schema.assert(null,{Foo:[['foo','bar']]}, false)";
         testResult(session, query, (result) -> {

--- a/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
+++ b/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
@@ -65,7 +65,7 @@ public class SchemasEnterpriseFeaturesTest {
         testResult(session, query, (result) -> {
             Map<String, Object> r = result.next();
             assertEquals("Foo", r.get("label"));
-            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
+            assertEquals(expectedKeys("foo", "bar"), r.get("keys"));
             assertEquals(true, r.get("unique"));
             assertEquals("KEPT", r.get("action"));
             assertFalse(result.hasNext());
@@ -81,7 +81,7 @@ public class SchemasEnterpriseFeaturesTest {
         testResult(session, "CALL apoc.schema.assert(null,{Foo:[['bar','foo'], 'baz'], Galileo: [['newton', 'tesla']]}, false)", (result) -> {
             Map<String, Object> r = result.next();
             assertEquals("Foo", r.get("label"));
-            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
+            assertEquals(expectedKeys("foo", "bar"), r.get("keys"));
             assertEquals(true, r.get("unique"));
             assertEquals("KEPT", r.get("action"));
             r = result.next();

--- a/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
+++ b/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
@@ -50,95 +50,25 @@ public class SchemasEnterpriseFeaturesTest {
     }
 
     @Test
-    public void testDropNodeKeyConstraintAndCreateNodeKeyConstraintWhenUsingDropExisting12() {
-        testResult(session, "CALL apoc.schema.assert(null,{Foo:['bar']}, false)", (result) -> {
-            Map<String, Object> r = result.next();
-//            assertEquals("Foo", r.get("label"));
-//            assertEquals(expectedKeys("bar","foo"), r.get("keys"));
-//            assertEquals(true, r.get("unique"));
-//            assertEquals("DROPPED", r.get("action"));
-//
-//            r = result.next();
-            assertEquals("Foo", r.get("label"));
-//            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
-//            assertEquals(true, r.get("unique"));
-//            assertEquals("CREATED", r.get("action"));
-        });
-
-        testResult(session, "CALL apoc.schema.assert(null,{Foo:['bar']}, false)", (result) -> {
-            Map<String, Object> r = result.next();
-//            assertEquals("Foo", r.get("label"));
-//            assertEquals(expectedKeys("bar","foo"), r.get("keys"));
-//            assertEquals(true, r.get("unique"));
-//            assertEquals("DROPPED", r.get("action"));
-//
-//            r = result.next();
-//            assertEquals("Foo", r.get("label"));
-//            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
-//            assertEquals(true, r.get("unique"));
-//            assertEquals("CREATED", r.get("action"));
-
-            assertNotNull(r);
-        });
-
-        testResult(session, "CALL apoc.schema.assert(null,{Foo:['bar']}, false)", (result) -> {
-            Map<String, Object> r = result.next();
-//            assertEquals("Foo", r.get("label"));
-//            assertEquals(expectedKeys("bar","foo"), r.get("keys"));
-//            assertEquals(true, r.get("unique"));
-//            assertEquals("DROPPED", r.get("action"));
-//
-//            r = result.next();
-//            assertEquals("Foo", r.get("label"));
-//            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
-//            assertEquals(true, r.get("unique"));
-//            assertEquals("CREATED", r.get("action"));
-
-            assertNotNull(r);
-        });
-
-        session.readTransaction(tx -> {
-            List<Record> result = tx.run("CALL db.constraints").list();
-            assertEquals(1, result.size());
-            tx.commit();
-            return null;
-        });
-
-//        session.writeTransaction(tx -> {
-//            tx.run("DROP CONSTRAINT ON (f:Foo) ASSERT (f.bar,f.foo) IS NODE KEY").list();
-//            tx.commit();
-//            return null;
-//        });
-    }
-
-    @Test
     public void testDropNodeKeyConstraintAndCreateNodeKeyConstraintWhenUsingDropExisting1() {
-        testResult(session, "CALL apoc.schema.assert(null,{Foo:[['foo','bar']]}, false)", (result) -> {
+
+        String query = "CALL apoc.schema.assert(null,{Foo:[['foo','bar']]}, false)";
+        testResult(session, query, (result) -> {
             Map<String, Object> r = result.next();
-//            assertEquals("Foo", r.get("label"));
-//            assertEquals(expectedKeys("bar","foo"), r.get("keys"));
-//            assertEquals(true, r.get("unique"));
-//            assertEquals("DROPPED", r.get("action"));
-//
-//            r = result.next();
-//            assertEquals("Foo", r.get("label"));
-//            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
-//            assertEquals(true, r.get("unique"));
-//            assertEquals("CREATED", r.get("action"));
+            assertEquals("Foo", r.get("label"));
+            assertEquals(expectedKeys("foo", "bar"), r.get("keys"));
+            assertEquals(true, r.get("unique"));
+            assertEquals("CREATED", r.get("action"));
+            assertFalse(result.hasNext());
         });
 
-        testResult(session, "CALL apoc.schema.assert(null,{Foo:[['foo','bar']]}, false)", (result) -> {
+        testResult(session, query, (result) -> {
             Map<String, Object> r = result.next();
-//            assertEquals("Foo", r.get("label"));
-//            assertEquals(expectedKeys("bar","foo"), r.get("keys"));
-//            assertEquals(true, r.get("unique"));
-//            assertEquals("DROPPED", r.get("action"));
-//
-//            r = result.next();
-//            assertEquals("Foo", r.get("label"));
-//            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
-//            assertEquals(true, r.get("unique"));
-//            assertEquals("CREATED", r.get("action"));
+            assertEquals("Foo", r.get("label"));
+            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
+            assertEquals(true, r.get("unique"));
+            assertEquals("KEPT", r.get("action"));
+            assertFalse(result.hasNext());
         });
 
         session.readTransaction(tx -> {
@@ -148,15 +78,43 @@ public class SchemasEnterpriseFeaturesTest {
             return null;
         });
 
-//        session.writeTransaction(tx -> {
-//            tx.run("DROP CONSTRAINT ON (f:Foo) ASSERT (f.bar,f.foo) IS NODE KEY").list();
-//            tx.commit();
-//            return null;
-//        });
+        testResult(session, "CALL apoc.schema.assert(null,{Foo:[['bar','foo'], 'baz'], Galileo: [['newton', 'tesla']]}, false)", (result) -> {
+            Map<String, Object> r = result.next();
+            assertEquals("Foo", r.get("label"));
+            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
+            assertEquals(true, r.get("unique"));
+            assertEquals("KEPT", r.get("action"));
+            r = result.next();
+            assertEquals("Galileo", r.get("label"));
+            assertEquals(expectedKeys("newton", "tesla"), r.get("keys"));
+            assertEquals(true, r.get("unique"));
+            assertEquals("CREATED", r.get("action"));
+            r = result.next();
+            assertEquals("Foo", r.get("label"));
+            assertEquals("baz", r.get("key"));
+            assertEquals(true, r.get("unique"));
+            assertEquals("CREATED", r.get("action"));
+            assertFalse(result.hasNext());
+        });
+
+        session.readTransaction(tx -> {
+            List<Record> result = tx.run("CALL db.constraints").list();
+            assertEquals(3, result.size());
+            tx.commit();
+            return null;
+        });
+
+        session.writeTransaction(tx -> {
+            tx.run("DROP CONSTRAINT ON (f:Foo) ASSERT (f.foo,f.bar) IS NODE KEY");
+            tx.run("DROP CONSTRAINT ON (f:Galileo) ASSERT (f.newton,f.tesla) IS NODE KEY");
+            tx.run("DROP CONSTRAINT ON (f:Foo) ASSERT (f.baz) IS UNIQUE");
+            tx.commit();
+            return null;
+        });
     }
 
     @Test
-    public void testDropNodeKeyConstraintAndCreateNodeKeyConstraintWhenUsingDropExisting() {
+    public void testDropNodeKeyConstraintAndCreateNodeKeyConstraintWhenUsingDropExistingOnlyIfNotExist() {
         session.writeTransaction(tx -> {
             tx.run("CREATE CONSTRAINT ON (f:Foo) ASSERT (f.bar,f.foo) IS NODE KEY");
             tx.commit();
@@ -168,12 +126,22 @@ public class SchemasEnterpriseFeaturesTest {
             assertEquals(expectedKeys("bar","foo"), r.get("keys"));
             assertEquals(true, r.get("unique"));
             assertEquals("KEPT", r.get("action"));
+        });
 
-//            r = result.next();
-//            assertEquals("Foo", r.get("label"));
-//            assertEquals(expectedKeys("bar", "foo"), r.get("keys"));
-//            assertEquals(true, r.get("unique"));
-//            assertEquals("CREATED", r.get("action"));
+        testResult(session, "CALL apoc.schema.assert(null,{Foo:[['baa','baz']]})", (result) -> {
+            Map<String, Object> r = result.next();
+            assertEquals("Foo", r.get("label"));
+            assertEquals(expectedKeys("bar","foo"), r.get("keys"));
+            assertEquals(true, r.get("unique"));
+            assertEquals("DROPPED", r.get("action"));
+
+            r = result.next();
+            assertEquals("Foo", r.get("label"));
+            assertEquals(expectedKeys("baa", "baz"), r.get("keys"));
+            assertEquals(true, r.get("unique"));
+            assertEquals("CREATED", r.get("action"));
+
+            assertFalse(result.hasNext());
         });
 
         session.readTransaction(tx -> {
@@ -184,7 +152,7 @@ public class SchemasEnterpriseFeaturesTest {
         });
 
         session.writeTransaction(tx -> {
-            tx.run("DROP CONSTRAINT ON (f:Foo) ASSERT (f.bar,f.foo) IS NODE KEY").list();
+            tx.run("DROP CONSTRAINT ON (f:Foo) ASSERT (f.baa,f.baz) IS NODE KEY").list();
             tx.commit();
             return null;
         });


### PR DESCRIPTION
Fixes #1657

One sentence summary of the change.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added method `checkIfConstraintNotExists` in `Schemas.java` to remove/kept/create a node key constraint, like unique constraints
