### PR TITLE
Fixes #1861: the procedure of apoc.meta.schema() get wrong result

### DIFF
--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -74,8 +74,6 @@ import static org.neo4j.internal.kernel.api.TokenRead.ANY_LABEL;
 import static org.neo4j.internal.kernel.api.TokenRead.ANY_RELATIONSHIP_TYPE;
 
 public class    Meta {
-
-
     
     @Context
     public Transaction tx;

--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -74,7 +74,7 @@ import static org.neo4j.internal.kernel.api.TokenRead.ANY_LABEL;
 import static org.neo4j.internal.kernel.api.TokenRead.ANY_RELATIONSHIP_TYPE;
 
 public class    Meta {
-    
+
     @Context
     public Transaction tx;
 

--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -46,6 +46,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.time.ZonedDateTime;
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -66,6 +67,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static apoc.util.MapUtil.map;
+import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonMap;
 import static org.neo4j.internal.kernel.api.TokenRead.ANY_LABEL;
@@ -73,8 +75,7 @@ import static org.neo4j.internal.kernel.api.TokenRead.ANY_RELATIONSHIP_TYPE;
 
 public class    Meta {
 
-    private static final String RELATIONSHIP_SUFFIX = " (relationship)";
-    private static final String NODE_SUFFIX = " (node)";
+
     
     @Context
     public Transaction tx;
@@ -492,11 +493,20 @@ public class    Meta {
     public Stream<MapResult> schema(@Name(value = "config",defaultValue = "{}") Map<String,Object> config) {
         MetaStats metaStats = collectStats();
         MetaConfig metaConfig = new MetaConfig(config);
-        Map<String, Map<String, MetaResult>> metaData = collectMetaData(new DatabaseSubGraph(transaction), metaConfig);
+        Map<Set<String>, Map<String, MetaResult>> metaData = collectMetaData(new DatabaseSubGraph(transaction), metaConfig);
 
         Map<String, Object> relationships = collectRelationshipsMetaData(metaStats, metaData);
         Map<String, Object> nodes = collectNodesMetaData(metaStats, metaData, relationships);
-
+        final Collection<String> commonKeys = CollectionUtils.intersection(nodes.keySet(), relationships.keySet());
+        if (!commonKeys.isEmpty()) {
+            relationships = relationships.entrySet().stream()
+                    .map(e -> { 
+                        final String key = e.getKey();
+                        return commonKeys.contains(key)
+                                ? new AbstractMap.SimpleEntry<>(format("%s (%s)", key, Types.RELATIONSHIP.name()), e.getValue())
+                                : e;
+                    }).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
         nodes.putAll(relationships);
         return Stream.of(new MapResult(nodes));
     }
@@ -615,24 +625,20 @@ public class    Meta {
 
     // End new code
 
-    private Map<String, Map<String, MetaResult>> collectMetaData(SubGraph graph, MetaConfig config) {
-        Map<String,Map<String,MetaResult>> metaData = new LinkedHashMap<>(100);
+    private Map<Set<String>, Map<String, MetaResult>> collectMetaData(SubGraph graph, MetaConfig config) {
+        Map<Set<String>, Map<String,MetaResult>> metaData = new LinkedHashMap<>(100);
 
         Set<RelationshipType> types = Iterables.asSet(graph.getAllRelationshipTypesInUse());
         Map<String, Iterable<ConstraintDefinition>> relConstraints = new HashMap<>(20);
         for (RelationshipType type : graph.getAllRelationshipTypesInUse()) {
-            metaData.put(type.name(), new LinkedHashMap<>(10));
+            metaData.put(Set.of(Types.RELATIONSHIP.name(), type.name()), new LinkedHashMap<>(10));
             relConstraints.put(type.name(),graph.getConstraints(type));
         }
         for (Label label : graph.getAllLabelsInUse()) {
             Map<String,MetaResult> nodeMeta = new LinkedHashMap<>(50);
             String labelName = label.name();
             // workaround in case of duplicated keys
-            if (metaData.containsKey(labelName)) {
-                metaData.put(labelName + RELATIONSHIP_SUFFIX, metaData.remove(labelName));
-                labelName += NODE_SUFFIX;
-            }
-            metaData.put(labelName, nodeMeta);
+            metaData.put(Set.of(Types.NODE.name(), labelName), nodeMeta);
             Iterable<ConstraintDefinition> constraints = graph.getConstraints(label);
             Set<String> indexed = new LinkedHashSet<>();
             for (IndexDefinition index : graph.getIndexes(label)) {
@@ -678,10 +684,10 @@ public class    Meta {
         }
     }
 
-    private Map<String, Object> collectNodesMetaData(MetaStats metaStats, Map<String, Map<String, MetaResult>> metaData, Map<String, Object> relationships) {
+    private Map<String, Object> collectNodesMetaData(MetaStats metaStats, Map<Set<String>, Map<String, MetaResult>> metaData, Map<String, Object> relationships) {
         Map<String, Object> nodes = new LinkedHashMap<>();
         Map<String, List<Map<String, Object>>> startNodeNameToRelationshipsMap = new HashMap<>();
-        for (String entityName : metaData.keySet()) {
+        for (Set<String> entityName : metaData.keySet()) {
             Map<String, MetaResult> entityData = metaData.get(entityName);
             Map<String, Object> entityProperties = new LinkedHashMap<>();
             Map<String, Object> entityRelationships = new LinkedHashMap<>();
@@ -719,12 +725,10 @@ public class    Meta {
                 }
             }
             if (isNode) {
-                final String normalizedEntityName = entityName.replace(NODE_SUFFIX, "");
-                nodes.put(entityName, MapUtil.map(
+                String key = getKeyFromEntityName(entityName, Types.NODE.name());
+                nodes.put(key, MapUtil.map(
                         "type", "node",
-                        "count", metaStats.relTypesCount.containsKey(normalizedEntityName) 
-                                ? metaStats.labels.get(normalizedEntityName) 
-                                : metaStats.labels.get(entityName),
+                        "count", metaStats.labels.get(key),
                         "labels", labels,
                         "properties", entityProperties,
                         "relationships", entityRelationships
@@ -756,9 +760,9 @@ public class    Meta {
         });
     }
 
-    private Map<String, Object> collectRelationshipsMetaData(MetaStats metaStats, Map<String, Map<String, MetaResult>> metaData) {
+    private Map<String, Object> collectRelationshipsMetaData(MetaStats metaStats, Map<Set<String>, Map<String, MetaResult>> metaData) {
         Map<String, Object> relationships = new LinkedHashMap<>();
-        for(String entityName : metaData.keySet()) {
+        for(Set<String> entityName : metaData.keySet()) {
             Map<String, MetaResult> entityData = metaData.get(entityName);
             Map<String, Object> entityProperties = new LinkedHashMap<>();
             if (entityData.isEmpty()) {
@@ -779,16 +783,18 @@ public class    Meta {
                 }
             }
             if (isRelationship) {
-                final String normalizedEntityName = entityName.replace(RELATIONSHIP_SUFFIX, "");
-                relationships.put(entityName, MapUtil.map(
+                String key = getKeyFromEntityName(entityName, Types.RELATIONSHIP.name());
+                relationships.put(key, MapUtil.map(
                         "type", "relationship",
-                        "count", metaStats.labels.containsKey(normalizedEntityName)
-                                ? metaStats.relTypesCount.get(normalizedEntityName) 
-                                : metaStats.relTypesCount.get(entityName),
+                        "count", metaStats.relTypesCount.get(key),
                         "properties", entityProperties));
             }
         }
         return relationships;
+    }
+
+    private String getKeyFromEntityName(Set<String> entityName, String suffix) {
+        return new HashSet<>(entityName).stream().filter(entity -> !entity.equals(suffix)).findFirst().get();
     }
 
     private void addProperties(Map<String, MetaResult> properties, String labelName, Iterable<ConstraintDefinition> constraints, Set<String> indexed, Entity pc, Node node) {
@@ -801,7 +807,7 @@ public class    Meta {
         }
     }
 
-    private void addRelationships(Map<String, Map<String, MetaResult>> metaData,
+    private void addRelationships(Map<Set<String>, Map<String, MetaResult>> metaData,
                                   Map<String, MetaResult> nodeMeta,
                                   String labelName,
                                   Node node,
@@ -815,23 +821,19 @@ public class    Meta {
 
                     String typeName = type.name();
                     // workaround in case of duplicated keys
-                    final boolean metaContainsSuffix = metaData.containsKey(typeName + RELATIONSHIP_SUFFIX);
-                    if (metaContainsSuffix) {
-                        typeName += RELATIONSHIP_SUFFIX;
-                    }
 
                     Iterable<ConstraintDefinition> constraints = relConstraints.get(typeName);
                     if (!nodeMeta.containsKey(typeName)) nodeMeta.put(typeName, new MetaResult(labelName,typeName));
 //            int in = node.getDegree(type, Direction.INCOMING);
 
-                    Map<String, MetaResult> typeMeta = metaData.get(typeName);
+                    Map<String, MetaResult> typeMeta = metaData.get(Set.of(typeName, Types.RELATIONSHIP.name()));
                     if (!typeMeta.containsKey(labelName)) typeMeta.put(labelName,new MetaResult(typeName,labelName));
                     MetaResult relMeta = nodeMeta.get(typeName);
-                    addOtherNodeInfo(node, labelName, out, type, relMeta , typeMeta, constraints, metaContainsSuffix);
+                    addOtherNodeInfo(node, labelName, out, type, relMeta , typeMeta, constraints);
                 });
     }
 
-    private void addOtherNodeInfo(Node node, String labelName, int out, RelationshipType type, MetaResult relMeta, Map<String, MetaResult> typeMeta, Iterable<ConstraintDefinition> relConstraints, boolean metaContainsSuffix) {
+    private void addOtherNodeInfo(Node node, String labelName, int out, RelationshipType type, MetaResult relMeta, Map<String, MetaResult> typeMeta, Iterable<ConstraintDefinition> relConstraints) {
         MetaResult relNodeMeta = typeMeta.get(labelName);
         relMeta.elementType(Types.of(node).name());
         for (Relationship rel : node.getRelationships(Direction.OUTGOING, type)) {
@@ -841,7 +843,7 @@ public class    Meta {
             relMeta.inc().other(labels).rel(out , in);
             relNodeMeta.inc().other(labels).rel(out,in);
             final String typeName = type.name();
-            addProperties(typeMeta, metaContainsSuffix ? typeName + RELATIONSHIP_SUFFIX : typeName, relConstraints, Collections.emptySet(), rel, node);
+            addProperties(typeMeta, typeName, relConstraints, Collections.emptySet(), rel, node);
             relNodeMeta.elementType(Types.RELATIONSHIP.name());
         }
     }

--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -827,7 +827,7 @@ public class    Meta {
                     Map<String, MetaResult> typeMeta = metaData.get(typeName);
                     if (!typeMeta.containsKey(labelName)) typeMeta.put(labelName,new MetaResult(typeName,labelName));
                     MetaResult relMeta = nodeMeta.get(typeName);
-                    addOtherNodeInfo(node, labelName, out, type, relMeta , typeMeta, constraints, metaContainsSuffix); // todo qui dentro metto pure le relazioni
+                    addOtherNodeInfo(node, labelName, out, type, relMeta , typeMeta, constraints, metaContainsSuffix);
                 });
     }
 

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -447,13 +447,13 @@ public class MetaTest {
             Map<String, Object> value = (Map<String, Object>) row.get("value");
             assertEquals(2, value.size());
             
-            Map<String, Object>  personRelationship = (Map<String, Object>) value.get("person (relationship)");
+            Map<String, Object>  personRelationship = (Map<String, Object>) value.get("person (RELATIONSHIP)");
             assertEquals(1L, personRelationship.get("count"));
             assertEquals("relationship", personRelationship.get("type"));
             Map<String, Object>  relationshipProps = (Map<String, Object>) personRelationship.get("properties");
             assertEquals(Set.of("alfa"), relationshipProps.keySet());
             
-            Map<String, Object>  personNode = (Map<String, Object>) value.get("person (node)");
+            Map<String, Object> personNode = (Map<String, Object>) value.get("person");
             assertEquals(2L, personNode.get("count"));
             assertEquals("node", personNode.get("type"));
             Map<String, Object>  nodeProps = (Map<String, Object>) personNode.get("properties");

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -439,6 +439,29 @@ public class MetaTest {
     }
 
     @Test
+    public void testIssue1861LabelAndTypeWithSameName() {
+        db.executeTransactionally("CREATE (s0 :person{id:1} ) SET s0.name = 'rose'\n" +
+                "CREATE (t0 :person{id:2}) SET t0.name = 'jack'\n" +
+                "MERGE (s0) -[r0:person {alfa: 'beta'}] -> (t0)");
+        testCall(db,"CALL apoc.meta.schema()", (row) -> {
+            Map<String, Object> value = (Map<String, Object>) row.get("value");
+            assertEquals(2, value.size());
+            
+            Map<String, Object>  personRelationship = (Map<String, Object>) value.get("person (relationship)");
+            assertEquals(1L, personRelationship.get("count"));
+            assertEquals("relationship", personRelationship.get("type"));
+            Map<String, Object>  relationshipProps = (Map<String, Object>) personRelationship.get("properties");
+            assertEquals(Set.of("alfa"), relationshipProps.keySet());
+            
+            Map<String, Object>  personNode = (Map<String, Object>) value.get("person (node)");
+            assertEquals(2L, personNode.get("count"));
+            assertEquals("node", personNode.get("type"));
+            Map<String, Object>  nodeProps = (Map<String, Object>) personNode.get("properties");
+            assertEquals(Set.of("name", "id"), nodeProps.keySet());
+        });
+    }
+    
+    @Test
     public void testSubGraphNoLimits() throws Exception {
         db.executeTransactionally("CREATE (:A)-[:X]->(b:B),(b)-[:Y]->(:C)");
         testCall(db,"CALL apoc.meta.subGraph({})", (row) -> {

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.data.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.data.adoc
@@ -25,7 +25,9 @@ CREATE (Keanu)-[:ACTED_IN {roles:['Kevin Lomax']}]->(TheDevilsAdvocate)
 CREATE (TomH)-[:ACTED_IN {roles:['Joe Fox']}]->(YouveGotMail)
 CREATE (TomH)-[:ACTED_IN {roles:['Sam Baldwin']}]->(SleeplessInSeattle)
 CREATE (TomH)-[:ACTED_IN {roles:['Mr. White']}]->(ThatThingYouDo)
-CREATE (TomH)-[:ACTED_IN {roles:['Zachry', 'Dr. Henry Goose', 'Isaac Sachs', 'Dermot Hoggins']}]->(CloudAtlas);
+CREATE (TomH)-[:ACTED_IN {roles:['Zachry', 'Dr. Henry Goose', 'Isaac Sachs', 'Dermot Hoggins']}]->(CloudAtlas)
+
+CREATE (s0:sameName{id:1}) -[r0:sameName {alfa: 'beta'}] -> (t0:sameName{id:2});
 ----
 
 [source,cypher]
@@ -33,16 +35,23 @@ CREATE (TomH)-[:ACTED_IN {roles:['Zachry', 'Dr. Henry Goose', 'Isaac Sachs', 'De
 CALL apoc.meta.data();
 ----
 
+Note that, in case of relationship type and node label with the same name, 
+they will be distinguished by the suffix " (node)" and " (relationships)".
+
 .Results
 [opts="header"]
 |===
-| label      | property   | count | unique | index | existence | type           | array | sample | leftCount | rightCount | left | right | other     | otherLabels | elementType
-| "ACTED_IN" | "Person"   | 9     | FALSE  | FALSE | FALSE     | "RELATIONSHIP" | TRUE  | NULL   | 41        | 9          | 4    | 1     | ["Movie"] | []          | "relationship"
-| "ACTED_IN" | "roles"    | 0     | FALSE  | FALSE | FALSE     | "LIST"         | TRUE  | NULL   | 0         | 0          | 0    | 0     | []        | []          | "relationship"
-| "Person"   | "ACTED_IN" | 9     | FALSE  | FALSE | FALSE     | "RELATIONSHIP" | TRUE  | NULL   | 41        | 9          | 4    | 1     | ["Movie"] | []          | "node"
-| "Person"   | "name"     | 0     | FALSE  | FALSE | FALSE     | "STRING"       | FALSE | NULL   | 0         | 0          | 0    | 0     | []        | []          | "node"
-| "Person"   | "born"     | 0     | FALSE  | FALSE | FALSE     | "INTEGER"      | FALSE | NULL   | 0         | 0          | 0    | 0     | []        | []          | "node"
-| "Movie"    | "title"    | 0     | FALSE  | FALSE | FALSE     | "STRING"       | FALSE | NULL   | 0         | 0          | 0    | 0     | []        | []          | "node"
-| "Movie"    | "tagline"  | 0     | FALSE  | FALSE | FALSE     | "STRING"       | FALSE | NULL   | 0         | 0          | 0    | 0     | []        | []          | "node"
-| "Movie"    | "released" | 0     | FALSE  | FALSE | FALSE     | "INTEGER"      | FALSE | NULL   | 0         | 0          | 0    | 0     | []        | []          | "node"
+| label                     | property                  | count | unique | index | existence | type           | array | sample | leftCount | rightCount | left | right | other      | otherLabels | elementType
+| "ACTED_IN"                | "Person"                  | 9     | FALSE  | FALSE | FALSE     | "RELATIONSHIP" | TRUE  | NULL   | 41        | 9          | 4    | 1     | ["Movie"]  | []          | "relationship"
+| "ACTED_IN"                | "roles"                   | 0     | FALSE  | FALSE | FALSE     | "LIST"         | TRUE  | NULL   | 0         | 0          | 0    | 0     | []         | []          | "relationship"
+| "sameName (relationship)"   | "sameName (node)"           |	1	| FALSE  | FALSE | FALSE     |"RELATIONSHIP"  |	FALSE |	NULL   |	1	   |1           |	1  | 1     | ["sameName"] | []	      | "relationship"
+| "sameName (relationship)"   | "alfa"                    |	0	| FALSE  | FALSE | FALSE     |"STRING"        |	FALSE |	NULL   |	0	   |0	        |0	   | 0     | []     	| []	      | "relationship"
+| "sameName (node)"           | "sameName (relationship)"   |	1	| FALSE  | FALSE | FALSE     |"RELATIONSHIP"  |	FALSE |	NULL   |	1	   |1	        |1	   | 1     | ["sameName"]	| []	      | "node"
+| "sameName (node)"           | "id"                      |	0	| FALSE  | FALSE | FALSE     |"INTEGER"       |	FALSE |	NULL   |	0	   |0	        |0	   | 0     | []	        | []	      | "node"
+| "Person"                  | "ACTED_IN"                | 9     | FALSE  | FALSE | FALSE     | "RELATIONSHIP" | TRUE  | NULL   | 41        | 9          | 4    | 1     | ["Movie"]  | []          | "node"
+| "Person"                  | "name"                    | 0     | FALSE  | FALSE | FALSE     | "STRING"       | FALSE | NULL   | 0         | 0          | 0    | 0     | []         | []          | "node"
+| "Person"                  | "born"                    | 0     | FALSE  | FALSE | FALSE     | "INTEGER"      | FALSE | NULL   | 0         | 0          | 0    | 0     | []         | []          | "node"
+| "Movie"                   | "title"                   | 0     | FALSE  | FALSE | FALSE     | "STRING"       | FALSE | NULL   | 0         | 0          | 0    | 0     | []         | []          | "node"
+| "Movie"                   | "tagline"                 | 0     | FALSE  | FALSE | FALSE     | "STRING"       | FALSE | NULL   | 0         | 0          | 0    | 0     | []         | []          | "node"
+| "Movie"                   | "released"                | 0     | FALSE  | FALSE | FALSE     | "INTEGER"      | FALSE | NULL   | 0         | 0          | 0    | 0     | []         | []          | "node"
 |===

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.data.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.data.adoc
@@ -25,9 +25,7 @@ CREATE (Keanu)-[:ACTED_IN {roles:['Kevin Lomax']}]->(TheDevilsAdvocate)
 CREATE (TomH)-[:ACTED_IN {roles:['Joe Fox']}]->(YouveGotMail)
 CREATE (TomH)-[:ACTED_IN {roles:['Sam Baldwin']}]->(SleeplessInSeattle)
 CREATE (TomH)-[:ACTED_IN {roles:['Mr. White']}]->(ThatThingYouDo)
-CREATE (TomH)-[:ACTED_IN {roles:['Zachry', 'Dr. Henry Goose', 'Isaac Sachs', 'Dermot Hoggins']}]->(CloudAtlas)
-
-CREATE (s0:sameName{id:1}) -[r0:sameName {alfa: 'beta'}] -> (t0:sameName{id:2});
+CREATE (TomH)-[:ACTED_IN {roles:['Zachry', 'Dr. Henry Goose', 'Isaac Sachs', 'Dermot Hoggins']}]->(CloudAtlas);
 ----
 
 [source,cypher]
@@ -35,23 +33,16 @@ CREATE (s0:sameName{id:1}) -[r0:sameName {alfa: 'beta'}] -> (t0:sameName{id:2});
 CALL apoc.meta.data();
 ----
 
-Note that, in case of relationship type and node label with the same name, 
-they will be distinguished by the suffix " (node)" and " (relationships)".
-
 .Results
 [opts="header"]
 |===
-| label                     | property                  | count | unique | index | existence | type           | array | sample | leftCount | rightCount | left | right | other      | otherLabels | elementType
-| "ACTED_IN"                | "Person"                  | 9     | FALSE  | FALSE | FALSE     | "RELATIONSHIP" | TRUE  | NULL   | 41        | 9          | 4    | 1     | ["Movie"]  | []          | "relationship"
-| "ACTED_IN"                | "roles"                   | 0     | FALSE  | FALSE | FALSE     | "LIST"         | TRUE  | NULL   | 0         | 0          | 0    | 0     | []         | []          | "relationship"
-| "sameName (relationship)"   | "sameName (node)"           |	1	| FALSE  | FALSE | FALSE     |"RELATIONSHIP"  |	FALSE |	NULL   |	1	   |1           |	1  | 1     | ["sameName"] | []	      | "relationship"
-| "sameName (relationship)"   | "alfa"                    |	0	| FALSE  | FALSE | FALSE     |"STRING"        |	FALSE |	NULL   |	0	   |0	        |0	   | 0     | []     	| []	      | "relationship"
-| "sameName (node)"           | "sameName (relationship)"   |	1	| FALSE  | FALSE | FALSE     |"RELATIONSHIP"  |	FALSE |	NULL   |	1	   |1	        |1	   | 1     | ["sameName"]	| []	      | "node"
-| "sameName (node)"           | "id"                      |	0	| FALSE  | FALSE | FALSE     |"INTEGER"       |	FALSE |	NULL   |	0	   |0	        |0	   | 0     | []	        | []	      | "node"
-| "Person"                  | "ACTED_IN"                | 9     | FALSE  | FALSE | FALSE     | "RELATIONSHIP" | TRUE  | NULL   | 41        | 9          | 4    | 1     | ["Movie"]  | []          | "node"
-| "Person"                  | "name"                    | 0     | FALSE  | FALSE | FALSE     | "STRING"       | FALSE | NULL   | 0         | 0          | 0    | 0     | []         | []          | "node"
-| "Person"                  | "born"                    | 0     | FALSE  | FALSE | FALSE     | "INTEGER"      | FALSE | NULL   | 0         | 0          | 0    | 0     | []         | []          | "node"
-| "Movie"                   | "title"                   | 0     | FALSE  | FALSE | FALSE     | "STRING"       | FALSE | NULL   | 0         | 0          | 0    | 0     | []         | []          | "node"
-| "Movie"                   | "tagline"                 | 0     | FALSE  | FALSE | FALSE     | "STRING"       | FALSE | NULL   | 0         | 0          | 0    | 0     | []         | []          | "node"
-| "Movie"                   | "released"                | 0     | FALSE  | FALSE | FALSE     | "INTEGER"      | FALSE | NULL   | 0         | 0          | 0    | 0     | []         | []          | "node"
+| label      | property   | count | unique | index | existence | type           | array | sample | leftCount | rightCount | left | right | other     | otherLabels | elementType
+| "ACTED_IN" | "Person"   | 9     | FALSE  | FALSE | FALSE     | "RELATIONSHIP" | TRUE  | NULL   | 41        | 9          | 4    | 1     | ["Movie"] | []          | "relationship"
+| "ACTED_IN" | "roles"    | 0     | FALSE  | FALSE | FALSE     | "LIST"         | TRUE  | NULL   | 0         | 0          | 0    | 0     | []        | []          | "relationship"
+| "Person"   | "ACTED_IN" | 9     | FALSE  | FALSE | FALSE     | "RELATIONSHIP" | TRUE  | NULL   | 41        | 9          | 4    | 1     | ["Movie"] | []          | "node"
+| "Person"   | "name"     | 0     | FALSE  | FALSE | FALSE     | "STRING"       | FALSE | NULL   | 0         | 0          | 0    | 0     | []        | []          | "node"
+| "Person"   | "born"     | 0     | FALSE  | FALSE | FALSE     | "INTEGER"      | FALSE | NULL   | 0         | 0          | 0    | 0     | []        | []          | "node"
+| "Movie"    | "title"    | 0     | FALSE  | FALSE | FALSE     | "STRING"       | FALSE | NULL   | 0         | 0          | 0    | 0     | []        | []          | "node"
+| "Movie"    | "tagline"  | 0     | FALSE  | FALSE | FALSE     | "STRING"       | FALSE | NULL   | 0         | 0          | 0    | 0     | []        | []          | "node"
+| "Movie"    | "released" | 0     | FALSE  | FALSE | FALSE     | "INTEGER"      | FALSE | NULL   | 0         | 0          | 0    | 0     | []        | []          | "node"
 |===

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.schema.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.schema.adoc
@@ -39,7 +39,7 @@ RETURN key, value[key] AS value;
 ----
 
 Note that, in case of relationship type and node label with the same name, 
-they will be distinguished by the suffix " (node)" and " (relationships)".
+the relationships will be distinguished by the suffix " (RELATIONSHIP)"
 
 .Results
 [opts="header"]
@@ -48,7 +48,7 @@ they will be distinguished by the suffix " (node)" and " (relationships)".
 | "Movie"                   | {count: 9, relationships: {ACTED_IN: {count: 41, properties: {roles: {existence: FALSE, type: "LIST", array: TRUE}}, direction: "in", labels: ["Person"]}}, type: "node", properties: {tagline: {existence: FALSE, type: "STRING", indexed: FALSE, unique: FALSE}, title: {existence: FALSE, type: "STRING", indexed: FALSE, unique: FALSE}, released: {existence: FALSE, type: "INTEGER", indexed: FALSE, unique: FALSE}}, labels: []}
 | "ACTED_IN"                | {count: 9, type: "relationship", properties: {roles: {existence: FALSE, type: "LIST", array: TRUE}}}
 | "Person"                  | {count: 2, relationships: {ACTED_IN: {count: 9, properties: {roles: {existence: FALSE, type: "LIST", array: TRUE}}, direction: "out", labels: ["Movie"]}}, type: "node", properties: {name: {existence: FALSE, type: "STRING", indexed: FALSE, unique: FALSE}, born: {existence: FALSE, type: "INTEGER", indexed: FALSE, unique: FALSE}}, labels: []}
-| "sameName (relationship)" | {count: 1, type: "relationship", properties: {alfa: {existence: false, type: "STRING", array: false}}}
-| "sameName (node)"         | {count: 2, relationships: {"sameName (relationship)": {count: 1, properties: {alfa: {existence: false, type: "STRING", array: false}}, direction: "out", labels: ["sameName"]}}, type:"node", properties: {id: {existence: false,type: "INTEGER", indexed: false,unique: false}},labels: []}
+| "sameName (RELATIONSHIP)" | {"count":1,"type":"relationship","properties":{"alfa":{"existence":false,"type":"STRING","array":false}}}
+| "sameName"                | {count: 2, relationships: {"sameName": {count: 1, properties: {alfa: {existence: false, type: "STRING", array: false}}, direction: "out", labels: ["sameName"]}}, type:"node", properties: {id: {existence: false,type: "INTEGER", indexed: false,unique: false}},labels: []}
 |===
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.schema.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.schema.adoc
@@ -25,7 +25,9 @@ CREATE (Keanu)-[:ACTED_IN {roles:['Kevin Lomax']}]->(TheDevilsAdvocate)
 CREATE (TomH)-[:ACTED_IN {roles:['Joe Fox']}]->(YouveGotMail)
 CREATE (TomH)-[:ACTED_IN {roles:['Sam Baldwin']}]->(SleeplessInSeattle)
 CREATE (TomH)-[:ACTED_IN {roles:['Mr. White']}]->(ThatThingYouDo)
-CREATE (TomH)-[:ACTED_IN {roles:['Zachry', 'Dr. Henry Goose', 'Isaac Sachs', 'Dermot Hoggins']}]->(CloudAtlas);
+CREATE (TomH)-[:ACTED_IN {roles:['Zachry', 'Dr. Henry Goose', 'Isaac Sachs', 'Dermot Hoggins']}]->(CloudAtlas)
+
+CREATE (s0:sameName{id:1}) -[r0:sameName {alfa: 'beta'}] -> (t0:sameName{id:2});
 ----
 
 [source,cypher]
@@ -36,12 +38,17 @@ UNWIND keys(value) AS key
 RETURN key, value[key] AS value;
 ----
 
+Note that, in case of relationship type and node label with the same name, 
+they will be distinguished by the suffix " (node)" and " (relationships)".
+
 .Results
 [opts="header"]
 |===
-| key        | value
-| "Movie"    | {count: 9, relationships: {ACTED_IN: {count: 41, properties: {roles: {existence: FALSE, type: "LIST", array: TRUE}}, direction: "in", labels: ["Person"]}}, type: "node", properties: {tagline: {existence: FALSE, type: "STRING", indexed: FALSE, unique: FALSE}, title: {existence: FALSE, type: "STRING", indexed: FALSE, unique: FALSE}, released: {existence: FALSE, type: "INTEGER", indexed: FALSE, unique: FALSE}}, labels: []}
-| "ACTED_IN" | {count: 9, type: "relationship", properties: {roles: {existence: FALSE, type: "LIST", array: TRUE}}}
-| "Person"   | {count: 2, relationships: {ACTED_IN: {count: 9, properties: {roles: {existence: FALSE, type: "LIST", array: TRUE}}, direction: "out", labels: ["Movie"]}}, type: "node", properties: {name: {existence: FALSE, type: "STRING", indexed: FALSE, unique: FALSE}, born: {existence: FALSE, type: "INTEGER", indexed: FALSE, unique: FALSE}}, labels: []}
+| key                       | value
+| "Movie"                   | {count: 9, relationships: {ACTED_IN: {count: 41, properties: {roles: {existence: FALSE, type: "LIST", array: TRUE}}, direction: "in", labels: ["Person"]}}, type: "node", properties: {tagline: {existence: FALSE, type: "STRING", indexed: FALSE, unique: FALSE}, title: {existence: FALSE, type: "STRING", indexed: FALSE, unique: FALSE}, released: {existence: FALSE, type: "INTEGER", indexed: FALSE, unique: FALSE}}, labels: []}
+| "ACTED_IN"                | {count: 9, type: "relationship", properties: {roles: {existence: FALSE, type: "LIST", array: TRUE}}}
+| "Person"                  | {count: 2, relationships: {ACTED_IN: {count: 9, properties: {roles: {existence: FALSE, type: "LIST", array: TRUE}}, direction: "out", labels: ["Movie"]}}, type: "node", properties: {name: {existence: FALSE, type: "STRING", indexed: FALSE, unique: FALSE}, born: {existence: FALSE, type: "INTEGER", indexed: FALSE, unique: FALSE}}, labels: []}
+| "sameName (relationship)" | {count: 1, type: "relationship", properties: {alfa: {existence: false, type: "STRING", array: false}}}
+| "sameName (node)"         | {count: 2, relationships: {"sameName (relationship)": {count: 1, properties: {alfa: {existence: false, type: "STRING", array: false}}, direction: "out", labels: ["sameName"]}}, type:"node", properties: {id: {existence: false,type: "INTEGER", indexed: false,unique: false}},labels: []}
 |===
 


### PR DESCRIPTION
Fixes #1861

Added suffix " (RELATIONSHIP)" only in case of duplicate `labelName/typeRel`