### PR TITLE
Provide update statistics for apoc.periodic.iterate (issue #1815)

### DIFF
--- a/core/src/main/java/apoc/periodic/BatchAndTotalResult.java
+++ b/core/src/main/java/apoc/periodic/BatchAndTotalResult.java
@@ -18,10 +18,12 @@ public class BatchAndTotalResult {
     public final Map<String,Object> operations;
     public final boolean wasTerminated;
     public final Map<String, List<Map<String,Object>>> failedParams;
+    public final Map<String, Long> updateStatistics;
 
     public BatchAndTotalResult(long batches, long total, long timeTaken, long committedOperations,
                                long failedOperations, long failedBatches, long retries,
-                               Map<String, Long> operationErrors, Map<String, Long> batchErrors, boolean wasTerminated, Map<String, List<Map<String, Object>>> failedParams) {
+                               Map<String, Long> operationErrors, Map<String, Long> batchErrors, boolean wasTerminated,
+                               Map<String, List<Map<String, Object>>> failedParams, Map<String, Long> updateStatistics) {
         this.batches = batches;
         this.total = total;
         this.timeTaken = timeTaken;
@@ -34,6 +36,7 @@ public class BatchAndTotalResult {
         this.failedParams = failedParams;
         this.batch = Util.map("total",batches,"failed",failedBatches,"committed",batches-failedBatches,"errors",batchErrors);
         this.operations = Util.map("total",total,"failed",failedOperations,"committed", committedOperations,"errors",operationErrors);
+        this.updateStatistics = updateStatistics;
     }
 
     public LoopingBatchAndTotalResult inLoop(Object loop) {

--- a/core/src/main/java/apoc/periodic/Periodic.java
+++ b/core/src/main/java/apoc/periodic/Periodic.java
@@ -22,7 +22,6 @@ import java.util.function.Function;
 import java.util.function.ToLongFunction;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static apoc.util.Util.merge;
@@ -227,14 +226,20 @@ public class Periodic {
         validateQuery(cypherIterate);
 
         long batchSize = Util.toLong(config.getOrDefault("batchSize", 10000));
+        if (batchSize < 1) {
+            throw new IllegalArgumentException("batchSize parameter must be > 0");
+        }
         int concurrency = Util.toInteger(config.getOrDefault("concurrency", 50));
+        if (concurrency < 1) {
+            throw new IllegalArgumentException("concurrency parameter must be > 0");
+        }
         boolean parallel = Util.toBoolean(config.getOrDefault("parallel", false));
+        long retries = Util.toLong(config.getOrDefault("retries", 0)); // todo sleep/delay or push to end of batch to try again or immediate ?
+        int failedParams = Util.toInteger(config.getOrDefault("failedParams", -1));
 
         BatchMode batchMode = BatchMode.fromConfig(config);
-
-        long retries = Util.toLong(config.getOrDefault("retries", 0)); // todo sleep/delay or push to end of batch to try again or immediate ?
         Map<String,Object> params = (Map<String, Object>) config.getOrDefault("params", Collections.emptyMap());
-        int failedParams = Util.toInteger(config.getOrDefault("failedParams", -1));
+
         try (Result result = tx.execute(slottedRuntime(cypherIterate),params)) {
             Pair<String,Boolean> prepared = PeriodicUtils.prepareInnerStatement(cypherAction, batchMode, result.columns(), "_batch");
             String innerStatement = prepared.first();

--- a/core/src/main/java/apoc/periodic/PeriodicUtils.java
+++ b/core/src/main/java/apoc/periodic/PeriodicUtils.java
@@ -3,6 +3,7 @@ package apoc.periodic;
 import apoc.Pools;
 import apoc.util.Util;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.QueryStatistics;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.helpers.collection.Pair;
 import org.neo4j.logging.Log;
@@ -17,6 +18,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
 import java.util.function.ToLongFunction;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -56,7 +58,7 @@ public class PeriodicUtils {
     public static Stream<BatchAndTotalResult> iterateAndExecuteBatchedInSeparateThread(
             GraphDatabaseService db, TerminationGuard terminationGuard, Log log, Pools pools,
             int batchsize, boolean parallel, boolean iterateList, long retries,
-            Iterator<Map<String, Object>> iterator, BiConsumer<Transaction, Map<String, Object>> consumer,
+            Iterator<Map<String, Object>> iterator, BiFunction<Transaction, Map<String, Object>, QueryStatistics> consumer,
             int concurrency, int failedParams) {
 
         ExecutorService pool = parallel ? pools.getDefaultExecutorService() : pools.getSingleExecutorService();

--- a/core/src/main/java/apoc/periodic/PeriodicUtils.java
+++ b/core/src/main/java/apoc/periodic/PeriodicUtils.java
@@ -1,12 +1,26 @@
 package apoc.periodic;
 
+import apoc.Pools;
 import apoc.util.Util;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.helpers.collection.Pair;
+import org.neo4j.logging.Log;
+import org.neo4j.procedure.TerminationGuard;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+import java.util.function.BiConsumer;
+import java.util.function.ToLongFunction;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class PeriodicUtils {
 
@@ -37,6 +51,63 @@ public class PeriodicUtils {
     
     public static Pattern regNoCaseMultiLine(String pattern) {
         return Pattern.compile(pattern,Pattern.CASE_INSENSITIVE|Pattern.MULTILINE|Pattern.DOTALL);
+    }
+
+    public static Stream<BatchAndTotalResult> iterateAndExecuteBatchedInSeparateThread(
+            GraphDatabaseService db, TerminationGuard terminationGuard, Log log, Pools pools,
+            int batchsize, boolean parallel, boolean iterateList, long retries,
+            Iterator<Map<String, Object>> iterator, BiConsumer<Transaction, Map<String, Object>> consumer,
+            int concurrency, int failedParams) {
+
+        ExecutorService pool = parallel ? pools.getDefaultExecutorService() : pools.getSingleExecutorService();
+        List<Future<Long>> futures = new ArrayList<>(concurrency);
+        BatchAndTotalCollector collector = new BatchAndTotalCollector(terminationGuard, failedParams);
+        AtomicInteger activeFutures = new AtomicInteger(0);
+
+        do {
+            if (Util.transactionIsTerminated(terminationGuard)) break;
+
+            if (activeFutures.get() < concurrency || !parallel) {
+                // we have capacity, add a new Future to the list
+                activeFutures.incrementAndGet();
+
+                if (log.isDebugEnabled()) log.debug("execute in batch no %d batch size ", batchsize);
+                List<Map<String,Object>> batch = Util.take(iterator, batchsize);
+                final long currentBatchSize = batch.size();
+                Periodic.ExecuteBatch executeBatch =
+                        iterateList ?
+                                new Periodic.ListExecuteBatch(terminationGuard, collector, batch, consumer) :
+                                new Periodic.OneByOneExecuteBatch(terminationGuard, collector, batch, consumer);
+
+                futures.add(Util.inTxFuture(log,
+                        pool,
+                        db,
+                        executeBatch,
+                        retries,
+                        retryCount -> collector.incrementRetried(),
+                        onComplete -> {
+                            collector.incrementBatches();
+                            executeBatch.release();
+                            activeFutures.decrementAndGet();
+                        }));
+                collector.incrementCount(currentBatchSize);
+            } else {
+                // we can't block until the counter decrease as we might miss a cancellation, so
+                // let this thread be preempted for a bit before we check for cancellation or
+                // capacity.
+                LockSupport.parkNanos(1000);
+            }
+        } while (iterator.hasNext());
+
+        boolean wasTerminated = Util.transactionIsTerminated(terminationGuard);
+        ToLongFunction<Future<Long>> toLongFunction = wasTerminated ?
+                f -> Util.getFutureOrCancel(f, collector.getBatchErrors(), collector.getFailedBatches(), 0L) :
+                f -> Util.getFuture(f, collector.getBatchErrors(), collector.getFailedBatches(), 0L);
+        collector.incrementSuccesses(futures.stream().mapToLong(toLongFunction).sum());
+
+        Util.logErrors("Error during iterate.commit:", collector.getBatchErrors(), log);
+        Util.logErrors("Error during iterate.execute:", collector.getOperationErrors(), log);
+        return Stream.of(collector.getResult());
     }
 }
 

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -420,6 +420,21 @@ public class PeriodicTest {
         testFail(query);
     }
 
+    @Test(expected = QueryExecutionException.class, timeout = 1000)
+    public void testIterateQueryFailInvalidConcurrency() {
+        final String query = "CALL apoc.periodic.iterate('UNWIND range(0, 10) AS x RETURN x', " +
+                "'RETURN x', " +
+                "{concurrency:0 ,parallel:true})";
+        testFail(query);
+    }
+
+    @Test(expected = QueryExecutionException.class, timeout = 1000)
+    public void testIterateQueryFailInvalidBatchSize() {
+        final String query = "CALL apoc.periodic.iterate('UNWIND range(0, 10) AS x RETURN x', " +
+                "'RETURN x', " +
+                "{batchSize:0 ,parallel:true})";
+        testFail(query);
+    }
 
     private void testFail(String query) {
         testCall(db, query, row -> fail("The test should fail but it didn't"));

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -111,7 +111,8 @@ public class PeriodicTest {
 
 
     @Test
-    public void testPeriodicIterateErrors() throws Exception {
+    public void testPeriodicIterateErrors() {
+        final String newline = System.lineSeparator();
         testResult(db, "CALL apoc.periodic.iterate('UNWIND range(0,99) as id RETURN id', 'CREATE null', {batchSize:10,iterateList:true})", result -> {
             Map<String, Object> row = Iterators.single(result);
             assertEquals(10L, row.get("batches"));
@@ -119,13 +120,13 @@ public class PeriodicTest {
             assertEquals(0L, row.get("committedOperations"));
             assertEquals(100L, row.get("failedOperations"));
             assertEquals(10L, row.get("failedBatches"));
-            Map<String, Object> batchErrors = map("org.neo4j.graphdb.QueryExecutionException: Invalid input 'null': expected \"shortestPath\", \"allShortestPaths\" or \"(\" (line 1, column 55 (offset: 54))\n" +
-                    "\"UNWIND $_batch AS _batch WITH _batch.id AS id  CREATE null\"\n" +
+            Map<String, Object> batchErrors = map("org.neo4j.graphdb.QueryExecutionException: Invalid input 'null': expected \"shortestPath\", \"allShortestPaths\" or \"(\" (line 1, column 55 (offset: 54))" + newline +
+                    "\"UNWIND $_batch AS _batch WITH _batch.id AS id  CREATE null\"" + newline +
                     "                                                       ^", 10L);
 
             assertEquals(batchErrors, ((Map) row.get("batch")).get("errors"));
-            Map<String, Object> operationsErrors = map("Invalid input 'null': expected \"shortestPath\", \"allShortestPaths\" or \"(\" (line 1, column 55 (offset: 54))\n" +
-                    "\"UNWIND $_batch AS _batch WITH _batch.id AS id  CREATE null\"\n" +
+            Map<String, Object> operationsErrors = map("Invalid input 'null': expected \"shortestPath\", \"allShortestPaths\" or \"(\" (line 1, column 55 (offset: 54))" + newline +
+                    "\"UNWIND $_batch AS _batch WITH _batch.id AS id  CREATE null\"" + newline +
                     "                                                       ^", 10L);
             assertEquals(operationsErrors, ((Map) row.get("operations")).get("errors"));
         });

--- a/docs/asciidoc/modules/ROOT/pages/overview/apoc.periodic/apoc.periodic.iterate.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/overview/apoc.periodic/apoc.periodic.iterate.adoc
@@ -14,7 +14,7 @@ apoc.periodic.iterate('statement returning items', 'statement per item', {batchS
 
 [source]
 ----
-apoc.periodic.iterate(cypherIterate :: STRING?, cypherAction :: STRING?, config :: MAP?) :: (batches :: INTEGER?, total :: INTEGER?, timeTaken :: INTEGER?, committedOperations :: INTEGER?, failedOperations :: INTEGER?, failedBatches :: INTEGER?, retries :: INTEGER?, errorMessages :: MAP?, batch :: MAP?, operations :: MAP?, wasTerminated :: BOOLEAN?, failedParams :: MAP?)
+apoc.periodic.iterate(cypherIterate :: STRING?, cypherAction :: STRING?, config :: MAP?) :: (batches :: INTEGER?, total :: INTEGER?, timeTaken :: INTEGER?, committedOperations :: INTEGER?, failedOperations :: INTEGER?, failedBatches :: INTEGER?, retries :: INTEGER?, errorMessages :: MAP?, batch :: MAP?, operations :: MAP?, wasTerminated :: BOOLEAN?, failedParams :: MAP?, updateStatistics :: MAP?)
 ----
 
 == Input parameters
@@ -45,6 +45,7 @@ include::partial$usage/config/apoc.periodic.iterate.adoc[]
 |operations|MAP?
 |wasTerminated|BOOLEAN?
 |failedParams|MAP?
+|updateStatistics|MAP?
 |===
 
 [[usage-apoc.periodic.iterate]]

--- a/docs/asciidoc/modules/ROOT/pages/overview/apoc.periodic/apoc.periodic.rock_n_roll.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/overview/apoc.periodic/apoc.periodic.rock_n_roll.adoc
@@ -14,7 +14,7 @@ apoc.periodic.rock_n_roll('some cypher for iteration', 'some cypher as action on
 
 [source]
 ----
-apoc.periodic.rock_n_roll(cypherIterate :: STRING?, cypherAction :: STRING?, batchSize :: INTEGER?) :: (batches :: INTEGER?, total :: INTEGER?, timeTaken :: INTEGER?, committedOperations :: INTEGER?, failedOperations :: INTEGER?, failedBatches :: INTEGER?, retries :: INTEGER?, errorMessages :: MAP?, batch :: MAP?, operations :: MAP?, wasTerminated :: BOOLEAN?, failedParams :: MAP?)
+apoc.periodic.rock_n_roll(cypherIterate :: STRING?, cypherAction :: STRING?, batchSize :: INTEGER?) :: (batches :: INTEGER?, total :: INTEGER?, timeTaken :: INTEGER?, committedOperations :: INTEGER?, failedOperations :: INTEGER?, failedBatches :: INTEGER?, retries :: INTEGER?, errorMessages :: MAP?, batch :: MAP?, operations :: MAP?, wasTerminated :: BOOLEAN?, failedParams :: MAP?, updateStatistics :: MAP?)
 ----
 
 == Input parameters
@@ -42,6 +42,7 @@ apoc.periodic.rock_n_roll(cypherIterate :: STRING?, cypherAction :: STRING?, bat
 |operations|MAP?
 |wasTerminated|BOOLEAN?
 |failedParams|MAP?
+|updateStatistics|MAP?
 |===
 
 xref::graph-updates/periodic-execution.adoc#periodic-rock-n-roll[More documentation of apoc.periodic.rock_n_roll,role=more information]

--- a/full/src/main/java/apoc/periodic/PeriodicExtended.java
+++ b/full/src/main/java/apoc/periodic/PeriodicExtended.java
@@ -77,7 +77,7 @@ public class PeriodicExtended {
                     PeriodicUtils.iterateAndExecuteBatchedInSeparateThread(
                             db, terminationGuard, log, pools,
                             (int) batchSize, false, false, 0,
-                            result, (tx, params) -> tx.execute(cypherAction, params), 50, -1);
+                            result, (tx, params) -> tx.execute(cypherAction, params).getQueryStatistics(), 50, -1);
                 final Object loopParam = value;
                 allResults = Stream.concat(allResults, oneResult.map(r -> r.inLoop(loopParam)));
             }
@@ -119,7 +119,7 @@ public class PeriodicExtended {
             return PeriodicUtils.iterateAndExecuteBatchedInSeparateThread(
                     db, terminationGuard, log, pools,
                     (int)batchSize, false, false, 0, result,
-                    (tx, p) -> tx.execute(cypherAction, p), 50, -1);
+                    (tx, p) -> tx.execute(cypherAction, p).getQueryStatistics(), 50, -1);
         }
     }
 

--- a/full/src/main/java/apoc/periodic/PeriodicExtended.java
+++ b/full/src/main/java/apoc/periodic/PeriodicExtended.java
@@ -10,17 +10,13 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.*;
 
-import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
-import java.util.function.ToLongFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static apoc.util.Util.merge;
 
 @Extended
 public class PeriodicExtended {
@@ -78,7 +74,10 @@ public class PeriodicExtended {
             log.info("starting batched operation using iteration `%s` in separate thread", cypherIterate);
             try (Result result = tx.execute(cypherIterate)) {
                 Stream<BatchAndTotalResult> oneResult =
-                    iterateAndExecuteBatchedInSeparateThread((int) batchSize, false, false,0, result, (tx, params) -> tx.execute(cypherAction, params), 50, -1);
+                    PeriodicUtils.iterateAndExecuteBatchedInSeparateThread(
+                            db, terminationGuard, log, pools,
+                            (int) batchSize, false, false, 0,
+                            result, (tx, params) -> tx.execute(cypherAction, params), 50, -1);
                 final Object loopParam = value;
                 allResults = Stream.concat(allResults, oneResult.map(r -> r.inLoop(loopParam)));
             }
@@ -117,70 +116,11 @@ public class PeriodicExtended {
 
         log.info("starting batched operation using iteration `%s` in separate thread", cypherIterate);
         try (Result result = tx.execute(cypherIterate)) {
-            return iterateAndExecuteBatchedInSeparateThread((int)batchSize, false, false, 0, result, (tx, p) -> tx.execute(cypherAction, p), 50, -1);
+            return PeriodicUtils.iterateAndExecuteBatchedInSeparateThread(
+                    db, terminationGuard, log, pools,
+                    (int)batchSize, false, false, 0, result,
+                    (tx, p) -> tx.execute(cypherAction, p), 50, -1);
         }
-    }
-
-    private Stream<BatchAndTotalResult> iterateAndExecuteBatchedInSeparateThread(int batchsize, boolean parallel, boolean iterateList, long retries,
-                  Iterator<Map<String, Object>> iterator, BiConsumer<Transaction, Map<String, Object>> consumer, int concurrency, int failedParams) {
-
-        ExecutorService pool = parallel ? pools.getDefaultExecutorService() : pools.getSingleExecutorService();
-        List<Future<Long>> futures = new ArrayList<>(concurrency);
-        BatchAndTotalCollector collector = new BatchAndTotalCollector(terminationGuard, failedParams);
-        do {
-            if (Util.transactionIsTerminated(terminationGuard)) break;
-            if (log.isDebugEnabled()) log.debug("execute in batch no %d batch size ", batchsize);
-            List<Map<String,Object>> batch = Util.take(iterator, batchsize);
-            final long currentBatchSize = batch.size();
-            Function<Transaction, Long> task;
-            if (iterateList) {
-                task = txInThread -> {
-                    if (Util.transactionIsTerminated(terminationGuard)) return 0L;
-                    Map<String, Object> params = Util.map("_count", collector.getCount(), "_batch", batch);
-                    long successes = executeAndReportErrors(txInThread, consumer, params, batch, batch.size(), null, collector);
-                    return successes;
-                };
-            } else {
-                task = txInThread -> {
-                    if (Util.transactionIsTerminated(terminationGuard)) return 0L;
-                    AtomicLong localCount = new AtomicLong(collector.getCount());
-                    return batch.stream().map(
-                            p -> {
-                                if (localCount.get() % 1000 == 0 && Util.transactionIsTerminated(terminationGuard)) {
-                                    return 0;
-                                }
-                                Map<String, Object> params = merge(p, Util.map("_count", localCount.get(), "_batch", batch));
-                                return executeAndReportErrors(txInThread, consumer, params, batch, 1, localCount, collector);
-                            }).mapToLong(n -> (Long) n).sum();
-                };
-            }
-            futures.add(Util.inTxFuture(log, pool, db, task, retries, aLong -> collector.incrementRetried(), _ignored -> collector.incrementBatches()));
-            /*  TODO: not sure if the block below is required
-            if (futures.size() > concurrency) {
-                while (futures.stream().noneMatch(Future::isDone)) { // none done yet, block for a bit
-                    LockSupport.parkNanos(1000);
-                }
-                Iterator<Future<Long>> it = futures.iterator();
-                while (it.hasNext()) {
-                    Future<Long> future = it.next();
-                    if (future.isDone()) {
-                        collector.incrementSuccesses(Util.getFuture(future, collector.getBatchErrors(), collector.getFailedBatches(), 0L));
-                        it.remove();
-                    }
-                }
-            }*/
-            collector.incrementCount(currentBatchSize);
-        } while (iterator.hasNext());
-
-        boolean wasTerminated = Util.transactionIsTerminated(terminationGuard);
-        ToLongFunction<Future<Long>> toLongFunction = wasTerminated ?
-                f -> Util.getFutureOrCancel(f, collector.getBatchErrors(), collector.getFailedBatches(), 0L) :
-                f -> Util.getFuture(f, collector.getBatchErrors(), collector.getFailedBatches(), 0L);
-        collector.incrementSuccesses(futures.stream().mapToLong(toLongFunction).sum());
-
-        Util.logErrors("Error during iterate.commit:", collector.getBatchErrors(), log);
-        Util.logErrors("Error during iterate.execute:", collector.getOperationErrors(), log);
-        return Stream.of(collector.getResult());
     }
 
     private long executeAndReportErrors(Transaction tx, BiConsumer<Transaction, Map<String, Object>> consumer, Map<String, Object> params,


### PR DESCRIPTION
This PR has a few pieces to it:

- cherry-picks my previous PR (#1769) to the 4.2 branch
- adds a guard for #1805 to prevent execution with non-sensical concurrency or batch sizes (i.e. < 1)
- tracks the `QueryStatistics` for each consuming transaction and adds parts of it as a new yielded field `updateStatistics`

Some things to note:
- this PR refactors and centralizes some of the batch transaction handling since it was shared with the (deprecated) `apoc.periodic.rock_n_roll` procedure, fixing the same issue that lead to #1769
- schema changes are _not_ include in the statistics as there's no easy way currently to perform them as part of `apoc.periodic.iterate` and `apoc.schema.assert` doesn't properly report them

![image](https://user-images.githubusercontent.com/9891346/109072586-3849e800-76c3-11eb-976e-a970b5b04768.png)
