### PR TITLE
Fixes #2074: apoc.import.csv failed for NULL values when using INT datatype with error [null] is not a supported property value

### DIFF
--- a/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
+++ b/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
@@ -136,7 +136,7 @@ public class CsvEntityLoader {
                         node.setProperty(field.getName(), idValue);
                         props++;
                     } else {
-                        boolean propertyAdded = CsvPropertyConverter.addPropertyToGraphEntity(node, field, value);
+                        boolean propertyAdded = CsvPropertyConverter.addPropertyToGraphEntity(node, field, value,clc);
                         props += propertyAdded ? 1 : 0;
                     }
                 }
@@ -232,7 +232,7 @@ public class CsvEntityLoader {
                 for (CsvHeaderField field : edgePropertiesFields) {
                     final String name = field.getName();
                     Object value = result.map.get(name);
-                    boolean propertyAdded = CsvPropertyConverter.addPropertyToGraphEntity(rel, field, value);
+                    boolean propertyAdded = CsvPropertyConverter.addPropertyToGraphEntity(rel, field, value, clc);
                     props += propertyAdded ? 1 : 0;
                 }
                 reporter.update(0, 1, props);

--- a/core/src/main/java/apoc/export/csv/CsvLoaderConfig.java
+++ b/core/src/main/java/apoc/export/csv/CsvLoaderConfig.java
@@ -15,6 +15,7 @@ public class CsvLoaderConfig {
     private static final String SKIP_LINES = "skipLines";
     private static final String BATCH_SIZE = "batchSize";
     private static final String IGNORE_DUPLICATE_NODES = "ignoreDuplicateNodes";
+    private static final String IGNORE_EMPTY_STRING = "ignoreEmptyString";
 
     private static char DELIMITER_DEFAULT = ',';
     private static char ARRAY_DELIMITER_DEFAULT = ';';
@@ -23,6 +24,7 @@ public class CsvLoaderConfig {
     private static int SKIP_LINES_DEFAULT = 1;
     private static int BATCH_SIZE_DEFAULT = 2000;
     private static boolean IGNORE_DUPLICATE_NODES_DEFAULT = false;
+    private static boolean IGNORE_EMPTY_STRING_DEFAULT = false;
 
     private final char delimiter;
     private final char arrayDelimiter;
@@ -31,6 +33,7 @@ public class CsvLoaderConfig {
     private final int skipLines;
     private final int batchSize;
     private final boolean ignoreDuplicateNodes;
+    private final boolean ignoreEmptyString;
 
     private CsvLoaderConfig(Builder builder) {
         this.delimiter = builder.delimiter;
@@ -40,6 +43,7 @@ public class CsvLoaderConfig {
         this.skipLines = builder.skipLines;
         this.batchSize = builder.batchSize;
         this.ignoreDuplicateNodes = builder.ignoreDuplicateNodes;
+        this.ignoreEmptyString = builder.ignoreEmptyString;
     }
 
     public char getDelimiter() {
@@ -67,6 +71,10 @@ public class CsvLoaderConfig {
     }
 
     public boolean getIgnoreDuplicateNodes() { return ignoreDuplicateNodes; }
+
+    public boolean isIgnoreEmptyString() {
+        return ignoreEmptyString;
+    }
 
     /**
      * Creates builder to build {@link CsvLoaderConfig}.
@@ -102,7 +110,7 @@ public class CsvLoaderConfig {
         if (config.get(SKIP_LINES) != null) builder.skipLines((int) config.get(SKIP_LINES));
         if (config.get(BATCH_SIZE) != null) builder.batchSize((int) config.get(BATCH_SIZE));
         if (config.get(IGNORE_DUPLICATE_NODES) != null) builder.ignoreDuplicateNodes((boolean) config.get(IGNORE_DUPLICATE_NODES));
-
+        if (config.get(IGNORE_EMPTY_STRING) != null) builder.ignoreEmptyString((boolean) config.get(IGNORE_EMPTY_STRING));
         return builder.build();
     }
 
@@ -117,6 +125,7 @@ public class CsvLoaderConfig {
         private int skipLines = SKIP_LINES_DEFAULT;
         private int batchSize = BATCH_SIZE_DEFAULT;
         private boolean ignoreDuplicateNodes = IGNORE_DUPLICATE_NODES_DEFAULT;
+        private boolean ignoreEmptyString = IGNORE_EMPTY_STRING_DEFAULT;
 
         private Builder() {
         }
@@ -153,6 +162,11 @@ public class CsvLoaderConfig {
 
         public Builder ignoreDuplicateNodes(boolean ignoreDuplicateNodes) {
             this.ignoreDuplicateNodes = ignoreDuplicateNodes;
+            return this;
+        }
+
+        public Builder ignoreEmptyString(boolean ignoreEmptyString) {
+            this.ignoreEmptyString = ignoreEmptyString;
             return this;
         }
 

--- a/core/src/main/java/apoc/export/csv/CsvLoaderConfig.java
+++ b/core/src/main/java/apoc/export/csv/CsvLoaderConfig.java
@@ -15,7 +15,7 @@ public class CsvLoaderConfig {
     private static final String SKIP_LINES = "skipLines";
     private static final String BATCH_SIZE = "batchSize";
     private static final String IGNORE_DUPLICATE_NODES = "ignoreDuplicateNodes";
-    private static final String IGNORE_EMPTY_STRING = "ignoreEmptyString";
+    private static final String IGNORE_BLANK_STRING = "ignoreBlankString";
 
     private static char DELIMITER_DEFAULT = ',';
     private static char ARRAY_DELIMITER_DEFAULT = ';';
@@ -24,7 +24,7 @@ public class CsvLoaderConfig {
     private static int SKIP_LINES_DEFAULT = 1;
     private static int BATCH_SIZE_DEFAULT = 2000;
     private static boolean IGNORE_DUPLICATE_NODES_DEFAULT = false;
-    private static boolean IGNORE_EMPTY_STRING_DEFAULT = false;
+    private static boolean IGNORE_BLANK_STRING_DEFAULT = false;
 
     private final char delimiter;
     private final char arrayDelimiter;
@@ -33,7 +33,7 @@ public class CsvLoaderConfig {
     private final int skipLines;
     private final int batchSize;
     private final boolean ignoreDuplicateNodes;
-    private final boolean ignoreEmptyString;
+    private final boolean ignoreBlankString;
 
     private CsvLoaderConfig(Builder builder) {
         this.delimiter = builder.delimiter;
@@ -43,7 +43,7 @@ public class CsvLoaderConfig {
         this.skipLines = builder.skipLines;
         this.batchSize = builder.batchSize;
         this.ignoreDuplicateNodes = builder.ignoreDuplicateNodes;
-        this.ignoreEmptyString = builder.ignoreEmptyString;
+        this.ignoreBlankString = builder.ignoreBlankString;
     }
 
     public char getDelimiter() {
@@ -72,8 +72,8 @@ public class CsvLoaderConfig {
 
     public boolean getIgnoreDuplicateNodes() { return ignoreDuplicateNodes; }
 
-    public boolean isIgnoreEmptyString() {
-        return ignoreEmptyString;
+    public boolean isIgnoreBlankString() {
+        return ignoreBlankString;
     }
 
     /**
@@ -110,7 +110,7 @@ public class CsvLoaderConfig {
         if (config.get(SKIP_LINES) != null) builder.skipLines((int) config.get(SKIP_LINES));
         if (config.get(BATCH_SIZE) != null) builder.batchSize((int) config.get(BATCH_SIZE));
         if (config.get(IGNORE_DUPLICATE_NODES) != null) builder.ignoreDuplicateNodes((boolean) config.get(IGNORE_DUPLICATE_NODES));
-        if (config.get(IGNORE_EMPTY_STRING) != null) builder.ignoreEmptyString((boolean) config.get(IGNORE_EMPTY_STRING));
+        if (config.get(IGNORE_BLANK_STRING) != null) builder.ignoreBlankString((boolean) config.get(IGNORE_BLANK_STRING));
         return builder.build();
     }
 
@@ -125,7 +125,7 @@ public class CsvLoaderConfig {
         private int skipLines = SKIP_LINES_DEFAULT;
         private int batchSize = BATCH_SIZE_DEFAULT;
         private boolean ignoreDuplicateNodes = IGNORE_DUPLICATE_NODES_DEFAULT;
-        private boolean ignoreEmptyString = IGNORE_EMPTY_STRING_DEFAULT;
+        private boolean ignoreBlankString = IGNORE_BLANK_STRING_DEFAULT;
 
         private Builder() {
         }
@@ -165,8 +165,8 @@ public class CsvLoaderConfig {
             return this;
         }
 
-        public Builder ignoreEmptyString(boolean ignoreEmptyString) {
-            this.ignoreEmptyString = ignoreEmptyString;
+        public Builder ignoreBlankString(boolean ignoreBlankString) {
+            this.ignoreBlankString = ignoreBlankString;
             return this;
         }
 

--- a/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
+++ b/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
@@ -22,7 +22,7 @@ public class CsvPropertyConverter {
             final Object[] array = list.toArray(prototype);
             entity.setProperty(field.getName(), array);
         } else {
-            if (config.isIgnoreEmptyString() && value instanceof String && StringUtils.isBlank((String) value)) {
+            if (config.isIgnoreBlankString() && value instanceof String && StringUtils.isBlank((String) value)) {
                 return false;
             }
             entity.setProperty(field.getName(), value);

--- a/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
+++ b/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
@@ -7,7 +7,7 @@ import java.util.List;
 public class CsvPropertyConverter {
 
     public static boolean addPropertyToGraphEntity(Entity entity, CsvHeaderField field, Object value) {
-        if (field.isIgnore()) {
+        if (field.isIgnore() || value == null) {
             return false;
         }
         if (field.isArray()) {

--- a/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
+++ b/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
@@ -3,6 +3,7 @@ package apoc.export.csv;
 import org.neo4j.graphdb.Entity;
 
 import java.util.List;
+import java.util.Objects;
 
 public class CsvPropertyConverter {
 
@@ -11,8 +12,13 @@ public class CsvPropertyConverter {
             return false;
         }
         if (field.isArray()) {
+            final List list = (List) value;
+            final boolean listContainingNull = list.stream().anyMatch(Objects::isNull);
+            if (listContainingNull) {
+                return false;
+            }
             final Object[] prototype = getPrototypeFor(field.getType());
-            final Object[] array = ((List<Object>) value).toArray(prototype);
+            final Object[] array = list.toArray(prototype);
             entity.setProperty(field.getName(), array);
         } else {
             entity.setProperty(field.getName(), value);
@@ -22,9 +28,9 @@ public class CsvPropertyConverter {
 
     static Object[] getPrototypeFor(String type) {
         switch (type) {
-            case "INT":     return new Integer  [] {};
+            case "INT":
             case "LONG":    return new Long     [] {};
-            case "FLOAT":   return new Float    [] {};
+            case "FLOAT":
             case "DOUBLE":  return new Double   [] {};
             case "BOOLEAN": return new Boolean  [] {};
             case "BYTE":    return new Byte     [] {};

--- a/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
+++ b/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
@@ -1,5 +1,6 @@
 package apoc.export.csv;
 
+import org.apache.commons.lang.StringUtils;
 import org.neo4j.graphdb.Entity;
 
 import java.util.List;
@@ -7,7 +8,7 @@ import java.util.Objects;
 
 public class CsvPropertyConverter {
 
-    public static boolean addPropertyToGraphEntity(Entity entity, CsvHeaderField field, Object value) {
+    public static boolean addPropertyToGraphEntity(Entity entity, CsvHeaderField field, Object value, CsvLoaderConfig config) {
         if (field.isIgnore() || value == null) {
             return false;
         }
@@ -21,6 +22,9 @@ public class CsvPropertyConverter {
             final Object[] array = list.toArray(prototype);
             entity.setProperty(field.getName(), array);
         } else {
+            if (config.isIgnoreEmptyString() && value instanceof String && StringUtils.isBlank((String) value)) {
+                return false;
+            }
             entity.setProperty(field.getName(), value);
         }
         return true;

--- a/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
+++ b/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
@@ -1,6 +1,6 @@
 package apoc.export.csv;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.Entity;
 
 import java.util.List;

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -297,15 +297,11 @@ public class ImportCsvTest {
     
     @Test
     public void testEmptyInteger() {
-        TestUtil.testCall(db,
-                "CALL apoc.import.csv([{fileName: 'file:/emptyInteger.csv', labels: ['entity']}], [], {})",
-                r -> assertEquals(3L, r.get("nodes"))
-        );
+        TestUtil.testCall(db, "CALL apoc.import.csv([{fileName: 'file:/emptyInteger.csv', labels: ['entity']}], [], {})",
+                r -> assertEquals(3L, r.get("nodes")));
 
-        TestUtil.testResult(db, "MATCH (n:Thing) RETURN n.int_attribute as int ORDER BY n.int_attribute", r -> {
-            final List<Object> anInt = Iterators.asList(r.columnAs("int"));
-            assertEquals(Arrays.asList(1L, 2L, null), anInt);
-        });
+        TestUtil.testResult(db, "MATCH (n:Thing) RETURN n.int_attribute as int ORDER BY n.int_attribute", 
+                r -> assertEquals(Arrays.asList(1L, 2L, null), Iterators.asList(r.columnAs("int"))));
     }
 
     @Test

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -304,8 +304,7 @@ public class ImportCsvTest {
         TestUtil.testCall(db, "CALL apoc.import.csv([{fileName: 'file:/emptyInteger.csv', labels: ['entity']}], [], {ignoreEmptyString: true})",
                 r -> assertEquals(3L, r.get("nodes")));
 
-        TestUtil.testResult(db, "MATCH (node:Thing) RETURN node ORDER BY node.int_attribute",
-                r -> {
+        TestUtil.testResult(db, "MATCH (node:Thing) RETURN node ORDER BY node.int_attribute", r -> {
                     final Node firstNode = (Node) r.next().get("node");
                     final Map<String, Object> firstProps = firstNode.getAllProperties();
                     assertEquals(1L, firstProps.get("int_attribute"));

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -301,7 +301,7 @@ public class ImportCsvTest {
     
     @Test
     public void testEmptyInteger() {
-        TestUtil.testCall(db, "CALL apoc.import.csv([{fileName: 'file:/emptyInteger.csv', labels: ['entity']}], [], {ignoreEmptyString: true})",
+        TestUtil.testCall(db, "CALL apoc.import.csv([{fileName: 'file:/emptyInteger.csv', labels: ['entity']}], [], {ignoreBlankString: true})",
                 r -> assertEquals(3L, r.get("nodes")));
 
         TestUtil.testResult(db, "MATCH (node:Thing) RETURN node ORDER BY node.int_attribute", r -> {

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.csv.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.csv.adoc
@@ -10,5 +10,5 @@ The procedure support the following config parameters:
 | quotationCharacter | String | " | quotation character   | `--quote='"'`
 | stringIds | Boolean | true | treat ids as strings  | `--id-type=STRING`
 | skipLines | Integer | 1 | lines to skip (incl. header)  | N/A
-| ignoreEmptyString | Boolean | false | if true ignore properties with an empty string | N/A
+| ignoreBlankString | Boolean | false | if true ignore properties with a blank string | N/A
 |===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.csv.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.csv.adoc
@@ -10,4 +10,5 @@ The procedure support the following config parameters:
 | quotationCharacter | String | " | quotation character   | `--quote='"'`
 | stringIds | Boolean | true | treat ids as strings  | `--id-type=STRING`
 | skipLines | Integer | 1 | lines to skip (incl. header)  | N/A
+| ignoreEmptyString | Boolean | false | If true ignore properties with empty string | N/A
 |===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.csv.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.csv.adoc
@@ -10,5 +10,5 @@ The procedure support the following config parameters:
 | quotationCharacter | String | " | quotation character   | `--quote='"'`
 | stringIds | Boolean | true | treat ids as strings  | `--id-type=STRING`
 | skipLines | Integer | 1 | lines to skip (incl. header)  | N/A
-| ignoreEmptyString | Boolean | false | If true ignore properties with empty string | N/A
+| ignoreEmptyString | Boolean | false | if true ignore properties with an empty string | N/A
 |===


### PR DESCRIPTION
Fixes #2074
- Ignore null properties during the import
- Added `ignoreBlankString` config

In addition to the fix, I've added in this pr the handling of `INT[]` and `FLOAT[]` (before they failed due to `Cast Exeption`)