### PR TITLE
Fixes #1911: apoc.load.directory path to directory not read correctly

### DIFF
--- a/core/src/main/java/apoc/util/FileUtils.java
+++ b/core/src/main/java/apoc/util/FileUtils.java
@@ -304,11 +304,7 @@ public class FileUtils {
     }
 
     public static Path getPathFromUrlString(String urlDir) {
-        final URI uri = URI.create(urlDir);
-        if(uri.isAbsolute()) {
-            return Paths.get(uri);
-        }
-        return Paths.get(uri.getPath());
+        return Paths.get(URI.create(urlDir));
     }
 
     // to exclude cases like 'testload.tar.gz?raw=true'

--- a/core/src/main/java/apoc/util/FileUtils.java
+++ b/core/src/main/java/apoc/util/FileUtils.java
@@ -304,7 +304,11 @@ public class FileUtils {
     }
 
     public static Path getPathFromUrlString(String urlDir) {
-        return Paths.get(URI.create(urlDir).getPath());
+        final URI uri = URI.create(urlDir);
+        if(uri.isAbsolute()) {
+            return Paths.get(uri);
+        }
+        return Paths.get(uri.getPath());
     }
 
     // to exclude cases like 'testload.tar.gz?raw=true'

--- a/full/src/main/java/apoc/load/LoadDirectory.java
+++ b/full/src/main/java/apoc/load/LoadDirectory.java
@@ -28,7 +28,6 @@ import static apoc.ApocConfig.apocConfig;
 import static apoc.load.LoadDirectoryHandler.getPathDependingOnUseNeo4jConfig;
 import static apoc.util.FileUtils.getDirImport;
 import static apoc.util.FileUtils.getPathFromUrlString;
-import static org.apache.commons.lang3.StringUtils.chop;
 import static org.eclipse.jetty.util.URIUtil.encodePath;
 import static org.neo4j.graphdb.QueryExecutionType.QueryType.READ_WRITE;
 import static org.neo4j.graphdb.QueryExecutionType.QueryType.WRITE;
@@ -114,7 +113,8 @@ public class LoadDirectory {
     public static String checkIfUrlBlankAndGetFileUrl(String urlDir) throws IOException {
         if (StringUtils.isBlank(urlDir)) {
             final Path pathImport = Paths.get(getDirImport()).toAbsolutePath();
-            return chop(encodePath(pathImport.toUri().toString()));
+            // with replaceAll we remove final "/" from path
+            return encodePath(pathImport.toUri().toString()).replaceAll(".$", "");
         }
         return FileUtils.changeFileUrlIfImportDirectoryConstrained(urlDir.replace("?", "%3F"));
     }

--- a/full/src/main/java/apoc/load/LoadDirectory.java
+++ b/full/src/main/java/apoc/load/LoadDirectory.java
@@ -18,6 +18,8 @@ import org.neo4j.procedure.Name;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Collection;
 import java.util.stream.Stream;
@@ -26,6 +28,7 @@ import static apoc.ApocConfig.apocConfig;
 import static apoc.load.LoadDirectoryHandler.getPathDependingOnUseNeo4jConfig;
 import static apoc.util.FileUtils.getDirImport;
 import static apoc.util.FileUtils.getPathFromUrlString;
+import static org.apache.commons.lang3.StringUtils.chop;
 import static org.eclipse.jetty.util.URIUtil.encodePath;
 import static org.neo4j.graphdb.QueryExecutionType.QueryType.READ_WRITE;
 import static org.neo4j.graphdb.QueryExecutionType.QueryType.WRITE;
@@ -109,9 +112,11 @@ public class LoadDirectory {
 
     // visible for test purpose
     public static String checkIfUrlBlankAndGetFileUrl(String urlDir) throws IOException {
-        return StringUtils.isBlank(urlDir)
-                ? encodePath(getDirImport())
-                : FileUtils.changeFileUrlIfImportDirectoryConstrained(urlDir.replace("?", "%3F"));
+        if (StringUtils.isBlank(urlDir)) {
+            final Path pathImport = Paths.get(getDirImport()).toAbsolutePath();
+            return chop(encodePath(pathImport.toUri().toString()));
+        }
+        return FileUtils.changeFileUrlIfImportDirectoryConstrained(urlDir.replace("?", "%3F"));
     }
 
 }

--- a/full/src/test/java/apoc/load/LoadDirectoryTest.java
+++ b/full/src/test/java/apoc/load/LoadDirectoryTest.java
@@ -54,7 +54,7 @@ public class LoadDirectoryTest {
     public static TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     private static GraphDatabaseService db;
-    private static File importFolder;
+    private static String importPath;
 
     private static final String IMPORT_DIR = "import";
     private static final String SUBFOLDER_1 = "sub1";
@@ -76,7 +76,8 @@ public class LoadDirectoryTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        importFolder = new File(temporaryFolder.getRoot() + File.separator + IMPORT_DIR);
+        File importFolder = new File(temporaryFolder.getRoot() + File.separator + IMPORT_DIR);
+        importPath = encodePath(FILE_PROTOCOL + importFolder.getPath());
         DatabaseManagementService databaseManagementService = new TestDatabaseManagementServiceBuilder(importFolder.toPath()).build();
         db = databaseManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
 
@@ -282,7 +283,7 @@ public class LoadDirectoryTest {
             Map<String, Object> mapTestOne = result.next();
             assertThat(mapTestOne.get("name"), isOneOf("testOne", "testTwo"));
             assertThat(mapTestOne.get("pattern"), isOneOf("*.csv", "*.json"));
-            assertEquals(encodePath(importFolder.getPath()), mapTestOne.get("urlDir"));
+            assertEquals(importPath, mapTestOne.get("urlDir"));
             assertEquals("CREATE (n:Test)", mapTestOne.get("cypher"));
             assertEquals(defaultConfig, mapTestOne.get("config"));
             assertEquals(LoadDirectoryItem.Status.RUNNING.name(), mapTestOne.get("status"));
@@ -290,7 +291,7 @@ public class LoadDirectoryTest {
             Map<String, Object> mapTestTwo = result.next();
             assertThat(mapTestTwo.get("name"), isOneOf("testOne", "testTwo"));
             assertThat(mapTestTwo.get("pattern"), isOneOf("*.csv", "*.json"));
-            assertEquals(encodePath(importFolder.getPath()), mapTestTwo.get("urlDir"));
+            assertEquals(importPath, mapTestTwo.get("urlDir"));
             assertEquals("CREATE (n:Test)", mapTestTwo.get("cypher"));
             assertEquals(defaultConfig, mapTestTwo.get("config"));
             assertEquals(LoadDirectoryItem.Status.RUNNING.name(), mapTestTwo.get("status"));
@@ -302,7 +303,7 @@ public class LoadDirectoryTest {
             // remains 2nd listener
             assertEquals("testTwo", result.get("name"));
             assertEquals("*.json", result.get("pattern"));
-            assertEquals(encodePath(importFolder.getPath()), result.get("urlDir"));
+            assertEquals(importPath, result.get("urlDir"));
             assertEquals("CREATE (n:Test)", result.get("cypher"));
             assertEquals(defaultConfig, result.get("config"));
             assertEquals(LoadDirectoryItem.Status.RUNNING.name(), result.get("status"));
@@ -334,7 +335,7 @@ public class LoadDirectoryTest {
         testCall(db, "CALL apoc.load.directory.async.add('test','CREATE (n:Test {file: $fileName})','*.json')", result -> {
             assertEquals("test", result.get("name"));
             assertEquals("*.json", result.get("pattern"));
-            assertEquals(encodePath(importFolder.getPath()), result.get("urlDir"));
+            assertEquals(importPath, result.get("urlDir"));
             assertEquals("CREATE (n:Test {file: $fileName})", result.get("cypher"));
             assertEquals(defaultConfig, result.get("config"));
             assertEquals(LoadDirectoryItem.Status.CREATED.name(), result.get("status"));
@@ -462,7 +463,7 @@ public class LoadDirectoryTest {
             // remain 1st listener
             assertEquals("testTwo", result.get("name"));
             assertEquals("*.json", result.get("pattern"));
-            assertEquals(encodePath(importFolder.getPath()), result.get("urlDir"));
+            assertEquals(importPath, result.get("urlDir"));
             assertEquals("CREATE (n:TestTwo)", result.get("cypher"));
             assertEquals("CREATE (n:TestTwo)", result.get("cypher"));
         });


### PR DESCRIPTION
Fixes #1911

- Changed `Paths.get(URI.create(urlDir).getPath());` to `Paths.get(URI.create(urlDir));` in `FileUtils.java`
to avoid `"java c:/ InvalidPathException: Illegal char"` on Windows path

- Changed `encodePath(getDirImport())` to `encodePath(pathImport.toUri().toString())` in `LoadDirectory.java`
to avoid `"java.nio.file.FileSystemNotFoundException: Provider "C" not installed"` on Windows path when an empty string is passed  