### PR TITLE
Fixes #1749: In version 4 of the database there is property dbms.directories.neo4j_home without unsupported. prefix

### DIFF
--- a/core/src/main/java/apoc/util/FileUtils.java
+++ b/core/src/main/java/apoc/util/FileUtils.java
@@ -242,10 +242,10 @@ public class FileUtils {
     }
 
     /**
-     * @returns a File pointing to Neo4j's log directory, if it exists and is readable, null otherwise.
+     * @return a File pointing to Neo4j's log directory, if it exists and is readable, null otherwise.
      */
     public static File getLogDirectory() {
-        String neo4jHome = apocConfig().getString("unsupported.dbms.directories.neo4j_home", "");
+        String neo4jHome = apocConfig().getString("dbms.directories.neo4j_home", "");
         String logDir = apocConfig().getString("dbms.directories.logs", "");
 
         File logs = logDir.isEmpty() ? new File(neo4jHome, "logs") : new File(logDir);

--- a/core/src/test/java/apoc/log/Neo4jLogStreamTest.java
+++ b/core/src/test/java/apoc/log/Neo4jLogStreamTest.java
@@ -1,0 +1,39 @@
+package apoc.log;
+
+import apoc.util.TestUtil;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.dbms.api.DatabaseManagementService;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.internal.helpers.collection.Iterators;
+import org.neo4j.test.TestDatabaseManagementServiceBuilder;
+
+import java.nio.file.Paths;
+import java.util.stream.Collectors;
+
+import static apoc.ApocConfig.apocConfig;
+import static apoc.util.TestUtil.testResult;
+import static org.junit.Assert.assertTrue;
+
+public class Neo4jLogStreamTest {
+    
+    private GraphDatabaseService db;
+
+    @Before
+    public void setUp() throws Exception {
+        DatabaseManagementService dbManagementService = new TestDatabaseManagementServiceBuilder(
+                Paths.get("target").toAbsolutePath()).build();
+        apocConfig().setProperty("dbms.directories.logs", "");
+        db = dbManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
+        TestUtil.registerProcedure(db, Neo4jLogStream.class);
+    }
+    
+    @Test
+    public void testLogStream() {
+        testResult(db, "CALL apoc.log.stream('debug.log')", res -> {
+            final String wholeFile = Iterators.stream(res.<String>columnAs("line")).collect(Collectors.joining(""));
+            assertTrue(wholeFile.contains("apoc.import.file.enabled=false"));
+        });
+    }
+}


### PR DESCRIPTION
Fixes #1749

- Added `Neo4jLogStreamTest`
