### PR TITLE
fixes #1860: Upgrade json-smart to avoid security issue

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,5 +1,3 @@
-import org.gradle.api.internal.artifacts.DefaultExcludeRule
-
 plugins {
     id 'java'
     id "com.bmuschko.nexus"
@@ -46,6 +44,7 @@ dependencies {
     compileOnly group: 'com.sun.mail', name: 'javax.mail', version: '1.6.0'
     testCompile group: 'com.sun.mail', name: 'javax.mail', version: '1.6.0'
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
+    compile group: 'net.minidev', name: 'json-smart', version: '2.4.2'
     compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
 
     antlr "org.antlr:antlr4:4.7.2", {


### PR DESCRIPTION
Fixes #1860

Forcing `json-smart` to the last version `2.4.5`