### PR TITLE
Fixed import package to account for pending refactor

### DIFF
--- a/full/src/main/java/apoc/monitor/Kernel.java
+++ b/full/src/main/java/apoc/monitor/Kernel.java
@@ -4,7 +4,7 @@ import apoc.Extended;
 import apoc.result.KernelInfoResult;
 
 import org.neo4j.common.DependencyResolver;
-import org.neo4j.configuration.helpers.DatabaseReadOnlyChecker;
+import org.neo4j.dbms.database.readonly.DatabaseReadOnlyChecker;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.kernel.database.Database;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;


### PR DESCRIPTION
Updates apoc's use of a non PublicApi class to account for a pending refactor which will land in 4.4