### PR TITLE
Fixes #1269: Document apoc.convert.toTree

### DIFF
--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.convert.toTree.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.convert.toTree.adoc
@@ -316,6 +316,7 @@ a|
 ----
 |===
 
+
 On the other hand, we can also include everything and specify certain nodes/relationships to exclude.
 For example:
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.convert.toTree.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.convert.toTree.adoc
@@ -315,3 +315,56 @@ a|
 }
 ----
 |===
+
+On the other hand, we can also include all nodes/rels exlcuding excluding some of them.
+For example:
+
+[source,cypher]
+----
+MATCH path = (p:Person {name:'James Thompson'})-[:REVIEWED]->(movie)
+WITH collect(path) AS paths
+CALL apoc.convert.toTree(paths, true, {
+  nodes: {Movie: ['-title']},
+  rels:  {reviewed: ['-rating']}
+})
+YIELD value
+RETURN value;
+----
+
+.Results
+[opts="header",cols="1"]
+|===
+| value
+a|
+[source,json]
+----
+{
+  "_type": "Person",
+  "name": "James Thompson",
+  "reviewed": [
+    {
+      "_type": "Movie",
+      "tagline": "Everything that has a beginning has an end",
+      "reviewed.summary": "The best of the three",
+      "_id": 6,
+      "released": 2003
+    },
+    {
+      "_type": "Movie",
+      "tagline": "Free your mind",
+      "reviewed.summary": "It was alright.",
+      "_id": 5,
+      "released": 2003
+    },
+    {
+      "_type": "Movie",
+      "tagline": "Welcome to the Real World",
+      "reviewed.summary": "Enjoyed it!",
+      "_id": 4,
+      "released": 1999
+    }
+  ],
+  "_id": 3
+}
+----
+|===

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.convert.toTree.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.convert.toTree.adoc
@@ -316,7 +316,7 @@ a|
 ----
 |===
 
-On the other hand, we can also include all nodes/rels exlcuding excluding some of them.
+On the other hand, we can also include everything and specify certain nodes/relationships to exclude.
 For example:
 
 [source,cypher]

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.convert.toTree.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.convert.toTree.adoc
@@ -4,6 +4,6 @@ The procedure support the following config parameters:
 [opts=header]
 |===
 | name | type | default | description
-| nodes | Map<String, List<String>> | {}| properties to include for each node label e.g. `{Movie: ['title']}`
-| rels | Map<String, List<String>> | {} | properties to include for each relationship type e.g. `{`ACTED_IN`: ["roles"]}`
+| nodes | Map<String, List<String>> | {}| properties to include for each node label e.g. `{Movie: ['title']}` or to exclude (e.g. `{Movie: ['-title']}`).
+| rels | Map<String, List<String>> | {} | properties to include for each relationship type e.g. `{`ACTED_IN`: ["roles"]}`  or to exclude (e.g. `{`ACTED_IN`: ["-roles"]}`).
 |===


### PR DESCRIPTION
Fixes #1269

- Added "exclude" example and config 
Other stuff are in https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/1290882935629dc91160097aec5936d0138c873b