### PR TITLE
fix uuid restore on restart (#2211)

### DIFF
--- a/full/src/main/java/apoc/uuid/UuidHandler.java
+++ b/full/src/main/java/apoc/uuid/UuidHandler.java
@@ -165,6 +165,7 @@ public class UuidHandler extends LifecycleAdapter implements TransactionEventLis
                     Pair.of(SystemPropertyKeys.label.name(), label),
                     Pair.of(SystemPropertyKeys.propertyName.name(), propertyName)
                     );
+            node.setProperty(SystemPropertyKeys.addToSetLabel.name(), config.isAddToSetLabels());
             sysTx.commit();
         }
     }


### PR DESCRIPTION
Fixes #2211

Correct the properties that make the uuid handler restoreable after server (re)start.

## Proposed Changes (Mandatory)
  - In the `add`-Methode inside the `UuidHandler.java` also save the missing `addToSetLabels` property.
