### PR TITLE
Fixes #1910: apoc.meta.stats return false relationship count when having multi-labeled nodes

### DIFF
--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -383,11 +383,11 @@ public class    Meta {
         TokenRead tokenRead = kernelTx.tokenRead();
         Read read = kernelTx.dataRead();
 
-        int labelCount = tokenRead.labelCount();
-        int relTypeCount = tokenRead.relationshipTypeCount();
+        long relTypeCount = Iterables.count(tx.getAllRelationshipTypesInUse());
+        long labelCount = Iterables.count(tx.getAllLabelsInUse());
 
-        Map<String, Long> labelStats = new LinkedHashMap<>(labelCount);
-        Map<String, Long> relStats = new LinkedHashMap<>(2 * relTypeCount);
+        Map<String, Long> labelStats = new LinkedHashMap<>((int) labelCount);
+        Map<String, Long> relStats = new LinkedHashMap<>(2 * (int) relTypeCount);
 
         collectStats(new DatabaseSubGraph(transaction), null, null, new StatsCallback() {
             public void label(int labelId, String labelName, long count) {

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -1092,22 +1092,41 @@ public class MetaTest {
 
     @Test
     public void testMetaStatsWithLabelAndRelTypeCountInUse() {
-        db.executeTransactionally("CREATE (:Node:Test)-[:REL {a:'b'}]->(:Node {c: 'd'})<-[:REL]-(:Node:Test)");
+        db.executeTransactionally("CREATE (:Node:Test)-[:REL {a: 'b'}]->(:Node {c: 'd'})<-[:REL]-(:Node:Test)");
         db.executeTransactionally("CREATE (:A {e: 'f'})-[:ANOTHER {g: 'h'}]->(:C)");
         
         TestUtil.testCall(db, "CALL apoc.meta.stats()", row -> {
-            assertEquals(4L, row.get("labelCount"));
-            assertEquals(2L, row.get("relTypeCount"));
+            assertEquals(map("A", 1L, "C", 1L, "Test", 2L, "Node", 3L), row.get("labels"));
             assertEquals(5L, row.get("nodeCount"));
+            assertEquals(4L, row.get("labelCount"));
+            
+            assertEquals(map("REL", 4L, "ANOTHER", 1L), row.get("relTypesCount"));
+            assertEquals(2L, row.get("relTypeCount"));
             assertEquals(3L, row.get("relCount"));
+            Map<String, Object> expectedRelTypes = map("(:A)-[:ANOTHER]->()", 1L,
+                    "()-[:REL]->(:Node)", 2L, 
+                    "(:Test)-[:REL]->()", 2L,
+                    "(:Node)-[:REL]->()", 2L, 
+                    "()-[:ANOTHER]->(:C)", 1L,
+                    "()-[:ANOTHER]->()", 1L, 
+                    "()-[:REL]->()", 2L);
+            assertEquals(expectedRelTypes, row.get("relTypes"));
         });
         
         db.executeTransactionally("match p=(:A)-[:ANOTHER]->(:C) delete p");
         TestUtil.testCall(db, "CALL apoc.meta.stats()", row -> {
-            assertEquals(2L, row.get("labelCount"));
-            assertEquals(1L, row.get("relTypeCount"));
+            assertEquals(map("Test", 2L, "Node", 3L), row.get("labels"));
             assertEquals(3L, row.get("nodeCount"));
+            assertEquals(2L, row.get("labelCount"));
+            
+            assertEquals(map("REL", 4L), row.get("relTypesCount"));
+            assertEquals(1L, row.get("relTypeCount"));
             assertEquals(2L, row.get("relCount"));
+            Map<String, Object> expectedRelTypes = map("()-[:REL]->(:Node)", 2L,
+                    "(:Test)-[:REL]->()", 2L,
+                    "(:Node)-[:REL]->()", 2L,
+                    "()-[:REL]->()", 2L);
+            assertEquals(expectedRelTypes, row.get("relTypes"));
         });
     }
 }

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -1089,4 +1089,25 @@ public class MetaTest {
         });
 
     }
+
+    @Test
+    public void testMetaStatsWithLabelAndRelTypeCountInUse() {
+        db.executeTransactionally("CREATE (:Node:Test)-[:REL {a:'b'}]->(:Node {c: 'd'})<-[:REL]-(:Node:Test)");
+        db.executeTransactionally("CREATE (:A {e: 'f'})-[:ANOTHER {g: 'h'}]->(:C)");
+        
+        TestUtil.testCall(db, "CALL apoc.meta.stats()", row -> {
+            assertEquals(4L, row.get("labelCount"));
+            assertEquals(2L, row.get("relTypeCount"));
+            assertEquals(5L, row.get("nodeCount"));
+            assertEquals(3L, row.get("relCount"));
+        });
+        
+        db.executeTransactionally("match p=(:A)-[:ANOTHER]->(:C) delete p");
+        TestUtil.testCall(db, "CALL apoc.meta.stats()", row -> {
+            assertEquals(2L, row.get("labelCount"));
+            assertEquals(1L, row.get("relTypeCount"));
+            assertEquals(3L, row.get("nodeCount"));
+            assertEquals(2L, row.get("relCount"));
+        });
+    }
 }

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -1129,4 +1129,5 @@ public class MetaTest {
             assertEquals(expectedRelTypes, row.get("relTypes"));
         });
     }
+    
 }

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.stats.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.stats.adoc
@@ -1,4 +1,4 @@
-The examples in this section are based on the following sample graph:
+The example below is based on the following sample graph:
 
 [source,cypher]
 ----
@@ -39,3 +39,15 @@ CALL apoc.meta.stats();
 | labelCount | relTypeCount | propertyKeyCount | nodeCount | relCount | labels                | relTypes                                                                                 | relTypesCount | stats
 | 9          | 5            | 17               | 11        | 9        | {Movie: 9, Person: 2} | {`(:Person)-[:ACTED_IN]->()`: 9, `()-[:ACTED_IN]->(:Movie)`: 9, `()-[:ACTED_IN]->()`: 9} | {ACTED_IN: 9} | {relTypeCount: 5, propertyKeyCount: 17, labelCount: 9, nodeCount: 11, relCount: 9, labels: {Movie: 9, Person: 2}, relTypes: {`(:Person)-[:ACTED_IN]->()`: 9, `()-[:ACTED_IN]->(:Movie)`: 9, `()-[:ACTED_IN]->()`: 9}}
 |===
+
+
+Note that the `relTypesCount` field counts unique patterns (from single label to single label)
+so multi-label nodes will be counted as separate paths.
+For example, with the following dataset with multiple labels `Node` and `Test`:
+
+[source,cypher]
+----
+CREATE (:Node:Test)-[:REL {a: 'b'}]->(:Node {c: 'd'})<-[:REL]-(:Node:Test)
+----
+
+`relTypesCount` will be `{REL: 4}`, otherwise, without label `Test`, it would be `{REL: 2}`.


### PR DESCRIPTION
Fixes #1910

The problem is that `TokenRead.labelCount()` and `TokenRead.relationshipTypeCount()` returns all labels/relTypes (even those deleted).
For consistency with the other results, we should return only labels/relTypes in use.