### PR TITLE
Added auto cherry-picking action: branch 4.1

### DIFF
--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -9,7 +9,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target-branch: ['4.2', '4.3']
+        target-branch: [
+          {name: '4.2', comment: '824917952'},
+          {name: '4.3', comment: '824917996'}
+        ]
     runs-on: ubuntu-latest
     name: cherry-pick
     if: github.event.pull_request.merged == true
@@ -19,8 +22,15 @@ jobs:
       - name: Create PR to branch ${{ matrix.target-branch }}
         uses: conker84/github-action-cherry-pick@0.1.1
         with:
-          pr_branch: ${{ matrix.target-branch }}
+          pr_branch: ${{ matrix.target-branch.name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           #          GITBOT_EMAIL: <BOT_EMAIL>
           DRY_RUN: false
+      - name: Add commit-id to comment in case the previous step fails
+        uses: peter-evans/create-or-update-comment@v1.4.4
+        if: ${{ failure() }}
+        with:
+          comment-id: ${{ matrix.target-branch.comment }}
+          body: |
+            - `git cherry-pick ${{ github.sha }}`

--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         target-branch: ['4.2', '4.3']
     runs-on: ubuntu-latest
-    name: release_pull_request
+    name: cherry-pick
     if: github.event.pull_request.merged == true
     steps:
       - name: checkout

--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -1,0 +1,26 @@
+name: APOC Auto Cherry Picking
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - '4.1'
+jobs:
+  cherry-pick:
+    strategy:
+      fail-fast: false
+      matrix:
+        target-branch: ['4.2', '4.3']
+    runs-on: ubuntu-latest
+    name: release_pull_request
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: checkout
+        uses: actions/checkout@v1
+      - name: Create PR to branch ${{ matrix.target-branch }}
+        uses: conker84/github-action-cherry-pick@0.1.1
+        with:
+          pr_branch: ${{ matrix.target-branch }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          #          GITBOT_EMAIL: <BOT_EMAIL>
+          DRY_RUN: false


### PR DESCRIPTION
Added auto cherry-picking action: branch 4.1.
In order to merge this, we need to have the branches as much as possible aligned, so it depends on #1830 and the next one that we need to have for branch `4.3`

An example of auto PR created with this action is available here:
https://github.com/conker84/neo4j-apoc-procedures/pull/12