### PR TITLE
Fixed xref errors

### DIFF
--- a/docs/asciidoc/modules/ROOT/examples/generated-documentation/apoc.schema.node.constraintExists.adoc
+++ b/docs/asciidoc/modules/ROOT/examples/generated-documentation/apoc.schema.node.constraintExists.adoc
@@ -1,4 +1,4 @@
-¦xref::overview/apoc.schema.node/apoc.schema.node.constraintExists.adoc[apoc.schema.node.constraintExists icon:book[]] +
+¦xref::overview/apoc.schema/apoc.schema.node.constraintExists.adoc[apoc.schema.node.constraintExists icon:book[]] +
 
 `RETURN apoc.schema.node.constraintExists(labelName, propertyNames)`
 ¦label:function[]

--- a/docs/asciidoc/modules/ROOT/examples/generated-documentation/apoc.schema.node.indexExists.adoc
+++ b/docs/asciidoc/modules/ROOT/examples/generated-documentation/apoc.schema.node.indexExists.adoc
@@ -1,4 +1,4 @@
-¦xref::overview/apoc.schema.node/apoc.schema.node.indexExists.adoc[apoc.schema.node.indexExists icon:book[]] +
+¦xref::overview/apoc.schema/apoc.schema.node.indexExists.adoc[apoc.schema.node.indexExists icon:book[]] +
 
 `RETURN apoc.schema.node.indexExists(labelName, propertyNames)`
 ¦label:function[]

--- a/docs/asciidoc/modules/ROOT/examples/generated-documentation/apoc.schema.relationship.constraintExists.adoc
+++ b/docs/asciidoc/modules/ROOT/examples/generated-documentation/apoc.schema.relationship.constraintExists.adoc
@@ -1,4 +1,4 @@
-¦xref::overview/apoc.schema.relationship/apoc.schema.relationship.constraintExists.adoc[apoc.schema.relationship.constraintExists icon:book[]] +
+¦xref::overview/apoc.schema/apoc.schema.relationship.constraintExists.adoc[apoc.schema.relationship.constraintExists icon:book[]] +
 
 `RETURN apoc.schema.relationship.constraintExists(type, propertyNames)`
 ¦label:function[]


### PR DESCRIPTION
Fixes errors from the documentation build identified by the linting process.

```
Unresolved xrefs (grouped by origin):

repo: https://github.com/neo4j-contrib/neo4j-apoc-procedures | branch: 4.1 | component: apoc | version: 4.1
  path: docs/asciidoc/modules/ROOT/pages/indexes/schema-index-operations.adoc | xref: :overview/apoc.schema.node/apoc.schema.node.constraintExists.adoc
  path: docs/asciidoc/modules/ROOT/pages/indexes/schema-index-operations.adoc | xref: :overview/apoc.schema.relationship/apoc.schema.relationship.constraintExists.adoc
  path: docs/asciidoc/modules/ROOT/pages/indexes/schema-index-operations.adoc | xref: :overview/apoc.schema.node/apoc.schema.node.indexExists.adoc
```