### PR TITLE
Fixes #2215: Unable to bring database up in Neo4j 4.3.2 using the `expand-commands' with APOC jar in the plugins directory

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -62,7 +62,11 @@ dependencies {
     }
     compile group: 'org.yaml', name: 'snakeyaml', version: '1.26'
     testCompile group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
-
+    compile(group: 'org.apache.commons', name: 'commons-lang3') {
+        version {
+            strictly '3.11'
+        }
+    }
     testCompile 'net.sourceforge.jexcelapi:jxl:2.6.12'
 
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'


### PR DESCRIPTION
Fixes #2215
Forced `org.apache.commons:commons-lang3` version.