### PR TITLE
Update APOC functions to work with new types of indexes

### DIFF
--- a/core/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
@@ -61,12 +61,15 @@ public class CypherResultSubGraph implements SubGraph
         }
         for ( IndexDefinition def : tx.schema().getIndexes() )
         {
-            for ( Label label : def.getLabels() )
+            if ( def.isNodeIndex() )
             {
-                if ( graph.getLabels().contains( label ) )
+                for ( Label label : def.getLabels() )
                 {
-                    graph.addIndex( def );
-                    break;
+                    if ( graph.getLabels().contains( label ) )
+                    {
+                        graph.addIndex( def );
+                        break;
+                    }
                 }
             }
         }

--- a/core/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
@@ -3,6 +3,7 @@ package org.neo4j.cypher.export;
 import org.neo4j.graphdb.*;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
+import org.neo4j.graphdb.schema.IndexType;
 import org.neo4j.internal.helpers.collection.Iterables;
 
 import java.util.*;
@@ -61,7 +62,7 @@ public class CypherResultSubGraph implements SubGraph
         }
         for ( IndexDefinition def : tx.schema().getIndexes() )
         {
-            if ( def.isNodeIndex() )
+            if ( def.isNodeIndex() && def.getIndexType() != IndexType.LOOKUP )
             {
                 for ( Label label : def.getLabels() )
                 {

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -16,6 +16,7 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.kernel.impl.index.schema.RelationshipTypeScanStoreSettings;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 import org.xmlunit.builder.DiffBuilder;
@@ -123,7 +124,7 @@ public class ExportGraphMLTest {
             "<edge id=\"e0\" source=\"n0\" target=\"n1\" label=\"KNOWS\"><data key=\"label\">KNOWS</data><data key=\"TYPE\">KNOWS</data></edge>%n";
 
     public static final String DATA_PATH_CAPTION_DEFAULT = "<node id=\"n0\" labels=\":Foo:Foo0:Foo2\"><data key=\"TYPE\">:Foo:Foo0:Foo2</data><data key=\"label\">point({x: 56.7, y: 12.78, z: 100.0, crs: 'wgs-84-3d'})</data><data key=\"place\">{\"crs\":\"wgs-84-3d\",\"latitude\":56.7,\"longitude\":12.78,\"height\":100.0}</data><data key=\"name\">foo</data><data key=\"born\">2018-10-10</data></node>%n" +
-            "<node id=\"n1\" labels=\":Bar\"><data key=\"TYPE\">:Bar</data><data key=\"label\">42</data><data key=\"age\">42</data><data key=\"name\">bar</data><data key=\"place\">{\"crs\":\"wgs-84\",\"latitude\":56.7,\"longitude\":12.78,\"height\":null}</data></node>%n" +
+            "<node id=\"n1\" labels=\":Bar\"><data key=\"TYPE\">:Bar</data><data key=\"label\">point({x: 56.7, y: 12.78, crs: 'wgs-84'})</data><data key=\"age\">42</data><data key=\"name\">bar</data><data key=\"place\">{\"crs\":\"wgs-84\",\"latitude\":56.7,\"longitude\":12.78,\"height\":null}</data></node>%n" +
             "<edge id=\"e0\" source=\"n0\" target=\"n1\" label=\"KNOWS\"><data key=\"label\">KNOWS</data><data key=\"TYPE\">KNOWS</data></edge>%n";
 
     public static final String DATA_DATA = "<node id=\"n3\" labels=\":Person\"><data key=\"labels\">:Person</data><data key=\"name\">Foo</data></node>\n" +
@@ -506,7 +507,7 @@ public class ExportGraphMLTest {
     @Test
     public void testExportGraphGraphMLQueryGephiWithArrayCaptionWrong() throws Exception {
         File output = new File(directory, "query.graphml");
-        TestUtil.testCall(db, "call apoc.export.graphml.query('MATCH p=()-[r]->() RETURN p limit 1000',$file,{useTypes:true, format: 'gephi', caption: ['a','b','c']}) ", map("file", output.getAbsolutePath()),
+        TestUtil.testCall(db, "call apoc.export.graphml.query('MATCH p=()-[r]->() RETURN p limit 1000',$file,{useTypes:true, format: 'gephi', caption: ['c','d','e']}) ", map("file", output.getAbsolutePath()),
                 (r) -> {
                     assertEquals(2L, r.get("nodes"));
                     assertEquals(1L, r.get("relationships"));

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -4,6 +4,7 @@ import apoc.graph.Graphs;
 import apoc.util.MapUtil;
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import org.assertj.core.api.Assertions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,6 +50,8 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.neo4j.configuration.SettingImpl.newBuilder;
 import static org.neo4j.configuration.SettingValueParsers.BOOL;
 import static org.neo4j.driver.Values.isoDuration;
@@ -657,10 +660,7 @@ public class MetaTest {
         db.executeTransactionally("CREATE (:Person {name:'Jeff', surname:'Logan'})");
         TestUtil.testResult(db, "CALL apoc.meta.data({sample:2})",
                 (r) -> {
-                    Map<String, Object>  personNameProperty = r.next();
-                    Map<String, Object>  personSurnameProperty = r.next();
-                    assertEquals("name", personNameProperty.get("property"));
-                    assertEquals("surname", personSurnameProperty.get("property"));
+                    Assertions.assertThat( r.stream().map( m -> m.get( "property" ) ) ).containsExactlyInAnyOrder( "name", "surname" );
                 });
     }
 
@@ -716,8 +716,7 @@ public class MetaTest {
         db.executeTransactionally("CREATE (:Person {name:'Tom'})");
         TestUtil.testResult(db, "CALL apoc.meta.data({sample:5})",
                 (r) -> {
-                    Map<String, Object>  personNameProperty = r.next();
-                    assertEquals("name", personNameProperty.get("property"));
+                    Assertions.assertThat( r.stream().map( m -> m.get("property") ) ).contains( "name" );
                     r.close();
                 });
     }

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -511,12 +511,7 @@ public class PeriodicTest {
         TestUtil.testCallEmpty(db, "CALL apoc.periodic.truncate", Collections.emptyMap());
         assertCountEntitiesAndIndexes(0, 0, 4,2);
 
-        try(Transaction tx = db.beginTx()) {
-            Schema schema = tx.schema();
-            schema.getConstraints().forEach(ConstraintDefinition::drop);
-            schema.getIndexes().forEach(IndexDefinition::drop);
-            tx.commit();
-        }
+        dropSchema();
 
         assertCountEntitiesAndIndexes(0, 0, 0,0);
     }
@@ -529,7 +524,20 @@ public class PeriodicTest {
         assertCountEntitiesAndIndexes(0, 0, 0,0);
     }
 
+    private void dropSchema()
+    {
+        try(Transaction tx = db.beginTx()) {
+            Schema schema = tx.schema();
+            schema.getConstraints().forEach(ConstraintDefinition::drop);
+            schema.getIndexes().forEach(IndexDefinition::drop);
+            tx.commit();
+        }
+    }
+
     private void createDatasetForTruncate() {
+        // drop schema to remove existing default token indexes if any
+        dropSchema();
+
         db.executeTransactionally("UNWIND range(1,99999) AS x CREATE (:One{name:'Person_'+x})-[:FOO {id: x}]->(:Two {surname: 'Two'+x})<-[:BAR {idBar: x}]-(:Three {other: x+'Three'})");
 
         db.executeTransactionally("CREATE INDEX ON :One(name)");


### PR DESCRIPTION
This PR makes existing APOC functions to not fail when new types of indexes are present in the database.