### PR TITLE
fixes #1564: Add Apache arrow read / write support

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -135,10 +135,10 @@ dependencies {
 
     compile group: 'xerces', name: 'xercesImpl', version: '2.12.1'
 
-    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '4.0.0'
-    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '4.0.0'
-    testCompile group: 'org.apache.arrow', name: 'arrow-vector', version: '4.0.0'
-    testCompile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '4.0.0'
+    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '6.0.0'
+    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '6.0.0'
+    testCompile group: 'org.apache.arrow', name: 'arrow-vector', version: '6.0.0'
+    testCompile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '6.0.0'
 
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -135,6 +135,11 @@ dependencies {
 
     compile group: 'xerces', name: 'xercesImpl', version: '2.12.1'
 
+    compileOnly group: 'org.apache.arrow', name: 'arrow-vector', version: '3.0.0'
+    compileOnly group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '3.0.0'
+    testCompile group: 'org.apache.arrow', name: 'arrow-vector', version: '3.0.0'
+    testCompile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '3.0.0'
+
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'
     }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -93,8 +93,8 @@ dependencies {
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
     compileOnly group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
 
-    testCompile 'org.mock-server:mockserver-netty:3.10.8'
-    testCompile 'org.mock-server:mockserver-client-java:3.10.8'
+    testCompile 'org.mock-server:mockserver-netty:5.6.0'
+    testCompile 'org.mock-server:mockserver-client-java:5.6.0'
 
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
@@ -135,10 +135,10 @@ dependencies {
 
     compile group: 'xerces', name: 'xercesImpl', version: '2.12.1'
 
-    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '3.0.0'
-    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '3.0.0'
-    testCompile group: 'org.apache.arrow', name: 'arrow-vector', version: '3.0.0'
-    testCompile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '3.0.0'
+    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '4.0.0'
+    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '4.0.0'
+    testCompile group: 'org.apache.arrow', name: 'arrow-vector', version: '4.0.0'
+    testCompile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '4.0.0'
 
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -135,8 +135,8 @@ dependencies {
 
     compile group: 'xerces', name: 'xercesImpl', version: '2.12.1'
 
-    compileOnly group: 'org.apache.arrow', name: 'arrow-vector', version: '3.0.0'
-    compileOnly group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '3.0.0'
+    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '3.0.0'
+    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '3.0.0'
     testCompile group: 'org.apache.arrow', name: 'arrow-vector', version: '3.0.0'
     testCompile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '3.0.0'
 

--- a/core/src/main/java/apoc/convert/Json.java
+++ b/core/src/main/java/apoc/convert/Json.java
@@ -25,7 +25,7 @@ public class Json {
     public static String NODE = "node";
     public static String RELATIONSHIP = "relationship";
 
-    private Object writeJsonResult(Object value) {
+    public static Object writeJsonResult(Object value) {
         Meta.Types type = Meta.Types.of(value);
         switch (type) {
             case NODE:
@@ -37,7 +37,7 @@ public class Json {
                         .map(i-> i instanceof Node ? nodeToMap((Node) i) : relToMap((Relationship) i))
                         .collect(Collectors.toList()));
             case LIST:
-                return Convert.convertToList(value).stream().map(this::writeJsonResult).collect(Collectors.toList());
+                return Convert.convertToList(value).stream().map(Json::writeJsonResult).collect(Collectors.toList());
             case MAP:
                 return ((Map<String, Object>) value).entrySet()
                         .stream()
@@ -49,7 +49,7 @@ public class Json {
         }
     }
 
-    private Map<String,Object> relToMap(Relationship rel) {
+    private static Map<String,Object> relToMap(Relationship rel) {
         Map<String, Object> mapRel = map(
                 "id", String.valueOf(rel.getId()),
                 "type", RELATIONSHIP,
@@ -60,7 +60,7 @@ public class Json {
         return mapWithOptionalProps(mapRel, rel.getAllProperties());
     }
 
-    private Map<String,Object> nodeToMap(Node node) {
+    private static Map<String,Object> nodeToMap(Node node) {
         Map<String, Object> mapNode = map("id", String.valueOf(node.getId()));
 
         mapNode.put("type", NODE);
@@ -71,7 +71,7 @@ public class Json {
         return mapWithOptionalProps(mapNode, node.getAllProperties());
     }
 
-    private Map<String, Object> mapWithOptionalProps(Map<String,Object> mapEntity, Map<String,Object> props) {
+    private static Map<String, Object> mapWithOptionalProps(Map<String,Object> mapEntity, Map<String,Object> props) {
         if (!props.isEmpty()) {
             mapEntity.put("properties", props);
         }

--- a/core/src/main/java/apoc/export/arrow/ArrowConfig.java
+++ b/core/src/main/java/apoc/export/arrow/ArrowConfig.java
@@ -1,0 +1,26 @@
+package apoc.export.arrow;
+
+import apoc.util.Util;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class ArrowConfig {
+
+    private final int batchSize;
+
+    private final Map<String, Object> config;
+
+    public ArrowConfig(Map<String, Object> config) {
+        this.config = config == null ? Collections.emptyMap() : config;
+        this.batchSize = Util.toInteger(this.config.getOrDefault("batchSize", 2000));
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public Map<String, Object> getConfig() {
+        return config;
+    }
+}

--- a/core/src/main/java/apoc/export/arrow/ArrowUtils.java
+++ b/core/src/main/java/apoc/export/arrow/ArrowUtils.java
@@ -1,0 +1,21 @@
+package apoc.export.arrow;
+
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+
+import java.util.List;
+
+public class ArrowUtils {
+
+    private ArrowUtils() {
+    }
+
+    public static Field FIELD_ID = new Field("<id>", FieldType.nullable(Types.MinorType.BIGINT.getType()), null);
+    public static Field FIELD_LABELS = new Field("labels", FieldType.nullable(Types.MinorType.LIST.getType()),
+            List.of(new Field("$data$", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null)));
+    public static Field FIELD_SOURCE_ID = new Field("<source.id>", FieldType.nullable(Types.MinorType.BIGINT.getType()), null);
+    public static Field FIELD_TARGET_ID = new Field("<target.id>", FieldType.nullable(Types.MinorType.BIGINT.getType()), null);
+    public static Field FIELD_TYPE = new Field("<type>", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
+
+}

--- a/core/src/main/java/apoc/export/arrow/ExportArrow.java
+++ b/core/src/main/java/apoc/export/arrow/ExportArrow.java
@@ -1,0 +1,80 @@
+package apoc.export.arrow;
+
+import apoc.ApocConfig;
+import apoc.Pools;
+import apoc.export.util.NodesAndRelsSubGraph;
+import apoc.result.ByteArrayResult;
+import apoc.result.VirtualGraph;
+import org.neo4j.cypher.export.DatabaseSubGraph;
+import org.neo4j.cypher.export.SubGraph;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.logging.Log;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.TerminationGuard;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class ExportArrow {
+
+    @Context
+    public Transaction tx;
+
+    @Context
+    public GraphDatabaseService db;
+
+    @Context
+    public ApocConfig apocConfig;
+
+    @Context
+    public Pools pools;
+
+    @Context
+    public Log logger;
+
+    @Context
+    public TerminationGuard terminationGuard;
+
+    @Procedure("apoc.export.arrow.stream.all")
+    @Description("apoc.export.arrow.stream.all(config) - exports whole database as arrow byte[] result")
+    public Stream<ByteArrayResult> all(@Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws Exception {
+        return new ExportArrowService(db, pools, terminationGuard, logger).stream(new DatabaseSubGraph(tx), new ArrowConfig(config));
+    }
+
+    @Procedure("apoc.export.arrow.stream.graph")
+    @Description("apoc.export.arrow.stream.graph(graph, config) - exports given nodes and relationships as arrow byte[] result")
+    public Stream<ByteArrayResult> graph(@Name("graph") Object graph, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws Exception {
+        final SubGraph subGraph;
+        if (graph instanceof Map) {
+            Map<String, Object> mGraph = (Map<String, Object>) graph;
+            if (!mGraph.containsKey("nodes")) {
+                throw new IllegalArgumentException("Graph Map must contains `nodes` field and `relationships` optionally");
+            }
+            subGraph = new NodesAndRelsSubGraph(tx, (Collection<Node>) mGraph.get("nodes"),
+                    (Collection<Relationship>) mGraph.get("relationships"));
+        } else if (graph instanceof VirtualGraph) {
+            VirtualGraph vGraph = (VirtualGraph) graph;
+            subGraph = new NodesAndRelsSubGraph(tx, vGraph.nodes(), vGraph.relationships());
+        } else {
+            throw new IllegalArgumentException("Supported inputs are VirtualGraph, Map");
+        }
+        return new ExportArrowService(db, pools, terminationGuard, logger).stream(subGraph, new ArrowConfig(config));
+    }
+
+    @Procedure("apoc.export.arrow.stream.query")
+    @Description("apoc.export.arrow.stream.query(query, config) - exports results from the cypher statement as arrow byte[] result")
+    public Stream<ByteArrayResult> query(@Name("query") String query, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws Exception {
+        Map<String, Object> params = config == null ? Collections.emptyMap() : (Map<String, Object>) config.getOrDefault("params", Collections.emptyMap());
+        Result result = tx.execute(query, params);
+        return new ExportArrowService(db, pools, terminationGuard, logger).stream(result, new ArrowConfig(config));
+    }
+}

--- a/core/src/main/java/apoc/export/arrow/ExportArrowFileStrategy.java
+++ b/core/src/main/java/apoc/export/arrow/ExportArrowFileStrategy.java
@@ -1,0 +1,129 @@
+package apoc.export.arrow;
+
+import apoc.convert.Json;
+import apoc.export.util.ProgressReporter;
+import apoc.result.ProgressInfo;
+import apoc.util.FileUtils;
+import apoc.util.QueueBasedSpliterator;
+import apoc.util.QueueUtil;
+import apoc.util.Util;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
+import org.apache.arrow.vector.ipc.ArrowFileWriter;
+import org.apache.arrow.vector.ipc.ArrowWriter;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.logging.Log;
+import org.neo4j.procedure.TerminationGuard;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public interface ExportArrowFileStrategy<IN> extends ExportArrowStrategy<IN, Stream<ProgressInfo>> {
+
+    Iterator<Map<String, Object>> toIterator(ProgressReporter reporter, IN data);
+
+    default Stream<ProgressInfo> export(IN data, ArrowConfig config) {
+        final BlockingQueue<ProgressInfo> queue = new ArrayBlockingQueue<>(10);
+        final OutputStream out = FileUtils.getOutputStream(getFileName(), null);
+        ProgressInfo progressInfo = new ProgressInfo(getFileName(), getSource(data), "arrow");
+        progressInfo.batchSize = config.getBatchSize();
+        ProgressReporter reporter = new ProgressReporter(null, null, progressInfo);
+        Util.inTxFuture(getExecutorService(), getGraphDatabaseApi(), txInThread -> {
+            int batchCount = 0;
+            List<Map<String, Object>> rows = new ArrayList<>(config.getBatchSize());
+            VectorSchemaRoot root = null;
+            ArrowWriter writer = null;
+            try {
+                Iterator<Map<String, Object>> it = toIterator(reporter, data);
+                while (!Util.transactionIsTerminated(getTerminationGuard()) && it.hasNext()) {
+                    rows.add(it.next());
+                    if (batchCount > 0 && batchCount % config.getBatchSize() == 0) {
+                        if (root == null) {
+                            root = VectorSchemaRoot.create(schemaFor(rows), getBufferAllocator());
+                            writer = newArrowWriter(root, out);
+                        }
+                        writeBatch(root, writer, rows);
+                        rows.clear();
+                    }
+                    ++batchCount;
+                }
+                if (!rows.isEmpty()) {
+                    if (root == null) {
+                        root = VectorSchemaRoot.create(schemaFor(rows), getBufferAllocator());
+                        writer = newArrowWriter(root, out);
+                    }
+                    writeBatch(root, writer, rows);
+                }
+                QueueUtil.put(queue, progressInfo, 10);
+            } catch (Exception e) {
+                getLogger().error("Exception while extracting Arrow data:", e);
+            } finally {
+                reporter.done();
+                Util.close(root);
+                Util.close(writer);
+                QueueUtil.put(queue, ProgressInfo.EMPTY, 10);
+            }
+            return true;
+        });
+        QueueBasedSpliterator<ProgressInfo> spliterator = new QueueBasedSpliterator<>(queue, ProgressInfo.EMPTY, getTerminationGuard(), Integer.MAX_VALUE);
+        return StreamSupport.stream(spliterator, false);
+    }
+
+    String getSource(IN data);
+
+
+    default void writeBatch(VectorSchemaRoot root, ArrowWriter writer, List<Map<String, Object>> rows) {
+        AtomicInteger counter = new AtomicInteger();
+        root.allocateNew();
+        rows.forEach(row -> {
+            final int index = counter.getAndIncrement();
+            root.getFieldVectors()
+                    .forEach(fe -> {
+                        Object value = convertValue(row.get(fe.getName()));
+                        write(index, value, fe);
+                    });
+        });
+        root.setRowCount(counter.get());
+        try {
+            writer.writeBatch();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        root.clear();
+    }
+
+    String getFileName();
+
+    TerminationGuard getTerminationGuard();
+
+    BufferAllocator getBufferAllocator();
+
+    GraphDatabaseService getGraphDatabaseApi();
+
+    ExecutorService getExecutorService();
+
+    Log getLogger();
+
+    default Object convertValue(Object data) {
+        return data == null ? null : Json.writeJsonResult(data);
+    }
+
+    default ArrowWriter newArrowWriter(VectorSchemaRoot root, OutputStream out) {
+        return new ArrowFileWriter(root, new DictionaryProvider.MapDictionaryProvider(), Channels.newChannel(out));
+    }
+
+    Schema schemaFor(List<Map<String, Object>> rows);
+}

--- a/core/src/main/java/apoc/export/arrow/ExportArrowService.java
+++ b/core/src/main/java/apoc/export/arrow/ExportArrowService.java
@@ -2,6 +2,7 @@ package apoc.export.arrow;
 
 import apoc.Pools;
 import apoc.result.ByteArrayResult;
+import apoc.result.ProgressInfo;
 import org.neo4j.cypher.export.SubGraph;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Result;
@@ -29,6 +30,14 @@ public class ExportArrowService {
             return new ExportResultStreamStrategy(db, pools, terminationGuard, logger).export((Result) data, config);
         } else {
             return new ExportGraphStreamStrategy(db, pools, terminationGuard, logger).export((SubGraph) data, config);
+        }
+    }
+
+    public Stream<ProgressInfo> file(String fileName, Object data, ArrowConfig config) {
+        if (data instanceof Result) {
+            return new ExportResultFileStrategy(fileName, db, pools, terminationGuard, logger).export((Result) data, config);
+        } else {
+            return new ExportGraphFileStrategy(fileName, db, pools, terminationGuard, logger).export((SubGraph) data, config);
         }
     }
 }

--- a/core/src/main/java/apoc/export/arrow/ExportArrowService.java
+++ b/core/src/main/java/apoc/export/arrow/ExportArrowService.java
@@ -1,0 +1,34 @@
+package apoc.export.arrow;
+
+import apoc.Pools;
+import apoc.result.ByteArrayResult;
+import org.neo4j.cypher.export.SubGraph;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Result;
+import org.neo4j.logging.Log;
+import org.neo4j.procedure.TerminationGuard;
+
+import java.util.stream.Stream;
+
+public class ExportArrowService {
+
+    private final GraphDatabaseService db;
+    private final Pools pools;
+    private final TerminationGuard terminationGuard;
+    private final Log logger;
+
+    public ExportArrowService(GraphDatabaseService db, Pools pools, TerminationGuard terminationGuard, Log logger) {
+        this.db = db;
+        this.pools = pools;
+        this.terminationGuard = terminationGuard;
+        this.logger = logger;
+    }
+
+    public Stream<ByteArrayResult> stream(Object data, ArrowConfig config) {
+        if (data instanceof Result) {
+            return new ExportResultStreamStrategy(db, pools, terminationGuard, logger).export((Result) data, config);
+        } else {
+            return new ExportGraphStreamStrategy(db, pools, terminationGuard, logger).export((SubGraph) data, config);
+        }
+    }
+}

--- a/core/src/main/java/apoc/export/arrow/ExportArrowStrategy.java
+++ b/core/src/main/java/apoc/export/arrow/ExportArrowStrategy.java
@@ -1,0 +1,286 @@
+package apoc.export.arrow;
+
+import apoc.meta.Meta;
+import apoc.util.JsonUtil;
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.BaseVariableWidthVector;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateMilliVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.impl.UnionListWriter;
+import org.apache.arrow.vector.ipc.ArrowWriter;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.neo4j.values.storable.DurationValue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public interface ExportArrowStrategy<IN, OUT> {
+
+    OUT export(IN data, ArrowConfig config);
+
+    Object convertValue(Object data);
+
+    ArrowWriter newArrowWriter(VectorSchemaRoot root, OutputStream out);
+
+    Schema schemaFor(List<Map<String, Object>> rows);
+
+    static String fromMetaType(Meta.Types type) {
+        switch (type) {
+            case INTEGER:
+                return "Long";
+            case FLOAT:
+                return "Double";
+            case LIST:
+                String inner = type.toString().substring("LIST OF ".length()).trim();
+                final Meta.Types innerType = Meta.Types.from(inner);
+                if (innerType == Meta.Types.LIST) {
+                    return "AnyArray";
+                }
+                return fromMetaType(innerType) + "Array";
+            case BOOLEAN:
+                return "Boolean";
+            case MAP:
+                return "Map";
+            case RELATIONSHIP:
+                return "Relationship";
+            case NODE:
+                return "Node";
+            case PATH:
+                return "Path";
+            case POINT:
+                return "Point";
+            case DATE:
+                return "Date";
+            case LOCAL_TIME:
+            case DATE_TIME:
+            case LOCAL_DATE_TIME:
+                return "DateTime";
+            case TIME:
+                return "Time";
+            case DURATION:
+                return "Duration";
+            default:
+                return "String";
+        }
+    }
+
+    static Field toField(String fieldName, Set<String> propertyTypes) {
+        if (propertyTypes.size() > 1) {
+            // return string type
+            return new Field(fieldName, FieldType.nullable(new ArrowType.Utf8()), null);
+        } else {
+            // convert to RelatedType
+            final String type = propertyTypes.iterator().next();
+            switch (type) {
+                case "Boolean":
+                    return new Field(fieldName, FieldType.nullable(Types.MinorType.BIT.getType()), null);
+                case "Long":
+                    return new Field(fieldName, FieldType.nullable(Types.MinorType.BIGINT.getType()), null);
+                case "Double":
+                    return new Field(fieldName, FieldType.nullable(Types.MinorType.FLOAT8.getType()), null);
+                case "DateTime":
+                case "LocalDateTime":
+                case "Date":
+                    return new Field(fieldName, FieldType.nullable(Types.MinorType.DATEMILLI.getType()), null);
+                case "Duration":
+                case "Node":
+                case "Relationship":
+//                    return new Field(fieldName, FieldType.nullable(Types.MinorType.STRUCT.getType()), null);
+                case "Point":
+                case "Map":
+//                    return new Field(fieldName, FieldType.nullable(Types.MinorType.MAP.getType()), null);
+                case "DateTimeArray":
+                case "DateArray":
+                case "BooleanArray":
+                case "LongArray":
+                case "DoubleArray":
+                case "StringArray":
+                case "PointArray":
+                default:
+                    return (type.endsWith("Array")) ? new Field(fieldName, FieldType.nullable(Types.MinorType.LIST.getType()),
+                            List.of(toField("$data$", Set.of(type.replace("Array", "")))))
+                            : new Field(fieldName, FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
+            }
+        }
+    }
+
+    default byte[] writeBatch(AtomicInteger counter, BufferAllocator bufferAllocator, List<Map<String, Object>> rows) {
+        try (final VectorSchemaRoot root = VectorSchemaRoot.create(schemaFor(rows), bufferAllocator);
+             final ByteArrayOutputStream out = new ByteArrayOutputStream();
+             final ArrowWriter writer = newArrowWriter(root, out)) {
+            rows.forEach(row -> {
+                final int index = counter.getAndIncrement();
+                root.allocateNew();
+                row.forEach((prop, value) -> {
+                    final FieldVector fieldVector = root.getVector(prop);
+                    value = convertValue(value);
+                    write(index, value, fieldVector);
+                });
+                root.setRowCount(counter.get());
+                try {
+                    writer.writeBatch();
+                } catch (IOException ignored) {
+                    ignored.printStackTrace();
+                }
+                root.clear();
+            });
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void write(int index, Object value, FieldVector fieldVector) {
+        if (fieldVector instanceof BaseVariableWidthVector) {
+            writeBaseVariableWidthVector(index, value, (BaseVariableWidthVector) fieldVector);
+        } else if (fieldVector instanceof BigIntVector) {
+            writeBigIntVector(index, value, (BigIntVector) fieldVector);
+        } else if (fieldVector instanceof DateMilliVector) {
+            writeDateMilliVector(index, value, (DateMilliVector) fieldVector);
+        } else if (fieldVector instanceof Float8Vector) {
+            writeFloat8Vector(index, value, (Float8Vector) fieldVector);
+        } else if (fieldVector instanceof BitVector) {
+            writeBitVector(index, value, (BitVector) fieldVector);
+        } else if (fieldVector instanceof ListVector) {
+            writeListVector(index, value, fieldVector);
+        }
+    }
+
+    private void writeListVector(int index, Object value, FieldVector fieldVector) {
+        ListVector listVector = (ListVector) fieldVector;
+        UnionListWriter listWriter = listVector.getWriter();
+        Object[] array;
+        if (value instanceof Collection) {
+            final Collection collection = (Collection) value;
+            array = collection.toArray(new Object[collection.size()]);
+        } else {
+            array = (Object[]) value;
+        }
+        listWriter.setPosition(index);
+        listWriter.startList();
+        FieldVector inner = listVector.getChildrenFromFields().get(0);
+        for (int i = 0; i < array.length; i++) {
+            Object val = convertValue(array[i]);
+            if (val == null) {
+                listWriter.writeNull();
+            } else if (inner instanceof ListVector) {
+                write(i, val, inner);
+            } else if (inner instanceof BaseVariableWidthVector) {
+                final byte[] bytes;
+                if (val instanceof String) {
+                    bytes = val.toString().getBytes(StandardCharsets.UTF_8);
+                } else {
+                    bytes = JsonUtil.writeValueAsBytes(val);
+                }
+                ArrowBuf tempBuf = fieldVector.getAllocator().buffer(bytes.length);
+                tempBuf.setBytes(0, bytes);
+                listWriter.varChar().writeVarChar(0, bytes.length, tempBuf);
+                tempBuf.close();
+            } else if (inner instanceof BigIntVector) {
+                long lng = (long) val;
+                listWriter.bigInt().writeBigInt(lng);
+            } else if (inner instanceof Float8Vector) {
+                double dbl = (double) val;
+                listWriter.float8().writeFloat8(dbl);
+            } else if (inner instanceof BitVector) {
+                boolean bool = (boolean) val;
+                listWriter.bit().writeBit(bool ? 1 : 0);
+            }
+        }
+        listWriter.endList();
+    }
+
+    private void writeBitVector(int index, Object value, BitVector fieldVector) {
+        BitVector baseVector = fieldVector;
+        if (value == null) {
+            baseVector.setNull(index);
+        } else {
+            baseVector.setSafe(index, (boolean) value ? 1 : 0);
+        }
+    }
+
+    private void writeFloat8Vector(int index, Object value, Float8Vector fieldVector) {
+        Float8Vector baseVector = fieldVector;
+        if (value == null) {
+            baseVector.setNull(index);
+        } else {
+            baseVector.setSafe(index, (double) value);
+        }
+    }
+
+    private void writeDateMilliVector(int index, Object value, DateMilliVector fieldVector) {
+        DateMilliVector baseVector = fieldVector;
+        final Long dateInMillis;
+        if (value == null) {
+            dateInMillis = null;
+        } else if (value instanceof Date) {
+            dateInMillis = ((Date) value).getTime();
+        } else if (value instanceof LocalDateTime) {
+            dateInMillis = ((LocalDateTime) value)
+                    .toInstant(ZoneOffset.UTC)
+                    .toEpochMilli();
+        } else if (value instanceof ZonedDateTime) {
+            dateInMillis = ((ZonedDateTime) value)
+                    .toInstant()
+                    .toEpochMilli();
+        } else if (value instanceof OffsetDateTime) {
+            dateInMillis = ((OffsetDateTime) value)
+                    .toInstant()
+                    .toEpochMilli();
+        } else {
+            dateInMillis = null;
+        }
+        if (dateInMillis == null) {
+            baseVector.setNull(index);
+        } else {
+            baseVector.setSafe(index, dateInMillis);
+        }
+    }
+
+    private void writeBigIntVector(int index, Object value, BigIntVector fieldVector) {
+        BigIntVector baseVector = fieldVector;
+        if (value == null) {
+            baseVector.setNull(index);
+        } else {
+            baseVector.setSafe(index, (long) value);
+        }
+    }
+
+    private void writeBaseVariableWidthVector(int index, Object value, BaseVariableWidthVector fieldVector) {
+        final BaseVariableWidthVector baseVector = fieldVector;
+        if (value == null) {
+            baseVector.setNull(index);
+        } else {
+            if (value instanceof DurationValue) {
+                value = ((DurationValue) value).toString();
+            }
+            if (value instanceof String) {
+                baseVector.setSafe(index, value.toString().getBytes(StandardCharsets.UTF_8));
+            } else {
+                baseVector.setSafe(index, JsonUtil.writeValueAsBytes(value));
+            }
+        }
+    }
+}

--- a/core/src/main/java/apoc/export/arrow/ExportArrowStreamStrategy.java
+++ b/core/src/main/java/apoc/export/arrow/ExportArrowStreamStrategy.java
@@ -1,0 +1,88 @@
+package apoc.export.arrow;
+
+import apoc.convert.Json;
+import apoc.result.ByteArrayResult;
+import apoc.util.QueueBasedSpliterator;
+import apoc.util.QueueUtil;
+import apoc.util.Util;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.ipc.ArrowWriter;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.logging.Log;
+import org.neo4j.procedure.TerminationGuard;
+
+import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public interface ExportArrowStreamStrategy<IN> extends ExportArrowStrategy<IN, Stream<ByteArrayResult>> {
+
+    Iterator<Map<String, Object>> toIterator(IN data);
+
+    default Stream<ByteArrayResult> export(IN data, ArrowConfig config) {
+        final BlockingQueue<apoc.result.ByteArrayResult> queue = new ArrayBlockingQueue<>(1000);
+        Util.inTxFuture(getExecutorService(), getGraphDatabaseApi(), txInThread -> {
+            int batchCount = 0;
+            List<Map<String, Object>> rows = new ArrayList<>(config.getBatchSize());
+            try {
+                Iterator<Map<String, Object>> it = toIterator(data);
+                while (!Util.transactionIsTerminated(getTerminationGuard()) && it.hasNext()) {
+                    rows.add(it.next());
+                    if (batchCount > 0 && batchCount % config.getBatchSize() == 0) {
+                        final byte[] bytes = writeBatch(getCounter(), getBufferAllocator(), rows);
+                        QueueUtil.put(queue, new apoc.result.ByteArrayResult(bytes), 10);
+                        rows.clear();
+                    }
+                    ++batchCount;
+                }
+                if (!rows.isEmpty()) {
+                    final byte[] bytes = writeBatch(getCounter(), getBufferAllocator(), rows);
+                    QueueUtil.put(queue, new apoc.result.ByteArrayResult(bytes), 10);
+                }
+            } catch (Exception e) {
+                getLogger().error("Exception while extracting Arrow data:", e);
+            } finally {
+                QueueUtil.put(queue, apoc.result.ByteArrayResult.NULL, 10);
+            }
+            return true;
+        });
+        QueueBasedSpliterator<apoc.result.ByteArrayResult> spliterator = new QueueBasedSpliterator<>(queue, apoc.result.ByteArrayResult.NULL, getTerminationGuard(), Integer.MAX_VALUE);
+        return StreamSupport.stream(spliterator, false)
+                .onClose(() -> Util.close(getBufferAllocator()));
+    }
+
+    TerminationGuard getTerminationGuard();
+
+    BufferAllocator getBufferAllocator();
+
+    AtomicInteger getCounter();
+
+    GraphDatabaseService getGraphDatabaseApi();
+
+    ExecutorService getExecutorService();
+
+    Log getLogger();
+
+    default Object convertValue(Object data) {
+        return Json.writeJsonResult(data);
+    }
+
+    default ArrowWriter newArrowWriter(VectorSchemaRoot root, OutputStream out) {
+        return new ArrowStreamWriter(root, new DictionaryProvider.MapDictionaryProvider(), Channels.newChannel(out));
+    }
+
+    Schema schemaFor(List<Map<String, Object>> rows);
+}

--- a/core/src/main/java/apoc/export/arrow/ExportGraphStrategy.java
+++ b/core/src/main/java/apoc/export/arrow/ExportGraphStrategy.java
@@ -1,0 +1,99 @@
+package apoc.export.arrow;
+
+import apoc.util.Util;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.neo4j.cypher.export.SubGraph;
+import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResultTransformer;
+import org.neo4j.internal.helpers.collection.Iterables;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static apoc.export.arrow.ArrowUtils.FIELD_ID;
+import static apoc.export.arrow.ArrowUtils.FIELD_LABELS;
+import static apoc.export.arrow.ArrowUtils.FIELD_SOURCE_ID;
+import static apoc.export.arrow.ArrowUtils.FIELD_TARGET_ID;
+import static apoc.export.arrow.ArrowUtils.FIELD_TYPE;
+import static apoc.export.arrow.ExportArrowStrategy.toField;
+
+public interface ExportGraphStrategy {
+
+    default Schema schemaFor(GraphDatabaseService db, List<Map<String, Object>> records) {
+        final Function<Map<String, Object>, Stream<? extends Field>> flatMapStream = m -> {
+            String propertyName = (String) m.get("propertyName");
+            List<String> propertyTypes = (List<String>) m.get("propertyTypes");
+            return propertyTypes.stream()
+                    .map(propertyType -> toField(propertyName, new HashSet<>(propertyTypes)));
+        };
+        final Predicate<Map<String, Object>> filterStream = m -> m.get("propertyName") != null;
+        final ResultTransformer<Set<Field>> parsePropertiesResult = result -> result.stream()
+                .filter(filterStream)
+                .flatMap(flatMapStream)
+                .collect(Collectors.toSet());
+
+        final Map<String, Object> cfg = records.get(0);
+        final Map<String, Object> parameters = Map.of("config", cfg);
+        final Set<Field> allFields = new HashSet<>();
+        Set<Field> nodeFields = db.executeTransactionally("CALL apoc.meta.nodeTypeProperties($config)",
+                parameters, parsePropertiesResult);
+
+        allFields.add(FIELD_ID);
+        allFields.add(FIELD_LABELS);
+        allFields.addAll(nodeFields);
+
+        if (cfg.containsKey("includeRels")) {
+            final Set<Field> relFields = db.executeTransactionally("CALL apoc.meta.relTypeProperties($config)",
+                    parameters, parsePropertiesResult);
+            allFields.add(FIELD_SOURCE_ID);
+            allFields.add(FIELD_TARGET_ID);
+            allFields.add(FIELD_TYPE);
+            allFields.addAll(relFields);
+        }
+        return new Schema(allFields);
+    }
+
+    default Map<String, Object> entityToMap(Entity entity) {
+        Map<String, Object> flattened = new HashMap<>();
+        flattened.put(FIELD_ID.getName(), entity.getId());
+        if (entity instanceof Node) {
+            flattened.put(FIELD_LABELS.getName(), Util.labelStrings((Node) entity));
+        } else {
+            Relationship rel = (Relationship) entity;
+            flattened.put(FIELD_TYPE.getName(), rel.getType().name());
+            flattened.put(FIELD_SOURCE_ID.getName(), rel.getStartNodeId());
+            flattened.put(FIELD_TARGET_ID.getName(), rel.getEndNodeId());
+        }
+        flattened.putAll(entity.getAllProperties());
+        return flattened;
+    }
+
+    default Map<String, Object> createConfigMap(SubGraph subGraph, ArrowConfig config) {
+        final List<String> allLabelsInUse = Iterables.stream(subGraph.getAllLabelsInUse())
+                .map(Label::name)
+                .collect(Collectors.toList());
+        final List<String> allRelationshipTypesInUse = Iterables.stream(subGraph.getAllRelationshipTypesInUse())
+                .map(RelationshipType::name)
+                .collect(Collectors.toList());
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("includeLabels", allLabelsInUse);
+        if (!allRelationshipTypesInUse.isEmpty()) {
+            configMap.put("includeRels", allRelationshipTypesInUse);
+        }
+        configMap.putAll(config.getConfig());
+        return configMap;
+    }
+}

--- a/core/src/main/java/apoc/export/arrow/ExportGraphStreamStrategy.java
+++ b/core/src/main/java/apoc/export/arrow/ExportGraphStreamStrategy.java
@@ -2,69 +2,44 @@ package apoc.export.arrow;
 
 import apoc.Pools;
 import apoc.result.ByteArrayResult;
-import apoc.util.Util;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.dictionary.DictionaryProvider;
 import org.apache.arrow.vector.ipc.ArrowStreamWriter;
 import org.apache.arrow.vector.ipc.ArrowWriter;
-import org.apache.arrow.vector.types.Types;
-import org.apache.arrow.vector.types.pojo.Field;
-import org.apache.arrow.vector.types.pojo.FieldType;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.neo4j.cypher.export.SubGraph;
-import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Label;
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Relationship;
-import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.internal.helpers.collection.Iterables;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.TerminationGuard;
 
 import java.io.OutputStream;
 import java.nio.channels.Channels;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static apoc.export.arrow.ExportArrowStrategy.toField;
-
-public class ExportGraphStreamStrategy implements ExportArrowStreamStrategy<SubGraph> {
+public class ExportGraphStreamStrategy implements ExportArrowStreamStrategy<SubGraph>, ExportGraphStrategy {
 
     private final GraphDatabaseService db;
     private final Pools pools;
     private final TerminationGuard terminationGuard;
     private final Log logger;
 
-    private final AtomicInteger counter;
-
     private final RootAllocator bufferAllocator;
 
     private Schema schema;
 
-    private static Field FIELD_ID = new Field("<id>", FieldType.nullable(Types.MinorType.BIGINT.getType()), null);
-    private static Field FIELD_LABELS = new Field("labels", FieldType.nullable(Types.MinorType.LIST.getType()),
-            List.of(new Field("$data$", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null)));
-    private static Field FIELD_SOURCE_ID = new Field("<source.id>", FieldType.nullable(Types.MinorType.BIGINT.getType()), null);
-    private static Field FIELD_TARGET_ID = new Field("<target.id>", FieldType.nullable(Types.MinorType.BIGINT.getType()), null);
-    private static Field FIELD_TYPE = new Field("<type>", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
 
     public ExportGraphStreamStrategy(GraphDatabaseService db, Pools pools, TerminationGuard terminationGuard, Log logger) {
         this.db = db;
         this.pools = pools;
         this.terminationGuard = terminationGuard;
         this.logger = logger;
-        this.counter = new AtomicInteger();
         this.bufferAllocator = new RootAllocator();
     }
 
@@ -93,11 +68,6 @@ public class ExportGraphStreamStrategy implements ExportArrowStreamStrategy<SubG
     }
 
     @Override
-    public AtomicInteger getCounter() {
-        return counter;
-    }
-
-    @Override
     public GraphDatabaseService getGraphDatabaseApi() {
         return db;
     }
@@ -112,37 +82,6 @@ public class ExportGraphStreamStrategy implements ExportArrowStreamStrategy<SubG
         return logger;
     }
 
-    private Map<String, Object> createConfigMap(SubGraph subGraph, ArrowConfig config) {
-        final List<String> allLabelsInUse = Iterables.stream(subGraph.getAllLabelsInUse())
-                .map(Label::name)
-                .collect(Collectors.toList());
-        final List<String> allRelationshipTypesInUse = Iterables.stream(subGraph.getAllRelationshipTypesInUse())
-                .map(RelationshipType::name)
-                .collect(Collectors.toList());
-        Map<String, Object> configMap = new HashMap<>();
-        configMap.put("includeLabels", allLabelsInUse);
-        if (!allRelationshipTypesInUse.isEmpty()) {
-            configMap.put("includeRels", allRelationshipTypesInUse);
-        }
-        configMap.putAll(config.getConfig());
-        return configMap;
-    }
-
-    private Map<String, Object> entityToMap(Entity entity) {
-        Map<String, Object> flattened = new HashMap<>();
-        flattened.put(FIELD_ID.getName(), entity.getId());
-        if (entity instanceof Node) {
-            flattened.put(FIELD_LABELS.getName(), Util.labelStrings((Node) entity));
-        } else {
-            Relationship rel = (Relationship) entity;
-            flattened.put(FIELD_TYPE.getName(), rel.getType().name());
-            flattened.put(FIELD_SOURCE_ID.getName(), rel.getStartNodeId());
-            flattened.put(FIELD_TARGET_ID.getName(), rel.getEndNodeId());
-        }
-        flattened.putAll(entity.getAllProperties());
-        return flattened;
-    }
-
     @Override
     public ArrowWriter newArrowWriter(VectorSchemaRoot root, OutputStream out) {
         return new ArrowStreamWriter(root, new DictionaryProvider.MapDictionaryProvider(), Channels.newChannel(out));
@@ -151,42 +90,8 @@ public class ExportGraphStreamStrategy implements ExportArrowStreamStrategy<SubG
     @Override
     public synchronized Schema schemaFor(List<Map<String, Object>> records) {
         if (schema == null) {
-            final Map<String, Object> cfg = records.get(0);
-            final Map<String, Object> parameters = Map.of("config", cfg);
-            final Set<Field> allFields = new HashSet<>();
-            Set<Field> nodeFields = db.executeTransactionally("CALL apoc.meta.nodeTypeProperties($config)",
-                    parameters, result -> result.stream()
-                            .flatMap(m -> {
-                                String propertyName = (String) m.get("propertyName");
-                                List<String> propertyTypes = (List<String>) m.get("propertyTypes");
-                                return propertyTypes.stream()
-                                        .map(propertyType -> toField(propertyName, new HashSet<>(propertyTypes)));
-                            })
-                            .collect(Collectors.toSet()));
-            allFields.add(FIELD_ID);
-            allFields.add(FIELD_LABELS);
-            allFields.addAll(nodeFields);
-
-            if (cfg.containsKey("includeRels")) {
-                final Set<Field> relFields = db.executeTransactionally("CALL apoc.meta.relTypeProperties($config)",
-                        parameters, result -> result.stream()
-                                .flatMap(m -> {
-                                    String propertyName = (String) m.get("propertyName");
-                                    List<String> propertyTypes = (List<String>) m.get("propertyTypes");
-                                    return propertyTypes.stream()
-                                            .map(propertyType -> toField(propertyName, new HashSet<>(propertyTypes)));
-                                })
-                                .collect(Collectors.toSet()));
-                allFields.add(FIELD_SOURCE_ID);
-                allFields.add(FIELD_TARGET_ID);
-                allFields.add(FIELD_TYPE);
-                allFields.addAll(relFields);
-            }
-
-            schema = new Schema(allFields);
+            schema = schemaFor(getGraphDatabaseApi(), records);
         }
         return schema;
     }
-
-
 }

--- a/core/src/main/java/apoc/export/arrow/ExportGraphStreamStrategy.java
+++ b/core/src/main/java/apoc/export/arrow/ExportGraphStreamStrategy.java
@@ -1,0 +1,192 @@
+package apoc.export.arrow;
+
+import apoc.Pools;
+import apoc.result.ByteArrayResult;
+import apoc.util.Util;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.dictionary.DictionaryProvider;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.ipc.ArrowWriter;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.neo4j.cypher.export.SubGraph;
+import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.internal.helpers.collection.Iterables;
+import org.neo4j.logging.Log;
+import org.neo4j.procedure.TerminationGuard;
+
+import java.io.OutputStream;
+import java.nio.channels.Channels;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static apoc.export.arrow.ExportArrowStrategy.toField;
+
+public class ExportGraphStreamStrategy implements ExportArrowStreamStrategy<SubGraph> {
+
+    private final GraphDatabaseService db;
+    private final Pools pools;
+    private final TerminationGuard terminationGuard;
+    private final Log logger;
+
+    private final AtomicInteger counter;
+
+    private final RootAllocator bufferAllocator;
+
+    private Schema schema;
+
+    private static Field FIELD_ID = new Field("<id>", FieldType.nullable(Types.MinorType.BIGINT.getType()), null);
+    private static Field FIELD_LABELS = new Field("labels", FieldType.nullable(Types.MinorType.LIST.getType()),
+            List.of(new Field("$data$", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null)));
+    private static Field FIELD_SOURCE_ID = new Field("<source.id>", FieldType.nullable(Types.MinorType.BIGINT.getType()), null);
+    private static Field FIELD_TARGET_ID = new Field("<target.id>", FieldType.nullable(Types.MinorType.BIGINT.getType()), null);
+    private static Field FIELD_TYPE = new Field("<type>", FieldType.nullable(Types.MinorType.VARCHAR.getType()), null);
+
+    public ExportGraphStreamStrategy(GraphDatabaseService db, Pools pools, TerminationGuard terminationGuard, Log logger) {
+        this.db = db;
+        this.pools = pools;
+        this.terminationGuard = terminationGuard;
+        this.logger = logger;
+        this.counter = new AtomicInteger();
+        this.bufferAllocator = new RootAllocator();
+    }
+
+    @Override
+    public Iterator<Map<String, Object>> toIterator(SubGraph subGraph) {
+        return Stream.concat(Iterables.stream(subGraph.getNodes()), Iterables.stream(subGraph.getRelationships()))
+                .map(this::entityToMap)
+                .iterator();
+    }
+
+    @Override
+    public Stream<ByteArrayResult> export(SubGraph subGraph, ArrowConfig config) {
+        Map<String, Object> configMap = createConfigMap(subGraph, config);
+        this.schemaFor(List.of(configMap));
+        return ExportArrowStreamStrategy.super.export(subGraph, config);
+    }
+
+    @Override
+    public TerminationGuard getTerminationGuard() {
+        return terminationGuard;
+    }
+
+    @Override
+    public BufferAllocator getBufferAllocator() {
+        return bufferAllocator;
+    }
+
+    @Override
+    public AtomicInteger getCounter() {
+        return counter;
+    }
+
+    @Override
+    public GraphDatabaseService getGraphDatabaseApi() {
+        return db;
+    }
+
+    @Override
+    public ExecutorService getExecutorService() {
+        return pools.getDefaultExecutorService();
+    }
+
+    @Override
+    public Log getLogger() {
+        return logger;
+    }
+
+    private Map<String, Object> createConfigMap(SubGraph subGraph, ArrowConfig config) {
+        final List<String> allLabelsInUse = Iterables.stream(subGraph.getAllLabelsInUse())
+                .map(Label::name)
+                .collect(Collectors.toList());
+        final List<String> allRelationshipTypesInUse = Iterables.stream(subGraph.getAllRelationshipTypesInUse())
+                .map(RelationshipType::name)
+                .collect(Collectors.toList());
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("includeLabels", allLabelsInUse);
+        if (!allRelationshipTypesInUse.isEmpty()) {
+            configMap.put("includeRels", allRelationshipTypesInUse);
+        }
+        configMap.putAll(config.getConfig());
+        return configMap;
+    }
+
+    private Map<String, Object> entityToMap(Entity entity) {
+        Map<String, Object> flattened = new HashMap<>();
+        flattened.put(FIELD_ID.getName(), entity.getId());
+        if (entity instanceof Node) {
+            flattened.put(FIELD_LABELS.getName(), Util.labelStrings((Node) entity));
+        } else {
+            Relationship rel = (Relationship) entity;
+            flattened.put(FIELD_TYPE.getName(), rel.getType().name());
+            flattened.put(FIELD_SOURCE_ID.getName(), rel.getStartNodeId());
+            flattened.put(FIELD_TARGET_ID.getName(), rel.getEndNodeId());
+        }
+        flattened.putAll(entity.getAllProperties());
+        return flattened;
+    }
+
+    @Override
+    public ArrowWriter newArrowWriter(VectorSchemaRoot root, OutputStream out) {
+        return new ArrowStreamWriter(root, new DictionaryProvider.MapDictionaryProvider(), Channels.newChannel(out));
+    }
+
+    @Override
+    public synchronized Schema schemaFor(List<Map<String, Object>> records) {
+        if (schema == null) {
+            final Map<String, Object> cfg = records.get(0);
+            final Map<String, Object> parameters = Map.of("config", cfg);
+            final Set<Field> allFields = new HashSet<>();
+            Set<Field> nodeFields = db.executeTransactionally("CALL apoc.meta.nodeTypeProperties($config)",
+                    parameters, result -> result.stream()
+                            .flatMap(m -> {
+                                String propertyName = (String) m.get("propertyName");
+                                List<String> propertyTypes = (List<String>) m.get("propertyTypes");
+                                return propertyTypes.stream()
+                                        .map(propertyType -> toField(propertyName, new HashSet<>(propertyTypes)));
+                            })
+                            .collect(Collectors.toSet()));
+            allFields.add(FIELD_ID);
+            allFields.add(FIELD_LABELS);
+            allFields.addAll(nodeFields);
+
+            if (cfg.containsKey("includeRels")) {
+                final Set<Field> relFields = db.executeTransactionally("CALL apoc.meta.relTypeProperties($config)",
+                        parameters, result -> result.stream()
+                                .flatMap(m -> {
+                                    String propertyName = (String) m.get("propertyName");
+                                    List<String> propertyTypes = (List<String>) m.get("propertyTypes");
+                                    return propertyTypes.stream()
+                                            .map(propertyType -> toField(propertyName, new HashSet<>(propertyTypes)));
+                                })
+                                .collect(Collectors.toSet()));
+                allFields.add(FIELD_SOURCE_ID);
+                allFields.add(FIELD_TARGET_ID);
+                allFields.add(FIELD_TYPE);
+                allFields.addAll(relFields);
+            }
+
+            schema = new Schema(allFields);
+        }
+        return schema;
+    }
+
+
+}

--- a/core/src/main/java/apoc/export/arrow/ExportResultStrategy.java
+++ b/core/src/main/java/apoc/export/arrow/ExportResultStrategy.java
@@ -1,0 +1,74 @@
+package apoc.export.arrow;
+
+import apoc.meta.Meta;
+import apoc.util.Util;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.neo4j.cypher.export.SubGraph;
+import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.internal.helpers.collection.Iterables;
+
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static apoc.export.arrow.ArrowUtils.FIELD_ID;
+import static apoc.export.arrow.ArrowUtils.FIELD_LABELS;
+import static apoc.export.arrow.ArrowUtils.FIELD_SOURCE_ID;
+import static apoc.export.arrow.ArrowUtils.FIELD_TARGET_ID;
+import static apoc.export.arrow.ArrowUtils.FIELD_TYPE;
+import static apoc.export.arrow.ExportArrowStrategy.fromMetaType;
+import static apoc.export.arrow.ExportArrowStrategy.toField;
+
+public interface ExportResultStrategy {
+
+    default Schema schemaFor(GraphDatabaseService db, List<Map<String, Object>> records) {
+        final List<Field> fields = records.stream()
+                .flatMap(m -> m.entrySet().stream())
+                .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), fromMetaType(Meta.Types.of(e.getValue()))))
+                .collect(Collectors.groupingBy(e -> e.getKey(), Collectors.mapping(e -> e.getValue(), Collectors.toSet())))
+                .entrySet()
+                .stream()
+                .map(e -> toField(e.getKey(), e.getValue()))
+                .collect(Collectors.toList());
+        return new Schema(fields);
+    }
+
+    default Map<String, Object> entityToMap(Entity entity) {
+        Map<String, Object> flattened = new HashMap<>();
+        flattened.put(FIELD_ID.getName(), entity.getId());
+        if (entity instanceof Node) {
+            flattened.put(FIELD_LABELS.getName(), Util.labelStrings((Node) entity));
+        } else {
+            Relationship rel = (Relationship) entity;
+            flattened.put(FIELD_TYPE.getName(), rel.getType().name());
+            flattened.put(FIELD_SOURCE_ID.getName(), rel.getStartNodeId());
+            flattened.put(FIELD_TARGET_ID.getName(), rel.getEndNodeId());
+        }
+        flattened.putAll(entity.getAllProperties());
+        return flattened;
+    }
+
+    default Map<String, Object> createConfigMap(SubGraph subGraph, ArrowConfig config) {
+        final List<String> allLabelsInUse = Iterables.stream(subGraph.getAllLabelsInUse())
+                .map(Label::name)
+                .collect(Collectors.toList());
+        final List<String> allRelationshipTypesInUse = Iterables.stream(subGraph.getAllRelationshipTypesInUse())
+                .map(RelationshipType::name)
+                .collect(Collectors.toList());
+        Map<String, Object> configMap = new HashMap<>();
+        configMap.put("includeLabels", allLabelsInUse);
+        if (!allRelationshipTypesInUse.isEmpty()) {
+            configMap.put("includeRels", allRelationshipTypesInUse);
+        }
+        configMap.putAll(config.getConfig());
+        return configMap;
+    }
+}

--- a/core/src/main/java/apoc/export/arrow/ExportResultStreamStrategy.java
+++ b/core/src/main/java/apoc/export/arrow/ExportResultStreamStrategy.java
@@ -1,0 +1,99 @@
+package apoc.export.arrow;
+
+import apoc.Pools;
+import apoc.meta.Meta;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.types.pojo.Field;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Result;
+import org.neo4j.logging.Log;
+import org.neo4j.procedure.TerminationGuard;
+
+import java.util.AbstractMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static apoc.export.arrow.ExportArrowStrategy.fromMetaType;
+import static apoc.export.arrow.ExportArrowStrategy.toField;
+
+public class ExportResultStreamStrategy implements ExportArrowStreamStrategy<Result> {
+
+    private final GraphDatabaseService db;
+    private final Pools pools;
+    private final TerminationGuard terminationGuard;
+    private final Log logger;
+
+    private final AtomicInteger counter;
+
+    private final RootAllocator bufferAllocator;
+
+    private Schema schema;
+
+    public ExportResultStreamStrategy(GraphDatabaseService db, Pools pools, TerminationGuard terminationGuard, Log logger) {
+        this.db = db;
+        this.pools = pools;
+        this.terminationGuard = terminationGuard;
+        this.logger = logger;
+        this.counter = new AtomicInteger();
+        this.bufferAllocator = new RootAllocator();
+    }
+
+    @Override
+    public Iterator<Map<String, Object>> toIterator(Result data) {
+        return data;
+    }
+
+    @Override
+    public TerminationGuard getTerminationGuard() {
+        return terminationGuard;
+    }
+
+    @Override
+    public BufferAllocator getBufferAllocator() {
+        return bufferAllocator;
+    }
+
+    @Override
+    public AtomicInteger getCounter() {
+        return counter;
+    }
+
+    @Override
+    public GraphDatabaseService getGraphDatabaseApi() {
+        return db;
+    }
+
+    @Override
+    public ExecutorService getExecutorService() {
+        return pools.getDefaultExecutorService();
+    }
+
+    @Override
+    public Log getLogger() {
+        return logger;
+    }
+
+    @Override
+    public synchronized Schema schemaFor(List<Map<String, Object>> records) {
+        if (schema == null) {
+            final List<Field> fields = records.stream()
+                    .flatMap(m -> m.entrySet().stream())
+                    .map(e -> new AbstractMap.SimpleEntry<>(e.getKey(), fromMetaType(Meta.Types.of(e.getValue()))))
+                    .collect(Collectors.groupingBy(e -> e.getKey(), Collectors.mapping(e -> e.getValue(), Collectors.toSet())))
+                    .entrySet()
+                    .stream()
+                    .map(e -> toField(e.getKey(), e.getValue()))
+                    .collect(Collectors.toList());
+            schema = new Schema(fields);
+        }
+        return schema;
+    }
+
+
+}

--- a/core/src/main/java/apoc/export/util/ProgressReporter.java
+++ b/core/src/main/java/apoc/export/util/ProgressReporter.java
@@ -111,4 +111,5 @@ public class ProgressReporter implements Reporter {
         this.totalEntities++;
         acceptBatch();
     }
+
 }

--- a/core/src/main/java/apoc/load/LoadArrow.java
+++ b/core/src/main/java/apoc/load/LoadArrow.java
@@ -2,14 +2,16 @@ package apoc.load;
 
 import apoc.Pools;
 import apoc.result.MapResult;
+import apoc.util.FileUtils;
 import apoc.util.JsonUtil;
-import apoc.util.QueueBasedSpliterator;
 import apoc.util.Util;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.DateMilliVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowFileReader;
+import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.arrow.vector.util.Text;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -22,15 +24,18 @@ import org.neo4j.procedure.TerminationGuard;
 import org.neo4j.values.storable.Values;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.channels.SeekableByteChannel;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -49,42 +54,82 @@ public class LoadArrow {
     @Context
     public TerminationGuard terminationGuard;
 
-    @Procedure(name = "apoc.load.arrow.stream")
-    @Description("apoc.load.arrow.stream(source, config) - imports nodes and relationships from the provided byte[] source with given labels and types")
-    public Stream<MapResult> stream(
-            @Name("source") byte[] source,
-            @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
-        final BlockingQueue<MapResult> queue = new ArrayBlockingQueue<>(1000);
-        RootAllocator allocator = new RootAllocator();
+    private static class ArrowSpliterator extends Spliterators.AbstractSpliterator<MapResult> {
 
-        Util.inThread(pools, () -> {
-            try (ArrowStreamReader streamReader = new ArrowStreamReader(new ByteArrayInputStream(source), allocator);
-                 VectorSchemaRoot schemaRoot = streamReader.getVectorSchemaRoot()) {
-                AtomicInteger counter = new AtomicInteger();
-                while (!Util.transactionIsTerminated(terminationGuard) && streamReader.loadNextBatch()) {
-                    while (counter.get() < schemaRoot.getRowCount()) {
-                        final Map<String, Object> row = schemaRoot.getFieldVectors()
-                                .stream()
-                                .map(fieldVector -> new AbstractMap.SimpleEntry<>(fieldVector.getName(), read(fieldVector, counter.get())))
-                                .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll); // please look at https://bugs.openjdk.java.net/browse/JDK-8148463
-                        queue.add(new MapResult(row));
-                        counter.incrementAndGet();
+        private final ArrowReader reader;
+        private final VectorSchemaRoot schemaRoot;
+        private final AtomicInteger counter;
+
+        public ArrowSpliterator(ArrowReader reader, VectorSchemaRoot schemaRoot) throws IOException {
+            super(Long.MAX_VALUE, Spliterator.ORDERED);
+            this.reader = reader;
+            this.schemaRoot = schemaRoot;
+            this.counter = new AtomicInteger();
+            this.reader.loadNextBatch();
+        }
+
+
+        @Override
+        public synchronized boolean tryAdvance(Consumer<? super MapResult> action) {
+            try {
+                if (counter.get() >= schemaRoot.getRowCount()) {
+                    if (reader.loadNextBatch()) {
+                        counter.set(0);
+                    } else {
+                        return false;
                     }
                 }
+                final Map<String, Object> row = schemaRoot.getFieldVectors()
+                        .stream()
+                        .map(fieldVector -> new AbstractMap.SimpleEntry<>(fieldVector.getName(), read(fieldVector, counter.get())))
+                        .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll); // please look at https://bugs.openjdk.java.net/browse/JDK-8148463
+                counter.incrementAndGet();
+                action.accept(new MapResult(row));
                 return true;
             } catch (Exception e) {
-                log.error("Exception while reading Arrow data", e);
-            } finally {
-                queue.add(MapResult.EMPTY);
+                return false;
             }
-            return null;
-        });
-        QueueBasedSpliterator<MapResult> spliterator = new QueueBasedSpliterator<>(queue, MapResult.EMPTY, terminationGuard, Integer.MAX_VALUE);
-        return StreamSupport.stream(spliterator, false)
-                .onClose(() -> Util.close(allocator));
+
+        }
     }
 
-    private Object read(FieldVector fieldVector, int index) {
+    @Procedure(name = "apoc.load.arrow.stream")
+    @Description("apoc.load.arrow.stream(source, config) - imports nodes and relationships from the provided byte[]")
+    public Stream<MapResult> stream(
+            @Name("source") byte[] source,
+            @Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws IOException {
+        RootAllocator allocator = new RootAllocator();
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(source);
+        ArrowStreamReader streamReader = new ArrowStreamReader(inputStream, allocator);
+        VectorSchemaRoot schemaRoot = streamReader.getVectorSchemaRoot();
+        return StreamSupport.stream(new ArrowSpliterator(streamReader, schemaRoot), false)
+                .onClose(() -> {
+                    Util.close(allocator);
+                    Util.close(streamReader);
+                    Util.close(schemaRoot);
+                    Util.close(inputStream);
+                });
+    }
+
+    @Procedure(name = "apoc.load.arrow")
+    @Description("apoc.load.arrow(fileName, config) - imports nodes and relationships from the provided file")
+    public Stream<MapResult> file(
+            @Name("source") String fileName,
+            @Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws IOException {
+        final SeekableByteChannel channel = FileUtils.seekableByteChannelFor(fileName);
+        RootAllocator allocator = new RootAllocator();
+        ArrowFileReader streamReader = new ArrowFileReader(channel, allocator);
+        VectorSchemaRoot schemaRoot = streamReader.getVectorSchemaRoot();
+        return StreamSupport.stream(new ArrowSpliterator(streamReader, schemaRoot), false)
+                .onClose(() -> {
+                    Util.close(allocator);
+                    Util.close(streamReader);
+                    Util.close(schemaRoot);
+                    Util.close(channel);
+                });
+    }
+
+    private static Object read(FieldVector fieldVector, int index) {
         if (fieldVector.isNull(index)) {
             return null;
         } else if (fieldVector instanceof DateMilliVector) {
@@ -99,10 +144,10 @@ public class LoadArrow {
         }
     }
 
-    private Object getObject(Object object) {
+    private static Object getObject(Object object) {
         if (object instanceof Collection) {
             return ((Collection<?>) object).stream()
-                    .map(this::getObject)
+                    .map(LoadArrow::getObject)
                     .collect(Collectors.toList());
         }
         if (object instanceof Map) {
@@ -117,13 +162,12 @@ public class LoadArrow {
             Values.of(object);
             return object;
         } catch (Exception e) {
-            log.error("Coercing to a String as we cannot coerce the Arrow Value to a Neo4j type", e);
             // otherwise we try coerce it
             return valueToString(object);
         }
     }
 
-    private String valueToString(Object value) {
+    private static String valueToString(Object value) {
         return JsonUtil.writeValueAsString(value);
     }
 

--- a/core/src/main/java/apoc/load/LoadArrow.java
+++ b/core/src/main/java/apoc/load/LoadArrow.java
@@ -1,0 +1,130 @@
+package apoc.load;
+
+import apoc.Pools;
+import apoc.result.MapResult;
+import apoc.util.JsonUtil;
+import apoc.util.QueueBasedSpliterator;
+import apoc.util.Util;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateMilliVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowStreamReader;
+import org.apache.arrow.vector.util.Text;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.logging.Log;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.TerminationGuard;
+import org.neo4j.values.storable.Values;
+
+import java.io.ByteArrayInputStream;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class LoadArrow {
+
+    @Context
+    public GraphDatabaseService db;
+
+    @Context
+    public Pools pools;
+
+    @Context
+    public Log log;
+
+    @Context
+    public TerminationGuard terminationGuard;
+
+    @Procedure(name = "apoc.load.arrow.stream")
+    @Description("apoc.load.arrow.stream(source, config) - imports nodes and relationships from the provided byte[] source with given labels and types")
+    public Stream<MapResult> stream(
+            @Name("source") byte[] source,
+            @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
+        final BlockingQueue<MapResult> queue = new ArrayBlockingQueue<>(1000);
+        RootAllocator allocator = new RootAllocator();
+
+        Util.inThread(pools, () -> {
+            try (ArrowStreamReader streamReader = new ArrowStreamReader(new ByteArrayInputStream(source), allocator);
+                 VectorSchemaRoot schemaRoot = streamReader.getVectorSchemaRoot()) {
+                AtomicInteger counter = new AtomicInteger();
+                while (!Util.transactionIsTerminated(terminationGuard) && streamReader.loadNextBatch()) {
+                    while (counter.get() < schemaRoot.getRowCount()) {
+                        final Map<String, Object> row = schemaRoot.getFieldVectors()
+                                .stream()
+                                .map(fieldVector -> new AbstractMap.SimpleEntry<>(fieldVector.getName(), read(fieldVector, counter.get())))
+                                .collect(HashMap::new, (m, e) -> m.put(e.getKey(), e.getValue()), HashMap::putAll); // please look at https://bugs.openjdk.java.net/browse/JDK-8148463
+                        queue.add(new MapResult(row));
+                        counter.incrementAndGet();
+                    }
+                }
+                return true;
+            } catch (Exception e) {
+                log.error("Exception while reading Arrow data", e);
+            } finally {
+                queue.add(MapResult.EMPTY);
+            }
+            return null;
+        });
+        QueueBasedSpliterator<MapResult> spliterator = new QueueBasedSpliterator<>(queue, MapResult.EMPTY, terminationGuard, Integer.MAX_VALUE);
+        return StreamSupport.stream(spliterator, false)
+                .onClose(() -> Util.close(allocator));
+    }
+
+    private Object read(FieldVector fieldVector, int index) {
+        if (fieldVector.isNull(index)) {
+            return null;
+        } else if (fieldVector instanceof DateMilliVector) {
+            DateMilliVector fe = (DateMilliVector) fieldVector;
+            return Instant.ofEpochMilli(fe.get(index)).atOffset(ZoneOffset.UTC);
+        } else if (fieldVector instanceof BitVector) {
+            BitVector fe = (BitVector) fieldVector;
+            return fe.get(index) == 1;
+        } else {
+            Object object = fieldVector.getObject(index);
+            return getObject(object);
+        }
+    }
+
+    private Object getObject(Object object) {
+        if (object instanceof Collection) {
+            return ((Collection<?>) object).stream()
+                    .map(this::getObject)
+                    .collect(Collectors.toList());
+        }
+        if (object instanceof Map) {
+            return ((Map<String, Object>) object).entrySet().stream()
+                    .collect(Collectors.toMap(e -> e.getKey(), e -> getObject(e.getValue())));
+        }
+        if (object instanceof Text) {
+            return object.toString();
+        }
+        try {
+            // we test if is a valid Neo4j type
+            Values.of(object);
+            return object;
+        } catch (Exception e) {
+            log.error("Coercing to a String as we cannot coerce the Arrow Value to a Neo4j type", e);
+            // otherwise we try coerce it
+            return valueToString(object);
+        }
+    }
+
+    private String valueToString(Object value) {
+        return JsonUtil.writeValueAsString(value);
+    }
+
+}

--- a/core/src/main/java/apoc/result/ByteArrayResult.java
+++ b/core/src/main/java/apoc/result/ByteArrayResult.java
@@ -1,0 +1,11 @@
+package apoc.result;
+
+public class ByteArrayResult {
+    public final static ByteArrayResult NULL = new ByteArrayResult(null);
+
+    public final byte[] value;
+
+    public ByteArrayResult(byte[] value) {
+        this.value = value;
+    }
+}

--- a/core/src/main/java/apoc/result/MapResult.java
+++ b/core/src/main/java/apoc/result/MapResult.java
@@ -8,7 +8,7 @@ import java.util.Map;
  * @since 26.02.16
  */
 public class MapResult {
-	private static final MapResult EMPTY = new MapResult(Collections.emptyMap());
+	public static final MapResult EMPTY = new MapResult(Collections.emptyMap());
 	public final Map<String, Object> value;
 
 	public static MapResult empty() {

--- a/core/src/main/java/apoc/util/FileUtils.java
+++ b/core/src/main/java/apoc/util/FileUtils.java
@@ -26,8 +26,10 @@ import java.io.Writer;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.nio.channels.SeekableByteChannel;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -99,7 +101,7 @@ public class FileUtils {
                 return new SeekableInMemoryByteChannel(readHdfsStream(fileName).readAllBytes());
             } else {
                 if (fileName.startsWith("file:")) {
-                    return new FileInputStream(URI.create(fileName).toURL().getFile()).getChannel();
+                    return new FileInputStream(URLDecoder.decode(URI.create(fileName).getPath(), StandardCharsets.UTF_8.name())).getChannel();
                 } else {
                     return new SeekableInMemoryByteChannel(Util.openInputStream(fileName,null,null).readAllBytes());
                 }
@@ -167,7 +169,7 @@ public class FileUtils {
             } else {
                 result = normalized.toFile();
             }
-            return result.toString();
+            return result.toURI().toString();
         }
         return url;
     }

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -32,7 +32,6 @@ import org.neo4j.procedure.TerminationGuard;
 import javax.lang.model.SourceVersion;
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;

--- a/core/src/test/java/apoc/export/arrow/ArrowTest.java
+++ b/core/src/test/java/apoc/export/arrow/ArrowTest.java
@@ -1,5 +1,6 @@
 package apoc.export.arrow;
 
+import apoc.ApocSettings;
 import apoc.graph.Graphs;
 import apoc.load.LoadArrow;
 import apoc.meta.Meta;
@@ -7,9 +8,11 @@ import apoc.util.TestUtil;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
+import java.io.File;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
@@ -17,13 +20,23 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.LongStream;
 
 import static org.junit.Assert.assertEquals;
 
 public class ArrowTest {
 
+    private static File directory = new File("target/import");
+    static { //noinspection ResultOfMethodCallIgnored
+        directory.mkdirs();
+    }
+
     @ClassRule
-    public static DbmsRule db = new ImpermanentDbmsRule();
+    public static DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(ApocSettings.apoc_import_file_enabled, true)
+            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath())
+            .withSetting(ApocSettings.apoc_export_file_enabled, true);
+
     public static final List<Map<String, Object>> EXPECTED = List.of(
             new HashMap<>() {{
                 put("name", "Adam");
@@ -79,7 +92,7 @@ public class ArrowTest {
     }
 
     @Test
-    public void testRoundtripArrowQuery() throws Exception {
+    public void testStreamRoundtripArrowQuery() {
         // given - when
         final String returnQuery = "RETURN 1 AS intData," +
                 "'a' AS stringData," +
@@ -116,7 +129,44 @@ public class ArrowTest {
     }
 
     @Test
-    public void testRoundtripArrowGraph() throws Exception {
+    public void testFileRoundtripArrowQuery() {
+        // given - when
+        final String returnQuery = "RETURN 1 AS intData," +
+                "'a' AS stringData," +
+                "true AS boolData," +
+                "[1, 2, 3] AS intArray," +
+                "[1.1, 2.2, 3.3] AS doubleArray," +
+                "[true, false, true] AS boolArray," +
+                "[1, '2', true, null] AS mixedArray," +
+                "{foo: 'bar'} AS mapData," +
+                "localdatetime('2015-05-18T19:32:24') as dateData," +
+                "[[0]] AS arrayArray," +
+                "1.1 AS doubleData";
+        final String query = "CALL apoc.export.arrow.query('query_test.arrow', \"" + returnQuery + "\") YIELD file " +
+                "CALL apoc.load.arrow(file) YIELD value " +
+                "RETURN value";
+
+        // then
+        db.executeTransactionally(query, Map.of(), result -> {
+            final Map<String, Object> row = (Map<String, Object>) result.next().get("value");
+            assertEquals(1L, row.get("intData"));
+            assertEquals("a", row.get("stringData"));
+            assertEquals(Arrays.asList(1L, 2L, 3L), row.get("intArray"));
+            assertEquals(Arrays.asList(1.1D, 2.2D, 3.3), row.get("doubleArray"));
+            assertEquals(Arrays.asList(true, false, true), row.get("boolArray"));
+            assertEquals(Arrays.asList("1", "2", "true", null), row.get("mixedArray"));
+            assertEquals("{\"foo\":\"bar\"}", row.get("mapData"));
+            assertEquals(LocalDateTime.parse("2015-05-18T19:32:24.000")
+                    .atOffset(ZoneOffset.UTC)
+                    .toZonedDateTime(), row.get("dateData"));
+            assertEquals(Arrays.asList("[0]"), row.get("arrayArray"));
+            assertEquals(1.1D, row.get("doubleData"));
+            return true;
+        });
+    }
+
+    @Test
+    public void testStreamRoundtripArrowGraph() {
         // given - when
         final String query = "CALL apoc.graph.fromDB('neo4j',{}) yield graph " +
                 "CALL apoc.export.arrow.stream.graph(graph) YIELD value AS byteArray " +
@@ -134,7 +184,25 @@ public class ArrowTest {
     }
 
     @Test
-    public void testRoundtripArrowAll() throws Exception {
+    public void testFileRoundtripArrowGraph() {
+        // given - when
+        final String query = "CALL apoc.graph.fromDB('neo4j',{}) yield graph " +
+                "CALL apoc.export.arrow.graph('graph_test.arrow', graph) YIELD file " +
+                "CALL apoc.load.arrow(file) YIELD value " +
+                "RETURN value";
+
+        // then
+        db.executeTransactionally(query, Map.of(), result -> {
+            final List<Map<String, Object>> actual = result.stream()
+                    .map(m -> (Map<String, Object>) m.get("value"))
+                    .collect(Collectors.toList());
+            assertEquals(EXPECTED, actual);
+            return null;
+        });
+    }
+
+    @Test
+    public void testStreamRoundtripArrowAll() {
         // given - when
         final String query = "CALL apoc.export.arrow.stream.all() YIELD value AS byteArray " +
                 "CALL apoc.load.arrow.stream(byteArray) YIELD value " +
@@ -149,4 +217,75 @@ public class ArrowTest {
             return null;
         });
     }
+
+    @Test
+    public void testFileRoundtripArrowAll() {
+        // given - when
+        final String query = "CALL apoc.export.arrow.all('all_test.arrow') YIELD file " +
+                "CALL apoc.load.arrow(file) YIELD value " +
+                "RETURN value";
+
+        // then
+        db.executeTransactionally(query, Map.of(), result -> {
+            final List<Map<String, Object>> actual = result.stream()
+                    .map(m -> (Map<String, Object>) m.get("value"))
+                    .collect(Collectors.toList());
+            assertEquals(EXPECTED, actual);
+            return null;
+        });
+    }
+
+    @Test
+    public void testStreamVolumeArrowAll() {
+        // given - when
+        db.executeTransactionally("UNWIND range(0, 10000 - 1) AS id CREATE (n:ArrowNode{id:id})");
+
+        final String query = "CALL apoc.export.arrow.stream.query('MATCH (n:ArrowNode) RETURN n.id AS id') YIELD value AS byteArray " +
+                "CALL apoc.load.arrow.stream(byteArray) YIELD value " +
+                "RETURN value.id AS id";
+
+        final List<Long> expected = LongStream.range(0, 10000)
+                .mapToObj(l -> l)
+                .collect(Collectors.toList());
+
+        // then
+        db.executeTransactionally(query, Map.of(), result -> {
+            final List<Long> actual = result.stream()
+                    .map(m -> (Long) m.get("id"))
+                    .sorted()
+                    .collect(Collectors.toList());
+            assertEquals(expected, actual);
+            return null;
+        });
+
+        db.executeTransactionally("MATCH (n:ArrowNode) DELETE n");
+    }
+
+    @Test
+    public void testFileVolumeArrowAll() {
+        // given - when
+        db.executeTransactionally("UNWIND range(0, 10000 - 1) AS id CREATE (:ArrowNode{id:id})");
+
+        final String query = "CALL apoc.export.arrow.query('volume_test.arrow', 'MATCH (n:ArrowNode) RETURN n.id AS id') YIELD file " +
+                "CALL apoc.load.arrow(file) YIELD value " +
+                "RETURN value.id AS id";
+
+        final List<Long> expected = LongStream.range(0, 10000)
+                .mapToObj(l -> l)
+                .collect(Collectors.toList());
+
+        // then
+        db.executeTransactionally(query, Map.of(), result -> {
+            final List<Long> actual = result.stream()
+                    .map(m -> (Long) m.get("id"))
+                    .sorted()
+                    .collect(Collectors.toList());
+            assertEquals(expected, actual);
+            return null;
+        });
+
+        db.executeTransactionally("MATCH (n:ArrowNode) DELETE n");
+    }
+
+
 }

--- a/core/src/test/java/apoc/export/arrow/ArrowTest.java
+++ b/core/src/test/java/apoc/export/arrow/ArrowTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertEquals;
 
 public class ArrowTest {
 
-    private static File directory = new File("target/import");
+    private static File directory = new File("target/imp ort");
     static { //noinspection ResultOfMethodCallIgnored
         directory.mkdirs();
     }

--- a/core/src/test/java/apoc/load/ArrowTest.java
+++ b/core/src/test/java/apoc/load/ArrowTest.java
@@ -1,0 +1,152 @@
+package apoc.export.arrow;
+
+import apoc.graph.Graphs;
+import apoc.load.LoadArrow;
+import apoc.meta.Meta;
+import apoc.util.TestUtil;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public class ArrowTest {
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule();
+    public static final List<Map<String, Object>> EXPECTED = List.of(
+            new HashMap<>() {{
+                put("name", "Adam");
+                put("bffSince", null);
+                put("<source.id>", null);
+                put("<id>", 0L);
+                put("age", 42L);
+                put("labels", List.of("User"));
+                put("male", true);
+                put("<type>", null);
+                put("kids", List.of("Sam", "Anna", "Grace"));
+                put("place", "{\"crs\":\"wgs-84-3d\",\"latitude\":33.46789,\"longitude\":13.1,\"height\":100.0}");
+                put("<target.id>", null);
+                put("since", null);
+                put("born", LocalDateTime.parse("2015-05-18T19:32:24.000").atOffset(ZoneOffset.UTC).toZonedDateTime());
+            }},
+            new HashMap<>() {{
+                put("name", "Jim");
+                put("bffSince", null);
+                put("<source.id>", null);
+                put("<id>", 1L);
+                put("age", 42L);
+                put("labels", List.of("User"));
+                put("male", null);
+                put("<type>", null);
+                put("kids", null);
+                put("place", null);
+                put("<target.id>", null);
+                put("since", null);
+                put("born", null);
+            }},
+            new HashMap<>() {{
+                put("name", null);
+                put("bffSince", "P5M1DT12H");
+                put("<source.id>", 0L);
+                put("<id>", 0L);
+                put("age", null);
+                put("labels", null);
+                put("male", null);
+                put("<type>", "KNOWS");
+                put("kids", null);
+                put("place", null);
+                put("<target.id>", 1L);
+                put("since", 1993L);
+                put("born", null);
+            }}
+    );
+
+    @BeforeClass
+    public static void beforeClass() {
+        db.executeTransactionally("CREATE (f:User {name:'Adam',age:42,male:true,kids:['Sam','Anna','Grace'], born:localdatetime('2015-05-18T19:32:24.000'), place:point({latitude: 13.1, longitude: 33.46789, height: 100.0})})-[:KNOWS {since: 1993, bffSince: duration('P5M1.5D')}]->(b:User {name:'Jim',age:42})");
+        TestUtil.registerProcedure(db, ExportArrow.class, LoadArrow.class, Graphs.class, Meta.class);
+    }
+
+    @Test
+    public void testRoundtripArrowQuery() throws Exception {
+        // given - when
+        final String returnQuery = "RETURN 1 AS intData," +
+                "'a' AS stringData," +
+                "true AS boolData," +
+                "[1, 2, 3] AS intArray," +
+                "[1.1, 2.2, 3.3] AS doubleArray," +
+                "[true, false, true] AS boolArray," +
+                "[1, '2', true, null] AS mixedArray," +
+                "{foo: 'bar'} AS mapData," +
+                "localdatetime('2015-05-18T19:32:24') as dateData," +
+                "[[0]] AS arrayArray," +
+                "1.1 AS doubleData";
+        final String query = "CALL apoc.export.arrow.stream.query(\"" + returnQuery + "\") YIELD value AS byteArray " +
+                "CALL apoc.load.arrow.stream(byteArray) YIELD value " +
+                "RETURN value";
+
+        // then
+        db.executeTransactionally(query, Map.of(), result -> {
+            final Map<String, Object> row = (Map<String, Object>) result.next().get("value");
+            assertEquals(1L, row.get("intData"));
+            assertEquals("a", row.get("stringData"));
+            assertEquals(Arrays.asList(1L, 2L, 3L), row.get("intArray"));
+            assertEquals(Arrays.asList(1.1D, 2.2D, 3.3), row.get("doubleArray"));
+            assertEquals(Arrays.asList(true, false, true), row.get("boolArray"));
+            assertEquals(Arrays.asList("1", "2", "true", null), row.get("mixedArray"));
+            assertEquals("{\"foo\":\"bar\"}", row.get("mapData"));
+            assertEquals(LocalDateTime.parse("2015-05-18T19:32:24.000")
+                    .atOffset(ZoneOffset.UTC)
+                    .toZonedDateTime(), row.get("dateData"));
+            assertEquals(Arrays.asList("[0]"), row.get("arrayArray"));
+            assertEquals(1.1D, row.get("doubleData"));
+            return true;
+        });
+    }
+
+    @Test
+    public void testRoundtripArrowGraph() throws Exception {
+        // given - when
+        final String query = "CALL apoc.graph.fromDB('neo4j',{}) yield graph " +
+                "CALL apoc.export.arrow.stream.graph(graph) YIELD value AS byteArray " +
+                "CALL apoc.load.arrow.stream(byteArray) YIELD value " +
+                "RETURN value";
+
+        // then
+        db.executeTransactionally(query, Map.of(), result -> {
+            final List<Map<String, Object>> actual = result.stream()
+                    .map(m -> (Map<String, Object>) m.get("value"))
+                    .collect(Collectors.toList());
+            assertEquals(EXPECTED, actual);
+            return null;
+        });
+    }
+
+    @Test
+    public void testRoundtripArrowAll() throws Exception {
+        // given - when
+        final String query = "CALL apoc.export.arrow.stream.all() YIELD value AS byteArray " +
+                "CALL apoc.load.arrow.stream(byteArray) YIELD value " +
+                "RETURN value";
+
+        // then
+        db.executeTransactionally(query, Map.of(), result -> {
+            final List<Map<String, Object>> actual = result.stream()
+                    .map(m -> (Map<String, Object>) m.get("value"))
+                    .collect(Collectors.toList());
+            assertEquals(EXPECTED, actual);
+            return null;
+        });
+    }
+}

--- a/core/src/test/java/apoc/load/LoadJsonTest.java
+++ b/core/src/test/java/apoc/load/LoadJsonTest.java
@@ -5,7 +5,7 @@ import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.junit.*;
-import org.mockserver.client.server.MockServerClient;
+import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
 import org.neo4j.graphdb.QueryExecutionException;
@@ -309,14 +309,12 @@ public class LoadJsonTest {
                 .when(
                         request()
                                 .withPath("/docs/search")
-                                .withHeader("Authorization", "Basic " + token)
-                                .withHeader("\"Content-type\", \"application/json\""),
+                                .withHeader("Authorization", "Basic " + token),
                         exactly(1))
                 .respond(
                         response()
                                 .withStatusCode(200)
                                 .withHeaders(
-                                        new Header("Content-Type", "application/json; charset=utf-8"),
                                         new Header("Cache-Control", "private, max-age=1000"))
                                 .withBody(JsonUtil.OBJECT_MAPPER.writeValueAsString(responseBody))
                                 .withDelay(TimeUnit.SECONDS, 1)
@@ -340,13 +338,14 @@ public class LoadJsonTest {
                                 .withMethod("POST")
                                 .withPath("/docs/search")
                                 .withHeader("Authorization", "Basic " + token)
-                                .withHeader("\"Content-type\", \"application/json\""),
+                                .withHeader("Content-type", "application/json")
+                                .withBody("{\"query\":\"pagecache\",\"version\":\"3.5\"}"),
                         exactly(1))
                 .respond(
                         response()
                                 .withStatusCode(200)
                                 .withHeaders(
-                                        new Header("Content-Type", "application/json; charset=utf-8"),
+                                        new Header("Content-Type", "application/json"),
                                         new Header("Cache-Control", "public, max-age=86400"))
                                 .withBody(JsonUtil.OBJECT_MAPPER.writeValueAsString(responseBody))
                                 .withDelay(TimeUnit.SECONDS, 1)
@@ -355,7 +354,7 @@ public class LoadJsonTest {
         testCall(db, "call apoc.load.jsonParams($url, $config, $payload)",
                     map("payload", "{\"query\":\"pagecache\",\"version\":\"3.5\"}",
                         "url", "http://" + userPass + "@localhost:1080/docs/search",
-                        "config", map("method", "POST")),
+                        "config", map("method", "POST", "Content-Type", "application/json")),
                     (row) -> assertEquals(responseBody, row.get("value"))
                 );
     }
@@ -367,13 +366,13 @@ public class LoadJsonTest {
                         request()
                                 .withMethod("POST")
                                 .withPath("/docs/search")
-                                .withHeader("\"Content-type\", \"application/json\""),
+                                .withHeader("Content-type", "application/json"),
                         exactly(1))
                 .respond(
                         response()
                                 .withStatusCode(200)
                                 .withHeaders(
-                                        new Header("Content-Type", "application/json; charset=utf-8"),
+                                        new Header("Content-Type", "application/json"),
                                         new Header("Cache-Control", "public, max-age=86400"))
                                 .withBody("{ result: 'message' }")
                                 .withDelay(TimeUnit.SECONDS,1)
@@ -383,7 +382,7 @@ public class LoadJsonTest {
         testCall(db, "call apoc.load.jsonParams($url, $config, $json)",
                 map("json", "{\"query\":\"pagecache\",\"version\":\"3.5\"}",
                         "url", "http://localhost:1080/docs/search",
-                        "config", map("method", "POST")),
+                        "config", map("method", "POST", "Content-Type", "application/json")),
                 (row) -> {
                     Map<String, Object> value = (Map<String, Object>) row.get("value");
                     assertFalse("value should be not empty", value.isEmpty());

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.arrow.all.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.arrow.all.adoc
@@ -1,0 +1,40 @@
+The procedure expose an Arrow file with the following structure
+- `<id>`: for node id
+- `<labels>`: list of labels
+- `<source.id>`: source node id (in case of relationship)
+- `<target.id>`: target node id (in case of relationship)
+- `<type>`: for relationship type
+- the list of properties of nodes and relationships flattened as table
+
+So for the following query:
+
+[source,cypher]
+----
+CREATE (f:User {name:'Adam',age:42,male:true,kids:['Sam','Anna','Grace'], born:localdatetime('2015185T19:32:24'), place:point({latitude: 13.1, longitude: 33.46789})})-[:KNOWS {since: 1993, bffSince: duration('P5M1.5D')}]->(b:User {name:'Jim',age:42}),(c:User {age:12}),(d:Another {foo: 'bar'})
+----
+
+With this query:
+
+[source,cypher]
+----
+CALL apoc.export.arrow.all('my_file.arrow') YIELD file, source, format,
+    nodes, relationships, properties,
+    time, rows, batchSize,
+    batches, done, data
+----
+
+We'll have an arrow file with the following columns:
+
+- `<id>`
+- `<labels>`
+- `<source.id>`
+- `<target.id>`
+- `<type>`
+- `name`
+- `age`
+- `male`
+- `kids`
+- `born`
+- `place`
+- `since`
+- `bffSince`

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.arrow.graph.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.arrow.graph.adoc
@@ -1,0 +1,41 @@
+The procedure expose an Arrow file of rows with the following structure
+- `<id>`: for node id
+- `<labels>`: list of labels
+- `<source.id>`: source node id (in case of relationship)
+- `<target.id>`: target node id (in case of relationship)
+- `<type>`: for relationship type
+- the list of properties of nodes and relationships flattened as table
+
+So for the following query:
+
+[source,cypher]
+----
+CREATE (f:User {name:'Adam',age:42,male:true,kids:['Sam','Anna','Grace'], born:localdatetime('2015185T19:32:24'), place:point({latitude: 13.1, longitude: 33.46789})})-[:KNOWS {since: 1993, bffSince: duration('P5M1.5D')}]->(b:User {name:'Jim',age:42}),(c:User {age:12}),(d:Another {foo: 'bar'})
+----
+
+With this query:
+
+[source,cypher]
+----
+CALL apoc.graph.fromDB('neo4j',{}) yield graph
+CALL apoc.export.arrow.graph('my_file.arrow', graph) YIELD file, source, format,
+    nodes, relationships, properties,
+    time, rows, batchSize,
+    batches, done, data
+----
+
+We'll have an arrow file with the following columns:
+
+- `<id>`
+- `<labels>`
+- `<source.id>`
+- `<target.id>`
+- `<type>`
+- `name`
+- `age`
+- `male`
+- `kids`
+- `born`
+- `place`
+- `since`
+- `bffSince`

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.arrow.query.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.arrow.query.adoc
@@ -1,0 +1,21 @@
+Let's suppose we have this data set:
+
+[source,cypher]
+----
+CREATE (f:User {name:'Adam',age:42,male:true,kids:['Sam','Anna','Grace'], born:localdatetime('2015185T19:32:24'), place:point({latitude: 13.1, longitude: 33.46789})})-[:KNOWS {since: 1993, bffSince: duration('P5M1.5D')}]->(b:User {name:'Jim',age:42}),(c:User {name: 'John', age:12}),(d:Another {foo: 'bar'})
+----
+
+With this query:
+
+[source,cypher]
+----
+CALL apoc.export.arrow.query('my_file.arrow', 'MATCH (n:User) RETURN count(n) as count, n.name as name') YIELD file, source, format,
+    nodes, relationships, properties,
+    time, rows, batchSize,
+    batches, done, data
+----
+
+We'll have an arrow file with the following columns:
+
+- `count`
+- `name`

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.arrow.stream.all.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.arrow.stream.all.adoc
@@ -1,0 +1,37 @@
+The procedure expose an Arrow byte[] for each batch of rows with the following structure
+- `<id>`: for node id
+- `<labels>`: list of labels
+- `<source.id>`: source node id (in case of relationship)
+- `<target.id>`: target node id (in case of relationship)
+- `<type>`: for relationship type
+- the list of properties of nodes and relationships flattened as table
+
+So for the following query:
+
+[source,cypher]
+----
+CREATE (f:User {name:'Adam',age:42,male:true,kids:['Sam','Anna','Grace'], born:localdatetime('2015185T19:32:24'), place:point({latitude: 13.1, longitude: 33.46789})})-[:KNOWS {since: 1993, bffSince: duration('P5M1.5D')}]->(b:User {name:'Jim',age:42}),(c:User {age:12}),(d:Another {foo: 'bar'})
+----
+
+With this query:
+
+[source,cypher]
+----
+CALL apoc.export.arrow.stream.all()
+----
+
+We'll have a table with the following columns:
+
+- `<id>`
+- `<labels>`
+- `<source.id>`
+- `<target.id>`
+- `<type>`
+- `name`
+- `age`
+- `male`
+- `kids`
+- `born`
+- `place`
+- `since`
+- `bffSince`

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.arrow.stream.graph.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.arrow.stream.graph.adoc
@@ -1,0 +1,39 @@
+The procedure expose an Arrow byte[] for each batch of rows with the following structure
+- `<id>`: for node id
+- `<labels>`: list of labels
+- `<source.id>`: source node id (in case of relationship)
+- `<target.id>`: target node id (in case of relationship)
+- `<type>`: for relationship type
+- the list of properties of nodes and relationships flattened as table
+
+So for the following query:
+
+[source,cypher]
+----
+CREATE (f:User {name:'Adam',age:42,male:true,kids:['Sam','Anna','Grace'], born:localdatetime('2015185T19:32:24'), place:point({latitude: 13.1, longitude: 33.46789})})-[:KNOWS {since: 1993, bffSince: duration('P5M1.5D')}]->(b:User {name:'Jim',age:42}),(c:User {age:12}),(d:Another {foo: 'bar'})
+----
+
+With this query:
+
+[source,cypher]
+----
+CALL apoc.graph.fromDB('neo4j',{}) yield graph
+CALL apoc.export.arrow.stream.graph(graph)
+YIELD value RETURN value"
+----
+
+We'll have a table with the following columns:
+
+- `<id>`
+- `<labels>`
+- `<source.id>`
+- `<target.id>`
+- `<type>`
+- `name`
+- `age`
+- `male`
+- `kids`
+- `born`
+- `place`
+- `since`
+- `bffSince`

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.arrow.stream.query.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.arrow.stream.query.adoc
@@ -1,0 +1,19 @@
+Let's suppose we have this data set:
+
+[source,cypher]
+----
+CREATE (f:User {name:'Adam',age:42,male:true,kids:['Sam','Anna','Grace'], born:localdatetime('2015185T19:32:24'), place:point({latitude: 13.1, longitude: 33.46789})})-[:KNOWS {since: 1993, bffSince: duration('P5M1.5D')}]->(b:User {name:'Jim',age:42}),(c:User {name: 'John', age:12}),(d:Another {foo: 'bar'})
+----
+
+With this query:
+
+[source,cypher]
+----
+CALL apoc.export.arrow.stream.query('MATCH (n:User) RETURN count(n) as count, n.name as name')
+YIELD value RETURN value
+----
+
+We'll have a table with the following columns:
+
+- `count`
+- `name`

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.import.arrow.stream.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.import.arrow.stream.adoc
@@ -1,0 +1,7 @@
+This procedure parses an arrow byte[] converting the content into a Cyper Types
+
+[source,cypher]
+----
+CALL apoc.load.arrow.stream(arrowByteArray) YIELD value
+RETURN value.myCol, value.myOtherCol
+----

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.load.arrow.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.load.arrow.adoc
@@ -1,0 +1,28 @@
+Given an arrow file named `test.arrow` that contains people and their properties:
+
+.test.arrow
+----
+name,age,beverage
+Selma,9,Soda
+Rana,12,Tea,Milk
+Selina,19,Cola
+----
+
+We'll place this file into the `import` directory of our Neo4j instance.
+
+We can load this file and return the contents by running the following query:
+
+[source, cypher]
+----
+CALL apoc.load.arrow('test.arrow') YIELD value
+RETURN value;
+----
+
+.Results
+[opts="header",cols="1"]
+|===
+| value
+| {name: "Selma", age: "9", beverage: "Soda"}
+| {name: "Rana", age: "12", beverage: "Tea;Milk"}
+| {name: "Selina", age: "19", beverage: "Cola"}
+|===

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.load.arrow.stream.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.load.arrow.stream.adoc
@@ -1,0 +1,29 @@
+Given an Arrow byte[] contains people and their properties:
+
+.test.arrow
+----
+name,age,beverage
+Selma,9,Soda
+Rana,12,Tea,Milk
+Selina,19,Cola
+----
+
+We'll provide a full roundtrip example where we use the `apoc.export.arrow.stream.all`
+in order to generate the arrow byte[]
+
+
+[source, cypher]
+----
+CALL apoc.export.arrow.stream.all() YIELD value AS byteArray
+CALL apoc.load.arrow.stream(byteArray) YIELD value
+RETURN value
+----
+
+.Results
+[opts="header",cols="1"]
+|===
+| value
+| {name: "Selma", age: "9", beverage: "Soda"}
+| {name: "Rana", age: "12", beverage: "Tea;Milk"}
+| {name: "Selina", age: "19", beverage: "Cola"}
+|===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.arrow.all.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.arrow.all.adoc
@@ -1,0 +1,8 @@
+The procedure support the following config parameters:
+
+.Config parameters
+[opts=header]
+|===
+| name | type | default | description
+| batchSize | Integer | 2000 | the batch size of the ArrowStreamWriter
+|===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.arrow.graph.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.arrow.graph.adoc
@@ -1,0 +1,8 @@
+The procedure support the following config parameters:
+
+.Config parameters
+[opts=header]
+|===
+| name | type | default | description
+| batchSize | Integer | 2000 | the batch size of the ArrowStreamWriter
+|===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.arrow.query.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.arrow.query.adoc
@@ -1,0 +1,8 @@
+The procedure support the following config parameters:
+
+.Config parameters
+[opts=header]
+|===
+| name | type | default | description
+| batchSize | Integer | 2000 | the batch size of the ArrowStreamWriter
+|===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.arrow.stream.all.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.arrow.stream.all.adoc
@@ -1,0 +1,8 @@
+The procedure support the following config parameters:
+
+.Config parameters
+[opts=header]
+|===
+| name | type | default | description
+| batchSize | Integer | 2000 | the batch size of the ArrowStreamWriter
+|===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.arrow.stream.graph.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.arrow.stream.graph.adoc
@@ -1,0 +1,8 @@
+The procedure support the following config parameters:
+
+.Config parameters
+[opts=header]
+|===
+| name | type | default | description
+| batchSize | Integer | 2000 | the batch size of the ArrowStreamWriter
+|===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.arrow.stream.query.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.arrow.stream.query.adoc
@@ -1,0 +1,8 @@
+The procedure support the following config parameters:
+
+.Config parameters
+[opts=header]
+|===
+| name | type | default | description
+| batchSize | Integer | 2000 | the batch size of the ArrowStreamWriter
+|===

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -113,8 +113,8 @@ dependencies {
     testCompile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.10.3'
     testCompile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71'
 
-    testCompile 'org.mock-server:mockserver-netty:3.10.8'
-    testCompile 'org.mock-server:mockserver-client-java:3.10.8'
+    testCompile 'org.mock-server:mockserver-netty:5.6.0'
+    testCompile 'org.mock-server:mockserver-client-java:5.6.0'
 
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'

--- a/full/src/test/java/apoc/load/LoadCsvTest.java
+++ b/full/src/test/java/apoc/load/LoadCsvTest.java
@@ -7,7 +7,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import org.junit.*;
-import org.mockserver.client.server.MockServerClient;
+import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
 import org.neo4j.configuration.GraphDatabaseSettings;
@@ -250,8 +250,7 @@ RETURN m.col_1,m.col_2,m.col_3
                 .when(
                         request()
                                 .withPath("/docs/csv")
-                                .withHeader("Authorization", "Basic " + token)
-                                .withHeader("\"Content-type\", \"text/csv\""),
+                                .withHeader("Authorization", "Basic " + token),
                         exactly(1))
                 .respond(
                         response()
@@ -279,8 +278,7 @@ RETURN m.col_1,m.col_2,m.col_3
                         request()
                                 .withMethod("POST")
                                 .withPath("/docs/csv")
-                                .withHeader("Authorization", "Basic " + token)
-                                .withHeader("\"Content-type\", \"text/csv\""),
+                                .withHeader("Authorization", "Basic " + token),
                         exactly(1))
                 .respond(
                         response()
@@ -311,7 +309,7 @@ RETURN m.col_1,m.col_2,m.col_3
                                 .withMethod("POST")
                                 .withPath("/docs/csv")
                                 .withHeader("Authorization", "Basic " + token)
-                                .withHeader("\"Content-type\", \"text/csv\""),
+                                .withHeader("Content-type", "application/json"),
                         exactly(1))
                 .respond(
                         response()
@@ -325,7 +323,9 @@ RETURN m.col_1,m.col_2,m.col_3
 
         testResult(db, "CALL apoc.load.csvParams($url, $header, $payload, {results:['map','list','stringMap','strings']})",
                     map("url", "http://localhost:1080/docs/csv",
-                        "header", map("method", "POST", "Authorization", "Basic " + token),
+                        "header", map("method",
+                                    "POST", "Authorization", "Basic " + token,
+                                    "Content-Type", "application/json"),
                             "payload", "{\"query\":\"pagecache\",\"version\":\"3.5\"}"),
                     (row) -> assertEquals(RESPONSE_BODY, row.stream().map(i->i.get("map")).collect(Collectors.toList()))
                 );

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -38,6 +38,6 @@ dependencies {
     compile group: 'org.testcontainers', name: 'postgresql', version: testContainersVersion
     compile group: 'org.testcontainers', name: 'cassandra', version: testContainersVersion
     compile group: 'org.testcontainers', name: 'localstack', version: testContainersVersion
-    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '3.0.0'
-    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '3.0.0'
+    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '4.0.0'
+    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '4.0.0'
 }

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -38,4 +38,6 @@ dependencies {
     compile group: 'org.testcontainers', name: 'postgresql', version: testContainersVersion
     compile group: 'org.testcontainers', name: 'cassandra', version: testContainersVersion
     compile group: 'org.testcontainers', name: 'localstack', version: testContainersVersion
+    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '3.0.0'
+    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '3.0.0'
 }

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -38,6 +38,6 @@ dependencies {
     compile group: 'org.testcontainers', name: 'postgresql', version: testContainersVersion
     compile group: 'org.testcontainers', name: 'cassandra', version: testContainersVersion
     compile group: 'org.testcontainers', name: 'localstack', version: testContainersVersion
-    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '4.0.0'
-    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '4.0.0'
+    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '6.0.0'
+    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '6.0.0'
 }


### PR DESCRIPTION
Fixes #1564

This procedure adds the support for Apache Arrow export/load

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added three export procedures that streams a list of byte[] one per each batch: `apoc.export.arrow.stream.all`, `apoc.export.arrow.stream.graph`, `apoc.export.arrow.stream.query`
  - Added three procedures export an Arrow file: `apoc.export.arrow.all`, `apoc.export.arrow.graph`, `apoc.export.arrow.query`
  - Added one load procedure `apoc.load.arrow.stream` that reads an Arrow byte[] and returns a map for each row
  - Added one load procedure `apoc.load.arrow` that reads an Arrow file and returns a map for each row
