### PR TITLE
Fixes #536: make export.csv configurable if it computes property types upfront

### DIFF
--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -154,8 +154,8 @@ public class CsvFormat implements Format {
         out.writeNext(header.toArray(new String[header.size()]), applyQuotesToAll);
         int cols = header.size();
 
-        writeNodes(graph, out, reporter, nodeHeader.subList(NODE_HEADER_FIXED_COLUMNS.length, nodeHeader.size()), cols, config.getBatchSize(), config.useTypes());
-        writeRels(graph, out, reporter, relHeader.subList(REL_HEADER_FIXED_COLUMNS.length, relHeader.size()), cols, nodeHeader.size(), config.getBatchSize(), config.useTypes());
+        writeNodes(graph, out, reporter, nodeHeader.subList(NODE_HEADER_FIXED_COLUMNS.length, nodeHeader.size()), cols, config.getBatchSize(), config.getDelim());
+        writeRels(graph, out, reporter, relHeader.subList(REL_HEADER_FIXED_COLUMNS.length, relHeader.size()), cols, nodeHeader.size(), config.getBatchSize(), config.getDelim());
     }
 
     private void writeAllBulkImport(SubGraph graph, Reporter reporter, ExportConfig config, ExportFileManager writer) {
@@ -283,13 +283,13 @@ public class CsvFormat implements Format {
         return result;
     }
 
-    private void writeNodes(SubGraph graph, CSVWriter out, Reporter reporter, List<String> header, int cols, int batchSize, boolean useTypes) {
+    private void writeNodes(SubGraph graph, CSVWriter out, Reporter reporter, List<String> header, int cols, int batchSize, String delimiter) {
         String[] row=new String[cols];
         int nodes = 0;
         for (Node node : graph.getNodes()) {
             row[0]=String.valueOf(node.getId());
             row[1]=getLabelsString(node);
-            collectProps(header, node, reporter, row, 2, useTypes);
+            collectProps(header, node, reporter, row, 2, delimiter);
             out.writeNext(row, applyQuotesToAll);
             nodes++;
             if (batchSize==-1 || nodes % batchSize == 0) {
@@ -302,11 +302,10 @@ public class CsvFormat implements Format {
         }
     }
 
-    private void collectProps(Collection<String> fields, Entity pc, Reporter reporter, String[] row, int offset, boolean useTypes) {
+    private void collectProps(Collection<String> fields, Entity pc, Reporter reporter, String[] row, int offset, String delimiter) {
         for (String field : fields) {
-            final String fieldNormalized = useTypes ? StringUtils.removeEnd(field, ":int") : field;
-            if (pc.hasProperty(fieldNormalized)) {
-                row[offset] = FormatUtils.toString(pc.getProperty(fieldNormalized));
+            if (pc.hasProperty(field)) {
+                row[offset] = FormatUtils.toString(pc.getProperty(field));
                 reporter.update(0,0,1);
             }
             else {
@@ -316,14 +315,14 @@ public class CsvFormat implements Format {
         }
     }
 
-    private void writeRels(SubGraph graph, CSVWriter out, Reporter reporter, List<String> relHeader, int cols, int offset, int batchSize, boolean useTypes) {
+    private void writeRels(SubGraph graph, CSVWriter out, Reporter reporter, List<String> relHeader, int cols, int offset, int batchSize, String delimiter) {
         String[] row=new String[cols];
         int rels = 0;
         for (Relationship rel : graph.getRelationships()) {
             row[offset]=String.valueOf(rel.getStartNode().getId());
             row[offset+1]=String.valueOf(rel.getEndNode().getId());
             row[offset+2]=rel.getType().name();
-            collectProps(relHeader, rel, reporter, row, 3 + offset, useTypes);
+            collectProps(relHeader, rel, reporter, row, 3 + offset, delimiter);
             out.writeNext(row, applyQuotesToAll);
             rels++;
             if (batchSize==-1 || rels % batchSize == 0) {

--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -6,9 +6,9 @@ import apoc.export.util.Format;
 import apoc.export.util.FormatUtils;
 import apoc.export.util.MetaInformation;
 import apoc.export.util.Reporter;
-import apoc.meta.Meta;
 import apoc.result.ProgressInfo;
 import com.opencsv.CSVWriter;
+import org.apache.commons.lang.StringUtils;
 import org.neo4j.cypher.export.SubGraph;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -38,8 +38,6 @@ import java.util.stream.StreamSupport;
 import static apoc.export.util.BulkImportUtil.formatHeader;
 import static apoc.export.util.MetaInformation.collectPropTypesForNodes;
 import static apoc.export.util.MetaInformation.collectPropTypesForRelationships;
-import static apoc.export.util.MetaInformation.getAllNodePropertyKeys;
-import static apoc.export.util.MetaInformation.getAllRelPropertyKeys;
 import static apoc.export.util.MetaInformation.getLabelsString;
 import static apoc.export.util.MetaInformation.updateKeyTypes;
 import static apoc.util.Util.joinLabels;
@@ -147,30 +145,16 @@ public class CsvFormat implements Format {
     }
 
     public void writeAll(SubGraph graph, Reporter reporter, ExportConfig config, CSVWriter out) {
-//        db.executeTransactionally("CALL apoc.meta.nodeTypeProperties()", Collections.emptyMap()/* Map.of("config", configNew)*/, result -> {
-//            System.out.println("MetaInformation.getAllNodePropertyKeys");
-//            return null;
-//        });
-        
-        Map<String, Class> nodePropTypes = getAllNodePropertyKeys(graph, db, config);
-        Map<String, Class> relPropTypes = getAllRelPropertyKeys(graph, db, config);
-        // todo - che serve la Map<String,Class> perché Class?
-//        Map<String,Class> nodePropTypes = collectPropTypesForNodes(graph);
-        // mappa nomeProp - classe
-        
-//        Map<String,Class> relPropTypes = collectPropTypesForRelationships(graph);
+        Map<String, Class> nodePropTypes = collectPropTypesForNodes(graph, db, config);
+        Map<String, Class> relPropTypes = collectPropTypesForRelationships(graph, db, config);
         List<String> nodeHeader = generateHeader(nodePropTypes, config.useTypes(), NODE_HEADER_FIXED_COLUMNS);
-
         List<String> relHeader = generateHeader(relPropTypes, config.useTypes(), REL_HEADER_FIXED_COLUMNS);
         List<String> header = new ArrayList<>(nodeHeader);
-
         header.addAll(relHeader);
         out.writeNext(header.toArray(new String[header.size()]), applyQuotesToAll);
         int cols = header.size();
 
         writeNodes(graph, out, reporter, nodeHeader.subList(NODE_HEADER_FIXED_COLUMNS.length, nodeHeader.size()), cols, config.getBatchSize(), config.getDelim());
-        
-        // TODO TODOISSIMO --> FARE LE RELAZIONI
         writeRels(graph, out, reporter, relHeader.subList(REL_HEADER_FIXED_COLUMNS.length, relHeader.size()), cols, nodeHeader.size(), config.getBatchSize(), config.getDelim());
     }
 
@@ -284,19 +268,15 @@ public class CsvFormat implements Format {
     private List<String> generateHeader(Map<String, Class> propTypes, boolean useTypes, String... starters) {
         List<String> result = new ArrayList<>();
         if (useTypes) {
-            // va qua lo starter con questo false... ma non me ne fotte
             Collections.addAll(result, starters);
         } else {
             result.addAll(Stream.of(starters).map(s -> s.split(":")[0]).collect(Collectors.toList()));
         }
-        // todo - se invece di Map<String, Class> propTypes, ci passo direttamente la stringa del tipo?
         result.addAll(propTypes.entrySet().stream()
                 .map(entry -> {
                     String type = MetaInformation.typeFor(entry.getValue(), null);
                     return (type == null || type.equals("string") || !useTypes)
                             ? entry.getKey() : entry.getKey() + ":" + type;
-
-                    // todo - come caisce :label?
                 })
                 .sorted()
                 .collect(Collectors.toList()));
@@ -324,8 +304,9 @@ public class CsvFormat implements Format {
 
     private void collectProps(Collection<String> fields, Entity pc, Reporter reporter, String[] row, int offset, String delimiter) {
         for (String field : fields) {
-            if (pc.hasProperty(field)) {
-                row[offset] = FormatUtils.toString(pc.getProperty(field));
+            final String fieldNormalized = StringUtils.removeEnd(field, ":int");
+            if (pc.hasProperty(fieldNormalized)) {
+                row[offset] = FormatUtils.toString(pc.getProperty(fieldNormalized));
                 reporter.update(0,0,1);
             }
             else {

--- a/core/src/main/java/apoc/export/csv/ExportCSV.java
+++ b/core/src/main/java/apoc/export/csv/ExportCSV.java
@@ -97,6 +97,11 @@ public class ExportCSV {
         ProgressInfo progressInfo = new ProgressInfo(fileName, source, format);
         progressInfo.batchSize = exportConfig.getBatchSize();
         ProgressReporter reporter = new ProgressReporter(null, null, progressInfo);
+//        final ResourceIterator<Object> signature = db.executeTransactionally("CALL dbms.procedures()", Collections.emptyMap(), result -> result.columnAs("signature"));
+//        db.executeTransactionally("CALL apoc.meta.nodeTypeProperties({})", Collections.emptyMap()/* Map.of("config", configNew)*/, result -> {
+//            System.out.println("MetaInformation.getAllNodePropertyKeys");
+//            return null;
+//        });
         CsvFormat exporter = new CsvFormat(db);
 
         ExportFileManager cypherFileManager = FileManagerFactory

--- a/core/src/main/java/apoc/export/csv/ExportCSV.java
+++ b/core/src/main/java/apoc/export/csv/ExportCSV.java
@@ -97,11 +97,6 @@ public class ExportCSV {
         ProgressInfo progressInfo = new ProgressInfo(fileName, source, format);
         progressInfo.batchSize = exportConfig.getBatchSize();
         ProgressReporter reporter = new ProgressReporter(null, null, progressInfo);
-//        final ResourceIterator<Object> signature = db.executeTransactionally("CALL dbms.procedures()", Collections.emptyMap(), result -> result.columnAs("signature"));
-//        db.executeTransactionally("CALL apoc.meta.nodeTypeProperties({})", Collections.emptyMap()/* Map.of("config", configNew)*/, result -> {
-//            System.out.println("MetaInformation.getAllNodePropertyKeys");
-//            return null;
-//        });
         CsvFormat exporter = new CsvFormat(db);
 
         ExportFileManager cypherFileManager = FileManagerFactory

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -45,7 +45,7 @@ public class ExportConfig {
     private OptimizationType optimizationType;
     private int unwindBatchSize;
     private long awaitForIndexes;
-    private final long sample;
+    private final Map<String, Object> samplingConfig;
 
     public int getBatchSize() {
         return batchSize;
@@ -100,7 +100,7 @@ public class ExportConfig {
         this.optimizations = (Map<String, Object>) config.getOrDefault("useOptimizations", Collections.emptyMap());
         this.optimizationType = OptimizationType.valueOf(optimizations.getOrDefault("type", OptimizationType.UNWIND_BATCH.toString()).toString().toUpperCase());
         this.batchSize = ((Number)config.getOrDefault("batchSize", DEFAULT_BATCH_SIZE)).intValue();
-        this.sample = Util.toLong(config.getOrDefault("sample", DEFAULT_BATCH_SIZE));
+        this.samplingConfig = (Map<String, Object>) config.getOrDefault("samplingConfig", new HashMap<>());
         this.unwindBatchSize = ((Number)getOptimizations().getOrDefault("unwindBatchSize", DEFAULT_UNWIND_BATCH_SIZE)).intValue();
         this.awaitForIndexes = ((Number)config.getOrDefault("awaitForIndexes", 300)).longValue();
         validate();
@@ -197,7 +197,7 @@ public class ExportConfig {
         return awaitForIndexes;
     }
 
-    public Map<String, Object> getConfig() {
-        return config;
+    public Map<String, Object> getSamplingConfig() {
+        return samplingConfig;
     }
 }

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -45,6 +45,7 @@ public class ExportConfig {
     private OptimizationType optimizationType;
     private int unwindBatchSize;
     private long awaitForIndexes;
+    private final long sample;
 
     public int getBatchSize() {
         return batchSize;
@@ -99,6 +100,7 @@ public class ExportConfig {
         this.optimizations = (Map<String, Object>) config.getOrDefault("useOptimizations", Collections.emptyMap());
         this.optimizationType = OptimizationType.valueOf(optimizations.getOrDefault("type", OptimizationType.UNWIND_BATCH.toString()).toString().toUpperCase());
         this.batchSize = ((Number)config.getOrDefault("batchSize", DEFAULT_BATCH_SIZE)).intValue();
+        this.sample = Util.toLong(config.getOrDefault("sample", DEFAULT_BATCH_SIZE));
         this.unwindBatchSize = ((Number)getOptimizations().getOrDefault("unwindBatchSize", DEFAULT_UNWIND_BATCH_SIZE)).intValue();
         this.awaitForIndexes = ((Number)config.getOrDefault("awaitForIndexes", 300)).longValue();
         validate();
@@ -195,4 +197,7 @@ public class ExportConfig {
         return awaitForIndexes;
     }
 
+    public Map<String, Object> getConfig() {
+        return config;
+    }
 }

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -206,4 +206,5 @@ public class ExportConfig {
     public boolean isSampling() {
         return sampling;
     }
+    
 }

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -28,6 +28,7 @@ public class ExportConfig {
     private int batchSize;
     private boolean silent;
     private boolean bulkImport = false;
+    private boolean sampling;
     private String delim;
     private String quotes;
     private boolean useTypes;
@@ -100,6 +101,7 @@ public class ExportConfig {
         this.optimizations = (Map<String, Object>) config.getOrDefault("useOptimizations", Collections.emptyMap());
         this.optimizationType = OptimizationType.valueOf(optimizations.getOrDefault("type", OptimizationType.UNWIND_BATCH.toString()).toString().toUpperCase());
         this.batchSize = ((Number)config.getOrDefault("batchSize", DEFAULT_BATCH_SIZE)).intValue();
+        this.sampling = toBoolean(config.getOrDefault("sampling", false));
         this.samplingConfig = (Map<String, Object>) config.getOrDefault("samplingConfig", new HashMap<>());
         this.unwindBatchSize = ((Number)getOptimizations().getOrDefault("unwindBatchSize", DEFAULT_UNWIND_BATCH_SIZE)).intValue();
         this.awaitForIndexes = ((Number)config.getOrDefault("awaitForIndexes", 300)).longValue();
@@ -199,5 +201,9 @@ public class ExportConfig {
 
     public Map<String, Object> getSamplingConfig() {
         return samplingConfig;
+    }
+
+    public boolean isSampling() {
+        return sampling;
     }
 }

--- a/core/src/main/java/apoc/export/util/MetaInformation.java
+++ b/core/src/main/java/apoc/export/util/MetaInformation.java
@@ -8,11 +8,13 @@ import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.ResultTransformer;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,6 +34,13 @@ public class MetaInformation {
     private static final Map<String, String> REVERSED_TYPE_MAP = MapUtils.invertMap(typeMappings);
     
     public static Map<String, Class> collectPropTypesForNodes(SubGraph graph, GraphDatabaseService db, ExportConfig config) {
+        if (!config.isSampling()) {
+            Map<String,Class> propTypes = new LinkedHashMap<>();
+            for (Node node : graph.getNodes()) {
+                updateKeyTypes(propTypes, node);
+            }
+            return propTypes;
+        }
         final Map<String, Object> conf = config.getSamplingConfig();
         conf.putIfAbsent("includeLabels", stream(graph.getAllLabelsInUse()).map(Label::name).collect(Collectors.toList()));
         
@@ -40,6 +49,13 @@ public class MetaInformation {
     }
 
     public static Map<String, Class> collectPropTypesForRelationships(SubGraph graph, GraphDatabaseService db, ExportConfig config) {
+        if (!config.isSampling()) {
+            Map<String,Class> propTypes = new LinkedHashMap<>();
+            for (Relationship relationship : graph.getRelationships()) {
+                updateKeyTypes(propTypes, relationship);
+            }
+            return propTypes;
+        }
         final Map<String, Object> conf = config.getSamplingConfig();
         conf.putIfAbsent("includeRels", stream(graph.getAllRelationshipTypesInUse()).map(RelationshipType::name).collect(Collectors.toList()));
 

--- a/core/src/main/java/apoc/meta/tablesforlabels/PropertyTracker.java
+++ b/core/src/main/java/apoc/meta/tablesforlabels/PropertyTracker.java
@@ -39,7 +39,7 @@ public class PropertyTracker {
         return ret;
     }
 
-    private static final Map<String,String> typeMappings = new HashMap<String,String>();
+    public static final Map<String,String> typeMappings = new HashMap<String,String>();
     static {
         typeMappings.put("java.lang.String", "String");
         typeMappings.put("java.lang.String[]", "StringArray");

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -173,7 +173,7 @@ public class ExportCsvTest {
         assertEquals(EXP_SAMPLE, readFile(fileName));
 
         // quotes: 'none' to simplify header testing
-        TestUtil.testCall(db, "CALL apoc.export.csv.all($file,{sample: 1, quotes: 'none'})", map("file", fileName),
+        TestUtil.testCall(db, "CALL apoc.export.csv.all($file, {samplingConfig: {sample: 1}, quotes: 'none'})", map("file", fileName),
                 (r) -> assertResults(fileName, r, "database", totalNodes, totalRels, totalProps, false));
         
         final String[] s = Files.lines(new File(directory, fileName).toPath()).findFirst().get().split(",");

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -296,10 +296,10 @@ public class ExportCsvTest {
     }
 
     private void assertResults(String fileName, Map<String, Object> r, final String source, 
-                               Long expectedNodes, Long expectedRelationships, Long expectedProperties, boolean assertEquals) {
+                               Long expectedNodes, Long expectedRelationships, Long expectedProperties, boolean assertPropEquality) {
         assertEquals(expectedNodes, r.get("nodes"));
         assertEquals(expectedRelationships, r.get("relationships"));
-        if (assertEquals) {
+        if (assertPropEquality) {
             assertEquals(expectedProperties, r.get("properties"));
         } else {
             assertTrue((Long) r.get("properties") < expectedProperties);

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -155,7 +155,7 @@ public class ExportCsvTest {
         assertEquals(EXP_SAMPLE, readFile(fileName));
 
         // quotes: 'none' to simplify header testing
-        TestUtil.testCall(db, "CALL apoc.export.csv.all($file, {samplingConfig: {sample: 1}, quotes: 'none'})", map("file", fileName),
+        TestUtil.testCall(db, "CALL apoc.export.csv.all($file, {sampling: true, samplingConfig: {sample: 1}, quotes: 'none'})", map("file", fileName),
                 (r) -> assertResults(fileName, r, "database", totalNodes, totalRels, totalProps, false));
         
         final String[] s = Files.lines(new File(directory, fileName).toPath()).findFirst().get().split(",");

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -64,17 +64,7 @@ public class ExportCsvTest {
             "\"5\",\":Address\",\"\",\"\",\"\",\"\",\"\",\"via Benni\",,,%n" +
             ",,,,,,,,\"0\",\"1\",\"KNOWS\"%n" +
             ",,,,,,,,\"3\",\"4\",\"NEXT_DELIVERY\"%n");
-    
-    private static final String EXPECTED_WITH_TYPES = "\"_id:id\",\"_labels:label\",\"age:int\",\"city\",\"kids\",\"male\",\"name\",\"street\",\"_start:id\",\"_end:id\",\"_type:label\"\n" +
-            "\"0\",\":User:User1\",\"42\",\"\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"true\",\"foo\",\"\",,,\n" +
-            "\"1\",\":User\",\"42\",\"\",\"\",\"\",\"bar\",\"\",,,\n" +
-            "\"2\",\":User\",\"12\",\"\",\"\",\"\",\"\",\"\",,,\n" +
-            "\"3\",\":Address:Address1\",\"\",\"Milano\",\"\",\"\",\"Andrea\",\"Via Garibaldi, 7\",,,\n" +
-            "\"4\",\":Address\",\"\",\"\",\"\",\"\",\"Bar Sport\",\"\",,,\n" +
-            "\"5\",\":Address\",\"\",\"\",\"\",\"\",\"\",\"via Benni\",,,\n" +
-            ",,,,,,,,\"0\",\"1\",\"KNOWS\"\n" +
-            ",,,,,,,,\"3\",\"4\",\"NEXT_DELIVERY\"\n";
-    
+
     private static final String EXP_SAMPLE = "\"_id\",\"_labels\",\"address\",\"age\",\"baz\",\"city\",\"foo\",\"kids\",\"last:Name\",\"male\",\"name\",\"street\",\"_start\",\"_end\",\"_type\",\"one\",\"three\"\n" +
             "\"0\",\":User:User1\",\"\",\"42\",\"\",\"\",\"\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"\",\"true\",\"foo\",\"\",,,,,\n" +
             "\"1\",\":User\",\"\",\"42\",\"\",\"\",\"\",\"\",\"\",\"\",\"bar\",\"\",,,,,\n" +
@@ -150,14 +140,6 @@ public class ExportCsvTest {
         TestUtil.testCall(db, "CALL apoc.export.csv.all($file,null)", map("file", fileName),
                 (r) -> assertResults(fileName, r, "database"));
         assertEquals(EXPECTED, readFile(fileName));
-    }
-
-    @Test
-    public void testExportAllCsvWithUseTypes() {
-        String fileName = "all.csv";
-        TestUtil.testCall(db, "CALL apoc.export.csv.all($file, {useTypes: true})", map("file", fileName),
-                (r) -> assertResults(fileName, r, "database"));
-        assertEquals(EXPECTED_WITH_TYPES, readFile(fileName));
     }
 
     @Test

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -2,6 +2,7 @@ package apoc.export.csv;
 
 import apoc.ApocSettings;
 import apoc.graph.Graphs;
+import apoc.meta.Meta;
 import apoc.util.TestUtil;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -60,6 +61,21 @@ public class ExportCsvTest {
             "\"5\",\":Address\",\"\",\"\",\"\",\"\",\"\",\"via Benni\",,,%n" +
             ",,,,,,,,\"0\",\"1\",\"KNOWS\"%n" +
             ",,,,,,,,\"3\",\"4\",\"NEXT_DELIVERY\"%n");
+    
+    private static final String EXP_SAMPLE = "\"_id\",\"_labels\",\"address\",\"age\",\"baz\",\"city\",\"foo\",\"kids\",\"lastName\",\"male\",\"name\",\"street\",\"_start\",\"_end\",\"_type\",\"one\",\"three\"\n" +
+            "\"0\",\":User:User1\",\"\",\"42\",\"\",\"\",\"\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"\",\"true\",\"foo\",\"\",,,,,\n" +
+            "\"1\",\":User\",\"\",\"42\",\"\",\"\",\"\",\"\",\"\",\"\",\"bar\",\"\",,,,,\n" +
+            "\"2\",\":User\",\"\",\"12\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",,,,,\n" +
+            "\"3\",\":Address:Address1\",\"\",\"\",\"\",\"Milano\",\"\",\"\",\"\",\"\",\"Andrea\",\"Via Garibaldi, 7\",,,,,\n" +
+            "\"4\",\":Address\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"Bar Sport\",\"\",,,,,\n" +
+            "\"5\",\":Address\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"via Benni\",,,,,\n" +
+            "\"6\",\":User\",\"\",\"\",\"\",\"\",\"\",\"\",\"Galilei\",\"\",\"\",\"\",,,,,\n" +
+            "\"7\",\":User\",\"Universe\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",,,,,\n" +
+            "\"8\",\":User\",\"\",\"\",\"\",\"\",\"bar\",\"\",\"\",\"\",\"\",\"\",,,,,\n" +
+            "\"9\",\":User\",\"\",\"\",\"baa\",\"\",\"\",\"\",\"\",\"\",\"\",\"\",,,,,\n" +
+            ",,,,,,,,,,,,\"0\",\"1\",\"KNOWS\",\"\",\"\"\n" +
+            ",,,,,,,,,,,,\"3\",\"4\",\"NEXT_DELIVERY\",\"\",\"\"\n" +
+            ",,,,,,,,,,,,\"8\",\"9\",\"KNOWS\",\"two\",\"four\"\n";
 
     private static final String EXPECTED_NONE_QUOTES = String.format("_id,_labels,age,city,kids,male,name,street,_start,_end,_type%n" +
             "0,:User:User1,42,,[\"a\",\"b\",\"c\"],true,foo,,,,%n" +
@@ -92,7 +108,8 @@ public class ExportCsvTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class);
+        // TODO TODOISSIMO --> MI SA CHE SPACCA CALL apoc.meta.relTypeProperties($conf) SE NON TROVA NULLA!!!!!
+        TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class, Meta.class);
         db.executeTransactionally("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})");
         db.executeTransactionally("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})");
     }
@@ -120,6 +137,58 @@ public class ExportCsvTest {
         TestUtil.testCall(db, "CALL apoc.export.csv.all($file,null)", map("file", fileName),
                 (r) -> assertResults(fileName, r, "database"));
         assertEquals(EXPECTED, readFile(fileName));
+    }
+
+    @Test
+    public void testExportAllCsvWithUseTypes() {
+        String fileName = "all.csv";
+        TestUtil.testCall(db, "CALL apoc.export.csv.all($file,{useTypes: true})", map("file", fileName),
+                (r) -> {});
+        assertEquals(EXPECTED, readFile(fileName));
+    }
+
+    @Test
+    public void testExportAllCsvWithSample() {
+        // todo - mettere degli altri nodi :User con altre prop e testare prima senza sample e poi con
+        db.executeTransactionally("CREATE (:User {lastName:'Galilei'}), (:User {address:'Universe'}),\n" +
+                "(:User {foo:'bar'})-[:KNOWS {one: 'two', three: 'four'}]->(:User {baz:'baa'})");
+        String fileName = "all.csv";
+        final long totalNodes = 10L;
+        final long totalRels = 3L;
+        final long totalProps = 18L;
+        TestUtil.testCall(db, "CALL apoc.export.csv.all($file, null)", map("file", fileName),
+                (r) -> assertResults(fileName, r, "database", totalNodes, totalRels, totalProps, true));
+
+        // todo - asserire  che gli header siano tutti
+        assertEquals(EXP_SAMPLE, readFile(fileName));
+
+        TestUtil.testCall(db, "CALL apoc.export.csv.all($file,{sample: 1})", map("file", fileName),
+                (r) -> {
+//                    assertEquals(expectedNodes, r.get("nodes"));
+//                    assertEquals(expectedRelationships, r.get("relationships"));
+//                    assertEquals(expectedProperties, r.get("properties"));
+
+                    assertResults(fileName, r, "database", totalNodes, totalRels, totalProps, false);
+//            assertCsvCommon(fileName, r);
+//            assertTrue((Long) r.get("nodes") < totalNodes);
+//            assertTrue((Long) r.get("relationships") < totalRels);
+//            assertTrue((Long) r.get("nodes") < totalProps);
+        });
+        
+        // todo - asserire solo che gli header siano di meno, non posso calcolare il csv esatto
+//        assertEquals(EXP_SAMPLE, readFile(fileName));
+
+        // todo - cancellare i suddetti nodi
+    }
+
+    @Test
+    public void testExportAllCsvWithPropRels() {
+        // todo - mettere due nodi con una relazione con alcune prop
+        String fileName = "all.csv";
+        TestUtil.testCall(db, "CALL apoc.export.csv.all($file,{sample: 1})", map("file", fileName),
+                (r) -> {});
+        assertEquals(EXPECTED, readFile(fileName));
+        // todo - cancellare i suddetti nodi
     }
 
     @Test
@@ -231,10 +300,24 @@ public class ExportCsvTest {
     }
 
     private void assertResults(String fileName, Map<String, Object> r, final String source) {
-        assertEquals(6L, r.get("nodes"));
-        assertEquals(2L, r.get("relationships"));
-        assertEquals(12L, r.get("properties"));
-        assertEquals(source + ": nodes(6), rels(2)", r.get("source"));
+        assertResults(fileName, r, source, 6L, 2L, 12L, true);
+    }
+
+    private void assertResults(String fileName, Map<String, Object> r, final String source, 
+                               Long expectedNodes, Long expectedRelationships, Long expectedProperties, boolean assertEquals) {
+        assertEquals(expectedNodes, r.get("nodes"));
+        assertEquals(expectedRelationships, r.get("relationships"));
+        if (assertEquals) {
+            assertEquals(expectedProperties, r.get("properties"));
+        } else {
+            assertTrue((Long) r.get("properties") < expectedProperties);
+        }
+        final String expectedSource = source + ": nodes(" + expectedNodes + "), rels(" + expectedRelationships + ")";
+        assertEquals(expectedSource, r.get("source"));
+        assertCsvCommon(fileName, r);
+    }
+
+    private void assertCsvCommon(String fileName, Map<String, Object> r) {
         assertEquals(fileName, r.get("file"));
         assertEquals("csv", r.get("format"));
         assertTrue("Should get time greater than 0",((long) r.get("time")) >= 0);

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.csv.all.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.csv.all.adoc
@@ -96,7 +96,8 @@ RETURN file, nodes, relationships, properties, data
 
 |===
 
-The `apoc.export.csv.all` procedure use under the hood
+You can use the configuration `sampling` (default: `false`).
+With this config, the `apoc.export.csv.all` procedure use under the hood
 the `apoc.meta.nodeTypeProperties` and the `apoc.meta.relTypeProperties` procedure to get the property types.
 You can customize the configuration of these 2 `apoc.meta.*` procedure, using the `samplingConfig: MAP` configuration, 
 to limit the number of nodes/rels to analyze.
@@ -112,7 +113,7 @@ CREATE (:User:Sample {`last:Name`:'Galilei'}), (:User:Sample {address:'Universe'
 the following query: 
 [source,cypher]
 ----
-CALL apoc.export.csv.all('movies.csv', {samplingConfig: {sample: 1}})
+CALL apoc.export.csv.all('movies.csv', {sampling: true, samplingConfig: {sample: 1}})
 ----
 
 .Results

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.csv.all.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.csv.all.adoc
@@ -97,12 +97,12 @@ RETURN file, nodes, relationships, properties, data
 |===
 
 You can use the configuration `sampling` (default: `false`).
-With this config, the `apoc.export.csv.all` procedure use under the hood
-the `apoc.meta.nodeTypeProperties` and the `apoc.meta.relTypeProperties` procedure to get the property types.
+With this config, the `apoc.export.csv.all` procedure uses
+the `apoc.meta.nodeTypeProperties` and the `apoc.meta.relTypeProperties` procedures under the hood to get the property types.
 You can customize the configuration of these 2 `apoc.meta.*` procedure, using the `samplingConfig: MAP` configuration, 
 to limit the number of nodes/rels to analyze.
 
-So you can execute with the following dataset
+So you can execute with the following data set:
 
 [source,cypher]
 ----
@@ -110,7 +110,7 @@ CREATE (:User:Sample {`last:Name`:'Galilei'}), (:User:Sample {address:'Universe'
     (:User:Sample {foo:'bar'})-[:KNOWS {one: 'two', three: 'four'}]->(:User:Sample {baz:'baa', foo: true})
 ----
 
-the following query: 
+Combined with the following query:
 [source,cypher]
 ----
 CALL apoc.export.csv.all('movies.csv', {sampling: true, samplingConfig: {sample: 1}})
@@ -123,7 +123,7 @@ CALL apoc.export.csv.all('movies.csv', {sampling: true, samplingConfig: {sample:
 | "movies.csv" | "database: nodes(4), rels(1)" | "csv"  | 4     | 1             | 3             | 4   | 5   | 20000         | 1         | TRUE | NULL
 |===
 
-with a content similar to this (with `sample` the result could change):
+Execution of the above query would output content similar to that below (result could change depending on the `sample`):
 
 .movies.csv
 [source,csv]

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.csv.all.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.export.csv.all.adoc
@@ -95,3 +95,42 @@ RETURN file, nodes, relationships, properties, data
 "
 
 |===
+
+The `apoc.export.csv.all` procedure use under the hood
+the `apoc.meta.nodeTypeProperties` and the `apoc.meta.relTypeProperties` procedure to get the property types.
+You can customize the configuration of these 2 `apoc.meta.*` procedure, using the `samplingConfig: MAP` configuration, 
+to limit the number of nodes/rels to analyze.
+
+So you can execute with the following dataset
+
+[source,cypher]
+----
+CREATE (:User:Sample {`last:Name`:'Galilei'}), (:User:Sample {address:'Universe'}), 
+    (:User:Sample {foo:'bar'})-[:KNOWS {one: 'two', three: 'four'}]->(:User:Sample {baz:'baa', foo: true})
+----
+
+the following query: 
+[source,cypher]
+----
+CALL apoc.export.csv.all('movies.csv', {samplingConfig: {sample: 1}})
+----
+
+.Results
+[opts="header"]
+|===
+| file         | source                        | format | nodes | relationships | properties    | time | rows | batchSize  | batches    | done | data
+| "movies.csv" | "database: nodes(4), rels(1)" | "csv"  | 4     | 1             | 3             | 4   | 5   | 20000         | 1         | TRUE | NULL
+|===
+
+with a content similar to this (with `sample` the result could change):
+
+.movies.csv
+[source,csv]
+----
+"_id","_labels","baz","foo","_start","_end","_type"
+"0",":Sample:User","","",,,
+"1",":Sample:User","","",,,
+"2",":Sample:User","","bar",,,
+"3",":Sample:User","baa","true",,,
+,,,,"2","3","KNOWS"
+----


### PR DESCRIPTION
Fixes #536

- Added `sampling` config (default: false). When it's `true`, we use under the hood
the `apoc.meta.nodeTypeProperties` and the `apoc.meta.relTypeProperties` procedure to get the property types

- Fixed wrong test `testExportInvalidQuoteValue`