### PR TITLE
Deprecate the apoc round function

### DIFF
--- a/core/src/main/java/apoc/math/Maths.java
+++ b/core/src/main/java/apoc/math/Maths.java
@@ -12,7 +12,8 @@ import java.math.RoundingMode;
  * @since 12.12.16
  */
 public class Maths {
-    @UserFunction
+    @UserFunction(deprecatedBy = "Neo4j round() function. This function will be removed in version 5.0")
+    @Deprecated
     @Description("apoc.math.round(value,[prec],mode=[CEILING,FLOOR,UP,DOWN,HALF_EVEN,HALF_DOWN,HALF_UP,DOWN,UNNECESSARY])")
     public Double round(@Name("value") Double value,
                         @Name(value = "precision",defaultValue = "0") long precision,

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.math.round.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.math.round.adoc
@@ -21,3 +21,8 @@ RETURN apoc.math.round(1.783, 0, "DOWN") AS output;
 | output
 | 1.0
 |===
+
+[NOTE]
+====
+This function has been deprecated and will be removed in version 5.0. Use Neo4j's `round()` function, which has the same signature since Neo4j 4.2, instead.
+====


### PR DESCRIPTION
Neo4j's built-in round() function has the same signature since 4.2