### PR TITLE
Fixes #1238: Update Apoc Periodic to allow for Cypher Planner Switch

### DIFF
--- a/core/src/main/java/apoc/periodic/Periodic.java
+++ b/core/src/main/java/apoc/periodic/Periodic.java
@@ -30,7 +30,7 @@ import static apoc.util.Util.merge;
 
 public class Periodic {
     
-    enum Planner { NONE, COST, IDP, DP }
+    enum Planner {DEFAULT, COST, IDP, DP }
 
     public static final Pattern PLANNER_PATTERN = Pattern.compile("\\bplanner\\s*=\\s*[^\\s]*", Pattern.CASE_INSENSITIVE);
     public static final Pattern RUNTIME_PATTERN = Pattern.compile("\\bruntime\\s*=", Pattern.CASE_INSENSITIVE);
@@ -263,7 +263,7 @@ public class Periodic {
 
         try (Result result = tx.execute(slottedRuntime(cypherIterate),params)) {
             Pair<String,Boolean> prepared = PeriodicUtils.prepareInnerStatement(cypherAction, batchMode, result.columns(), "_batch");
-            String innerStatement = applyPlanner(prepared.first(), Planner.valueOf((String) config.getOrDefault("planner", Planner.NONE.name())));
+            String innerStatement = applyPlanner(prepared.first(), Planner.valueOf((String) config.getOrDefault("planner", Planner.DEFAULT.name())));
             boolean iterateList = prepared.other();
             log.info("starting batching from `%s` operation using iteration `%s` in separate thread", cypherIterate,cypherAction);
             return PeriodicUtils.iterateAndExecuteBatchedInSeparateThread(
@@ -287,7 +287,7 @@ public class Periodic {
     }
 
     public static String applyPlanner(String query, Planner planner) {
-        if(planner.equals(Planner.NONE)) {
+        if(planner.equals(Planner.DEFAULT)) {
             return query;
         }
         Matcher matcher = PLANNER_PATTERN.matcher(query);

--- a/core/src/main/java/apoc/periodic/Periodic.java
+++ b/core/src/main/java/apoc/periodic/Periodic.java
@@ -29,10 +29,13 @@ import java.util.stream.Stream;
 import static apoc.util.Util.merge;
 
 public class Periodic {
+    
+    enum Planner { NONE, COST, IDP, DP }
 
+    public static final Pattern PLANNER_PATTERN = Pattern.compile("\\bplanner\\s*=\\s*[^\\s]*", Pattern.CASE_INSENSITIVE);
     public static final Pattern RUNTIME_PATTERN = Pattern.compile("\\bruntime\\s*=", Pattern.CASE_INSENSITIVE);
-    public static final Pattern CYPHER_PREFIX_PATTERN = Pattern.compile("\\bcypher\\b", Pattern.CASE_INSENSITIVE);
-    public static final String CYPHER_RUNTIME_SLOTTED = "cypher runtime=slotted ";
+    public static final Pattern CYPHER_PREFIX_PATTERN = Pattern.compile("^\\s*\\bcypher\\b", Pattern.CASE_INSENSITIVE);
+    public static final String CYPHER_RUNTIME_SLOTTED = " runtime=slotted ";
     final static Pattern LIMIT_PATTERN = Pattern.compile("\\slimit\\s", Pattern.CASE_INSENSITIVE);
 
     @Context public GraphDatabaseService db;
@@ -260,7 +263,7 @@ public class Periodic {
 
         try (Result result = tx.execute(slottedRuntime(cypherIterate),params)) {
             Pair<String,Boolean> prepared = PeriodicUtils.prepareInnerStatement(cypherAction, batchMode, result.columns(), "_batch");
-            String innerStatement = prepared.first();
+            String innerStatement = applyPlanner(prepared.first(), Planner.valueOf((String) config.getOrDefault("planner", Planner.NONE.name())));
             boolean iterateList = prepared.other();
             log.info("starting batching from `%s` operation using iteration `%s` in separate thread", cypherIterate,cypherAction);
             return PeriodicUtils.iterateAndExecuteBatchedInSeparateThread(
@@ -279,10 +282,29 @@ public class Periodic {
         if (RUNTIME_PATTERN.matcher(cypherIterate).find()) {
             return cypherIterate;
         }
-        Matcher matcher = CYPHER_PREFIX_PATTERN.matcher(cypherIterate.substring(0, Math.min(15,cypherIterate.length())));
-        return matcher.find() ? CYPHER_PREFIX_PATTERN.matcher(cypherIterate).replaceFirst(CYPHER_RUNTIME_SLOTTED) : CYPHER_RUNTIME_SLOTTED + cypherIterate;
+        
+        return prependQueryOption(cypherIterate, CYPHER_RUNTIME_SLOTTED);
     }
 
+    public static String applyPlanner(String query, Planner planner) {
+        if(planner.equals(Planner.NONE)) {
+            return query;
+        }
+        Matcher matcher = PLANNER_PATTERN.matcher(query);
+        String cypherPlanner = String.format(" planner=%s ", planner.name().toLowerCase());
+        if (matcher.find()) {
+            return matcher.replaceFirst(cypherPlanner);
+        }
+        return prependQueryOption(query, cypherPlanner);
+    }
+
+    private static String prependQueryOption(String query, String cypherOption) {
+        String cypherPrefix = "cypher";
+        String completePrefix = cypherPrefix + cypherOption;
+        return CYPHER_PREFIX_PATTERN.matcher(query).find()
+                ? query.replaceFirst("(?i)" + cypherPrefix, completePrefix)
+                : completePrefix + query;
+    }
 
 
     static abstract class ExecuteBatch implements Function<Transaction, Long> {

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import static apoc.periodic.Periodic.applyPlanner;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
 import static apoc.util.Util.map;
@@ -101,11 +102,31 @@ public class PeriodicTest {
     }
 
     @Test
+    public void testApplyPlanner() {
+        assertEquals("RETURN 1", applyPlanner("RETURN 1", Periodic.Planner.NONE));
+        assertEquals("cypher planner=cost MATCH (n:cypher) RETURN n", 
+                applyPlanner("MATCH (n:cypher) RETURN n", Periodic.Planner.COST));
+        assertEquals("cypher planner=idp MATCH (n:cypher) RETURN n", 
+                applyPlanner("MATCH (n:cypher) RETURN n", Periodic.Planner.IDP));
+        assertEquals("cypher planner=dp  runtime=compiled MATCH (n) RETURN n", 
+                applyPlanner("cypher runtime=compiled MATCH (n) RETURN n", Periodic.Planner.DP));
+        assertEquals("cypher planner=dp  3.1 MATCH (n) RETURN n", 
+                applyPlanner("cypher 3.1 MATCH (n) RETURN n", Periodic.Planner.DP));
+        assertEquals("cypher planner=idp  expressionEngine=compiled MATCH (n) RETURN n", 
+                applyPlanner("cypher expressionEngine=compiled MATCH (n) RETURN n", Periodic.Planner.IDP));
+        assertEquals("cypher expressionEngine=compiled  planner=cost  MATCH (n) RETURN n",
+                applyPlanner("cypher expressionEngine=compiled planner=idp MATCH (n) RETURN n", Periodic.Planner.COST));
+        assertEquals("cypher  planner=cost  MATCH (n) RETURN n",
+                applyPlanner("cypher planner=cost MATCH (n) RETURN n", Periodic.Planner.COST));
+    }
+
+    @Test
     public void testSlottedRuntime() throws Exception {
+        assertEquals("cypher runtime=slotted MATCH (n:cypher) RETURN n", Periodic.slottedRuntime("MATCH (n:cypher) RETURN n"));
         assertTrue(Periodic.slottedRuntime("MATCH (n) RETURN n").contains("cypher runtime=slotted "));
-        assertFalse(Periodic.slottedRuntime("cypher runtime=compiled MATCH (n) RETURN n").contains("cypher runtime=slotted "));
+        assertFalse(Periodic.slottedRuntime(" cypher runtime=compiled MATCH (n) RETURN n").contains("cypher runtime=slotted "));
         assertFalse(Periodic.slottedRuntime("cypher runtime=compiled MATCH (n) RETURN n").contains("cypher runtime=slotted cypher"));
-        assertTrue(Periodic.slottedRuntime("cypher 3.1 MATCH (n) RETURN n").contains(" runtime=slotted "));
+        assertTrue(Periodic.slottedRuntime(" cypher 3.1 MATCH (n) RETURN n").contains(" runtime=slotted "));
         assertFalse(Periodic.slottedRuntime("cypher 3.1 MATCH (n) RETURN n").contains(" runtime=slotted cypher "));
         assertTrue(Periodic.slottedRuntime("cypher expressionEngine=compiled MATCH (n) RETURN n").contains(" runtime=slotted "));
         assertFalse(Periodic.slottedRuntime("cypher expressionEngine=compiled MATCH (n) RETURN n").contains(" runtime=slotted cypher"));
@@ -256,6 +277,25 @@ public class PeriodicTest {
                 "MATCH (p:Person) where p.lastname is not null return count(p) as count",
                 row -> assertEquals(100L, row.get("count"))
         );
+    }
+
+    @Test
+    public void testIterateWithQueryPlanner() throws Exception {
+        db.executeTransactionally("UNWIND range(1,100) AS x CREATE (:Person{name:'Person_'+x})");
+
+        String cypherIterate = "match (p:Person) return p";
+        String cypherAction = "SET p.lastname =p.name REMOVE p.name";
+        testResult(db, "CALL apoc.periodic.iterate($cypherIterate, $cypherAction, $config)", 
+                map("cypherIterate", cypherIterate, "cypherAction", cypherAction,
+                        "config", map("batchSize", 10, "planner", "DP")),
+                result -> assertEquals(10L, Iterators.single(result).get("batches")));
+
+        String cypherActionUnwind = "cypher runtime=slotted UNWIND $_batch AS batch WITH batch.p AS p  SET p.lastname =p.name";
+        
+        testResult(db, "CALL apoc.periodic.iterate($cypherIterate, $cypherActionUnwind, $config)",
+                map("cypherIterate", cypherIterate, "cypherActionUnwind", cypherActionUnwind,
+                        "config", map("batchSize", 10, "batchMode", "BATCH_SINGLE", "planner", "DP")),
+                result -> assertEquals(10L, Iterators.single(result).get("batches")));
     }
 
     @Test

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -103,7 +103,7 @@ public class PeriodicTest {
 
     @Test
     public void testApplyPlanner() {
-        assertEquals("RETURN 1", applyPlanner("RETURN 1", Periodic.Planner.NONE));
+        assertEquals("RETURN 1", applyPlanner("RETURN 1", Periodic.Planner.DEFAULT));
         assertEquals("cypher planner=cost MATCH (n:cypher) RETURN n", 
                 applyPlanner("MATCH (n:cypher) RETURN n", Periodic.Planner.COST));
         assertEquals("cypher planner=idp MATCH (n:cypher) RETURN n", 

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.periodic.iterate.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.periodic.iterate.adoc
@@ -22,7 +22,7 @@ The operation query can access the batched values via the `$_batch` parameter.
 | params | Map | {} | externally pass in map of params
 | concurrency | Long | 50 | number of concurrent tasks are generated when using `parallel:true`
 | failedParams | Long |  -1 | if set to a non-negative value, each failed batch up to `failedParams` parameter sets are returned in `yield failedParams`.
-| planner | Enum[NONE, COST, IDP, DP] |  NONE | If not `NONE` prepend to the `statement per item` parameter a `cypher planner=[VALUE_OF_CONFIG]` (or planner=[VALUE_OF_CONFIG] if the statement already has the `cypher` options)
+| planner | Enum[DEFAULT, COST, IDP, DP] |  DEFAULT | If not `DEFAULT` prepend to the `statement per item` parameter a `cypher planner=[VALUE_OF_CONFIG]` (or planner=[VALUE_OF_CONFIG] if the statement already has the `cypher` options)
 |===
 
 [NOTE]

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.periodic.iterate.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.periodic.iterate.adoc
@@ -22,7 +22,8 @@ The operation query can access the batched values via the `$_batch` parameter.
 | params | Map | {} | externally pass in map of params
 | concurrency | Long | 50 | number of concurrent tasks are generated when using `parallel:true`
 | failedParams | Long |  -1 | if set to a non-negative value, each failed batch up to `failedParams` parameter sets are returned in `yield failedParams`.
-| planner | Enum[DEFAULT, COST, IDP, DP] |  DEFAULT | If not `DEFAULT` prepend to the `statement per item` parameter a `cypher planner=[VALUE_OF_CONFIG]` (or planner=[VALUE_OF_CONFIG] if the statement already has the `cypher` options)
+| planner | Enum[DEFAULT, COST, IDP, DP] |  DEFAULT | Any planner other than `DEFAULT` will be prepended to the second statement as `cypher planner=[VALUE_OF_CONFIG]` (or insert `planner=[VALUE_OF_CONFIG]` with any existing query options).
+    This planner value (except for `DEFAULT`) has higher precedence than the planner defined in the query (if any).
 |===
 
 [NOTE]

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.periodic.iterate.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.periodic.iterate.adoc
@@ -22,6 +22,7 @@ The operation query can access the batched values via the `$_batch` parameter.
 | params | Map | {} | externally pass in map of params
 | concurrency | Long | 50 | number of concurrent tasks are generated when using `parallel:true`
 | failedParams | Long |  -1 | if set to a non-negative value, each failed batch up to `failedParams` parameter sets are returned in `yield failedParams`.
+| planner | Enum[NONE, COST, IDP, DP] |  NONE | If not `NONE` prepend to the `statement per item` parameter a `cypher planner=[VALUE_OF_CONFIG]` (or planner=[VALUE_OF_CONFIG] if the statement already has the `cypher` options)
 |===
 
 [NOTE]


### PR DESCRIPTION
Fixes #1238
- Added config planner (If not `DEFAULT` prepend to the `statement` parameter a `cypher planner=[VALUE_OF_CONFIG]` (or `planner=[VALUE_OF_CONFIG]` if the statement already has the `cypher ` options))


Fixed bug in slottedRuntime parser (query with cypher, for example `match (n:cypher) return n`, test case in `PeriodicTest.java` on line 125)

