### PR TITLE
Fixes #1765: apoc.refactor.mergeNodes option to not create self-relationships

### DIFF
--- a/core/src/main/java/apoc/nodes/Nodes.java
+++ b/core/src/main/java/apoc/nodes/Nodes.java
@@ -189,6 +189,7 @@ public class Nodes {
         if (nodes == null || nodes.isEmpty()) return Stream.empty();
         if (nodes.size() == 1) return Stream.of(new VirtualPathResult(nodes.get(0), null, null));
         Set<Node> nodeSet = new LinkedHashSet<>(nodes);
+        config.putIfAbsent("selfRel", false);
         RefactorConfig conf = new RefactorConfig(config);
         VirtualNode first = createVirtualNode(nodeSet, conf);
         if (first.getRelationships().iterator().hasNext()) {

--- a/core/src/main/java/apoc/nodes/Nodes.java
+++ b/core/src/main/java/apoc/nodes/Nodes.java
@@ -189,7 +189,6 @@ public class Nodes {
         if (nodes == null || nodes.isEmpty()) return Stream.empty();
         if (nodes.size() == 1) return Stream.of(new VirtualPathResult(nodes.get(0), null, null));
         Set<Node> nodeSet = new LinkedHashSet<>(nodes);
-        config.putIfAbsent("selfRel", false);
         RefactorConfig conf = new RefactorConfig(config);
         VirtualNode first = createVirtualNode(nodeSet, conf);
         if (first.getRelationships().iterator().hasNext()) {

--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -583,8 +583,7 @@ public class GraphRefactoring {
             copyRelationships(source, copyLabels(source, target), delete);
             if (conf.getMergeRelsAllowed()) {
                 if(!conf.hasProperties()) {
-                    Map<String, Object> map = Collections.singletonMap("properties", "combine");
-                    conf = new RefactorConfig(map);
+                    conf.setPropertiesManagement("combine");
                 }
                 mergeRelsWithSameTypeAndDirectionInMergeNodes(target, conf, Direction.OUTGOING);
                 mergeRelsWithSameTypeAndDirectionInMergeNodes(target, conf, Direction.INCOMING);

--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -54,7 +54,7 @@ public class GraphRefactoring {
 
                 Node copy = copyProperties(properties, newNode);
                 if (withRelationships) {
-                    copyRelationships(node, copy, false);
+                    copyRelationships(node, copy, false, true);
                 }
                 return result.withOther(copy);
             } catch (Exception e) {
@@ -587,7 +587,7 @@ public class GraphRefactoring {
         try {
             Map<String, Object> properties = source.getAllProperties();
 
-            copyRelationships(source, copyLabels(source, target), delete);
+            copyRelationships(source, copyLabels(source, target), delete, conf.isProduceSelfRel());
             if (conf.getMergeRelsAllowed()) {
                 mergeRelsWithSameTypeAndDirectionInMergeNodes(target, conf, Direction.OUTGOING, excludeRelIds);
                 mergeRelsWithSameTypeAndDirectionInMergeNodes(target, conf, Direction.INCOMING, excludeRelIds);
@@ -600,9 +600,11 @@ public class GraphRefactoring {
         return target;
     }
 
-    private Node copyRelationships(Node source, Node target, boolean delete) {
+    private Node copyRelationships(Node source, Node target, boolean delete, boolean isProduceSelfRel) {
         for (Relationship rel : source.getRelationships()) {
-            copyRelationship(rel, source, target);
+            if (isProduceSelfRel) {
+                copyRelationship(rel, source, target);
+            }
             if (delete) rel.delete();
         }
         return target;

--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -283,13 +283,13 @@ public class GraphRefactoring {
         nodes.stream().distinct().sorted(Comparator.comparingLong(Node::getId)).forEach(tx::acquireWriteLock);
 
         final Node first = nodes.get(0);
-        final List<Long> existingIdSelfRelsIfPreserveConfTrue = conf.isPreserveExistingSelfRels()
+        final List<Long> existingRels = conf.isPreserveExistingSelfRels()
                 ? StreamSupport.stream(first.getRelationships().spliterator(), false).filter(Util::isSelfRel)
                     .map(Entity::getId)
                     .collect(Collectors.toList())
                 : Collections.emptyList();
 
-        nodes.stream().skip(1).distinct().forEach(node -> mergeNodes(node, first, true, conf, existingIdSelfRelsIfPreserveConfTrue));
+        nodes.stream().skip(1).distinct().forEach(node -> mergeNodes(node, first, true, conf, existingRels));
         return Stream.of(new NodeResult(first));
     }
 

--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -582,9 +582,6 @@ public class GraphRefactoring {
             Map<String, Object> properties = source.getAllProperties();
             copyRelationships(source, copyLabels(source, target), delete);
             if (conf.getMergeRelsAllowed()) {
-                if(!conf.hasProperties()) {
-                    conf.setPropertiesManagement("combine");
-                }
                 mergeRelsWithSameTypeAndDirectionInMergeNodes(target, conf, Direction.OUTGOING);
                 mergeRelsWithSameTypeAndDirectionInMergeNodes(target, conf, Direction.INCOMING);
             }

--- a/core/src/main/java/apoc/refactor/util/RefactorConfig.java
+++ b/core/src/main/java/apoc/refactor/util/RefactorConfig.java
@@ -30,6 +30,7 @@ public class RefactorConfig {
 	private boolean hasProperties;
 	private boolean collapsedLabel;
 	private boolean singleElementAsArray;
+	private boolean excludeSelfRel;
 
 	private final RelationshipSelectionStrategy relationshipSelectionStrategy;
 
@@ -37,7 +38,7 @@ public class RefactorConfig {
 		Object value = config.get("properties");
 		hasProperties = value != null;
 		if (value instanceof String) {
-			this.propertiesManagement = Collections.singletonMap(MATCH_ALL, value.toString());
+			setPropertiesManagement(value.toString());
 		} else if (value instanceof Map) {
 			this.propertiesManagement = (Map<String,String>)value;
 		}
@@ -48,6 +49,7 @@ public class RefactorConfig {
 		this.countMerge = toBoolean(config.getOrDefault("countMerge", true));
 		this.collapsedLabel = toBoolean(config.get("collapsedLabel"));
 		this.singleElementAsArray = toBoolean(config.getOrDefault("singleElementAsArray", false));
+		this.excludeSelfRel = toBoolean(config.getOrDefault("excludeSelfRel", false));
 		this.relationshipSelectionStrategy = RelationshipSelectionStrategy.valueOf(
 				((String) config.getOrDefault("relationshipSelectionStrategy", RelationshipSelectionStrategy.INCOMING.toString())).toUpperCase() );
 	}
@@ -94,6 +96,14 @@ public class RefactorConfig {
 
 	public boolean isSingleElementAsArray() {
 		return singleElementAsArray;
+	}
+
+	public boolean isExcludeSelfRel() {
+		return excludeSelfRel;
+	}
+
+	public void setPropertiesManagement(String value) {
+		this.propertiesManagement = Collections.singletonMap(MATCH_ALL, value);
 	}
 
 	public RelationshipSelectionStrategy getRelationshipSelectionStrategy() {

--- a/core/src/main/java/apoc/refactor/util/RefactorConfig.java
+++ b/core/src/main/java/apoc/refactor/util/RefactorConfig.java
@@ -30,7 +30,6 @@ public class RefactorConfig {
 	private boolean hasProperties;
 	private boolean collapsedLabel;
 	private boolean singleElementAsArray;
-	private boolean excludeSelfRel;
 
 	private final RelationshipSelectionStrategy relationshipSelectionStrategy;
 
@@ -45,11 +44,10 @@ public class RefactorConfig {
 
 		this.mergeRelsAllowed = toBoolean(config.get("mergeRels"));
 		this.mergeVirtualRels = toBoolean(config.getOrDefault("mergeRelsVirtual", true));
-		this.selfRel = toBoolean(config.get("selfRel"));
+		this.selfRel = toBoolean(config.getOrDefault("selfRel", true));
 		this.countMerge = toBoolean(config.getOrDefault("countMerge", true));
 		this.collapsedLabel = toBoolean(config.get("collapsedLabel"));
 		this.singleElementAsArray = toBoolean(config.getOrDefault("singleElementAsArray", false));
-		this.excludeSelfRel = toBoolean(config.getOrDefault("excludeSelfRel", false));
 		this.relationshipSelectionStrategy = RelationshipSelectionStrategy.valueOf(
 				((String) config.getOrDefault("relationshipSelectionStrategy", RelationshipSelectionStrategy.INCOMING.toString())).toUpperCase() );
 	}
@@ -96,10 +94,6 @@ public class RefactorConfig {
 
 	public boolean isSingleElementAsArray() {
 		return singleElementAsArray;
-	}
-
-	public boolean isExcludeSelfRel() {
-		return excludeSelfRel;
 	}
 
 	public void setPropertiesManagement(String value) {

--- a/core/src/main/java/apoc/refactor/util/RefactorConfig.java
+++ b/core/src/main/java/apoc/refactor/util/RefactorConfig.java
@@ -26,6 +26,8 @@ public class RefactorConfig {
 	private boolean mergeRelsAllowed;
 	private boolean mergeVirtualRels;
 	private boolean selfRel;
+	private boolean produceSelfRel;
+	private boolean preserveExistingSelfRels;
 	private boolean countMerge;
 	private boolean hasProperties;
 	private boolean collapsedLabel;
@@ -37,7 +39,9 @@ public class RefactorConfig {
 
 		this.mergeRelsAllowed = toBoolean(config.get("mergeRels"));
 		this.mergeVirtualRels = toBoolean(config.getOrDefault("mergeRelsVirtual", true));
-		this.selfRel = toBoolean(config.getOrDefault("selfRel", true));
+		this.selfRel = toBoolean(config.get("selfRel"));
+		this.produceSelfRel = toBoolean(config.getOrDefault("produceSelfRel", true));
+		this.preserveExistingSelfRels = toBoolean(config.getOrDefault("preserveExistingSelfRels", true));
 		this.countMerge = toBoolean(config.getOrDefault("countMerge", true));
 		this.collapsedLabel = toBoolean(config.get("collapsedLabel"));
 		this.singleElementAsArray = toBoolean(config.getOrDefault("singleElementAsArray", false));
@@ -80,6 +84,14 @@ public class RefactorConfig {
 	}
 
 	public boolean isSelfRel(){ return selfRel; }
+
+	public boolean isProduceSelfRel() {
+		return produceSelfRel;
+	}
+
+	public boolean isPreserveExistingSelfRels() {
+		return preserveExistingSelfRels;
+	}
 
 	public boolean hasProperties() {
 		return hasProperties;

--- a/core/src/main/java/apoc/refactor/util/RefactorConfig.java
+++ b/core/src/main/java/apoc/refactor/util/RefactorConfig.java
@@ -34,13 +34,6 @@ public class RefactorConfig {
 	private final RelationshipSelectionStrategy relationshipSelectionStrategy;
 
 	public RefactorConfig(Map<String,Object> config) {
-		Object value = config.get("properties");
-		hasProperties = value != null;
-		if (value instanceof String) {
-			setPropertiesManagement(value.toString());
-		} else if (value instanceof Map) {
-			this.propertiesManagement = (Map<String,String>)value;
-		}
 
 		this.mergeRelsAllowed = toBoolean(config.get("mergeRels"));
 		this.mergeVirtualRels = toBoolean(config.getOrDefault("mergeRelsVirtual", true));
@@ -50,6 +43,16 @@ public class RefactorConfig {
 		this.singleElementAsArray = toBoolean(config.getOrDefault("singleElementAsArray", false));
 		this.relationshipSelectionStrategy = RelationshipSelectionStrategy.valueOf(
 				((String) config.getOrDefault("relationshipSelectionStrategy", RelationshipSelectionStrategy.INCOMING.toString())).toUpperCase() );
+
+		Object value = config.get("properties");
+		hasProperties = value != null;
+		if (value instanceof String) {
+			this.propertiesManagement = Collections.singletonMap(MATCH_ALL, value.toString());
+		} else if (value instanceof Map) {
+			this.propertiesManagement = (Map<String,String>)value;
+		} else if (mergeRelsAllowed && !hasProperties) {
+			this.propertiesManagement = Collections.singletonMap(MATCH_ALL, COMBINE);
+		}
 	}
 
 	public String getMergeMode(String name){
@@ -94,10 +97,6 @@ public class RefactorConfig {
 
 	public boolean isSingleElementAsArray() {
 		return singleElementAsArray;
-	}
-
-	public void setPropertiesManagement(String value) {
-		this.propertiesManagement = Collections.singletonMap(MATCH_ALL, value);
 	}
 
 	public RelationshipSelectionStrategy getRelationshipSelectionStrategy() {

--- a/core/src/main/java/apoc/refactor/util/RefactorUtil.java
+++ b/core/src/main/java/apoc/refactor/util/RefactorUtil.java
@@ -7,6 +7,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
+import static apoc.util.Util.isSelfRel;
+
 public class RefactorUtil {
 
     public static void mergeRelsWithSameTypeAndDirectionInMergeNodes(Node node, RefactorConfig config, Direction dir) {
@@ -17,7 +19,7 @@ public class RefactorUtil {
                     .filter(list -> !list.isEmpty())
                     .forEach(list -> {
                         Relationship first = list.get(0);
-                        if (first.getStartNodeId() == first.getEndNodeId() && !config.isSelfRel()) {
+                        if (isSelfRel(first) && !config.isSelfRel()) {
                             list.forEach(Relationship::delete);
                         } else {
                             for (int i = 1; i < list.size(); i++) {

--- a/core/src/main/java/apoc/refactor/util/RefactorUtil.java
+++ b/core/src/main/java/apoc/refactor/util/RefactorUtil.java
@@ -17,9 +17,13 @@ public class RefactorUtil {
                     .filter(list -> !list.isEmpty())
                     .forEach(list -> {
                         Relationship first = list.get(0);
-                        for (int i = 1; i < list.size(); i++) {
-                            Relationship relationship = list.get(i);
-                            mergeRels(relationship, first, true,  config);
+                        if (config.isExcludeSelfRel() && first.getStartNodeId() == first.getEndNodeId()) {
+                            list.forEach(Relationship::delete);
+                        } else {
+                            for (int i = 1; i < list.size(); i++) {
+                                Relationship relationship = list.get(i);
+                                mergeRels(relationship, first, true,  config);
+                            }
                         }
                     });
         }

--- a/core/src/main/java/apoc/refactor/util/RefactorUtil.java
+++ b/core/src/main/java/apoc/refactor/util/RefactorUtil.java
@@ -17,7 +17,7 @@ public class RefactorUtil {
                     .filter(list -> !list.isEmpty())
                     .forEach(list -> {
                         Relationship first = list.get(0);
-                        if (config.isExcludeSelfRel() && first.getStartNodeId() == first.getEndNodeId()) {
+                        if (first.getStartNodeId() == first.getEndNodeId() && !config.isSelfRel()) {
                             list.forEach(Relationship::delete);
                         } else {
                             for (int i = 1; i < list.size(); i++) {

--- a/core/src/main/java/apoc/refactor/util/RefactorUtil.java
+++ b/core/src/main/java/apoc/refactor/util/RefactorUtil.java
@@ -3,6 +3,7 @@ package apoc.refactor.util;
 import org.neo4j.graphdb.*;
 import org.neo4j.internal.helpers.collection.Pair;
 
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -11,15 +12,16 @@ import static apoc.util.Util.isSelfRel;
 
 public class RefactorUtil {
 
-    public static void mergeRelsWithSameTypeAndDirectionInMergeNodes(Node node, RefactorConfig config, Direction dir) {
+    public static void mergeRelsWithSameTypeAndDirectionInMergeNodes(Node node, RefactorConfig config, Direction dir, List<Long> excludeRelIds) {
         for (RelationshipType type : node.getRelationshipTypes()) {
             StreamSupport.stream(node.getRelationships(dir,type).spliterator(), false)
+                    .filter(rel -> !excludeRelIds.contains(rel.getId()))
                     .collect(Collectors.groupingBy(rel -> Pair.of(rel.getStartNode(), rel.getEndNode())))
                     .values().stream()
                     .filter(list -> !list.isEmpty())
                     .forEach(list -> {
                         Relationship first = list.get(0);
-                        if (isSelfRel(first) && !config.isSelfRel()) {
+                        if (isSelfRel(first) && !config.isProduceSelfRel()) {
                             list.forEach(Relationship::delete);
                         } else {
                             for (int i = 1; i < list.size(); i++) {

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -942,4 +942,7 @@ public class Util {
         return Collections.emptyMap();
     }
 
+    public static boolean isSelfRel(Relationship rel) {
+        return rel.getStartNodeId() == rel.getEndNodeId();
+    }
 }

--- a/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -1001,7 +1001,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     public void testMergeNodeShouldNotCreateSelfRelationshipsInPreExistingSelfRel() {
         db.executeTransactionally("CREATE (a:TestNode {a:'a'})-[:TEST_REL]->(b:TestNode {a:'b'})-[:TEST_REL]->(c:TestNode {a:'c'})\n" +
                 "WITH a, c CREATE (a)-[:TEST_REL]->(a) WITH c CREATE (c)-[:TEST_REL]->(c);");
-        testCall(db, "MATCH (n:TestNode) WITH collect(n) as nodes CALL apoc.refactor.mergeNodes(nodes, {mergeRels: true, excludeSelfRel: true}) yield node return node",
+        testCall(db, "MATCH (n:TestNode) WITH collect(n) as nodes CALL apoc.refactor.mergeNodes(nodes, {mergeRels: true, selfRel: false}) yield node return node",
                 (r) -> {
                     Node node = (Node) r.get("node");
                     assertFalse(node.getRelationships().iterator().hasNext());
@@ -1012,7 +1012,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     public void testMergeNodeShouldCreateSelfRelationshipsInPreExistingSelfRel() {
         db.executeTransactionally("CREATE (a:TestNode {a:'a'})-[:TEST_REL]->(b:TestNode {a:'b'})-[:TEST_REL]->(c:TestNode {a:'c'})\n" +
                 "WITH a, c CREATE (a)-[:TEST_REL]->(a) WITH c CREATE (c)-[:TEST_REL]->(c);");
-        testCall(db, "MATCH (n:TestNode) WITH collect(n) as nodes CALL apoc.refactor.mergeNodes(nodes, {mergeRels: true, excludeSelfRel: false}) yield node return node",
+        testCall(db, "MATCH (n:TestNode) WITH collect(n) as nodes CALL apoc.refactor.mergeNodes(nodes, {mergeRels: true, selfRel: true}) yield node return node",
                 (r) -> {
                     Node node = (Node) r.get("node");
                     assertTrue(node.getRelationships().iterator().hasNext());
@@ -1023,7 +1023,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     public void testMergeNodeShouldNotCreateSelfRelationshipsWithCircularPath() {
         db.executeTransactionally("CREATE (a:TestNode {a:'a'})-[:TEST_REL]->(b:TestNode {a:'b'})-[:TEST_REL]->(c:TestNode {a:'c'})\n" +
                 "WITH a, c CREATE (c)-[:TEST_REL]->(a);");
-        testCall(db, "MATCH (n:TestNode) WITH collect(n) as nodes CALL apoc.refactor.mergeNodes(nodes, {mergeRels: true, excludeSelfRel: true}) yield node return node",
+        testCall(db, "MATCH (n:TestNode) WITH collect(n) as nodes CALL apoc.refactor.mergeNodes(nodes, {mergeRels: true, selfRel: false}) yield node return node",
                 (r) -> {
                     Node node = (Node) r.get("node");
                     assertFalse(node.getRelationships().iterator().hasNext());
@@ -1034,7 +1034,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     public void testMergeNodeShouldCreateSelfRelationshipsWithCircularPath() {
         db.executeTransactionally("CREATE (a:TestNode {a:'a'})-[:TEST_REL]->(b:TestNode {a:'b'})-[:TEST_REL]->(c:TestNode {a:'c'})\n" +
                 "WITH a, c CREATE (c)-[:TEST_REL]->(a);");
-        testCall(db, "MATCH (n:TestNode) WITH collect(n) as nodes CALL apoc.refactor.mergeNodes(nodes, {mergeRels: true, excludeSelfRel: false}) yield node return node",
+        testCall(db, "MATCH (n:TestNode) WITH collect(n) as nodes CALL apoc.refactor.mergeNodes(nodes, {mergeRels: true, selfRel: true}) yield node return node",
                 (r) -> {
                     Node node = (Node) r.get("node");
                     assertTrue(node.getRelationships().iterator().hasNext());
@@ -1045,7 +1045,7 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     public void testMergeNodeShouldNotCreateSelfRelationshipsWithPathWithOtherRels() {
         db.executeTransactionally("CREATE (a:One)-[:TEST_REL1]->(b:Two)-[:TEST_REL2]->(c:Three)\n" +
                 "WITH b, c CREATE (b)-[:ASD]->(q:Four), (b)-[:ZXC]->(w:Five) WITH b, c CREATE (b)-[:QWE]->(c)");
-        testCall(db, "match (a:One),(b:Two),(c:Three) with [a,b,c] as nodes CALL apoc.refactor.mergeNodes(nodes, {mergeRels: true, excludeSelfRel: true}) yield node return node",
+        testCall(db, "match (a:One),(b:Two),(c:Three) with [a,b,c] as nodes CALL apoc.refactor.mergeNodes(nodes, {mergeRels: true, selfRel: false}) yield node return node",
                 (r) -> {
                     Node node = (Node) r.get("node");
                     List<String> relNodeList = IteratorUtils.toList(node.getRelationships().iterator()).stream().

--- a/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -1025,31 +1025,6 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
-    public void testMergeNodeShouldNotCancelOtherRelsWithSelfRelsFalse() {
-        db.executeTransactionally("CREATE (a:A {a:'a'})-[:KNOWS]->(b:B {a:'b'})-[:KNOWS]->(c:C {a:'c'})\n" +
-                "WITH a,b,c CREATE (a)-[:KNOWS]->(a) WITH a,b,c CREATE (a)-[:KNOWS]->(c) WITH c,b CREATE (c)-[:KNOWS]->(b);");
-        testCall(db, "MATCH (n:A), (m:B) WITH [n,m] as nodes CALL apoc.refactor.mergeNodes(nodes, {mergeRels: true, selfRel: false}) yield node return node",
-                (r) -> {
-                    Node node = (Node) r.get("node");
-                    List<Relationship> relationships = IteratorUtils.toList(node.getRelationships().iterator());
-
-                    assertEquals(2, relationships.size());
-                    relationships.sort(Comparator.comparingLong(Relationship::getStartNodeId)
-                            .thenComparingLong(Relationship::getEndNodeId));
-
-                    Relationship firstRel = relationships.get(0);
-                    assertEquals("A", firstRel.getStartNode().getLabels().iterator().next().name());
-                    assertEquals("C", firstRel.getEndNode().getLabels().iterator().next().name());
-                    assertEquals("KNOWS", firstRel.getType().name());
-
-                    Relationship secondRel = relationships.get(1);
-                    assertEquals("C", secondRel.getStartNode().getLabels().iterator().next().name());
-                    assertEquals("A", secondRel.getEndNode().getLabels().iterator().next().name());
-                    assertEquals("KNOWS", secondRel.getType().name());
-                });
-    }
-
-    @Test
     public void testMergeNodeShouldNotCancelOtherRelsWithSelfRelsTrue() {
         db.executeTransactionally("CREATE (a:A {a:'a'})-[:KNOWS]->(b:B {a:'b'})-[:KNOWS]->(c:C {a:'c'})\n" +
                 "WITH a,b,c CREATE (a)-[:KNOWS]->(a) WITH a,b,c CREATE (a)-[:KNOWS]->(c) WITH c,b CREATE (c)-[:KNOWS]->(b);");
@@ -1084,36 +1059,6 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
         db.executeTransactionally("CREATE (a:A {a:'a'})-[:KNOWS]->(b:B {a:'b'})-[:KNOWS]->(c:C {a:'c'})\n" +
                 "WITH a,b,c CREATE (a)-[:KNOWS]->(a) WITH a,b,c CREATE (a)-[:KNOWS]->(c) WITH c,b CREATE (c)-[:KNOWS]->(b);");
         testCall(db, "MATCH (n:A) WITH collect(n) as nodes CALL apoc.refactor.mergeNodes(nodes, {mergeRels: true, selfRel: false}) yield node return node",
-                (r) -> {
-                    Node node = (Node) r.get("node");
-                    List<Relationship> relationships = IteratorUtils.toList(node.getRelationships().iterator());
-
-                    assertEquals(3, relationships.size());
-                    relationships.sort(Comparator.comparingLong(Relationship::getStartNodeId)
-                            .thenComparingLong(Relationship::getEndNodeId));
-
-                    Relationship firstRel = relationships.get(0);
-                    assertEquals("A", firstRel.getStartNode().getLabels().iterator().next().name());
-                    assertEquals("A", firstRel.getEndNode().getLabels().iterator().next().name());
-                    assertEquals("KNOWS", firstRel.getType().name());
-
-                    Relationship secondRel = relationships.get(1);
-                    assertEquals("A", secondRel.getStartNode().getLabels().iterator().next().name());
-                    assertEquals("B", secondRel.getEndNode().getLabels().iterator().next().name());
-                    assertEquals("KNOWS", secondRel.getType().name());
-
-                    Relationship thirdRel = relationships.get(2);
-                    assertEquals("A", thirdRel.getStartNode().getLabels().iterator().next().name());
-                    assertEquals("C", thirdRel.getEndNode().getLabels().iterator().next().name());
-                    assertEquals("KNOWS", thirdRel.getType().name());
-                });
-    }
-
-    @Test
-    public void testMergeNodeShouldNotCancelOtherRelsWithSelfRelsTrueAndSingleNode() {
-        db.executeTransactionally("CREATE (a:A {a:'a'})-[:KNOWS]->(b:B {a:'b'})-[:KNOWS]->(c:C {a:'c'})\n" +
-                "WITH a,b,c CREATE (a)-[:KNOWS]->(a) WITH a,b,c CREATE (a)-[:KNOWS]->(c) WITH c,b CREATE (c)-[:KNOWS]->(b);");
-        testCall(db, "MATCH (n:A) WITH collect(n) as nodes CALL apoc.refactor.mergeNodes(nodes, {mergeRels: true, selfRel: true}) yield node return node",
                 (r) -> {
                     Node node = (Node) r.get("node");
                     List<Relationship> relationships = IteratorUtils.toList(node.getRelationships().iterator());

--- a/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -1032,7 +1032,6 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                     Iterator<Relationship> relIterator = node.getRelationships().iterator();
                     assertSelfRel(relIterator.next());
                     assertSelfRel(relIterator.next());
-                    assertSelfRel(relIterator.next());
                     assertFalse(relIterator.hasNext());
                 });
     }
@@ -1122,7 +1121,6 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                 (r) -> {
                     Node node = (Node) r.get("node");
                     Iterator<Relationship> relIterator = node.getRelationships().iterator();
-                    assertSelfRel(relIterator.next());
                     assertSelfRel(relIterator.next());
                     assertFalse(relIterator.hasNext());
                 });

--- a/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/merge-nodes.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/merge-nodes.adoc
@@ -41,7 +41,8 @@ In addition, mergeNodes supports the following config properties:
 |===
 | type | operations
 | mergeRels | true/false: give the possibility to merge relationships with same type and direction.
-| selfRel | true/false: is valid only with `mergeRels:true`. If `true` (default), the self-relationships will be created into new node, if exist, and vice versa.
+| produceSelfRel | true/false: is valid only with `mergeRels:true`. If `true` (default), the self-relationships will be created into new node, if exist, and vice versa.
+| preserveExistingSelfRels | true/false: is valid only with `mergeRels:true`. If `true` (default), the pre-existing self-relationships in the final node will remain, otherwise will be deleted.
 | singleElementAsArray | false/true: if is `false` (default) and `type` is `combine` in case the merge of two arrays is a new array with size 1 it extracts the single value.
 |===
 

--- a/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/merge-nodes.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/merge-nodes.adoc
@@ -41,6 +41,7 @@ In addition, mergeNodes supports the following config properties:
 |===
 | type | operations
 | mergeRels | true/false: give the possibility to merge relationships with same type and direction.
+| excludeSelfRel | true/false: is valid only with `mergeRels:true`. If true, the self-relationships will not be created into new node, if exist
 | singleElementAsArray | false/true: if is `false` (default) and `type` is `combine` in case the merge of two arrays is a new array with size 1 it extracts the single value.
 |===
 

--- a/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/merge-nodes.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/merge-nodes.adoc
@@ -41,7 +41,7 @@ In addition, mergeNodes supports the following config properties:
 |===
 | type | operations
 | mergeRels | true/false: give the possibility to merge relationships with same type and direction.
-| selfRel | true/false: is valid only with `mergeRels:true`. If `true` (default), the self-relationships will not be created into new node, if exist.
+| selfRel | true/false: is valid only with `mergeRels:true`. If `true` (default), the self-relationships will be created into new node, if exist, and vice versa.
 | singleElementAsArray | false/true: if is `false` (default) and `type` is `combine` in case the merge of two arrays is a new array with size 1 it extracts the single value.
 |===
 

--- a/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/merge-nodes.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/merge-nodes.adoc
@@ -41,7 +41,8 @@ In addition, mergeNodes supports the following config properties:
 |===
 | type | operations
 | mergeRels | true/false: give the possibility to merge relationships with same type and direction.
-| produceSelfRel | true/false: is valid only with `mergeRels:true`. If `true` (default), the self-relationships will be created into new node, if exist, and vice versa.
+| produceSelfRel | true/false: if `true` (default), any eventual new self-relationship that would be created from the nodes merged into target node are inserted, otherwise not.
+    Please note that this param is independent from `mergeRels` config and doesn't affect on pre-existing self-relationships (in this case it is used the `preserveExistingSelfRels` config).
 | preserveExistingSelfRels | true/false: is valid only with `mergeRels:true`. If `true` (default), the pre-existing self-relationships in the final node will remain, otherwise will be deleted.
 | singleElementAsArray | false/true: if is `false` (default) and `type` is `combine` in case the merge of two arrays is a new array with size 1 it extracts the single value.
 |===

--- a/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/merge-nodes.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/merge-nodes.adoc
@@ -41,7 +41,7 @@ In addition, mergeNodes supports the following config properties:
 |===
 | type | operations
 | mergeRels | true/false: give the possibility to merge relationships with same type and direction.
-| excludeSelfRel | true/false: is valid only with `mergeRels:true`. If true, the self-relationships will not be created into new node, if exist
+| selfRel | true/false: is valid only with `mergeRels:true`. If `true` (default), the self-relationships will not be created into new node, if exist.
 | singleElementAsArray | false/true: if is `false` (default) and `type` is `combine` in case the merge of two arrays is a new array with size 1 it extracts the single value.
 |===
 


### PR DESCRIPTION
Fixes #1765

  - added `config.isSelfRel()` in `RefactorUtil.java`
  - added `config.putIfAbsent("selfRel", false);` in `Nodes.java` to reuse `selfRel` configuration

