### PR TITLE
Fixes #1691: Document (and list) which APOC procs start their own transaction

### DIFF
--- a/docs/asciidoc/modules/ROOT/nav.adoc
+++ b/docs/asciidoc/modules/ROOT/nav.adoc
@@ -148,3 +148,5 @@ include::partial$generated-documentation/nav.adoc[]
 * xref:algorithms/index.adoc[]
     ** xref::algorithms/path-finding-procedures.adoc[]
     ** xref::algorithms/similarity.adoc[]
+
+* xref::transaction/index.adoc[]

--- a/docs/asciidoc/modules/ROOT/pages/transaction/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/transaction/index.adoc
@@ -1,0 +1,34 @@
+[[transaction]]
+= List of procedures with its own transaction
+:description: This chapter describes a list of procedures with its own transaction in the APOC library.
+
+The list of procedures that start their own transaction:
+
+* apoc.trigger.add
+* apoc.trigger.remove
+* apoc.trigger.removeAll
+* apoc.trigger.pause
+* apoc.trigger.resume
+* apoc.uuid.install
+* apoc.uuid.remove
+* apoc.uuid.removeAll
+* apoc.load.csv
+* apoc.import.graphml
+* apoc.export.csv.*
+* apoc.export.json.*
+* apoc.export.graphml.*
+* apoc.export.cypher.*
+* apoc.schema.properties.distinctCount
+* apoc.stats.degrees
+* apoc.bolt.load
+* apoc.cypher.runMany
+* apoc.cypher.runSchemaFiles
+* apoc.cypher.runFiles
+* apoc.refactor.categorize
+* apoc.nodes.group
+* apoc.nodes.delete
+* apoc.periodic.iterate
+* apoc.periodic.rock_n_roll_while
+* apoc.periodic.rock_n_roll
+* apoc.cypher.runTimeboxed
+* apoc.cypher.runTimeboxed

--- a/docs/asciidoc/modules/ROOT/pages/transaction/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/transaction/index.adoc
@@ -4,31 +4,32 @@
 
 The list of procedures that start their own transaction:
 
+* apoc.bolt.load
+* apoc.cypher.runFiles
+* apoc.cypher.runMany
+* apoc.cypher.runSchemaFiles
+* apoc.cypher.runTimeboxed
+* apoc.export.csv.*
+* apoc.export.cypher.** 
+* apoc.export.graphml* .*
+* apoc.export.json.*
+* apoc.import.graphml
+* apoc.load.csv
+* apoc.nodes.delete
+* apoc.nodes.group
+* apoc.periodic.iterate
+* apoc.periodic.rock_n_roll
+* apoc.periodic.rock_n_roll_while
+* apoc.refactor.categorize
+* apoc.schema.properties.distinctCount
+* apoc.stats.degrees
 * apoc.trigger.add
+* apoc.trigger.pause
 * apoc.trigger.remove
 * apoc.trigger.removeAll
-* apoc.trigger.pause
 * apoc.trigger.resume
 * apoc.uuid.install
 * apoc.uuid.remove
 * apoc.uuid.removeAll
-* apoc.load.csv
-* apoc.import.graphml
-* apoc.export.csv.*
-* apoc.export.json.*
-* apoc.export.graphml.*
-* apoc.export.cypher.*
-* apoc.schema.properties.distinctCount
-* apoc.stats.degrees
-* apoc.bolt.load
-* apoc.cypher.runMany
-* apoc.cypher.runSchemaFiles
-* apoc.cypher.runFiles
-* apoc.refactor.categorize
-* apoc.nodes.group
-* apoc.nodes.delete
-* apoc.periodic.iterate
-* apoc.periodic.rock_n_roll_while
-* apoc.periodic.rock_n_roll
-* apoc.cypher.runTimeboxed
-* apoc.cypher.runTimeboxed
+
+

--- a/docs/asciidoc/modules/ROOT/pages/transaction/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/transaction/index.adoc
@@ -1,6 +1,6 @@
 [[transaction]]
 = List of procedures with its own transaction
-:description: This chapter describes a list of procedures with its own transaction in the APOC library.
+:description: This chapter describes the list of procedures that start their own transaction in the APOC library.
 
 The list of procedures that start their own transaction:
 


### PR DESCRIPTION
Fixes #1691

To extract these, 
I found the classes that call `Transaction.java` class through a `beginTx()`
and from these I obtained the procedures / functions from which they were used.