### PR TITLE
Fixes #1803: `apoc.import.csv` Caused by: java.util.NoSuchElementException: No value present

### DIFF
--- a/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
+++ b/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
@@ -9,6 +9,7 @@ import apoc.load.util.Results;
 import apoc.util.FileUtils;
 import com.opencsv.CSVReader;
 import org.neo4j.graphdb.*;
+import org.neo4j.logging.Log;
 
 import java.io.IOException;
 import java.util.*;
@@ -19,14 +20,16 @@ public class CsvEntityLoader {
 
     private final CsvLoaderConfig clc;
     private final ProgressReporter reporter;
+    private final Log log;
 
     /**
      * @param clc configuration object
      * @param reporter
      */
-    public CsvEntityLoader(CsvLoaderConfig clc, ProgressReporter reporter) {
+    public CsvEntityLoader(CsvLoaderConfig clc, ProgressReporter reporter, Log log) {
         this.clc = clc;
         this.reporter = reporter;
+        this.log = log;
     }
 
     /**
@@ -50,6 +53,10 @@ public class CsvEntityLoader {
         final Optional<CsvHeaderField> idField = fields.stream()
                 .filter(f -> CsvLoaderConstants.ID_FIELD.equals(f.getType()))
                 .findFirst();
+
+        if (!idField.isPresent()) {
+            log.warn("Please note that if no ID is specified, the node will be imported but it will not be able to be connected by any relationships during the import");
+        }
 
         final Optional<String> idAttribute = idField.isPresent() ? Optional.of(idField.get().getName()) : Optional.empty();
         final String idSpace = idField.isPresent() ? idField.get().getIdSpace() : CsvLoaderConstants.DEFAULT_IDSPACE;
@@ -84,7 +91,7 @@ public class CsvEntityLoader {
                         loadCsvCompatibleHeader, line, lineNo, false, mapping, Collections.emptyList(), results
                 );
 
-                final String nodeCsvId = idField.isPresent() ? result.map.get(idAttribute.get()).toString() : null;
+                final String nodeCsvId = (String) idAttribute.map(result.map::get).orElse(null);
 
                 // if 'ignore duplicate nodes' is false, there is an id field and the mapping already has the current id,
                 // we either fail the loading process or skip it depending on the 'ignore duplicate nodes' setting

--- a/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
+++ b/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
@@ -84,7 +84,7 @@ public class CsvEntityLoader {
                         loadCsvCompatibleHeader, line, lineNo, false, mapping, Collections.emptyList(), results
                 );
 
-                final String nodeCsvId = result.map.get(idAttribute.get()).toString();
+                final String nodeCsvId = idField.isPresent() ? result.map.get(idAttribute.get()).toString() : null;
 
                 // if 'ignore duplicate nodes' is false, there is an id field and the mapping already has the current id,
                 // we either fail the loading process or skip it depending on the 'ignore duplicate nodes' setting

--- a/core/src/main/java/apoc/export/csv/ImportCsv.java
+++ b/core/src/main/java/apoc/export/csv/ImportCsv.java
@@ -5,6 +5,7 @@ import apoc.export.util.ProgressReporter;
 import apoc.result.ProgressInfo;
 import apoc.util.Util;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.logging.Log;
 import org.neo4j.procedure.*;
 
 import java.util.HashMap;
@@ -18,6 +19,9 @@ public class ImportCsv {
 
     @Context
     public Pools pools;
+
+    @Context
+    public Log log;
 
     public ImportCsv(GraphDatabaseService db) {
         this.db = db;
@@ -38,7 +42,7 @@ public class ImportCsv {
                     final ProgressReporter reporter = new ProgressReporter(null, null, new ProgressInfo("progress.csv", "file", "csv"));
 
                     final CsvLoaderConfig clc = CsvLoaderConfig.from(config);
-                    final CsvEntityLoader loader = new CsvEntityLoader(clc, reporter);
+                    final CsvEntityLoader loader = new CsvEntityLoader(clc, reporter, log);
 
                     final Map<String, Map<String, Long>> idMapping = new HashMap<>();
                     for (Map<String, Object> node : nodes) {

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -264,7 +264,7 @@ public class ImportCsvTest {
         );
 
         List<String> names = TestUtil.firstColumn(db, "MATCH (n:Person) RETURN n.name AS name ORDER BY name");
-        assertThat(names, Matchers.containsInAnyOrder("Jane", "John"));
+        assertEquals(List.of("Jane", "John"), names);
     }
 
     @Test

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -96,7 +96,10 @@ public class ImportCsvTest {
                             "2|1||2016\n"),
                     new AbstractMap.SimpleEntry<>("typeless", ":ID|name\n" +
                             "1|John\n" +
-                            "2|Jane\n")
+                            "2|Jane\n"),
+                    new AbstractMap.SimpleEntry<>("personsWithoutIdField", "name:STRING\n" +
+                            "John\n" +
+                            "Jane\n")
             ).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
 
     @Before
@@ -233,7 +236,26 @@ public class ImportCsvTest {
                 "CALL apoc.import.csv([{fileName: $file, labels: ['Person']}], [], $config)",
                 map(
                         "file", "file:/typeless.csv",
-                        "config", map("delimiter", '|')
+                        "config", map("delimiter", '|', "ignoreDuplicateNodes", true)
+                ),
+                (r) -> {
+                    assertEquals(2L, r.get("nodes"));
+                    assertEquals(0L, r.get("relationships"));
+                }
+        );
+
+        List<String> names = TestUtil.firstColumn(db, "MATCH (n:Person) RETURN n.name AS name ORDER BY name");
+        assertThat(names, Matchers.containsInAnyOrder("Jane", "John"));
+    }
+
+    @Test
+    public void testCsvWithoutIdField() {
+        TestUtil.testCall(
+                db,
+                "CALL apoc.import.csv([{fileName: $file, labels: ['Person']}], [], $config)",
+                map(
+                        "file", "file:/personsWithoutIdField.csv",
+                        "config", map()
                 ),
                 (r) -> {
                     assertEquals(2L, r.get("nodes"));

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -236,7 +236,7 @@ public class ImportCsvTest {
                 "CALL apoc.import.csv([{fileName: $file, labels: ['Person']}], [], $config)",
                 map(
                         "file", "file:/typeless.csv",
-                        "config", map("delimiter", '|', "ignoreDuplicateNodes", true)
+                        "config", map("delimiter", '|')
                 ),
                 (r) -> {
                     assertEquals(2L, r.get("nodes"));


### PR DESCRIPTION
Fixes #1803

A brief list of proposed changes in order to fix the issue:

  - improved `nodeCsvId` assignment when `idField` is not present
  - added `log.warn()` if `idField` is not present

