### PR TITLE
fixes #1808: APOC NLP functions for Azure cognitive services - Failed - returned HTTP response code: 400

### DIFF
--- a/full/src/main/kotlin/apoc/nlp/azure/azure/RealAzureClient.kt
+++ b/full/src/main/kotlin/apoc/nlp/azure/azure/RealAzureClient.kt
@@ -42,7 +42,7 @@ class RealAzureClient(private val baseUrl: String, private val key: String, priv
         connection.setRequestProperty("Ocp-Apim-Subscription-Key", subscriptionKeyValue)
         connection.doOutput = true
 
-        connection.setRequestProperty("Content-Type", "text/json")
+        connection.setRequestProperty("Content-Type", "application/json")
         DataOutputStream(connection.outputStream).use { it.write(JsonUtil.writeValueAsBytes(mapOf("documents" to convertInput(data)))) }
 
         return connection.inputStream


### PR DESCRIPTION
Fixes #1808

The `Content-Type=text/json` does not work anymore. Switched to `application/json` 

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Fixed the problem