### PR TITLE
Fixes #1149: request apoc.load.json not hard fail if url results in 404

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/import/load-csv.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/load-csv.adoc
@@ -142,7 +142,7 @@ See the following usage-examples for the procedures.
 
 === Error handling
 
-You can use `failOnError` configuration to handle the result in case of incorrect url or json.
+You can use `failOnError` configuration to handle the result in case of incorrect url or csv.
 For example, with the help of the `apoc.when` procedure, you can return `nothingToList` and `nothingToMap` as list and map result, with incorrect url:
 [source,cypher]
 ----

--- a/docs/asciidoc/modules/ROOT/pages/import/load-csv.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/load-csv.adoc
@@ -80,6 +80,7 @@ Besides the file you can pass in a config map:
 | ignore | [] | which columns to ignore
 | nullValues | [] | which values to treat as null, e.g. `['na',false]`
 | mapping | {} | per field mapping, entry key is field name, .e.g `{years:{....}` see below
+| failOnError | boolean | true | fail if error encountered while parsing CSV
 |===
 
 .mapping config for each field in the `mapping` entry
@@ -138,6 +139,20 @@ NOTE: in previous releases we've had `apoc.load.xmlSimple`.
 This is now deprecated and has been superseded by `apoc.load.xml(url, [xPath], [config], true)`.Simple XML Format
 
 See the following usage-examples for the procedures.
+
+=== Error handling
+
+You can use `failOnError` configuration to handle the result in case of incorrect url or json.
+For example, with the help of the `apoc.when` procedure, you can return `nothingToList` and `nothingToMap` as list and map result, with incorrect url:
+[source,cypher]
+----
+CALL apoc.load.csv("MY_CSV_URL", {failOnError:false})
+YIELD list, map
+WITH list, map
+call apoc.do.when(list = [], "return 'nothingToList' as list, 'nothingToMap' as map", "return list, map", {list: list, map: map})
+YIELD value
+RETURN value["list"], value["map"]
+----
 
 
 

--- a/docs/asciidoc/modules/ROOT/pages/import/load-json.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/load-json.adoc
@@ -183,6 +183,21 @@ The Neo4j Browser visualization below shows the imported graph:
 
 image::apoc.load.json.local.file.svg[]
 
+You can use `failOnError` configuration to handle the result in case of incorrect url or json.
+For example, with the help of the `apoc.when` procedure, you can return `nothingToDo` as result with incorrect url:
+
+[source,cypher]
+----
+CALL apoc.load.json("MY_JSON_URL", null, {failOnError:false})
+YIELD value
+WITH collect(value) as values
+call apoc.do.when(values = [], "return 'nothingToDo' as result", "return values as result", {values: values})
+YIELD value
+UNWIND value["result"] as result
+RETURN result
+----
+
+
 [[load-json-examples-stackoverflow]]
 === Import from StackOverflow API
 

--- a/docs/asciidoc/modules/ROOT/pages/import/load-json.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/load-json.adoc
@@ -197,7 +197,6 @@ UNWIND value["result"] as result
 RETURN result
 ----
 
-
 [[load-json-examples-stackoverflow]]
 === Import from StackOverflow API
 

--- a/docs/asciidoc/modules/ROOT/pages/import/xml.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/xml.adoc
@@ -277,6 +277,22 @@ The Neo4j Browser visualization below shows the imported graph:
 
 image::apoc.load.xml.local.books.svg[]
 
+
+You can use `failOnError` configuration to handle the result in case of incorrect url or json.
+For example, with the help of the `apoc.when` procedure, you can return `nothingToDo` as result with incorrect url:
+
+[source,cypher]
+----
+CALL apoc.load.xml("MY_XML_URL", '', {failOnError:false})
+YIELD value
+WITH value as valueXml
+call apoc.do.when(valueXml["_type"] is null, "return 'nothingToDo' as result", "return valueXml as result", {valueXml: valueXml})
+YIELD value
+UNWIND value["result"] as result
+RETURN result
+----
+
+
 [[load-xml-examples-simple-xml-format]]
 === Import from GitHub
 

--- a/docs/asciidoc/modules/ROOT/pages/import/xml.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/xml.adoc
@@ -278,7 +278,7 @@ The Neo4j Browser visualization below shows the imported graph:
 image::apoc.load.xml.local.books.svg[]
 
 
-You can use `failOnError` configuration to handle the result in case of incorrect url or json.
+You can use `failOnError` configuration to handle the result in case of incorrect url or xml.
 For example, with the help of the `apoc.when` procedure, you can return `nothingToDo` as result with incorrect url:
 
 [source,cypher]


### PR DESCRIPTION
Fixes #1149
This feature exists, but poorly documented 

- Added `failOnError` in `apoc.load.csv` doc
- Added examples for `failOnError` procedures to handle with incorrect url / file