### PR TITLE
Cleanup schema sampling procs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -100,6 +100,11 @@ subprojects {
     compileJava {
         options.annotationProcessorPath = configurations.apt
         options.compilerArgs += ["-AIgnoreContextWarnings"]
+        options.encoding = "UTF-8"
+    }
+
+    compileTestJava {
+        options.encoding = "UTF-8"
     }
 
 }

--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -66,12 +66,10 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static apoc.util.MapUtil.map;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonMap;
 import static org.neo4j.internal.kernel.api.TokenRead.ANY_LABEL;
 import static org.neo4j.internal.kernel.api.TokenRead.ANY_RELATIONSHIP_TYPE;
 
-public class    Meta {
+public class Meta {
 
     @Context
     public Transaction tx;
@@ -238,8 +236,6 @@ public class    Meta {
         }
     }
 
-    static final int SAMPLE = 100;
-
     @Deprecated
     @UserFunction
     @Description("apoc.meta.type(value) - type name of a value (INTEGER,FLOAT,STRING,BOOLEAN,RELATIONSHIP,NODE,PATH,NULL,UNKNOWN,MAP,LIST)")
@@ -319,7 +315,6 @@ public class    Meta {
         }
     }
 
-
     @UserFunction("apoc.meta.cypher.types")
     @Description("apoc.meta.cypher.types(node-relationship-map)  - returns a map of keys to types")
     public Map<String,Object> typesCypher(@Name("properties") Object target) {
@@ -338,7 +333,6 @@ public class    Meta {
 
         return result;
     }
-
 
     public static class MetaStats {
         public final long labelCount;
@@ -498,40 +492,45 @@ public class    Meta {
         return Stream.of(new MapResult(nodes));
     }
 
-
-    // Start new code
-
     /**
      * This procedure is intended to replicate what's in the core Neo4j product, but with the crucial difference that it
      * supports flexible sampling options, and does not scan the entire database.  The result is producing a table of
      * metadata that is useful for generating "Tables 4 Labels" schema designs for RDBMSs, but in a more performant way.
      */
     @Procedure
-    @Description("apoc.meta.nodeTypeProperties()")
-    public Stream<Tables4LabelsProfile.NodeTypePropertiesEntry> nodeTypeProperties(@Name(value = "config",defaultValue = "{}") Map<String,Object> config) {
-        MetaConfig metaConfig = new MetaConfig(config);
-        try {
-            return collectTables4LabelsProfile(metaConfig).asNodeStream();
-        } catch (Exception e) {
-            log.debug("meta.nodeTypeProperties(): Failed to return stream", e);
-            throw new RuntimeException(e);
+    @Description( "apoc.meta.nodeTypeProperties()" )
+    public Stream<Tables4LabelsProfile.NodeTypePropertiesEntry> nodeTypeProperties( @Name( value = "config", defaultValue = "{}" ) Map<String,Object> config )
+    {
+        MetaConfig metaConfig = new MetaConfig( config );
+        try
+        {
+            return collectTables4LabelsProfile( metaConfig ).asNodeStream();
+        }
+        catch ( Exception e )
+        {
+            log.debug( "apoc.meta.nodeTypeProperties(): Failed to return stream", e );
+            throw new RuntimeException( e );
         }
     }
 
     /**
-     * This procedure is intended to replicate what's in the core Neo4j product, but with the crucial difference that it
-     * supports flexible sampling options, and does not scan the entire database.  The result is producing a table of
-     * metadata that is useful for generating "Tables 4 Labels" schema designs for RDBMSs, but in a more performant way.
+     * This procedure is intended to replicate what's in the core Neo4j product, but with the crucial difference that it supports flexible sampling options, and
+     * does not scan the entire database.  The result is producing a table of metadata that is useful for generating "Tables 4 Labels" schema designs for
+     * RDBMSs, but in a more performant way.
      */
     @Procedure
-    @Description("apoc.meta.relTypeProperties()")
-    public Stream<Tables4LabelsProfile.RelTypePropertiesEntry> relTypeProperties(@Name(value = "config",defaultValue = "{}") Map<String,Object> config) {
-        MetaConfig metaConfig = new MetaConfig(config);
-        try {
-            return collectTables4LabelsProfile(metaConfig).asRelStream();
-        } catch (Exception e) {
-            log.debug("meta.relTypeProperties(): Failed to return stream", e);
-            throw new RuntimeException(e);
+    @Description( "apoc.meta.relTypeProperties()" )
+    public Stream<Tables4LabelsProfile.RelTypePropertiesEntry> relTypeProperties( @Name( value = "config", defaultValue = "{}" ) Map<String,Object> config )
+    {
+        MetaConfig metaConfig = new MetaConfig( config );
+        try
+        {
+            return collectTables4LabelsProfile( metaConfig ).asRelStream();
+        }
+        catch ( Exception e )
+        {
+            log.debug( "apoc.meta.relTypeProperties(): Failed to return stream", e );
+            throw new RuntimeException( e );
         }
     }
 
@@ -542,7 +541,7 @@ public class    Meta {
 
         for (ConstraintDefinition cd : schema.getConstraints()) {
             if (cd.isConstraintType(ConstraintType.NODE_PROPERTY_EXISTENCE)) {
-                List<String> props = new ArrayList<String>(10);
+                List<String> props = new ArrayList<>( 10 );
                 if (ConstraintTracker.nodeConstraints.containsKey(cd.getLabel().name())) {
                     props = ConstraintTracker.nodeConstraints.get(cd.getLabel().name());
                 }
@@ -550,8 +549,8 @@ public class    Meta {
                 ConstraintTracker.nodeConstraints.put(cd.getLabel().name(),props);
 
             } else if (cd.isConstraintType(ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE)) {
-                List<ConstraintDefinition> tcd = new ArrayList<ConstraintDefinition>(10);
-                List<String> props = new ArrayList<String>(10);
+                List<ConstraintDefinition> tcd = new ArrayList<>( 10 );
+                List<String> props = new ArrayList<>( 10 );
                 if (ConstraintTracker.relConstraints.containsKey(cd.getRelationshipType().name())) {
                     props = ConstraintTracker.relConstraints.get(cd.getRelationshipType().name());
                 }
@@ -648,7 +647,7 @@ public class    Meta {
     }
 
     private Map<String, Long> getLabelCountStore() {
-        List<String> labels = Iterables.stream(tx.getAllLabelsInUse()).map(label -> label.name()).collect(Collectors.toList());
+        List<String> labels = Iterables.stream(tx.getAllLabelsInUse()).map( Label::name ).collect( Collectors.toList());
         TokenRead tokenRead = kernelTx.tokenRead();
         return labels
                 .stream()
@@ -1130,80 +1129,5 @@ public class    Meta {
         }
         if (increment > 0 ) vNode.setProperty("count",(((Number)vNode.getProperty("count",0L)).longValue())+increment);
         return vNode;
-    }
-
-    private void addRel(Map<List<String>, Relationship> rels, Map<String, Node> labels, Relationship rel, boolean strict) {
-        String typeName = rel.getType().name();
-        Node startNode = rel.getStartNode();
-        Node endNode = rel.getEndNode();
-        for (Label labelA : startNode.getLabels()) {
-            Node nodeA = strict ? labels.get(labelA.name()) : mergeMetaNode(labelA,labels,0);
-            if (nodeA == null) continue;
-            for (Label labelB : endNode.getLabels()) {
-                List<String> key = asList(labelA.name(), labelB.name(), typeName);
-                Relationship vRel = rels.get(key);
-                if (vRel==null) {
-                    Node nodeB = strict ? labels.get(labelB.name()) : mergeMetaNode(labelB,labels,0);
-                    if (nodeB == null) continue;
-                    vRel = new VirtualRelationship(nodeA,nodeB,rel.getType()).withProperties(singletonMap("type",typeName));
-                    rels.put(key,vRel);
-                }
-                vRel.setProperty("count",((long)vRel.getProperty("count",0L))+1);
-            }
-        }
-    }
-
-    static class RelInfo {
-        final Set<String> properties = new HashSet<>();
-        final NodeInfo from,to;
-        final String type;
-        int count;
-
-        public RelInfo(NodeInfo from, NodeInfo to, String type) {
-            this.from = from;
-            this.to = to;
-            this.type = type;
-        }
-        public void add(Relationship relationship) {
-            for (String key : relationship.getPropertyKeys()) properties.add(key);
-            count++;
-        }
-    }
-    static class NodeInfo {
-        final Set<String> labels=new HashSet<>();
-        final Set<String> properties = new HashSet<>();
-        long count, minDegree, maxDegree, sumDegree;
-
-        private void add(Node node) {
-            count++;
-            int degree = node.getDegree();
-            sumDegree += degree;
-            if (degree > maxDegree) maxDegree = degree;
-            if (degree < minDegree) minDegree = degree;
-
-            for (Label label : node.getLabels()) labels.add(label.name());
-            for (String key : node.getPropertyKeys()) properties.add(key);
-        }
-        Map<String,Object> toMap() {
-            Map<String, Object> map = new LinkedHashMap<>();
-            map.put("labels",labels.toArray());
-            map.put("properties",properties.toArray());
-            map.put("count",count);
-            map.put("minDegree",minDegree);
-            map.put("maxDegree",maxDegree);
-            map.put("avgDegree",sumDegree/count);
-            return map;
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            return this == o || o instanceof NodeInfo && labels.equals(((NodeInfo) o).labels);
-
-        }
-
-        @Override
-        public int hashCode() {
-            return labels.hashCode();
-        }
     }
 }

--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -499,15 +499,12 @@ public class Meta {
      */
     @Procedure
     @Description( "apoc.meta.nodeTypeProperties()" )
-    public Stream<Tables4LabelsProfile.NodeTypePropertiesEntry> nodeTypeProperties( @Name( value = "config", defaultValue = "{}" ) Map<String,Object> config )
-    {
+    public Stream<Tables4LabelsProfile.NodeTypePropertiesEntry> nodeTypeProperties( @Name( value = "config", defaultValue = "{}" ) Map<String,Object> config ) {
         MetaConfig metaConfig = new MetaConfig( config );
-        try
-        {
+        try {
             return collectTables4LabelsProfile( metaConfig ).asNodeStream();
         }
-        catch ( Exception e )
-        {
+        catch ( Exception e ) {
             log.debug( "apoc.meta.nodeTypeProperties(): Failed to return stream", e );
             throw new RuntimeException( e );
         }
@@ -520,15 +517,12 @@ public class Meta {
      */
     @Procedure
     @Description( "apoc.meta.relTypeProperties()" )
-    public Stream<Tables4LabelsProfile.RelTypePropertiesEntry> relTypeProperties( @Name( value = "config", defaultValue = "{}" ) Map<String,Object> config )
-    {
+    public Stream<Tables4LabelsProfile.RelTypePropertiesEntry> relTypeProperties( @Name( value = "config", defaultValue = "{}" ) Map<String,Object> config ) {
         MetaConfig metaConfig = new MetaConfig( config );
-        try
-        {
+        try {
             return collectTables4LabelsProfile( metaConfig ).asRelStream();
         }
-        catch ( Exception e )
-        {
+        catch ( Exception e ) {
             log.debug( "apoc.meta.relTypeProperties(): Failed to return stream", e );
             throw new RuntimeException( e );
         }

--- a/core/src/main/java/apoc/meta/Tables4LabelsProfile.java
+++ b/core/src/main/java/apoc/meta/Tables4LabelsProfile.java
@@ -6,7 +6,6 @@ import apoc.meta.tablesforlabels.PropertyTracker;
 import org.neo4j.graphdb.*;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
-import org.neo4j.graphdb.schema.*;
 
 import java.util.*;
 import java.util.stream.Stream;
@@ -123,26 +122,6 @@ public class Tables4LabelsProfile {
         }
     }
 
-    public boolean compareLabelLists(Map<String, List<String>> a, Map<String, List<String>> b) {
-        boolean equal = true;
-        for (Map.Entry<String, List<String>> comp : a.entrySet()) {
-            List<String> list1 = comp.getValue();
-            Collections.sort(list1);
-            if (b.containsKey(comp.getKey())) {
-                List<String> list2 = b.get(comp.getKey());
-                Collections.sort(list2);
-                if (!list1.equals(list2)) {
-                    equal = false;
-                }
-            }
-        }
-        if (equal) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
     public static String labelJoin(Iterable<Label> labels) {
         return StreamSupport.stream(labels.spliterator(), true)
         .map(Label::name)
@@ -171,20 +150,10 @@ public class Tables4LabelsProfile {
         OrderedLabels labels = new OrderedLabels(n.getLabels());
         PropertyContainerProfile localNodeProfile = getNodeProfile(labels);
 
-        Set<String> excludes = config.getExcludes();
-        Set<String> includesRels = config.getIncludesRels();
-
         // Only descend and look at properties if it's in our match list.
         if (config.matches(n.getLabels())) {
             sawNode(labels);
             localNodeProfile.observe(n, true);
-        }
-
-        for (RelationshipType type : n.getRelationshipTypes()) {
-            String labelString = "";
-            for (Label label : n.getLabels()) {
-                labelString += "@@@" + label.name();
-            }
         }
 
         // Even if the node isn't in our match list, do rel processing.  This
@@ -234,7 +203,7 @@ public class Tables4LabelsProfile {
 
     public Stream<NodeTypePropertiesEntry> asNodeStream() {
         Set<OrderedLabels> labels = labelMap.keySet();
-        List<NodeTypePropertiesEntry> results = new ArrayList<NodeTypePropertiesEntry>(100);
+        List<NodeTypePropertiesEntry> results = new ArrayList<>( 100 );
 
         for(OrderedLabels ol : labels) {
             PropertyContainerProfile prof = labelMap.get(ol);

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -805,13 +805,11 @@ public class MetaTest {
     // Tests for T4L
 
     @Test
-    public void testRelTypePropertiesBasic()
-    {
+    public void testRelTypePropertiesBasic() {
         db.executeTransactionally( "CREATE (:Base)-[:RELTYPE { a: 1, d: null }]->(:Target)" );
         db.executeTransactionally( "CREATE (:Base)-[:RELTYPE { a: 2, b: 2, c: 2, d: 4 }]->(:Target);" );
 
-        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties()", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties()", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
 
 //            System.out.println("REL TYPE PROPERTIES");
@@ -840,13 +838,11 @@ public class MetaTest {
     }
 
     @Test
-    public void testRelTypePropertiesIncludes()
-    {
+    public void testRelTypePropertiesIncludes() {
         db.executeTransactionally( "CREATE (:A)-[:CATCHME { c: 1 }]->(:B)" );
         db.executeTransactionally( "CREATE (:A)-[:IGNOREME { d: 1 }]->(:B)" );
 
-        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeRels: ['CATCHME'] })", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeRels: ['CATCHME'] })", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 1, records.size() );
             assertEquals( records.get( 0 ).get( "propertyName" ).equals( "c" ), true );
@@ -854,13 +850,11 @@ public class MetaTest {
     }
 
     @Test
-    public void testNodeTypePropertiesNodeExcludes()
-    {
+    public void testNodeTypePropertiesNodeExcludes() {
         db.executeTransactionally( "CREATE (:ExcludeMe)" );
         db.executeTransactionally( "CREATE (:IncludeMe)" );
 
-        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ excludeLabels: ['ExcludeMe'] })", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ excludeLabels: ['ExcludeMe'] })", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 1, records.size() );
             assertEquals( ":`IncludeMe`", records.get( 0 ).get( "nodeType" ) );
@@ -868,13 +862,11 @@ public class MetaTest {
     }
 
     @Test
-    public void testNodeTypePropertiesNodeIncludes()
-    {
+    public void testNodeTypePropertiesNodeIncludes() {
         db.executeTransactionally( "CREATE (:ExcludeMe)" );
         db.executeTransactionally( "CREATE (:IncludeMe)" );
 
-        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ includeLabels: ['IncludeMe'] })", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ includeLabels: ['IncludeMe'] })", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 1, records.size() );
             assertEquals( ":`IncludeMe`", records.get( 0 ).get( "nodeType" ) );
@@ -882,23 +874,18 @@ public class MetaTest {
     }
 
     @Test
-    public void testNodeTypePropertiesRelExcludes()
-    {
+    public void testNodeTypePropertiesRelExcludes() {
         db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
         db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
 
-        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ excludeRels: ['RELA'] })", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ excludeRels: ['RELA'] })", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 2, records.size() );
-            for ( Map<String,Object> rec : records )
-            {
-                if ( rec.get( "nodeType" ).equals( ":`A`" ) )
-                {
+            for ( Map<String,Object> rec : records ) {
+                if ( rec.get( "nodeType" ).equals( ":`A`" ) ) {
                     assertEquals( ":`B`", rec.get( "nodeType" ) );
                 }
-                if ( rec.get( "nodeType" ).equals( ":`C`" ) )
-                {
+                if ( rec.get( "nodeType" ).equals( ":`C`" ) ) {
                     assertEquals( ":`D`", rec.get( "nodeType" ) );
                 }
             }
@@ -906,23 +893,18 @@ public class MetaTest {
     }
 
     @Test
-    public void testNodeTypePropertiesRelIncludes()
-    {
+    public void testNodeTypePropertiesRelIncludes() {
         db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
         db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
 
-        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ includeRels: ['RELA'] })", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ includeRels: ['RELA'] })", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 2, records.size() );
-            for ( Map<String,Object> rec : records )
-            {
-                if ( rec.get( "nodeType" ).equals( ":`A`" ) )
-                {
+            for ( Map<String,Object> rec : records ) {
+                if ( rec.get( "nodeType" ).equals( ":`A`" ) ) {
                     assertEquals( ":`A`", rec.get( "nodeType" ) );
                 }
-                if ( rec.get( "nodeType" ).equals( ":`C`" ) )
-                {
+                if ( rec.get( "nodeType" ).equals( ":`C`" ) ) {
                     assertEquals( ":`C`", rec.get( "nodeType" ) );
                 }
             }
@@ -930,24 +912,19 @@ public class MetaTest {
     }
 
     @Test
-    public void testNodeTypePropertiesWithWeirdConfig()
-    {
+    public void testNodeTypePropertiesWithWeirdConfig() {
         db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
         db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
 
-        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ includeRels: ['RELA'], stupidInput: ['RELB'] })", r ->
-                // should ignore all unknown input
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ includeRels: ['RELA'], stupidInput: ['RELB'] })", r -> {
+                // should ignore all unknown input{
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 2, records.size() );
-            for ( Map<String,Object> rec : records )
-            {
-                if ( rec.get( "nodeType" ).equals( ":`A`" ) )
-                {
+            for ( Map<String,Object> rec : records ) {
+                if ( rec.get( "nodeType" ).equals( ":`A`" ) ) {
                     assertEquals( ":`A`", rec.get( "nodeType" ) );
                 }
-                if ( rec.get( "nodeType" ).equals( ":`C`" ) )
-                {
+                if ( rec.get( "nodeType" ).equals( ":`C`" ) ) {
                     assertEquals( ":`C`", rec.get( "nodeType" ) );
                 }
             }
@@ -955,19 +932,15 @@ public class MetaTest {
     }
 
     @Test
-    public void testRelTypePropertiesWithWeirdConfig()
-    {
+    public void testRelTypePropertiesWithWeirdConfig() {
         db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
         db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
 
-        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeLabels: ['A'], stupidInput: ['B'] })", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeLabels: ['A'], stupidInput: ['B'] })", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 1, records.size() );
-            for ( Map<String,Object> rec : records )
-            {
-                if ( rec.get( "relType" ).equals( ":`RELA`" ) )
-                {
+            for ( Map<String,Object> rec : records ) {
+                if ( rec.get( "relType" ).equals( ":`RELA`" ) ) {
                     assertEquals( ":`RELA`", rec.get( "relType" ) );
                 }
             }
@@ -975,13 +948,11 @@ public class MetaTest {
     }
 
     @Test
-    public void testRelTypePropertiesRelExcludes()
-    {
+    public void testRelTypePropertiesRelExcludes() {
         db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
         db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
 
-        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ excludeRels: ['RELA'] })", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ excludeRels: ['RELA'] })", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 1, records.size() );
             assertEquals( ":`RELB`", records.get( 0 ).get( "relType" ) );
@@ -989,13 +960,11 @@ public class MetaTest {
     }
 
     @Test
-    public void testRelTypePropertiesRelIncludes()
-    {
+    public void testRelTypePropertiesRelIncludes() {
         db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
         db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
 
-        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeRels: ['RELA'] })", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeRels: ['RELA'] })", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 1, records.size() );
             assertEquals( ":`RELA`", records.get( 0 ).get( "relType" ) );
@@ -1003,19 +972,15 @@ public class MetaTest {
     }
 
     @Test
-    public void testRelTypePropertiesNodeExcludes()
-    {
+    public void testRelTypePropertiesNodeExcludes() {
         db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
         db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
 
-        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ excludeLabels: ['A'] })", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ excludeLabels: ['A'] })", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 1, records.size() );
-            for ( Map<String,Object> rec : records )
-            {
-                if ( rec.get( "relType" ).equals( ":`RELB`" ) )
-                {
+            for ( Map<String,Object> rec : records ) {
+                if ( rec.get( "relType" ).equals( ":`RELB`" ) ) {
                     assertEquals( ":`RELB`", rec.get( "relType" ) );
                 }
             }
@@ -1023,19 +988,15 @@ public class MetaTest {
     }
 
     @Test
-    public void testRelTypePropertiesNodeIncludes()
-    {
+    public void testRelTypePropertiesNodeIncludes() {
         db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
         db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
 
-        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeLabels: ['A'] })", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeLabels: ['A'] })", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 1, records.size() );
-            for ( Map<String,Object> rec : records )
-            {
-                if ( rec.get( "relType" ).equals( ":`RELA`" ) )
-                {
+            for ( Map<String,Object> rec : records ) {
+                if ( rec.get( "relType" ).equals( ":`RELA`" ) ) {
                     assertEquals( ":`RELA`", rec.get( "relType" ) );
                 }
             }
@@ -1043,32 +1004,26 @@ public class MetaTest {
     }
 
     @Test
-    public void testNodeTypePropertiesNodeIncludesRelIncludes1()
-    {
+    public void testNodeTypePropertiesNodeIncludesRelIncludes1() {
         db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
         db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
 
         // both together contract the data model and it should result in 0 results
-        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ includeLabels: ['A'], includeRels: ['RELB'] })", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ includeLabels: ['A'], includeRels: ['RELB'] })", r -> {
             assertEquals( 0, gatherRecords( r ).size() );
         } );
     }
 
     @Test
-    public void testNodeTypePropertiesNodeIncludesRelIncludes2()
-    {
+    public void testNodeTypePropertiesNodeIncludesRelIncludes2() {
         db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
         db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
 
-        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ includeLabels: ['A'], includeRels: ['RELA'] })", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ includeLabels: ['A'], includeRels: ['RELA'] })", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 1, records.size() ); // why not A and C? The label has to be on the start of the rel
-            for ( Map<String,Object> rec : records )
-            {
-                if ( rec.get( "nodeType" ).equals( ":`A`" ) )
-                {
+            for ( Map<String,Object> rec : records ) {
+                if ( rec.get( "nodeType" ).equals( ":`A`" ) ) {
                     assertEquals( ":`A`", rec.get( "nodeType" ) );
                 }
             }
@@ -1076,32 +1031,26 @@ public class MetaTest {
     }
 
     @Test
-    public void testRelTypePropertiesNodeIncludesAndRelsInclude1()
-    {
+    public void testRelTypePropertiesNodeIncludesAndRelsInclude1() {
         db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
         db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
 
         // both together contract the data model and it should result in 0 results
-        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeLabels: ['A'], includeRels: ['RELB'] })", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeLabels: ['A'], includeRels: ['RELB'] })", r -> {
             assertEquals( 0, gatherRecords( r ).size() );
         } );
     }
 
     @Test
-    public void testRelTypePropertiesNodeIncludesAndRelsInclude2()
-    {
+    public void testRelTypePropertiesNodeIncludesAndRelsInclude2() {
         db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
         db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
 
-        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeLabels: ['A'], includeRels: ['RELA'] })", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeLabels: ['A'], includeRels: ['RELA'] })", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 1, records.size() );
-            for ( Map<String,Object> rec : records )
-            {
-                if ( rec.get( "relType" ).equals( ":`RELA`" ) )
-                {
+            for ( Map<String,Object> rec : records ) {
+                if ( rec.get( "relType" ).equals( ":`RELA`" ) ) {
                     assertEquals( ":`RELA`", rec.get( "relType" ) );
                 }
             }
@@ -1109,17 +1058,14 @@ public class MetaTest {
     }
 
     @Test
-    public void testNodeTypePropertiesCompleteResult()
-    {
+    public void testNodeTypePropertiesCompleteResult() {
         db.executeTransactionally( "CREATE (:Foo { z: 'hej' });" );
         db.executeTransactionally( "CREATE (:Foo { z: 1 });" );
 
-        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties()", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties()", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 1, records.size() );
-            for ( Map<String,Object> rec : records )
-            {
+            for ( Map<String,Object> rec : records ) {
                 assertEquals( ":`Foo`", rec.get( "nodeType" ) );
                 assertEquals( List.of( "Foo" ), rec.get( "nodeLabels" ) );
                 assertEquals( "z", rec.get( "propertyName" ) );
@@ -1132,17 +1078,14 @@ public class MetaTest {
     }
 
     @Test
-    public void testRelTypePropertiesCompleteResult()
-    {
+    public void testRelTypePropertiesCompleteResult() {
         db.executeTransactionally( "CREATE (:A)-[:Foo { z: 'hej' }]->(:B);" );
         db.executeTransactionally( "CREATE (:A)-[:Foo { z: 1 }]->(:B);" );
 
-        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties()", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties()", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 1, records.size() );
-            for ( Map<String,Object> rec : records )
-            {
+            for ( Map<String,Object> rec : records ) {
                 assertEquals( ":`Foo`", rec.get( "relType" ) );
                 assertEquals( List.of( "A" ), rec.get( "sourceNodeLabels" ) );
                 assertEquals( List.of( "B" ), rec.get( "targetNodeLabels" ) );
@@ -1156,20 +1099,17 @@ public class MetaTest {
     }
 
     @Test
-    public void testNodeTypePropertiesWithSpecialSampleSize()
-    {
+    public void testNodeTypePropertiesWithSpecialSampleSize() {
         db.executeTransactionally( "CREATE (:Foo { z: 'hej' });" );
         db.executeTransactionally( "CREATE (:Foo { z: 1 });" );
         db.executeTransactionally( "CREATE (:Foo { z: true });" );
         db.executeTransactionally( "CREATE (:Foo { z: 1.5 });" );
 
         // sample = -1 scans all entities
-        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ pollingPeriod: -1})", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ pollingPeriod: -1})", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 1, records.size() );
-            for ( Map<String,Object> rec : records )
-            {
+            for ( Map<String,Object> rec : records ) {
                 assertEquals( ":`Foo`", rec.get( "nodeType" ) );
                 assertEquals( "z", rec.get( "propertyName" ) );
                 assertEquals( 4L, rec.get( "propertyObservations" ) );
@@ -1178,12 +1118,10 @@ public class MetaTest {
         } );
 
         // not scan all of them, might not reach maxSampleSize
-        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ pollingPeriod: 1 })", r ->
-        {
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ pollingPeriod: 1 })", r -> {
             List<Map<String,Object>> records = gatherRecords( r );
             assertEquals( 1, records.size() );
-            for ( Map<String,Object> rec : records )
-            {
+            for ( Map<String,Object> rec : records ) {
                 assertEquals( ":`Foo`", rec.get( "nodeType" ) );
                 assertEquals( "z", rec.get( "propertyName" ) );
                 assertTrue( (long) rec.get( "propertyObservations" ) <=4L );
@@ -1193,8 +1131,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testNodeTypePropertiesEquivalenceAdvanced()
-    {
+    public void testNodeTypePropertiesEquivalenceAdvanced() {
         db.executeTransactionally( "CREATE (:Foo { l: 1, s: 'foo', d: datetime(), ll: ['a', 'b'], dl: [2.0, 3.0] });" );
         // Missing all properties to make everything non-mandatory.
         db.executeTransactionally( "CREATE (:Foo { z: 1 });" );
@@ -1202,8 +1139,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testRelTypePropertiesEquivalenceAdvanced()
-    {
+    public void testRelTypePropertiesEquivalenceAdvanced() {
         db.executeTransactionally( "CREATE (:Foo)-[:REL { l: 1, s: 'foo', d: datetime(), ll: ['a', 'b'], dl: [2.0, 3.0] }]->();" );
         // Missing all properties to make everything non-mandatory.
         db.executeTransactionally( "CREATE (:Foo)-[:REL { z: 1 }]->();" );
@@ -1211,8 +1147,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testNodeTypePropertiesEquivalenceTypeMapping()
-    {
+    public void testNodeTypePropertiesEquivalenceTypeMapping() {
         String q =
                 "CREATE (:Test {" +
                 "    longProp: 1," +
@@ -1235,8 +1170,7 @@ public class MetaTest {
     }
 
     @Test
-    public void testRelTypePropertiesEquivalenceTypeMapping()
-    {
+    public void testRelTypePropertiesEquivalenceTypeMapping() {
         String q =
                 "CREATE (t:Test)-[:REL{" +
                 "    longProp: 1," +

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -127,11 +127,13 @@ public class MetaTest {
             testSet.set(gatherRecords(r));
         });
 
-//        System.out.println("COMPARE TO:");
-//        System.out.println(toCSV(compareTo.get()));
-//
-//        System.out.println("TEST SET:");
-//        System.out.println(toCSV(testSet.get()));
+        // Uncomment this for debugging purposes
+        /*
+        System.out.println("COMPARE TO:");
+        System.out.println(toCSV(compareTo.get()));
+        System.out.println("TEST SET:");
+        System.out.println(toCSV(testSet.get()));
+        */
 
         return resultSetsEquivalent(compareTo.get(), testSet.get());
     }

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -70,12 +70,6 @@ public class MetaTest {
         TestUtil.registerProcedure(db, Meta.class, Graphs.class);
     }
 
-    /*
-        @Test public void testMetaStats() throws Exception {
-            testResult(db,"CALL apoc.meta.stats", (r) -> assertEquals(true, r.hasNext()));
-        }
-    */
-
     public static boolean hasRecordMatching(List<Map<String,Object>> records, Map<String,Object> record) {
         return hasRecordMatching(records, row -> {
             boolean okSoFar = true;
@@ -103,7 +97,8 @@ public class MetaTest {
         }
         return rows;
     }
-
+    // Can be valuable for debugging purposes
+    @SuppressWarnings( "unused" )
     private static String toCSV(List<Map<String, Object>> list) {
         List<String> headers = list.stream().flatMap(map -> map.keySet().stream()).distinct().collect(Collectors.toList());
         final StringBuffer sb = new StringBuffer();
@@ -132,11 +127,11 @@ public class MetaTest {
             testSet.set(gatherRecords(r));
         });
 
-        System.out.println("COMPARE TO:");
-        System.out.println(toCSV(compareTo.get()));
-
-        System.out.println("TEST SET:");
-        System.out.println(toCSV(testSet.get()));
+//        System.out.println("COMPARE TO:");
+//        System.out.println(toCSV(compareTo.get()));
+//
+//        System.out.println("TEST SET:");
+//        System.out.println(toCSV(testSet.get()));
 
         return resultSetsEquivalent(compareTo.get(), testSet.get());
     }
@@ -808,198 +803,457 @@ public class MetaTest {
     // Tests for T4L
 
     @Test
-    public void testRelTypePropertiesBasic() throws Exception {
-        db.executeTransactionally("CREATE (:Base)-[:RELTYPE { a: 1, d: null }]->(:Target)");
-        db.executeTransactionally("CREATE (:Base)-[:RELTYPE { a: 2, b: 2, c: 2, d: 4 }]->(:Target);");
+    public void testRelTypePropertiesBasic()
+    {
+        db.executeTransactionally( "CREATE (:Base)-[:RELTYPE { a: 1, d: null }]->(:Target)" );
+        db.executeTransactionally( "CREATE (:Base)-[:RELTYPE { a: 2, b: 2, c: 2, d: 4 }]->(:Target);" );
 
-        TestUtil.testResult(db, "CALL apoc.meta.relTypeProperties()", r -> {
-            List<Map<String,Object>> records = gatherRecords(r);
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties()", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
 
-            System.out.println("REL TYPE PROPERTIES");
-            System.out.println(toCSV(records));
+//            System.out.println("REL TYPE PROPERTIES");
+//            System.out.println(toCSV(records));
 
-            assertEquals(true, hasRecordMatching(records, m ->
-                    m.get("propertyName").equals("a") &&
-                            ((List)m.get("propertyTypes")).get(0).equals("Long") &&
-                            m.get("mandatory").equals(false)));
+            assertEquals( true, hasRecordMatching( records, m ->
+                    m.get( "propertyName" ).equals( "a" ) &&
+                    ((List) m.get( "propertyTypes" )).get( 0 ).equals( "Long" ) &&
+                    m.get( "mandatory" ).equals( false ) ) );
 
-            assertEquals(true, hasRecordMatching(records, m ->
-                    m.get("propertyName").equals("b") &&
-                            ((List)m.get("propertyTypes")).get(0).equals("Long") &&
-                            m.get("mandatory").equals(false)));
+            assertEquals( true, hasRecordMatching( records, m ->
+                    m.get( "propertyName" ).equals( "b" ) &&
+                    ((List) m.get( "propertyTypes" )).get( 0 ).equals( "Long" ) &&
+                    m.get( "mandatory" ).equals( false ) ) );
 
-            assertEquals(true, hasRecordMatching(records, m ->
-                    m.get("propertyName").equals("c") &&
-                            ((List)m.get("propertyTypes")).get(0).equals("Long") &&
-                            m.get("mandatory").equals(false)));
+            assertEquals( true, hasRecordMatching( records, m ->
+                    m.get( "propertyName" ).equals( "c" ) &&
+                    ((List) m.get( "propertyTypes" )).get( 0 ).equals( "Long" ) &&
+                    m.get( "mandatory" ).equals( false ) ) );
 
-            assertEquals(true, hasRecordMatching(records, m ->
-                    m.get("propertyName").equals("d") &&
-                            ((List)m.get("propertyTypes")).get(0).equals("Long") &&
-                            m.get("mandatory").equals(false)));
-        });
+            assertEquals( true, hasRecordMatching( records, m ->
+                    m.get( "propertyName" ).equals( "d" ) &&
+                    ((List) m.get( "propertyTypes" )).get( 0 ).equals( "Long" ) &&
+                    m.get( "mandatory" ).equals( false ) ) );
+        } );
     }
 
     @Test
-    public void testRelTypePropertiesIncludes() throws Exception {
-        db.executeTransactionally("CREATE (:A)-[:CATCHME { c: 1 }]->(:B)");
-        db.executeTransactionally("CREATE (:A)-[:IGNOREME { d: 1 }]->(:B)");
+    public void testRelTypePropertiesIncludes()
+    {
+        db.executeTransactionally( "CREATE (:A)-[:CATCHME { c: 1 }]->(:B)" );
+        db.executeTransactionally( "CREATE (:A)-[:IGNOREME { d: 1 }]->(:B)" );
 
-        TestUtil.testResult(db, "CALL apoc.meta.relTypeProperties({ includeRels: ['CATCHME'] })", r -> {
-            List<Map<String,Object>> records = gatherRecords(r);
-            assertEquals(1, records.size());
-            assertEquals(records.get(0).get("propertyName").equals("c"), true);
-        });
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeRels: ['CATCHME'] })", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 1, records.size() );
+            assertEquals( records.get( 0 ).get( "propertyName" ).equals( "c" ), true );
+        } );
     }
 
     @Test
-    public void testNodeTypePropertiesNodeExcludes() throws Exception {
-        db.executeTransactionally("CREATE (:ExcludeMe)");
-        db.executeTransactionally("CREATE (:IncludeMe)");
+    public void testNodeTypePropertiesNodeExcludes()
+    {
+        db.executeTransactionally( "CREATE (:ExcludeMe)" );
+        db.executeTransactionally( "CREATE (:IncludeMe)" );
 
-        TestUtil.testResult(db, "CALL apoc.meta.nodeTypeProperties({ excludeLabels: ['ExcludeMe'] })", r -> {
-            List<Map<String,Object>> records = gatherRecords(r);
-            assertEquals(1, records.size());
-            assertEquals(true, records.get(0).get("nodeType").equals(":`IncludeMe`"));
-        });
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ excludeLabels: ['ExcludeMe'] })", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 1, records.size() );
+            assertEquals( ":`IncludeMe`", records.get( 0 ).get( "nodeType" ) );
+        } );
     }
 
     @Test
-    public void testNodeTypePropertiesNodeIncludes() throws Exception {
-        db.executeTransactionally("CREATE (:ExcludeMe)");
-        db.executeTransactionally("CREATE (:IncludeMe)");
+    public void testNodeTypePropertiesNodeIncludes()
+    {
+        db.executeTransactionally( "CREATE (:ExcludeMe)" );
+        db.executeTransactionally( "CREATE (:IncludeMe)" );
 
-        TestUtil.testResult(db, "CALL apoc.meta.nodeTypeProperties({ includeLabels: ['IncludeMe'] })", r -> {
-            List<Map<String,Object>> records = gatherRecords(r);
-            assertEquals(1, records.size());
-            assertEquals(true, records.get(0).get("nodeType").equals(":`IncludeMe`"));
-        });
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ includeLabels: ['IncludeMe'] })", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 1, records.size() );
+            assertEquals( ":`IncludeMe`", records.get( 0 ).get( "nodeType" ) );
+        } );
     }
 
     @Test
-    public void testNodeTypePropertiesRelExcludes() throws Exception {
-        db.executeTransactionally("CREATE (:A)-[:RELA { x: 1 }]->(:C)");
-        db.executeTransactionally("CREATE (:B)-[:RELB { x: 1 }]->(:D)");
+    public void testNodeTypePropertiesRelExcludes()
+    {
+        db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
+        db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
 
-        TestUtil.testResult(db, "CALL apoc.meta.nodeTypeProperties({ excludeRels: ['RELA'] })", r -> {
-            List<Map<String,Object>> records = gatherRecords(r);
-            assertEquals(2, records.size());
-            for (Map<String,Object> rec : records) {
-                if (rec.get("nodeType").equals(":`A`")) {
-                    assertEquals(true, rec.get("nodeType").equals(":`B`"));
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ excludeRels: ['RELA'] })", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 2, records.size() );
+            for ( Map<String,Object> rec : records )
+            {
+                if ( rec.get( "nodeType" ).equals( ":`A`" ) )
+                {
+                    assertEquals( ":`B`", rec.get( "nodeType" ) );
                 }
-                if (rec.get("nodeType").equals(":`C`")) {
-                    assertEquals(true, rec.get("nodeType").equals(":`D`"));
-                }
-            }
-        });
-    }
-
-    @Test
-    public void testNodeTypePropertiesRelIncludes() throws Exception {
-        db.executeTransactionally("CREATE (:A)-[:RELA { x: 1 }]->(:C)");
-        db.executeTransactionally("CREATE (:B)-[:RELB { x: 1 }]->(:D)");
-
-        TestUtil.testResult(db, "CALL apoc.meta.nodeTypeProperties({ includeRels: ['RELA'] })", r -> {
-            List<Map<String,Object>> records = gatherRecords(r);
-            assertEquals(2, records.size());
-            for (Map<String,Object> rec : records) {
-                if (rec.get("nodeType").equals(":`A`")) {
-                    assertEquals(true, rec.get("nodeType").equals(":`A`"));
-                }
-                if (rec.get("nodeType").equals(":`C`")) {
-                    assertEquals(true, rec.get("nodeType").equals(":`C`"));
+                if ( rec.get( "nodeType" ).equals( ":`C`" ) )
+                {
+                    assertEquals( ":`D`", rec.get( "nodeType" ) );
                 }
             }
-        });
+        } );
     }
 
     @Test
-    public void testRelTypePropertiesRelExcludes() throws Exception {
-        db.executeTransactionally("CREATE (:A)-[:RELA { x: 1 }]->(:C)");
-        db.executeTransactionally("CREATE (:B)-[:RELB { x: 1 }]->(:D)");
+    public void testNodeTypePropertiesRelIncludes()
+    {
+        db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
+        db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
 
-        TestUtil.testResult(db, "CALL apoc.meta.relTypeProperties({ excludeRels: ['RELA'] })", r -> {
-            List<Map<String,Object>> records = gatherRecords(r);
-            assertEquals(1, records.size());
-            assertEquals(true, records.get(0).get("relType").equals(":`RELB`"));
-        });
-    }
-
-    @Test
-    public void testRelTypePropertiesRelIncludes() throws Exception {
-        db.executeTransactionally("CREATE (:A)-[:RELA { x: 1 }]->(:C)");
-        db.executeTransactionally("CREATE (:B)-[:RELB { x: 1 }]->(:D)");
-
-        TestUtil.testResult(db, "CALL apoc.meta.relTypeProperties({ includeRels: ['RELA'] })", r -> {
-            List<Map<String,Object>> records = gatherRecords(r);
-            assertEquals(1, records.size());
-            assertEquals(true, records.get(0).get("relType").equals(":`RELA`"));
-        });
-    }
-
-    @Test
-    public void testRelTypePropertiesNodeExcludes() throws Exception {
-        db.executeTransactionally("CREATE (:A)-[:RELA { x: 1 }]->(:C)");
-        db.executeTransactionally("CREATE (:B)-[:RELB { x: 1 }]->(:D)");
-
-        TestUtil.testResult(db, "CALL apoc.meta.relTypeProperties({ excludeLabels: ['A'] })", r -> {
-            List<Map<String,Object>> records = gatherRecords(r);
-            assertEquals(1, records.size());
-            for (Map<String,Object> rec : records) {
-                if (rec.get("relType").equals(":`RELB`")) {
-                    assertEquals(true, rec.get("relType").equals(":`RELB`"));
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ includeRels: ['RELA'] })", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 2, records.size() );
+            for ( Map<String,Object> rec : records )
+            {
+                if ( rec.get( "nodeType" ).equals( ":`A`" ) )
+                {
+                    assertEquals( ":`A`", rec.get( "nodeType" ) );
+                }
+                if ( rec.get( "nodeType" ).equals( ":`C`" ) )
+                {
+                    assertEquals( ":`C`", rec.get( "nodeType" ) );
                 }
             }
-        });
+        } );
     }
 
     @Test
-    public void testRelTypePropertiesNodeIncludes() throws Exception {
-        db.executeTransactionally("CREATE (:A)-[:RELA { x: 1 }]->(:C)");
-        db.executeTransactionally("CREATE (:B)-[:RELB { x: 1 }]->(:D)");
+    public void testNodeTypePropertiesWithWeirdConfig()
+    {
+        db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
+        db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
 
-        TestUtil.testResult(db, "CALL apoc.meta.relTypeProperties({ includeLabels: ['A'] })", r -> {
-            List<Map<String,Object>> records = gatherRecords(r);
-            assertEquals(1, records.size());
-            for (Map<String,Object> rec : records) {
-                if (rec.get("relType").equals(":`RELA`")) {
-                    assertEquals(true, rec.get("relType").equals(":`RELA`"));
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ includeRels: ['RELA'], stupidInput: ['RELB'] })", r ->
+                // should ignore all unknown input
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 2, records.size() );
+            for ( Map<String,Object> rec : records )
+            {
+                if ( rec.get( "nodeType" ).equals( ":`A`" ) )
+                {
+                    assertEquals( ":`A`", rec.get( "nodeType" ) );
+                }
+                if ( rec.get( "nodeType" ).equals( ":`C`" ) )
+                {
+                    assertEquals( ":`C`", rec.get( "nodeType" ) );
                 }
             }
-        });
+        } );
     }
 
     @Test
-    public void testNodeTypePropertiesEquivalenceAdvanced() throws Exception {
-        db.executeTransactionally("CREATE (:Foo { l: 1, s: 'foo', d: datetime(), ll: ['a', 'b'], dl: [2.0, 3.0] });");
+    public void testRelTypePropertiesWithWeirdConfig()
+    {
+        db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
+        db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
+
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeLabels: ['A'], stupidInput: ['B'] })", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 1, records.size() );
+            for ( Map<String,Object> rec : records )
+            {
+                if ( rec.get( "relType" ).equals( ":`RELA`" ) )
+                {
+                    assertEquals( ":`RELA`", rec.get( "relType" ) );
+                }
+            }
+        } );
+    }
+
+    @Test
+    public void testRelTypePropertiesRelExcludes()
+    {
+        db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
+        db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
+
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ excludeRels: ['RELA'] })", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 1, records.size() );
+            assertEquals( ":`RELB`", records.get( 0 ).get( "relType" ) );
+        } );
+    }
+
+    @Test
+    public void testRelTypePropertiesRelIncludes()
+    {
+        db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
+        db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
+
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeRels: ['RELA'] })", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 1, records.size() );
+            assertEquals( ":`RELA`", records.get( 0 ).get( "relType" ) );
+        } );
+    }
+
+    @Test
+    public void testRelTypePropertiesNodeExcludes()
+    {
+        db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
+        db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
+
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ excludeLabels: ['A'] })", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 1, records.size() );
+            for ( Map<String,Object> rec : records )
+            {
+                if ( rec.get( "relType" ).equals( ":`RELB`" ) )
+                {
+                    assertEquals( ":`RELB`", rec.get( "relType" ) );
+                }
+            }
+        } );
+    }
+
+    @Test
+    public void testRelTypePropertiesNodeIncludes()
+    {
+        db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
+        db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
+
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeLabels: ['A'] })", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 1, records.size() );
+            for ( Map<String,Object> rec : records )
+            {
+                if ( rec.get( "relType" ).equals( ":`RELA`" ) )
+                {
+                    assertEquals( ":`RELA`", rec.get( "relType" ) );
+                }
+            }
+        } );
+    }
+
+    @Test
+    public void testNodeTypePropertiesNodeIncludesRelIncludes1()
+    {
+        db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
+        db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
+
+        // both together contract the data model and it should result in 0 results
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ includeLabels: ['A'], includeRels: ['RELB'] })", r ->
+        {
+            assertEquals( 0, gatherRecords( r ).size() );
+        } );
+    }
+
+    @Test
+    public void testNodeTypePropertiesNodeIncludesRelIncludes2()
+    {
+        db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
+        db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
+
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ includeLabels: ['A'], includeRels: ['RELA'] })", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 1, records.size() ); // why not A and C? The label has to be on the start of the rel
+            for ( Map<String,Object> rec : records )
+            {
+                if ( rec.get( "nodeType" ).equals( ":`A`" ) )
+                {
+                    assertEquals( ":`A`", rec.get( "nodeType" ) );
+                }
+            }
+        } );
+    }
+
+    @Test
+    public void testRelTypePropertiesNodeIncludesAndRelsInclude1()
+    {
+        db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
+        db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
+
+        // both together contract the data model and it should result in 0 results
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeLabels: ['A'], includeRels: ['RELB'] })", r ->
+        {
+            assertEquals( 0, gatherRecords( r ).size() );
+        } );
+    }
+
+    @Test
+    public void testRelTypePropertiesNodeIncludesAndRelsInclude2()
+    {
+        db.executeTransactionally( "CREATE (:A)-[:RELA { x: 1 }]->(:C)" );
+        db.executeTransactionally( "CREATE (:B)-[:RELB { x: 1 }]->(:D)" );
+
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties({ includeLabels: ['A'], includeRels: ['RELA'] })", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 1, records.size() );
+            for ( Map<String,Object> rec : records )
+            {
+                if ( rec.get( "relType" ).equals( ":`RELA`" ) )
+                {
+                    assertEquals( ":`RELA`", rec.get( "relType" ) );
+                }
+            }
+        } );
+    }
+
+    @Test
+    public void testNodeTypePropertiesCompleteResult()
+    {
+        db.executeTransactionally( "CREATE (:Foo { z: 'hej' });" );
+        db.executeTransactionally( "CREATE (:Foo { z: 1 });" );
+
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties()", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 1, records.size() );
+            for ( Map<String,Object> rec : records )
+            {
+                assertEquals( ":`Foo`", rec.get( "nodeType" ) );
+                assertEquals( List.of( "Foo" ), rec.get( "nodeLabels" ) );
+                assertEquals( "z", rec.get( "propertyName" ) );
+                assertEquals( List.of( "Long", "String" ), rec.get( "propertyTypes" ) );
+                assertEquals( 2L, rec.get( "propertyObservations" ) );
+                assertEquals( 2L, rec.get( "totalObservations" ) );
+                assertEquals( false, rec.get( "mandatory" ) );
+            }
+        } );
+    }
+
+    @Test
+    public void testRelTypePropertiesCompleteResult()
+    {
+        db.executeTransactionally( "CREATE (:A)-[:Foo { z: 'hej' }]->(:B);" );
+        db.executeTransactionally( "CREATE (:A)-[:Foo { z: 1 }]->(:B);" );
+
+        TestUtil.testResult( db, "CALL apoc.meta.relTypeProperties()", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 1, records.size() );
+            for ( Map<String,Object> rec : records )
+            {
+                assertEquals( ":`Foo`", rec.get( "relType" ) );
+                assertEquals( List.of( "A" ), rec.get( "sourceNodeLabels" ) );
+                assertEquals( List.of( "B" ), rec.get( "targetNodeLabels" ) );
+                assertEquals( "z", rec.get( "propertyName" ) );
+                assertEquals( List.of( "Long", "String" ), rec.get( "propertyTypes" ) );
+                assertEquals( 2L, rec.get( "propertyObservations" ) );
+                assertEquals( 2L, rec.get( "totalObservations" ) );
+                assertEquals( false, rec.get( "mandatory" ) );
+            }
+        } );
+    }
+
+    @Test
+    public void testNodeTypePropertiesWithSpecialSampleSize()
+    {
+        db.executeTransactionally( "CREATE (:Foo { z: 'hej' });" );
+        db.executeTransactionally( "CREATE (:Foo { z: 1 });" );
+        db.executeTransactionally( "CREATE (:Foo { z: true });" );
+        db.executeTransactionally( "CREATE (:Foo { z: 1.5 });" );
+
+        // sample = -1 scans all entities
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ pollingPeriod: -1})", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 1, records.size() );
+            for ( Map<String,Object> rec : records )
+            {
+                assertEquals( ":`Foo`", rec.get( "nodeType" ) );
+                assertEquals( "z", rec.get( "propertyName" ) );
+                assertEquals( 4L, rec.get( "propertyObservations" ) );
+                assertEquals( 4L, rec.get( "totalObservations" ) );
+            }
+        } );
+
+        // not scan all of them, might not reach maxSampleSize
+        TestUtil.testResult( db, "CALL apoc.meta.nodeTypeProperties({ pollingPeriod: 1 })", r ->
+        {
+            List<Map<String,Object>> records = gatherRecords( r );
+            assertEquals( 1, records.size() );
+            for ( Map<String,Object> rec : records )
+            {
+                assertEquals( ":`Foo`", rec.get( "nodeType" ) );
+                assertEquals( "z", rec.get( "propertyName" ) );
+                assertTrue( (long) rec.get( "propertyObservations" ) <=4L );
+                assertTrue( (long) rec.get( "totalObservations" ) <= 4L );
+            }
+        } );
+    }
+
+    @Test
+    public void testNodeTypePropertiesEquivalenceAdvanced()
+    {
+        db.executeTransactionally( "CREATE (:Foo { l: 1, s: 'foo', d: datetime(), ll: ['a', 'b'], dl: [2.0, 3.0] });" );
         // Missing all properties to make everything non-mandatory.
-        db.executeTransactionally("CREATE (:Foo { z: 1 });");
-        assertEquals(true, testDBCallEquivalence(db, "CALL apoc.meta.nodeTypeProperties()", "CALL db.schema.nodeTypeProperties()"));
+        db.executeTransactionally( "CREATE (:Foo { z: 1 });" );
+        assertEquals( true, testDBCallEquivalence( db, "CALL apoc.meta.nodeTypeProperties()", "CALL db.schema.nodeTypeProperties()" ) );
     }
 
     @Test
-    public void testNodeTypePropertiesEquivalenceTypeMapping() throws Exception {
+    public void testRelTypePropertiesEquivalenceAdvanced()
+    {
+        db.executeTransactionally( "CREATE (:Foo)-[:REL { l: 1, s: 'foo', d: datetime(), ll: ['a', 'b'], dl: [2.0, 3.0] }]->();" );
+        // Missing all properties to make everything non-mandatory.
+        db.executeTransactionally( "CREATE (:Foo)-[:REL { z: 1 }]->();" );
+        assertEquals( true, testDBCallEquivalence( db, "CALL apoc.meta.relTypeProperties()", "CALL db.schema.relTypeProperties()" ) );
+    }
+
+    @Test
+    public void testNodeTypePropertiesEquivalenceTypeMapping()
+    {
         String q =
-            "CREATE (:Test {" +
-            "    longProp: 1," +
-            "    doubleProp: 3.14," +
-            "    stringProp: 'Hello'," +
-            "    longArrProp: [1,2,3]," +
-            "    doubleArrProp: [3.14, 3.14]," +
-            "    stringArrProp: ['Hello', 'World']," +
-            "    dateTimeProp: datetime()," +
-            "    dateProp: date()," +
-            "    pointProp: point({ x:0, y:4, z:1 })," +
-            "    pointArrProp: [point({ x:0, y:4, z:1 }), point({ x:0, y:4, z:1 })]," +
-            "    boolProp: true," +
-            "    boolArrProp: [true, false]\n" +
-            "})" +
-            "CREATE (:Test { randomProp: 'this property is here to make everything mandatory = false'});";
+                "CREATE (:Test {" +
+                "    longProp: 1," +
+                "    doubleProp: 3.14," +
+                "    stringProp: 'Hello'," +
+                "    longArrProp: [1,2,3]," +
+                "    doubleArrProp: [3.14, 3.14]," +
+                "    stringArrProp: ['Hello', 'World']," +
+                "    dateTimeProp: datetime()," +
+                "    dateProp: date()," +
+                "    pointProp: point({ x:0, y:4, z:1 })," +
+                "    pointArrProp: [point({ x:0, y:4, z:1 }), point({ x:0, y:4, z:1 })]," +
+                "    boolProp: true," +
+                "    boolArrProp: [true, false]\n" +
+                "})" +
+                "CREATE (:Test { randomProp: 'this property is here to make everything mandatory = false'});";
 
+        db.executeTransactionally( q );
+        assertEquals( true, testDBCallEquivalence( db, "CALL apoc.meta.nodeTypeProperties()", "CALL db.schema.nodeTypeProperties()" ) );
+    }
 
-        db.executeTransactionally(q);
-        assertEquals(true, testDBCallEquivalence(db, "CALL apoc.meta.nodeTypeProperties()", "CALL db.schema.nodeTypeProperties()"));
+    @Test
+    public void testRelTypePropertiesEquivalenceTypeMapping()
+    {
+        String q =
+                "CREATE (t:Test)-[:REL{" +
+                "    longProp: 1," +
+                "    doubleProp: 3.14," +
+                "    stringProp: 'Hello'," +
+                "    longArrProp: [1,2,3]," +
+                "    doubleArrProp: [3.14, 3.14]," +
+                "    stringArrProp: ['Hello', 'World']," +
+                "    dateTimeProp: datetime()," +
+                "    dateProp: date()," +
+                "    pointProp: point({ x:0, y:4, z:1 })," +
+                "    pointArrProp: [point({ x:0, y:4, z:1 }), point({ x:0, y:4, z:1 })]," +
+                "    boolProp: true," +
+                "    boolArrProp: [true, false]\n" +
+                "}]->(t)" +
+                "CREATE (b:Test)-[:REL{ randomProp: 'this property is here to make everything mandatory = false'}]->(b);";
+
+        db.executeTransactionally( q );
+        assertEquals( true, testDBCallEquivalence( db, "CALL apoc.meta.relTypeProperties()", "CALL db.schema.relTypeProperties()" ) );
     }
 
     @Test


### PR DESCRIPTION
Fixes #1903

Cleanup apoc.meta.nodeTypeProperties() and apoc.meta.relTypeProperties()

## Proposed Changes

A brief list of proposed changes in order to fix the issue:

  - Make APOC compile on windows
  - Code cleanup
  
