### PR TITLE
Fixes #1744: Stored procedure error on neo4j restart

### DIFF
--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -254,6 +254,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
             setLastUpdate(tx);
             registerFunction(signature, statement, forceSingle);
+            registeredUserFunctionSignatures.add(signature);
             return null;
         });
     }
@@ -272,6 +273,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             node.setProperty(SystemPropertyKeys.mode.name(), signature.mode().name());
             setLastUpdate(tx);
             registerProcedure(signature, statement);
+            registeredProcedureSignatures.add(signature);
             return null;
         });
     }
@@ -361,9 +363,12 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                     }
                 }
             }, true);
+//            System.out.println("CypherProceduresHandler.registerProcedure1");
             registeredProcedureSignatures.add(signature);
             return true;
         } catch (Exception e) {
+//            System.out.println("e.getCause().getMessage()" + e.getCause().getMessage());
+            System.out.println("e.getClass().getName()" + e.getClass().getName());
             log.error("Could not register procedure: " + signature.name() + " with " + statement + "\n accepting" + signature.inputSignature() + " resulting in " + signature.outputSignature() + " mode " + signature.mode(), e);
             return false;
         }
@@ -410,7 +415,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
                 }
             }, true);
-            registeredUserFunctionSignatures.add(signature);
+//            registeredUserFunctionSignatures.add(signature);
             return true;
         } catch (Exception e) {
             log.error("Could not register function: " + signature + "\nwith: " + statement + "\n single result " + forceSingle, e);

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -98,8 +98,8 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
     private final JobScheduler jobScheduler;
     private long lastUpdate;
     private final ThrowingFunction<Context, Transaction, ProcedureException> transactionComponentFunction;
-    private Set<ProcedureSignature> registeredProcedureSignatures = emptySet();
-    private Set<UserFunctionSignature> registeredUserFunctionSignatures = emptySet();
+    private final Set<ProcedureSignature> registeredProcedureSignatures = Collections.synchronizedSet(new HashSet<>());
+    private final Set<UserFunctionSignature> registeredUserFunctionSignatures = Collections.synchronizedSet(new HashSet<>());
     private static Group REFRESH_GROUP = Group.STORAGE_MAINTENANCE;
     private JobHandle restoreProceduresHandle;
 
@@ -205,28 +205,23 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
     public void restoreProceduresAndFunctions() {
         lastUpdate = System.currentTimeMillis();
-        Set<ProcedureSignature> currentProcedureSignatures = Collections.synchronizedSet(new HashSet<>());
-        Set<UserFunctionSignature> currentUserFunctionSignatures = Collections.synchronizedSet(new HashSet<>());
+        Set<ProcedureSignature> currentProceduresToRemove = new HashSet<>(registeredProcedureSignatures);
+        Set<UserFunctionSignature> currentUserFunctionsToRemove = new HashSet<>(registeredUserFunctionSignatures);
 
         readSignatures().forEach(descriptor -> {
             descriptor.register();
             if (descriptor instanceof ProcedureDescriptor) {
                 ProcedureSignature signature = ((ProcedureDescriptor) descriptor).getSignature();
-                currentProcedureSignatures.add(signature);
-                registeredProcedureSignatures.remove(signature);
+                currentProceduresToRemove.remove(signature);
             } else {
                 UserFunctionSignature signature = ((UserFunctionDescriptor) descriptor).getSignature();
-                currentUserFunctionSignatures.add(signature);
-                registeredUserFunctionSignatures.remove(signature);
+                currentUserFunctionsToRemove.remove(signature);
             }
         });
 
         // de-register removed procs/functions
-        registeredProcedureSignatures.forEach(signature -> registerProcedure(signature, null));
-        registeredUserFunctionSignatures.forEach(signature -> registerFunction(signature, null, false));
-
-        registeredProcedureSignatures = currentProcedureSignatures;
-        registeredUserFunctionSignatures = currentUserFunctionSignatures;
+        currentProceduresToRemove.forEach(signature -> registerProcedure(signature, null));
+        currentUserFunctionsToRemove.forEach(signature -> registerFunction(signature, null, false));
 
         api.executeTransactionally("call db.clearQueryCaches()");
     }
@@ -341,10 +336,11 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
      */
     public boolean registerProcedure(ProcedureSignature signature, String statement) {
         try {
+            final boolean isStatementNull = statement == null;
             globalProceduresRegistry.register(new CallableProcedure.BasicProcedure(signature) {
                 @Override
                 public RawIterator<AnyValue[], ProcedureException> apply(org.neo4j.kernel.api.procedure.Context ctx, AnyValue[] input, ResourceTracker resourceTracker) throws ProcedureException {
-                    if (statement == null) {
+                    if (isStatementNull) {
                         final String error = String.format("There is no procedure with the name `%s` registered for this database instance. " +
                                 "Please ensure you've spelled the procedure name correctly and that the procedure is properly deployed.", signature.name());
                         throw new QueryExecutionException(error, null, "Neo.ClientError.Statement.SyntaxError");
@@ -363,6 +359,11 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                     }
                 }
             }, true);
+            if (isStatementNull) {
+                registeredProcedureSignatures.remove(signature);
+            } else {
+                registeredProcedureSignatures.add(signature);
+            }
             return true;
         } catch (Exception e) {
             log.error("Could not register procedure: " + signature.name() + " with " + statement + "\n accepting" + signature.inputSignature() + " resulting in " + signature.outputSignature() + " mode " + signature.mode(), e);
@@ -372,10 +373,11 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
     public boolean registerFunction(UserFunctionSignature signature, String statement, boolean forceSingle) {
         try {
+            final boolean isStatementNull = statement == null;
             globalProceduresRegistry.register(new CallableUserFunction.BasicUserFunction(signature) {
                 @Override
                 public AnyValue apply(org.neo4j.kernel.api.procedure.Context ctx, AnyValue[] input) throws ProcedureException {
-                    if (statement == null) {
+                    if (isStatementNull) {
                         final String error = String.format("Unknown function '%s'", signature.name());
                         throw new QueryExecutionException(error, null, "Neo.ClientError.Statement.SyntaxError");
                     } else {
@@ -411,6 +413,11 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
                 }
             }, true);
+            if (isStatementNull) {
+                registeredUserFunctionSignatures.remove(signature);
+            } else {
+                registeredUserFunctionSignatures.add(signature);
+            }
             return true;
         } catch (Exception e) {
             log.error("Could not register function: " + signature + "\nwith: " + statement + "\n single result " + forceSingle, e);

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -363,12 +363,8 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                     }
                 }
             }, true);
-//            System.out.println("CypherProceduresHandler.registerProcedure1");
-            registeredProcedureSignatures.add(signature);
             return true;
         } catch (Exception e) {
-//            System.out.println("e.getCause().getMessage()" + e.getCause().getMessage());
-            System.out.println("e.getClass().getName()" + e.getClass().getName());
             log.error("Could not register procedure: " + signature.name() + " with " + statement + "\n accepting" + signature.inputSignature() + " resulting in " + signature.outputSignature() + " mode " + signature.mode(), e);
             return false;
         }
@@ -415,7 +411,6 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
                 }
             }, true);
-//            registeredUserFunctionSignatures.add(signature);
             return true;
         } catch (Exception e) {
             log.error("Could not register function: " + signature + "\nwith: " + statement + "\n single result " + forceSingle, e);

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -249,7 +249,6 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
             setLastUpdate(tx);
             registerFunction(signature, statement, forceSingle);
-            registeredUserFunctionSignatures.add(signature);
             return null;
         });
     }
@@ -268,7 +267,6 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             node.setProperty(SystemPropertyKeys.mode.name(), signature.mode().name());
             setLastUpdate(tx);
             registerProcedure(signature, statement);
-            registeredProcedureSignatures.add(signature);
             return null;
         });
     }

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -618,7 +618,6 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             ).stream().filter(n -> n.hasLabel(SystemLabels.Procedure)).forEach(node -> {
                 ProcedureDescriptor descriptor = procedureDescriptor(node);
                 registerProcedure(descriptor.getSignature(), null);
-                registeredProcedureSignatures.remove(descriptor.getSignature());
                 node.delete();
                 setLastUpdate(tx);
             });
@@ -636,7 +635,6 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             ).stream().filter(n -> n.hasLabel(SystemLabels.Function)).forEach(node -> {
                 UserFunctionDescriptor descriptor = userFunctionDescriptor(node);
                 registerFunction(descriptor.getSignature(), null, false);
-                registeredUserFunctionSignatures.remove(descriptor.getSignature());
                 node.delete();
                 setLastUpdate(tx);
             });

--- a/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -215,7 +215,7 @@ public class CypherProceduresStorageTest {
                 "  [['areaName', 'STRING']],\n" +
                 "  \"Get vantage points within an area and all included areas\");");
 
-        // function analogue to procedure
+        // function analogous to procedure
         db.executeTransactionally("CALL apoc.custom.asFunction('vantagepoint_within_area',\n" +
                 "  \"MATCH (start:Area {name: $areaName} )\n" +
                 "    CALL apoc.path.expand(start,'CONTAINS>|<SEES|CURRENT','',0,100) YIELD path\n" +


### PR DESCRIPTION
Fixes #1744
Fixes #1871

- Added test emulating the issue 1744
- Changed `registeredProcedureSignatures` and `registeredUserFunctionSignatures ` from immutable to mutable Sets
- Simplified logic removing de-register on restoreProcedure and replacing with `registeredProcedureSignatures.remove(signature);` in `registerProcedure()` and `registeredUserFunctionSignatures.remove(signature);` in `registerFunction()`
