### PR TITLE
Update readme.adoc

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -5,6 +5,10 @@
 :neo4j-version: 4.2.2
 :img: https://raw.githubusercontent.com/neo4j-contrib/neo4j-apoc-procedures/{branch}/docs/images
 
+https://community.neo4j.com[image:https://img.shields.io/discourse/users?logo=discourse&server=https%3A%2F%2Fcommunity.neo4j.com[Discourse users]]
+https://discord.gg/neo4j[image:https://img.shields.io/discord/787399249741479977?logo=discord&logoColor=white[Discord]]
+
+
 = Awesome Procedures for Neo4j {branch}.x
 
 // tag::readme[]


### PR DESCRIPTION
badges for discord and discourse

Fixes nothing.

This adds badges for discord and discourse to the readme, to improve discoverability of community channels.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Add badges to Discord and Discourse
