### PR TITLE
fixes #2200: apoc.export allows writes anywhere in the host filesystem

### DIFF
--- a/core/src/main/java/apoc/ApocConfig.java
+++ b/core/src/main/java/apoc/ApocConfig.java
@@ -8,13 +8,13 @@ import org.apache.commons.configuration2.builder.combined.CombinedConfigurationB
 import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.configuration2.ex.ConversionException;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.configuration.Config;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.config.Setting;
-import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.kernel.api.procedure.GlobalProcedures;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
@@ -86,6 +86,7 @@ public class ApocConfig extends LifecycleAdapter {
     ));
     private static final String DEFAULT_PATH = ".";
     private static final String CONFIG_DIR = "config-dir=";
+    public static final String EXPORT_TO_FILE_ERROR = "Export to files not enabled, please set apoc.export.file.enabled=true in your apoc.conf";
 
     private final Config neo4jConfig;
     private final Log log;
@@ -253,10 +254,10 @@ public class ApocConfig extends LifecycleAdapter {
         }
     }
 
-    public void checkWriteAllowed(ExportConfig exportConfig) {
+    public void checkWriteAllowed(ExportConfig exportConfig, String fileName) {
         if (!config.getBoolean(APOC_EXPORT_FILE_ENABLED)) {
-            if (exportConfig==null || !exportConfig.streamStatements()) {
-                throw new RuntimeException("Export to files not enabled, please set apoc.export.file.enabled=true in your apoc.conf");
+            if (exportConfig == null || StringUtils.isNotBlank(fileName) || !exportConfig.streamStatements()) {
+                throw new RuntimeException(EXPORT_TO_FILE_ERROR);
             }
         }
     }

--- a/core/src/main/java/apoc/ApocConfig.java
+++ b/core/src/main/java/apoc/ApocConfig.java
@@ -8,7 +8,6 @@ import org.apache.commons.configuration2.builder.combined.CombinedConfigurationB
 import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.configuration2.ex.ConversionException;
-import org.apache.commons.lang3.StringUtils;
 import org.neo4j.configuration.Config;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.dbms.api.DatabaseManagementService;
@@ -33,10 +32,10 @@ import java.util.stream.Stream;
 import static apoc.util.FileUtils.isFile;
 import static org.neo4j.configuration.ExternalSettings.lib_directory;
 import static org.neo4j.configuration.ExternalSettings.run_directory;
+import static org.neo4j.configuration.GraphDatabaseInternalSettings.logical_logs_location;
 import static org.neo4j.configuration.GraphDatabaseSettings.SYSTEM_DATABASE_NAME;
 import static org.neo4j.configuration.GraphDatabaseSettings.data_directory;
 import static org.neo4j.configuration.GraphDatabaseSettings.load_csv_file_url_root;
-import static org.neo4j.configuration.GraphDatabaseInternalSettings.logical_logs_location;
 import static org.neo4j.configuration.GraphDatabaseSettings.logs_directory;
 import static org.neo4j.configuration.GraphDatabaseSettings.neo4j_home;
 import static org.neo4j.configuration.GraphDatabaseSettings.plugin_dir;
@@ -256,7 +255,7 @@ public class ApocConfig extends LifecycleAdapter {
 
     public void checkWriteAllowed(ExportConfig exportConfig, String fileName) {
         if (!config.getBoolean(APOC_EXPORT_FILE_ENABLED)) {
-            if (exportConfig == null || StringUtils.isNotBlank(fileName) || !exportConfig.streamStatements()) {
+            if (exportConfig == null || (fileName != null && !fileName.equals("")) || !exportConfig.streamStatements()) {
                 throw new RuntimeException(EXPORT_TO_FILE_ERROR);
             }
         }

--- a/core/src/main/java/apoc/export/csv/ExportCSV.java
+++ b/core/src/main/java/apoc/export/csv/ExportCSV.java
@@ -10,14 +10,17 @@ import apoc.export.util.NodesAndRelsSubGraph;
 import apoc.export.util.ProgressReporter;
 import apoc.result.ProgressInfo;
 import apoc.util.Util;
-import org.apache.commons.lang3.StringUtils;
 import org.neo4j.cypher.export.DatabaseSubGraph;
 import org.neo4j.cypher.export.SubGraph;
-import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
-import org.neo4j.procedure.Description;
 import org.neo4j.procedure.TerminationGuard;
 
 import java.util.Collection;
@@ -92,7 +95,7 @@ public class ExportCSV {
     }
 
     private Stream<ProgressInfo> exportCsv(@Name("file") String fileName, String source, Object data, ExportConfig exportConfig) throws Exception {
-        if (StringUtils.isNotBlank(fileName)) apocConfig.checkWriteAllowed(exportConfig);
+        apocConfig.checkWriteAllowed(exportConfig, fileName);
         final String format = "csv";
         ProgressInfo progressInfo = new ProgressInfo(fileName, source, format);
         progressInfo.batchSize = exportConfig.getBatchSize();

--- a/core/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/core/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -9,7 +9,6 @@ import apoc.result.ProgressInfo;
 import apoc.util.QueueBasedSpliterator;
 import apoc.util.QueueUtil;
 import apoc.util.Util;
-import org.apache.commons.lang3.StringUtils;
 import org.neo4j.cypher.export.CypherResultSubGraph;
 import org.neo4j.cypher.export.DatabaseSubGraph;
 import org.neo4j.cypher.export.SubGraph;
@@ -115,7 +114,7 @@ public class ExportCypher {
     }
 
     private Stream<DataProgressInfo> exportCypher(@Name("file") String fileName, String source, SubGraph graph, ExportConfig c, boolean onlySchema) throws IOException {
-        if (StringUtils.isNotBlank(fileName)) apocConfig.checkWriteAllowed(c);
+        apocConfig.checkWriteAllowed(c, fileName);
 
         ProgressInfo progressInfo = new ProgressInfo(fileName, source, "cypher");
         progressInfo.batchSize = c.getBatchSize();

--- a/core/src/main/java/apoc/export/cypher/FileManagerFactory.java
+++ b/core/src/main/java/apoc/export/cypher/FileManagerFactory.java
@@ -1,6 +1,7 @@
 package apoc.export.cypher;
 
 import apoc.util.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -13,7 +14,7 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class FileManagerFactory {
     public static ExportFileManager createFileManager(String fileName, boolean separatedFiles) {
-        if (fileName == null) {
+        if (StringUtils.isBlank(fileName)) {
             return new StringExportCypherFileManager(separatedFiles);
         }
 

--- a/core/src/main/java/apoc/export/cypher/FileManagerFactory.java
+++ b/core/src/main/java/apoc/export/cypher/FileManagerFactory.java
@@ -1,7 +1,6 @@
 package apoc.export.cypher;
 
 import apoc.util.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -14,7 +13,7 @@ import java.util.concurrent.ConcurrentMap;
  */
 public class FileManagerFactory {
     public static ExportFileManager createFileManager(String fileName, boolean separatedFiles) {
-        if (StringUtils.isBlank(fileName)) {
+        if (fileName == null || "".equals(fileName)) {
             return new StringExportCypherFileManager(separatedFiles);
         }
 

--- a/core/src/main/java/apoc/export/graphml/ExportGraphML.java
+++ b/core/src/main/java/apoc/export/graphml/ExportGraphML.java
@@ -11,13 +11,21 @@ import apoc.export.util.ProgressReporter;
 import apoc.result.ProgressInfo;
 import apoc.util.FileUtils;
 import apoc.util.Util;
-import org.apache.commons.lang3.StringUtils;
 import org.neo4j.cypher.export.CypherResultSubGraph;
 import org.neo4j.cypher.export.DatabaseSubGraph;
 import org.neo4j.cypher.export.SubGraph;
-import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.helpers.collection.Iterables;
-import org.neo4j.procedure.*;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Mode;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.TerminationGuard;
 
 import java.io.PrintWriter;
 import java.util.Collection;
@@ -102,7 +110,7 @@ public class ExportGraphML {
     }
 
     private Stream<ProgressInfo> exportGraphML(@Name("file") String fileName, String source, SubGraph graph, ExportConfig exportConfig) throws Exception {
-        if (StringUtils.isNotBlank(fileName)) apocConfig.checkWriteAllowed(exportConfig);
+        apocConfig.checkWriteAllowed(exportConfig, fileName);
         final String format = "graphml";
         ProgressReporter reporter = new ProgressReporter(null, null, new ProgressInfo(fileName, source, format));
         XmlGraphMLWriter exporter = new XmlGraphMLWriter();

--- a/core/src/main/java/apoc/export/json/ExportJson.java
+++ b/core/src/main/java/apoc/export/json/ExportJson.java
@@ -10,10 +10,13 @@ import apoc.export.util.NodesAndRelsSubGraph;
 import apoc.export.util.ProgressReporter;
 import apoc.result.ProgressInfo;
 import apoc.util.Util;
-import org.apache.commons.lang3.StringUtils;
 import org.neo4j.cypher.export.DatabaseSubGraph;
 import org.neo4j.cypher.export.SubGraph;
-import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
@@ -85,7 +88,7 @@ public class ExportJson {
 
     private Stream<ProgressInfo> exportJson(String fileName, String source, Object data, Map<String,Object> config) throws Exception {
         ExportConfig exportConfig = new ExportConfig(config);
-        if (StringUtils.isNotBlank(fileName)) apocConfig.checkWriteAllowed(exportConfig);
+        apocConfig.checkWriteAllowed(exportConfig, fileName);
         final String format = "json";
         ProgressReporter reporter = new ProgressReporter(null, null, new ProgressInfo(fileName, source, format));
         JsonFormat exporter = new JsonFormat(db, getJsonFormat(config));

--- a/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
+++ b/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
@@ -1,6 +1,7 @@
 package apoc.export;
 
 import apoc.ApocConfig;
+import apoc.ApocSettings;
 import apoc.export.csv.ExportCSV;
 import apoc.export.cypher.ExportCypher;
 import apoc.export.graphml.ExportGraphML;
@@ -42,7 +43,8 @@ public class ExportCoreSecurityTest {
 
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule()
-            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath());
+            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath())
+            .withSetting(ApocSettings.apoc_export_file_enabled, false);
 
     @BeforeClass
     public static void setUp() throws Exception {

--- a/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
+++ b/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
@@ -1,0 +1,189 @@
+package apoc.export;
+
+import apoc.ApocConfig;
+import apoc.export.csv.ExportCSV;
+import apoc.export.cypher.ExportCypher;
+import apoc.export.graphml.ExportGraphML;
+import apoc.export.json.ExportJson;
+import apoc.util.TestUtil;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.graphdb.Result;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author mh
+ * @since 22.05.16
+ */
+@RunWith(Parameterized.class)
+public class ExportCoreSecurityTest {
+
+    private static File directory = new File("target/import");
+
+    static {
+        directory.mkdirs();
+    }
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath());
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        TestUtil.registerProcedure(db, ExportCSV.class, ExportJson.class, ExportGraphML.class, ExportCypher.class);
+    }
+
+    private final String exportMethod;
+
+    public ExportCoreSecurityTest(String exportMethod) {
+        this.exportMethod = exportMethod;
+    }
+
+
+    @Parameterized.Parameters
+    public static Collection<String> data() {
+        return Arrays.asList("csv", "json", "graphml", "cypher");
+    }
+
+    @Test
+    public void testIllegalFSAccessExportQuery() {
+        final String message = "apoc.export." + exportMethod + ".query should throw an exception";
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".query(\"RETURN 'hello' as key\", './hello', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".query(\"RETURN 'hello' as key\", './hello', {stream:true})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".query(\"RETURN 'hello' as key\", '  ', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+    }
+
+    @Test
+    public void testIllegalFSAccessExportAll() {
+        final String message = "apoc.export." + exportMethod + ".all should throw an exception";
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".all('./hello', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".all('./hello', {stream:true})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".all('  ', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+    }
+
+    @Test
+    public void testIllegalFSAccessExportData() {
+        final String message = "apoc.export." + exportMethod + ".data should throw an exception";
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".data([], [], './hello', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".data([], [], './hello', {stream:true})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".data([], [], '  ', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+    }
+
+    @Test
+    public void testIllegalFSAccessExportGraph() {
+        final String message = "apoc.export." + exportMethod + ".data should throw an exception";
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".graph({nodes: [], relationships: []}, './hello', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".graph({nodes: [], relationships: []}, './hello', {stream:true})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".graph({nodes: [], relationships: []}, '  ', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+    }
+
+    @Test
+    public void testIllegalFSAccessExportCypherSchema() {
+        Assume.assumeTrue(exportMethod.equals("cypher"));
+        try {
+            final String message = "apoc.export." + exportMethod + ".schema should throw an exception";
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".schema('./hello', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+    }
+
+
+
+    private void assertExportError(Exception e) {
+        final Throwable rootCause = ExceptionUtils.getRootCause(e);
+        assertTrue("it should be an instance of Runtime Exception", rootCause instanceof RuntimeException);
+        assertEquals(ApocConfig.EXPORT_TO_FILE_ERROR, rootCause.getMessage());
+    }
+
+}

--- a/core/src/test/java/apoc/log/Neo4jLogStreamTest.java
+++ b/core/src/test/java/apoc/log/Neo4jLogStreamTest.java
@@ -10,6 +10,7 @@ import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 
 import java.nio.file.Paths;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static apoc.ApocConfig.apocConfig;
@@ -23,7 +24,7 @@ public class Neo4jLogStreamTest {
     @Before
     public void setUp() throws Exception {
         DatabaseManagementService dbManagementService = new TestDatabaseManagementServiceBuilder(
-                Paths.get("target").toAbsolutePath()).build();
+                Paths.get("target", UUID.randomUUID().toString()).toAbsolutePath()).build();
         apocConfig().setProperty("dbms.directories.logs", "");
         db = dbManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
         TestUtil.registerProcedure(db, Neo4jLogStream.class);

--- a/full/src/main/java/apoc/export/xls/ExportXls.java
+++ b/full/src/main/java/apoc/export/xls/ExportXls.java
@@ -79,7 +79,7 @@ public class ExportXls {
 
     private Stream<ProgressInfo> exportXls(@Name("file") String fileName, String source, Object data, Map<String,Object> configMap) throws Exception {
         ExportConfig c = new ExportConfig(configMap);
-        apocConfig.checkWriteAllowed(c);
+        apocConfig.checkWriteAllowed(c, fileName);
         try (Transaction tx = db.beginTx();
              OutputStream out = getOutputStream(fileName, null);
              SXSSFWorkbook wb = new SXSSFWorkbook(-1)) {

--- a/full/src/test/java/apoc/export/ExportFullSecurityTest.java
+++ b/full/src/test/java/apoc/export/ExportFullSecurityTest.java
@@ -1,0 +1,170 @@
+package apoc.export;
+
+import apoc.ApocConfig;
+import apoc.export.xls.ExportXls;
+import apoc.util.TestUtil;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.graphdb.Result;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author mh
+ * @since 22.05.16
+ */
+@RunWith(Parameterized.class)
+public class ExportFullSecurityTest {
+
+    private static File directory = new File("target/import");
+
+    static {
+        directory.mkdirs();
+    }
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath());
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        TestUtil.registerProcedure(db, ExportXls.class);
+    }
+
+    private final String exportMethod;
+
+    public ExportFullSecurityTest(String exportMethod) {
+        this.exportMethod = exportMethod;
+    }
+
+
+    @Parameterized.Parameters
+    public static Collection<String> data() {
+        return Arrays.asList("xls");
+    }
+
+    @Test
+    public void testIllegalFSAccessExportQuery() {
+        final String message = "apoc.export." + exportMethod + ".query should throw an exception";
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".query(\"RETURN 'hello' as key\", './hello', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".query(\"RETURN 'hello' as key\", './hello', {stream:true})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".query(\"RETURN 'hello' as key\", '  ', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+    }
+
+    @Test
+    public void testIllegalFSAccessExportAll() {
+        final String message = "apoc.export." + exportMethod + ".all should throw an exception";
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".all('./hello', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".all('./hello', {stream:true})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".all('  ', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+    }
+
+    @Test
+    public void testIllegalFSAccessExportData() {
+        final String message = "apoc.export." + exportMethod + ".data should throw an exception";
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".data([], [], './hello', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".data([], [], './hello', {stream:true})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".data([], [], '  ', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+    }
+
+    @Test
+    public void testIllegalFSAccessExportGraph() {
+        final String message = "apoc.export." + exportMethod + ".data should throw an exception";
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".graph({nodes: [], relationships: []}, './hello', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".graph({nodes: [], relationships: []}, './hello', {stream:true})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+        try {
+            db.executeTransactionally("CALL apoc.export." + exportMethod + ".graph({nodes: [], relationships: []}, '  ', {})", Map.of(),
+                    Result::resultAsString);
+            fail(message);
+        } catch (Exception e) {
+            assertExportError(e);
+        }
+    }
+
+    private void assertExportError(Exception e) {
+        final Throwable rootCause = ExceptionUtils.getRootCause(e);
+        assertTrue("it should be an instance of Runtime Exception", rootCause instanceof RuntimeException);
+        assertEquals(ApocConfig.EXPORT_TO_FILE_ERROR, rootCause.getMessage());
+    }
+
+}

--- a/full/src/test/java/apoc/export/ExportFullSecurityTest.java
+++ b/full/src/test/java/apoc/export/ExportFullSecurityTest.java
@@ -1,6 +1,7 @@
 package apoc.export;
 
 import apoc.ApocConfig;
+import apoc.ApocSettings;
 import apoc.export.xls.ExportXls;
 import apoc.util.TestUtil;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -38,7 +39,8 @@ public class ExportFullSecurityTest {
 
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule()
-            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath());
+            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath())
+            .withSetting(ApocSettings.apoc_export_file_enabled, false);
 
     @BeforeClass
     public static void setUp() throws Exception {


### PR DESCRIPTION
Fixes #2200

This PR restrict the cases when procedures are allowed to write data into the file system

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Fixed the bug
  - Added tests
