### PR TITLE
Fixes #1901: apoc.uuid.install addToExistingNodes does not work

### DIFF
--- a/core/src/main/java/apoc/SystemPropertyKeys.java
+++ b/core/src/main/java/apoc/SystemPropertyKeys.java
@@ -22,5 +22,6 @@ public enum SystemPropertyKeys  {
 
     // uuid handler
     label,
+    addToSetLabel,
     propertyName;
 }

--- a/core/src/main/java/apoc/uuid/UuidConfig.java
+++ b/core/src/main/java/apoc/uuid/UuidConfig.java
@@ -8,10 +8,12 @@ import static apoc.util.Util.toBoolean;
 public class UuidConfig {
 
     private boolean addToExistingNodes;
+    private boolean addToSetLabels;
     private String uuidProperty;
 
     private static final String DEFAULT_UUID_PROPERTY = "uuid";
     private static final boolean DEFAULT_ADD_TO_EXISTING_NODES = true;
+    private static final boolean DEFAULT_ADD_TO_SET_LABELS = false;
 
 
     public UuidConfig(Map<String, Object> config) {
@@ -19,6 +21,7 @@ public class UuidConfig {
             config = Collections.emptyMap();
         }
         this.addToExistingNodes = toBoolean(config.getOrDefault("addToExistingNodes", DEFAULT_ADD_TO_EXISTING_NODES));
+        this.addToSetLabels = toBoolean(config.getOrDefault("addToSetLabels", DEFAULT_ADD_TO_SET_LABELS));
         this.uuidProperty = config.getOrDefault("uuidProperty", DEFAULT_UUID_PROPERTY).toString();
 
     }
@@ -41,4 +44,7 @@ public class UuidConfig {
         this.uuidProperty = uuidProperty;
     }
 
+    public boolean isAddToSetLabels() {
+        return addToSetLabels;
+    }
 }

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.uuid.install.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.uuid.install.adoc
@@ -63,7 +63,7 @@ RETURN p;
 | (:Person {name: "Tom Hanks", uuid: "cec34337-9709-46af-bbb7-9e0742d8aaa7"})
 |===
 
-The `uuid` property will be created also with a label `SET`. For example:
+The `uuid` property will be created also with a label `SET` when the `addToSetLabels` configuration is set to true. For example:
 
 [source,cypher]
 ----

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.uuid.install.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.uuid.install.adoc
@@ -63,6 +63,15 @@ RETURN p;
 | (:Person {name: "Tom Hanks", uuid: "cec34337-9709-46af-bbb7-9e0742d8aaa7"})
 |===
 
+The `uuid` property will be created also with a label `SET`. For example:
+
+[source,cypher]
+----
+CREATE (:AnotherLabel {name: "Tom Hanks"});
+// ...
+MATCH (n:AnotherLabel) SET n:Person;
+----
+
 If we want to use a different property key for our UUID value, we can pass in the `uuidProperty` key, not forgetting to first setup a constraint:
 
 [source,cypher]

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.uuid.install.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.uuid.install.adoc
@@ -5,5 +5,6 @@ The procedure support the following config parameters:
 |===
 | name | type | default | description
 | addToExistingNodes | Boolean | true | adds UUID values to existing nodes. Will override an existing value.
+| addToSetLabels | Boolean | false | adds UUID values even when there is a set label. For example: `MATCH (p:OtherLabel) SET p:LabelWithUuid`.
 | uuidProperty | String | "uuid" | the property key for the UUID value
 |===

--- a/full/src/main/java/apoc/uuid/Uuid.java
+++ b/full/src/main/java/apoc/uuid/Uuid.java
@@ -26,7 +26,7 @@ public class Uuid {
     @Context
     public Transaction tx;
 
-    @Procedure(mode = Mode.DBMS)
+    @Procedure(mode = Mode.WRITE)
     @Description("CALL apoc.uuid.install(label, {addToExistingNodes: true/false, uuidProperty: 'uuid'}) yield label, installed, properties, batchComputationResult | it will add the uuid transaction handler\n" +
             "for the provided `label` and `uuidProperty`, in case the UUID handler is already present it will be replaced by the new one")
     public Stream<UuidInstallInfo> install(@Name("label") String label, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {

--- a/full/src/main/java/apoc/uuid/Uuid.java
+++ b/full/src/main/java/apoc/uuid/Uuid.java
@@ -42,35 +42,44 @@ public class Uuid {
                             .next()
             );
         }
-        uuidHandler.add(tx, label, uuidConfig.getUuidProperty());
-        return Stream.of(new UuidInstallInfo(label, true, Collections.singletonMap("uuidProperty", uuidConfig.getUuidProperty()), addToExistingNodesResult));
+        uuidHandler.add(tx, label, uuidConfig);
+        return Stream.of(new UuidInstallInfo(label, true, 
+                Map.of("uuidProperty", uuidConfig.getUuidProperty(), "addToSetLabels", uuidConfig.isAddToSetLabels()), 
+                addToExistingNodesResult));
     }
 
     @Procedure(mode = Mode.WRITE)
     @Description("CALL apoc.uuid.remove(label) yield label, installed, properties | remove previously added uuid handler and returns uuid information. All the existing uuid properties are left as-is")
     public Stream<UuidInfo> remove(@Name("label") String label) {
-        String removed = uuidHandler.remove(label);
+        UuidConfig removed = uuidHandler.remove(label);
         if (removed == null) {
             return Stream.of(new UuidInfo(null, false));
         }
-        return Stream.of(new UuidInfo(label, false, Collections.singletonMap("uuidProperty", removed)));
+        return Stream.of(new UuidInfo(label, false, 
+                Map.of("uuidProperty", removed.getUuidProperty(), "addToSetLabels", removed.isAddToSetLabels())));
     }
 
     @Procedure(mode = Mode.WRITE)
     @Description("CALL apoc.uuid.removeAll() yield label, installed, properties | it removes all previously added uuid handlers and returns uuids information. All the existing uuid properties are left as-is")
     public Stream<UuidInfo> removeAll() {
-        Map<String, String> removed = uuidHandler.removeAll();
+        Map<String, UuidConfig> removed = uuidHandler.removeAll();
         if (removed == null) {
             return Stream.of(new UuidInfo(null, false));
         }
-        return removed.entrySet().stream().map(e -> new UuidInfo(e.getKey(), false, Collections.singletonMap("uuidProperty", e.getValue())));
+        return removed.entrySet().stream().map(e -> {
+            final UuidConfig conf = e.getValue();
+            return new UuidInfo(e.getKey(), false, Map.of("uuidProperty", conf.getUuidProperty(), "addToSetLabels", conf.isAddToSetLabels()));
+        });
     }
 
     @Procedure(mode = Mode.READ)
     @Description("CALL apoc.uuid.list() yield label, installed, properties | provides a list of all the uuid handlers installed with the related configuration")
     public Stream<UuidInfo> list() {
         return uuidHandler.list().entrySet().stream()
-                .map((e) -> new UuidInfo(e.getKey(),true, Collections.singletonMap("uuidProperty", e.getValue())));
+                .map((e) -> {
+                    final UuidConfig conf = e.getValue();
+                    return new UuidInfo(e.getKey(),true, Map.of("uuidProperty", conf.getUuidProperty(), "addToSetLabels", conf.isAddToSetLabels()));
+                });
     }
 
     public static class UuidInfo {

--- a/full/src/test/java/apoc/uuid/UUIDTest.java
+++ b/full/src/test/java/apoc/uuid/UUIDTest.java
@@ -66,7 +66,7 @@ public class UUIDTest {
     public void testUUIDWithSetLabel() {
         // given
         db.executeTransactionally("CREATE CONSTRAINT ON (p:Mario) ASSERT p.uuid IS UNIQUE");
-        db.executeTransactionally("CALL apoc.uuid.install('Mario') YIELD label RETURN label");
+        db.executeTransactionally("CALL apoc.uuid.install('Mario', {addToSetLabels: true}) YIELD label RETURN label");
         // when
         db.executeTransactionally("CREATE (p:Luigi {foo:'bar'}) SET p:Mario");
         // then
@@ -76,10 +76,14 @@ public class UUIDTest {
         // - set after creation
         db.executeTransactionally("CREATE (:Peach)");
         // when
-        db.executeTransactionally("CREATE (p:Peach) SET p:Mario");
+        db.executeTransactionally("MATCH (p:Peach) SET p:Mario");
         // then
         TestUtil.testCall(db, "MATCH (a:Peach:Mario) RETURN a.uuid as uuid", 
                 row -> assertTrue(((String) row.get("uuid")).matches(UUID_TEST_REGEXP)));
+
+        TestUtil.testCall(db, "CALL apoc.uuid.remove('Mario')",
+                (row) -> assertResult(row, "Mario", false,
+                        Util.map("uuidProperty", "uuid", "addToSetLabels", true)));
     }
 
     @Test
@@ -168,7 +172,7 @@ public class UUIDTest {
         // then
         TestUtil.testCall(db, "CALL apoc.uuid.list()",
                 (row) -> assertResult(row, "Bar", true,
-                        Util.map("uuidProperty", "uuid")));
+                        Util.map("uuidProperty", "uuid", "addToSetLabels", false)));
     }
 
     @Test
@@ -197,10 +201,10 @@ public class UUIDTest {
         // then
         TestUtil.testCall(db, "CALL apoc.uuid.list()",
                 (row) -> assertResult(row, "Test", true,
-                        Util.map("uuidProperty", "foo")));
+                        Util.map("uuidProperty", "foo", "addToSetLabels", false)));
         TestUtil.testCall(db, "CALL apoc.uuid.remove('Test')",
                 (row) -> assertResult(row, "Test", false,
-                        Util.map("uuidProperty", "foo")));
+                        Util.map("uuidProperty", "foo", "addToSetLabels", false)));
     }
 
     @Test
@@ -272,10 +276,10 @@ public class UUIDTest {
                     // then
                     Map<String, Object> row = result.next();
                     assertResult(row, "Test", false,
-                            Util.map("uuidProperty", "foo"));
+                            Util.map("uuidProperty", "foo", "addToSetLabels", false));
                     row = result.next();
                     assertResult(row, "Bar", false,
-                            Util.map("uuidProperty", "uuid"));
+                            Util.map("uuidProperty", "uuid", "addToSetLabels", false));
                 });
     }
 


### PR DESCRIPTION
Fixes #1901

- Changed `Mode.DBMS` to `Mode.WRITE` to fix the `addToExistingNodes` bug
- Changed `txData.createdNodes()` to `txData.assignedLabels();` to handle uuid with `SET n:LabelName` in `UUIDHandler.java`