### PR TITLE
Fixes #1829: Bug in CALL apoc.metrics.storage('dbms.directories.data') due to APOC configuration check

### DIFF
--- a/core/src/main/java/apoc/ApocConfig.java
+++ b/core/src/main/java/apoc/ApocConfig.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import static apoc.util.FileUtils.isFile;
+import static org.neo4j.configuration.ExternalSettings.lib_directory;
+import static org.neo4j.configuration.ExternalSettings.run_directory;
 import static org.neo4j.configuration.GraphDatabaseSettings.SYSTEM_DATABASE_NAME;
 import static org.neo4j.configuration.GraphDatabaseSettings.data_directory;
 import static org.neo4j.configuration.GraphDatabaseSettings.load_csv_file_url_root;
@@ -78,6 +80,8 @@ public class ApocConfig extends LifecycleAdapter {
             plugin_dir,
             logical_logs_location,
             transaction_logs_root_path,
+            run_directory,
+            lib_directory,
             neo4j_home
     ));
     private static final String DEFAULT_PATH = ".";

--- a/core/src/main/java/apoc/util/FileUtils.java
+++ b/core/src/main/java/apoc/util/FileUtils.java
@@ -274,7 +274,7 @@ public class FileUtils {
     //
     // More likely, they'll be largely similar metrics.
     public static final List<String> NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES = Arrays.asList(
-            "dbms.directories.certificates",
+//            "dbms.directories.certificates",  // not  in 4.x version
             "dbms.directories.data",
             "dbms.directories.import",
             "dbms.directories.lib",
@@ -283,7 +283,7 @@ public class FileUtils {
             "dbms.directories.plugins",
             "dbms.directories.run",
             "dbms.directories.tx_log",
-            "unsupported.dbms.directories.neo4j_home"
+            "dbms.directories.neo4j_home"
     );
 
     public static void closeReaderSafely(CountingReader reader) {

--- a/core/src/main/java/apoc/util/FileUtils.java
+++ b/core/src/main/java/apoc/util/FileUtils.java
@@ -274,7 +274,7 @@ public class FileUtils {
     //
     // More likely, they'll be largely similar metrics.
     public static final List<String> NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES = Arrays.asList(
-//            "dbms.directories.certificates",  // not  in 4.x version
+//            "dbms.directories.certificates",  // not in 4.x version
             "dbms.directories.data",
             "dbms.directories.import",
             "dbms.directories.lib",

--- a/full/src/main/java/apoc/metrics/Metrics.java
+++ b/full/src/main/java/apoc/metrics/Metrics.java
@@ -43,7 +43,7 @@ public class Metrics {
         public static StoragePair fromDirectorySetting(String dir) {
             if (dir == null) return null;
 
-            String configLocation = apocConfig().getString("apoc." + dir, null);
+            String configLocation = apocConfig().getString(dir, null);
             if (configLocation == null) return null;
 
             File f = new File(configLocation);

--- a/full/src/test/java/apoc/metrics/MetricsTest.java
+++ b/full/src/test/java/apoc/metrics/MetricsTest.java
@@ -6,12 +6,18 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.neo4j.driver.Session;
+import org.neo4j.internal.helpers.collection.Iterators;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static apoc.util.FileUtils.NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES;
 import static apoc.util.TestContainerUtil.createEnterpriseDB;
+import static apoc.util.TestContainerUtil.testCall;
 import static apoc.util.TestContainerUtil.testResult;
 import static apoc.util.TestUtil.isTravis;
 import static apoc.util.Util.map;
@@ -60,6 +66,32 @@ public class MetricsTest {
                     assertEquals(Stream.of("timestamp", "metric", "map").collect(Collectors.toSet()), map.keySet());
                     assertEquals(metricKey, map.get("metric"));
                 });
+    }
+
+    @Test
+    public void shouldRetrieveStorageMetrics() {
+
+        final Set<String> expectedSet = Stream.of("setting", "freeSpaceBytes", "totalSpaceBytes", "usableSpaceBytes", "percentFree")
+                .collect(Collectors.toSet());
+
+        NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES.forEach(setting ->
+                testCall(session, "CALL apoc.metrics.storage($setting)", map("setting", setting), (res) -> {
+                    assertEquals(expectedSet, res.keySet());
+                    assertEquals(setting, res.get("setting"));
+                })
+        );
+
+        // all metrics with null
+        testResult(session, "CALL apoc.metrics.storage(null)", (res) -> {
+            final List<Map<String, Object>> maps = Iterators.asList(res);
+            final Set<String> setSetting = maps.stream().map(item -> {
+                assertEquals(expectedSet, item.keySet());
+
+                return (String) item.get("setting");
+            }).collect(Collectors.toSet());
+
+            assertEquals(new HashSet<>(NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES), setSetting);
+        });
     }
 
     @Test


### PR DESCRIPTION
Fixes #1829
Fixes #1544

- Removed `apoc.` prefix in `Metrics.java`
- Added missing dir settings in `ApocConfig.java`
- Changed `unsupported.dbms.directories.neo4j_home` to `dbms.directories.neo4j_home` and commented `dbms.directories.certificates` (not present in neo4j 4.x) in `FileUtils.java`
- Added test to `apoc.metrics.storage` for each `Directory configuration` and with `apoc.metrics.storage(null)`