### PR TITLE
Fixes #1793: apoc.load.html procedure fail silently

### DIFF
--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.load.html.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.load.html.adoc
@@ -143,3 +143,85 @@ a|
 }
 ----
 |===
+
+Let's suppose we have a `test.html` file like this:
+[source,html]
+----
+<!DOCTYPE html>
+<html class="client-nojs" lang="en" dir="ltr">
+  <h6 i d="error">test</h6>
+  <h6 id="correct">test</h6>
+</html>
+----
+
+We can handle the parse error caused by `i d` through `failSilently` configuration.
+So, we can execute:
+
+[source,cypher]
+----
+CALL apoc.load.html("test.html",{h6:"h6"});
+----
+.Results
+[opts="header"]
+|===
+| Failed to invoke procedure `apoc.load.html`: Caused by: java.lang.RuntimeException: Error during parsing element: <h6 i d="error">test</h6>
+|===
+
+or with failSilently `WITH_LIST`:
+
+[source,cypher]
+----
+CALL apoc.load.html("test.html",{h6:"h6"}, {failSilently: 'WITH_LIST'});
+----
+
+.Results
+[opts="header"]
+|===
+| Output
+a|
+[source,json]
+----
+{
+  "errorList": [
+    "<h6 i d="error">test</h6>"
+  ],
+  "h6": [
+    {
+      "attributes": {
+        "id": "correct"
+      },
+      "text": "test",
+      "tagName": "h6"
+    }
+  ]
+}
+----
+|===
+
+or with failSilently `WITH_LOG` (note that will be created a `log.warn("Error during parsing element: <h6 i d="error">test</h6>")` ):
+
+[source,cypher]
+----
+CALL apoc.load.html("test.html",{h6:"h6"}, {failSilently: 'WITH_LOG'});
+----
+
+.Results
+[opts="header"]
+|===
+| Output
+a|
+[source,json]
+----
+{
+  "h6": [
+    {
+      "attributes": {
+        "id": "correct"
+      },
+      "text": "test",
+      "tagName": "h6"
+    }
+  ]
+}
+----
+|===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.html.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.html.adoc
@@ -6,5 +6,5 @@ The procedure support the following config parameters:
 | name | type | default | description
 | charset | String | "UTF-8" | the character set of the page being scraped
 | baseUri | String | "" | Base URI used to resolve relative paths
-| failSilently | boolean | false | Return the list of the values, except for values not correctly parsed
+| failSilently | boolean | false | Returns the list of the values, except for values not correctly parsed
 |===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.html.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.html.adoc
@@ -6,5 +6,5 @@ The procedure support the following config parameters:
 | name | type | default | description
 | charset | String | "UTF-8" | the character set of the page being scraped
 | baseUri | String | "" | Base URI used to resolve relative paths
-| failSilently | boolean | false | Return an empty list if a value to return doesn't parse correctly, for example `"a": []`
+| failSilently | boolean | false | Return the list of the values, except for values not correctly parsed
 |===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.html.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.html.adoc
@@ -6,5 +6,5 @@ The procedure support the following config parameters:
 | name | type | default | description
 | charset | String | "UTF-8" | the character set of the page being scraped
 | baseUri | String | "" | Base URI used to resolve relative paths
-| failSilently | boolean | false | Return an empty map if a value to return doesn't parse correctly, for example `"a": {}`
+| failSilently | boolean | false | Return an empty list if a value to return doesn't parse correctly, for example `"a": []`
 |===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.html.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.html.adoc
@@ -6,4 +6,5 @@ The procedure support the following config parameters:
 | name | type | default | description
 | charset | String | "UTF-8" | the character set of the page being scraped
 | baseUri | String | "" | Base URI used to resolve relative paths
+| failSilently | boolean | false | Return an empty map if a value to return doesn't parse correctly, for example `"a": {}`
 |===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.html.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.html.adoc
@@ -6,5 +6,5 @@ The procedure support the following config parameters:
 | name | type | default | description
 | charset | String | "UTF-8" | the character set of the page being scraped
 | baseUri | String | "" | Base URI used to resolve relative paths
-| failSilently | boolean | false | Returns the list of the values, except for values not correctly parsed
+| failSilently | Enum [FALSE, WITH_LOG, WITH_LIST] | FALSE | If the parse fails with one or more elements, using `FALSE` it throws a `RuntimeException`, using `WITH_LOG` a `log.warn` is created for each incorrect item and using `WITH_LIST` an `errorList` key is added to the result with the failed tags.
 |===

--- a/full/src/main/java/apoc/load/LoadHtml.java
+++ b/full/src/main/java/apoc/load/LoadHtml.java
@@ -15,6 +15,8 @@ import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -44,14 +46,19 @@ public class LoadHtml {
 
             Map<String, Object> output = new HashMap<>();
 
-            query.keySet().stream().forEach(key -> {
-                Elements elements = document.select(query.get(key));
+            query.keySet().forEach(key -> {
+                try {
+                    Elements elements = document.select(query.get(key));
 
-                output.put(key, getElements(elements, config));
+                    output.put(key, getElements(elements, config));
+
+                } catch (Exception e) {
+                    output.put(key, Collections.emptyMap());
+                }
             });
 
-            return Stream.of( new MapResult(output) );
-        } catch(Exception e){
+            return Stream.of(new MapResult(output));
+        } catch(Exception e) {
             throw new RuntimeException("Can't read the HTML from: "+ url);
         }
     }

--- a/full/src/main/java/apoc/load/LoadHtml.java
+++ b/full/src/main/java/apoc/load/LoadHtml.java
@@ -49,8 +49,7 @@ public class LoadHtml {
 
             query.keySet().forEach(key -> {
                         Elements elements = document.select(query.get(key));
-                        List<Map<String, Object>> elementsParsed = getElements(elements, config);
-                        output.put(key, elementsParsed == null ? Collections.emptyMap() : elementsParsed);
+                        output.put(key, getElements(elements, config));
             });
 
             return Stream.of(new MapResult(output) );
@@ -86,10 +85,11 @@ public class LoadHtml {
 
                     elementList.add(result);
             } catch (Exception e) {
+                final String parseError = "Error during parsing element: " + element;
                 if (failSilently) {
-                    return null;
+                    log.warn(parseError);
                 } else {
-                    throw new RuntimeException("Error during parsing element: " + element);
+                    throw new RuntimeException(parseError);
                 }
             }
         }

--- a/full/src/main/java/apoc/load/LoadHtml.java
+++ b/full/src/main/java/apoc/load/LoadHtml.java
@@ -15,8 +15,6 @@ import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -57,7 +55,7 @@ public class LoadHtml {
                 }
             });
 
-            return Stream.of(new MapResult(output));
+            return Stream.of( new MapResult(output) );
         } catch(Exception e) {
             throw new RuntimeException("Can't read the HTML from: "+ url);
         }

--- a/full/src/test/java/apoc/load/LoadHtmlTest.java
+++ b/full/src/test/java/apoc/load/LoadHtmlTest.java
@@ -43,9 +43,6 @@ public class LoadHtmlTest {
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
 
-//    @Rule
-//    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Before
     public void setup() {
         TestUtil.registerProcedure(db, LoadHtml.class);
@@ -133,7 +130,7 @@ public class LoadHtmlTest {
 
     @Test
     public void testQueryWithFailsSilently() {
-        Map<String, Object> query = map("a", "a", "h2", "h2");
+        Map<String, Object> query = map("h2", "h2","a", "a");
 
         testResult(db, "CALL apoc.load.html($url,$query, {failSilently: true})",
                 map("url", new File("src/test/resources/wikipedia.html").toURI().toString(), "query", query),

--- a/full/src/test/resources/wikipedia.html
+++ b/full/src/test/resources/wikipedia.html
@@ -205,6 +205,9 @@ Transclusion expansion time report (%,ms,calls,template)
 		</div>
 			<div class="portal" role="navigation" id="p-lang" aria-labelledby="p-lang-label">
 			<h3 id="p-lang-label">Languages</h3>
+			<h6 i d="error">test</h6>
+			<h6 id="correct">test</h6>
+			<h6 id="childIncorrect">incorrect<span i d="incorrect">test</span></h6>
 			<div class="body">
 								<ul>
 									</ul>


### PR DESCRIPTION
Fixes #1793

A brief list of proposed changes in order to fix the issue:

  - added `failsSilently: true/false` config (default `false`). With `true`, will be returned the list of the values, except for values not correctly parsed. In case of errors, will be printed a `log.warn`
  - improved the error returned, with `UnsupportedEncodingException`, `FileNotFoundException` and, in case of incorrect parse, with a message containing the incorrect tag 


