### PR TITLE
Fixes #2218: combination of Neo4j 4.3.3 and Redis dependencies causes Neo4j to crash on start (Linux only)

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/database-integration/redis.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/redis.adoc
@@ -44,7 +44,7 @@ Here is a list of all available Redis procedures:
 == Install Dependencies
 
 The Redis procedures have dependencies on a client library that is not included in the APOC Library.
-You can download it from https://github.com/lettuce-io/lettuce-core/releases/tag/6.1.1.RELEASE[the lettuce-core repository] 
+You can download it from https://github.com/lettuce-io/lettuce-core/releases/tag/6.1.1.RELEASE[the lettuce-core repository](except for `netty` jars because they are already included within neo4j)
 or https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/{apoc-release}/apoc-redis-dependencies-{apoc-release}.jar[apoc repository]
 Once that file is downloaded, it should be placed in the `plugins` directory and the Neo4j Server restarted.
 

--- a/extra-dependencies/redis/build.gradle
+++ b/extra-dependencies/redis/build.gradle
@@ -17,5 +17,7 @@ jar {
 }
 
 dependencies {
-    compile group: 'io.lettuce', name: 'lettuce-core', version: '6.1.1.RELEASE'
+    compile group: 'io.lettuce', name: 'lettuce-core', version: '6.1.1.RELEASE', {
+        exclude group: 'io.netty'
+    }
 }


### PR DESCRIPTION
Fixes #2218