### PR TITLE
SecurityContext.allowExecuteAdminProcedure is changing in 4.4

### DIFF
--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -659,8 +659,15 @@ public class Util {
         }
     }
 
-    public static void checkAdmin(SecurityContext securityContext, ProcedureCallContext callContext, String procedureName) {
-        if (!securityContext.allowExecuteAdminProcedure(callContext.id())) throw new RuntimeException("This procedure "+ procedureName +" is only available to admin users");
+    public static void checkAdmin( SecurityContext securityContext, ProcedureCallContext callContext, String procedureName )
+    {
+        switch ( securityContext.allowExecuteAdminProcedure( callContext.id() ) )
+        {
+        case EXPLICIT_GRANT:
+            return;
+        default:
+            throw new RuntimeException( "This procedure " + procedureName + " is only available to admin users" );
+        }
     }
 
     public static void sleep(int millis) {


### PR DESCRIPTION
Fixes #<Replace with the number of the issue, Mandatory>

SecurityContext.allowExecuteAdminProcedure is changing in 4.4 to provide more information than just true / false. 

## Proposed Changes (Mandatory)

- Update to reflect this change to the interface . 
- I haven't done so, but it would be possible to use this to provide a better error message if this is desirable.