### PR TITLE
fixed guava cve

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -110,8 +110,8 @@ dependencies {
 
     testCompile group: 'org.apache.hive', name: 'hive-jdbc', version: '1.2.2', withoutServers
 
-    compileOnly group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '2.7.5', withoutServers
-    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '2.7.5', withoutServers
+    compileOnly group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.1', withoutServers
+    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.1', withoutServers
 
     compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     // explicit update comomns.io version
@@ -133,8 +133,9 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
 
-    // there is a compatibility problem between the Guava Library used by HDFS, Google Cloud Storage and Reflections; the only version that fits for all is the following
-    compile group: 'com.google.guava', name: 'guava', version: '20.0'
+    compile group: 'com.google.guava', name: 'guava', version: '27.0-jre'
+
+    compile group: 'xerces', name: 'xercesImpl', version: '2.12.1'
 
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'

--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -8,7 +8,6 @@ import apoc.export.util.MetaInformation;
 import apoc.export.util.Reporter;
 import apoc.result.ProgressInfo;
 import com.opencsv.CSVWriter;
-import org.apache.commons.lang.StringUtils;
 import org.neo4j.cypher.export.SubGraph;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.GraphDatabaseService;

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
@@ -3,7 +3,7 @@ package apoc.export.graphml;
 import apoc.export.util.BatchTransaction;
 import apoc.export.util.Reporter;
 import apoc.util.JsonUtil;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.*;
 
 import javax.xml.namespace.QName;

--- a/core/src/main/java/apoc/load/util/LoadJdbcConfig.java
+++ b/core/src/main/java/apoc/load/util/LoadJdbcConfig.java
@@ -1,7 +1,7 @@
 package apoc.load.util;
 
 import apoc.util.Util;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.time.DateTimeException;
 import java.time.ZoneId;

--- a/core/src/main/java/apoc/number/exact/Exact.java
+++ b/core/src/main/java/apoc/number/exact/Exact.java
@@ -1,6 +1,6 @@
 package apoc.number.exact;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.UserFunction;

--- a/core/src/main/java/apoc/util/FileUtils.java
+++ b/core/src/main/java/apoc/util/FileUtils.java
@@ -7,7 +7,7 @@ import apoc.util.hdfs.HDFSUtils;
 import apoc.util.s3.S3URLConnection;
 import apoc.util.s3.S3UploadUtils;
 import org.apache.commons.io.output.WriterOutputStream;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.configuration.GraphDatabaseSettings;
 
 import java.io.*;

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -6,7 +6,7 @@ import apoc.export.util.CountingInputStream;
 import apoc.result.VirtualNode;
 import apoc.result.VirtualRelationship;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.collections.api.iterator.LongIterator;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Entity;

--- a/core/src/main/java/apoc/util/google/cloud/GCStorageURLConnection.java
+++ b/core/src/main/java/apoc/util/google/cloud/GCStorageURLConnection.java
@@ -4,7 +4,7 @@ import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.util.VisibleForTesting;
 
 import java.io.ByteArrayInputStream;

--- a/core/src/test/java/apoc/path/SubgraphTest.java
+++ b/core/src/test/java/apoc/path/SubgraphTest.java
@@ -5,7 +5,7 @@ import apoc.result.NodeResult;
 import apoc.result.RelationshipResult;
 import apoc.util.TestUtil;
 import apoc.util.Util;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.BeforeClass;

--- a/full/src/main/java/apoc/load/LoadDirectory.java
+++ b/full/src/main/java/apoc/load/LoadDirectory.java
@@ -7,7 +7,7 @@ import apoc.util.Util;
 import org.apache.commons.io.filefilter.FileFileFilter;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.logging.Log;

--- a/full/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/full/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -14,20 +14,15 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
-import org.neo4j.graphdb.Result;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.io.File;
 import java.nio.file.Files;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
 
 import static apoc.util.MapUtil.map;
-import static apoc.util.TestUtil.testResult;
 import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author mh
@@ -73,7 +68,7 @@ public class ExportCsvTest {
 
     @Test
     public void testExportAllCsvHDFS() throws Exception {
-        String hdfsUrl = String.format("hdfs://localhost:12345/user/%s/all.csv", System.getProperty("user.name"));
+        String hdfsUrl = String.format("%s/user/%s/all.csv", miniDFSCluster.getURI().toString(), System.getProperty("user.name"));
         TestUtil.testCall(db, "CALL apoc.export.csv.all($file,null)", map("file", hdfsUrl),
                 (r) -> {
                     try {

--- a/full/src/test/java/apoc/load/LoadHdfsTest.java
+++ b/full/src/test/java/apoc/load/LoadHdfsTest.java
@@ -29,7 +29,7 @@ public class LoadHdfsTest {
     public DbmsRule db = new ImpermanentDbmsRule().withSetting(ApocSettings.apoc_import_file_enabled, true);
 
     private MiniDFSCluster miniDFSCluster;
-    
+
     @Before public void setUp() throws Exception {
         TestUtil.registerProcedure(db, LoadCsv.class);
         miniDFSCluster = HdfsTestUtils.getLocalHDFSCluster();
@@ -49,7 +49,8 @@ public class LoadHdfsTest {
     }
 
     @Test public void testLoadCsvFromHDFS() throws Exception {
-        testResult(db, "CALL apoc.load.csv($url,{results:['map','list','stringMap','strings']})", map("url", String.format("hdfs://localhost:12345/user/%s/%s",
+        testResult(db, "CALL apoc.load.csv($url,{results:['map','list','stringMap','strings']})", map("url", String.format("%s/user/%s/%s",
+        		miniDFSCluster.getURI().toString(),
         		System.getProperty("user.name"), "test.csv")), // 'hdfs://localhost:12345/user/<sys_user_name>/test.csv'
                 (r) -> {
                     assertRow(r,0L,"name","Selma","age","8");

--- a/full/src/test/java/apoc/load/relative/LoadRelativePathTest.java
+++ b/full/src/test/java/apoc/load/relative/LoadRelativePathTest.java
@@ -7,7 +7,6 @@ import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mortbay.util.StringMap;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.Result;
 import org.neo4j.test.rule.DbmsRule;
@@ -17,6 +16,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -58,7 +58,7 @@ public class LoadRelativePathTest {
         Map<String, Object> row = r.next();
         Map<String, Object> map = map(data);
         List<Object> values = new ArrayList<>(map.values());
-        StringMap stringMap = new StringMap();
+        Map<String, Object> stringMap = new HashMap<>();
         stringMap.putAll(map);
         assertEquals(map, row.get("map"));
         assertEquals(values, row.get("list"));

--- a/full/src/test/java/apoc/util/HdfsTestUtils.java
+++ b/full/src/test/java/apoc/util/HdfsTestUtils.java
@@ -5,6 +5,8 @@ import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
 
 public class HdfsTestUtils {
 
@@ -31,16 +33,23 @@ public class HdfsTestUtils {
             return windowsLibDir.getAbsolutePath();
         }
     }
+
+    private static int getFreePort() throws IOException {
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            return serverSocket.getLocalPort();
+        }
+    }
     
     public static MiniDFSCluster getLocalHDFSCluster() throws Exception {
     	setHadoopHomeWindows();
     	Configuration conf = new HdfsConfiguration();
     	conf.set("fs.defaultFS", "hdfs://localhost");
 		File hdfsPath = new File(System.getProperty("user.dir") + File.separator + "hadoop" + File.separator + "hdfs");
-		conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, hdfsPath.getAbsolutePath());
+        hdfsPath.setWritable(true);
+        conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, hdfsPath.getAbsolutePath());
 		MiniDFSCluster miniDFSCluster = new MiniDFSCluster.Builder(conf)
-                .nameNodePort(12345)
-                .nameNodeHttpPort(12341)
+                .nameNodePort(getFreePort())
+//                .nameNodeHttpPort(12341)
                 .numDataNodes(1)
                 .storagesPerDatanode(2)
                 .format(true)

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -10,8 +10,7 @@ dependencies {
     compile group: 'org.neo4j', name: 'neo4j-kernel', version: neo4jVersionEffective, classifier: "tests"
     compile group: 'org.neo4j', name: 'neo4j-io', version: neo4jVersionEffective, classifier: "tests"
 
-    // there is a compatibility problem between the Guava Library used by HDFS, Google Cloud Storage and Reflections; the only version that fits for all is the following
-    compile group: 'com.google.guava', name: 'guava', version: '20.0'
+    compile group: 'com.google.guava', name: 'guava', version: '27.0-jre'
 
     compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.2.0'
 
@@ -23,9 +22,9 @@ dependencies {
         exclude group: 'org.apache.hive', module: 'hive-service'
     }
 
-    compile group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '2.7.5', withoutServers
-    compile group: 'org.apache.hadoop', name: 'hadoop-common', version: '2.7.5', withoutServers
-    compile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '2.7.5', withoutServers
+    compile group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.1', withoutServers
+    compile group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.1', withoutServers
+    compile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.3.1', withoutServers
 
     compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.2.0'
     compile group: 'org.jetbrains', name: 'annotations', version: "17.0.0"


### PR DESCRIPTION
Fixes `Security vulnerability with Neo4j enterprise 4.2.7` trello card

https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=CVE-2018-10237

`Unbounded memory allocation in Google Guava 11.0 through 24.x before 24.1.1`