### PR TITLE
fixes #1880: 4.1.0.7 / 4.2.0.3 has no apoc.coll package

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -132,7 +132,7 @@ dependencies {
     }
 
     // there is a compatibility problem between the Guava Library used by HDFS, Google Cloud Storage and Reflections; the only version that fits for all is the following
-    testCompile group: 'com.google.guava', name: 'guava', version: '20.0'
+    compile group: 'com.google.guava', name: 'guava', version: '20.0'
 
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'


### PR DESCRIPTION
Fixes #1880

Due to transitive dependency issue, Google Guava is not included into the package anymore so we need to include it manually
