### PR TITLE
extend apoc.periodic.submit to accept parameters

### DIFF
--- a/core/src/main/java/apoc/periodic/Periodic.java
+++ b/core/src/main/java/apoc/periodic/Periodic.java
@@ -150,12 +150,13 @@ public class Periodic {
     }
 
     @Procedure(mode = Mode.WRITE)
-    @Description("apoc.periodic.submit('name',statement) - submit a one-off background statement")
-    public Stream<JobInfo> submit(@Name("name") String name, @Name("statement") String statement) {
+    @Description("apoc.periodic.submit('name',statement,config) - submit a one-off background statement; parameter 'config' is optional and can contain 'params' entry for nested statement")
+    public Stream<JobInfo> submit(@Name("name") String name, @Name("statement") String statement, @Name(value = "config", defaultValue = "{}") Map<String,Object> config) {
         validateQuery(statement);
+        Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());
         JobInfo info = submit(name, () -> {
             try {
-                db.executeTransactionally(statement);
+                db.executeTransactionally(statement, params);
             } catch(Exception e) {
                 log.warn("in background task via submit", e);
                 throw new RuntimeException(e);

--- a/core/src/main/java/apoc/periodic/Periodic.java
+++ b/core/src/main/java/apoc/periodic/Periodic.java
@@ -150,7 +150,7 @@ public class Periodic {
     }
 
     @Procedure(mode = Mode.WRITE)
-    @Description("apoc.periodic.submit('name',statement,config) - submit a one-off background statement; parameter 'config' is optional and can contain 'params' entry for nested statement")
+    @Description("apoc.periodic.submit('name',statement,params) - submit a one-off background statement; parameter 'params' is optional and can contain query parameters for Cypher statement")
     public Stream<JobInfo> submit(@Name("name") String name, @Name("statement") String statement, @Name(value = "config", defaultValue = "{}") Map<String,Object> config) {
         validateQuery(statement);
         Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());

--- a/core/src/main/java/apoc/periodic/Periodic.java
+++ b/core/src/main/java/apoc/periodic/Periodic.java
@@ -151,7 +151,7 @@ public class Periodic {
 
     @Procedure(mode = Mode.WRITE)
     @Description("apoc.periodic.submit('name',statement,params) - submit a one-off background statement; parameter 'params' is optional and can contain query parameters for Cypher statement")
-    public Stream<JobInfo> submit(@Name("name") String name, @Name("statement") String statement, @Name(value = "config", defaultValue = "{}") Map<String,Object> config) {
+    public Stream<JobInfo> submit(@Name("name") String name, @Name("statement") String statement, @Name(value = "params", defaultValue = "{}") Map<String,Object> config) {
         validateQuery(statement);
         Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());
         JobInfo info = submit(name, () -> {

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -79,6 +79,28 @@ public class PeriodicTest {
     }
 
     @Test
+    public void testSubmitStatementWithParams() throws Exception {
+        String callList = "CALL apoc.periodic.list()";
+        // force pre-caching the queryplan
+        assertFalse(db.executeTransactionally(callList, Collections.emptyMap(), Result::hasNext));
+
+        testCall(db, "CALL apoc.periodic.submit('foo','create (:Foo { id: $id })', { id: '(╯°□°)╯︵ ┻━┻' })",
+                (row) -> {
+                    assertEquals("foo", row.get("name"));
+                    assertEquals(false, row.get("done"));
+                    assertEquals(false, row.get("cancelled"));
+                    assertEquals(0L, row.get("delay"));
+                    assertEquals(0L, row.get("rate"));
+                });
+
+        long count = tryReadCount(50, "MATCH (:Foo { id: '(╯°□°)╯︵ ┻━┻' }) RETURN COUNT(*) AS count", 1L);
+
+        assertThat(count, equalTo(1L));
+
+        testCall(db, callList, (r) -> assertEquals(true, r.get("done")));
+    }
+
+    @Test
     public void testSlottedRuntime() throws Exception {
         assertTrue(Periodic.slottedRuntime("MATCH (n) RETURN n").contains("cypher runtime=slotted "));
         assertFalse(Periodic.slottedRuntime("cypher runtime=compiled MATCH (n) RETURN n").contains("cypher runtime=slotted "));


### PR DESCRIPTION
Extend `apoc.periodic.submit` to accept parameters.

At present, this proc runs a query in a background job, but can only accept raw string Cypher queries.  It is not possible to pass parameters to these background jobs.  All other forms of the procedure require work-arounds, and may for example loop or execute more than once, which is not desired.

This change should be very safe, in that it adds a third (optional) argument to apoc.periodic.submit.  The default is an empty map, so it should be 100% backwards compatible and not affect any existing query patterns.

## GDS

This is important for using GDS in certain environments, such as with Aura.  In Neo4j, [transactions are tightly coupled to connections](https://trello.com/c/vOV9NLAv/722-connection-transaction-coupling) (internal link only).  This means that when submitting certain very long running jobs (such as GDS similarity algorithms that run for hours), those jobs may terminate if the connection terminates in the middle of the session.  As a result, the use of APOC background jobs is desirable when you can't keep a steady tcp connection for many hours at a time.

Recently, apoc.periodic.submit without parameters was insufficient, because GDS algos typically take nested map parameters; in several application scenarios it wasn't really practical to use apoc.periodic.submit without parameters.

