### PR TITLE
Fixes #2037: apoc.export.cypher.all to generate constraints with IF NOT EXISTS

### DIFF
--- a/core/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/core/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -141,7 +141,7 @@ public class ExportCypher {
         MultiStatementCypherSubGraphExporter exporter = new MultiStatementCypherSubGraphExporter(graph, c, db);
 
         if (onlySchema)
-            exporter.exportOnlySchema(cypherFileManager);
+            exporter.exportOnlySchema(cypherFileManager, c);
         else
             exporter.export(c, reporter, cypherFileManager);
     }

--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -103,12 +103,12 @@ public class MultiStatementCypherSubGraphExporter {
         switch (useOptimizations) {
             case NONE:
                 exportNodes(nodesWriter, reporter, batchSize);
-                exportSchema(schemaWriter);
+                exportSchema(schemaWriter, config);
                 exportRelationships(relationshipsWriter, reporter, batchSize);
                 break;
             default:
                 artificialUniques += countArtificialUniques(graph.getNodes());
-                exportSchema(schemaWriter);
+                exportSchema(schemaWriter, config);
                 exportNodesUnwindBatch(nodesWriter, reporter);
                 exportRelationshipsUnwindBatch(relationshipsWriter, reporter);
                 break;
@@ -123,9 +123,9 @@ public class MultiStatementCypherSubGraphExporter {
         reporter.done();
     }
 
-    public void exportOnlySchema(ExportFileManager cypherFileManager) {
+    public void exportOnlySchema(ExportFileManager cypherFileManager, ExportConfig config) {
         PrintWriter schemaWriter = cypherFileManager.getPrintWriter("schema");
-        exportSchema(schemaWriter);
+        exportSchema(schemaWriter, config);
         schemaWriter.close();
     }
 
@@ -204,7 +204,7 @@ public class MultiStatementCypherSubGraphExporter {
 
     // ---- Schema ----
 
-    private void exportSchema(PrintWriter out) {
+    private void exportSchema(PrintWriter out, ExportConfig config) {
         List<String> indexesAndConstraints = new ArrayList<>();
         indexesAndConstraints.addAll(exportIndexes());
         indexesAndConstraints.addAll(exportConstraints());
@@ -214,7 +214,7 @@ public class MultiStatementCypherSubGraphExporter {
             out.println(index);
         }
         if (artificialUniques > 0) {
-            String cypher = this.cypherFormat.statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP), false);
+            String cypher = this.cypherFormat.statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP), config.ifNotExists());
             if (cypher != null && !"".equals(cypher)) {
                 out.println(cypher);
             }

--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -214,7 +214,7 @@ public class MultiStatementCypherSubGraphExporter {
             out.println(index);
         }
         if (artificialUniques > 0) {
-            String cypher = this.cypherFormat.statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP));
+            String cypher = this.cypherFormat.statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP), false);
             if (cypher != null && !"".equals(cypher)) {
                 out.println(cypher);
             }
@@ -253,7 +253,7 @@ public class MultiStatementCypherSubGraphExporter {
                     }
                     // "normal" schema index
                     String tokenName = tokenNames.get(0);
-                    return this.cypherFormat.statementForIndex(tokenName, props);
+                    return this.cypherFormat.statementForIndex(tokenName, props, exportConfig.ifNotExists());
 
                 })
                 .filter(StringUtils::isNotBlank)
@@ -295,7 +295,7 @@ public class MultiStatementCypherSubGraphExporter {
                 .map(index -> {
                     String label = Iterables.single(index.getLabels()).name();
                     Iterable<String> props = index.getPropertyKeys();
-                    return this.cypherFormat.statementForConstraint(label, props);
+                    return this.cypherFormat.statementForConstraint(label, props, exportConfig.ifNotExists());
                 })
                 .filter(StringUtils::isNotBlank)
                 .collect(Collectors.toList());
@@ -315,7 +315,8 @@ public class MultiStatementCypherSubGraphExporter {
                 artificialUniques -= batchSize;
             }
             begin(out);
-            String cypher = this.cypherFormat.statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP)).replaceAll("^CREATE", "DROP");
+            String cypher = this.cypherFormat.statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP), false)
+                    .replaceAll("^CREATE", "DROP");
             if (cypher != null && !"".equals(cypher)) {
                 out.println(cypher);
             }

--- a/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -46,12 +46,10 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 
 	@Override
 	public String statementForIndex(String label, Iterable<String> keys, boolean ifNotExists) {
-		String prefix = "CREATE INDEX ";
-		if (ifNotExists) {
-			return String.format(prefix + "IF NOT EXISTS FOR (node:%s) ON (%s);", Util.quote(label), getPropertiesQuoted(keys));
-		} else {
-			return prefix +"ON :" + Util.quote(label) + "(" + CypherFormatterUtils.quote(keys) + ");";
-		}
+		return String.format("CREATE INDEX%s FOR (node:%s) ON (%s);", 
+				getIfNotExists(ifNotExists),
+				Util.quote(label),
+				getPropertiesQuoted(keys));
 	}
 
 	@Override
@@ -86,7 +84,11 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists) {
 		String keysString = getPropertiesQuoted(keys);
 
-		return String.format(STATEMENT_CONSTRAINTS, ifNotExists ? " IF NOT EXISTS" : "", Util.quote(label), keysString, Iterables.count(keys) > 1 ? "IS NODE KEY" : "IS UNIQUE");
+		return String.format(STATEMENT_CONSTRAINTS, getIfNotExists(ifNotExists), Util.quote(label), keysString, Iterables.count(keys) > 1 ? "IS NODE KEY" : "IS UNIQUE");
+	}
+
+	private String getIfNotExists(boolean ifNotExists) {
+		return ifNotExists ? " IF NOT EXISTS" : "";
 	}
 
 

--- a/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -33,12 +33,12 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
-	public String statementForIndex(String label, Iterable<String> key) {
+	public String statementForIndex(String label, Iterable<String> key, boolean ifNotExist) {
 		return "";
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> keys) {
+	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -19,13 +19,13 @@ public interface CypherFormatter {
 
 	String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties);
 
-	String statementForIndex(String label, Iterable<String> keys);
+	String statementForIndex(String label, Iterable<String> keys, boolean ifNotExist);
 
 	String statementForNodeFullTextIndex(String name, Iterable<Label> labels, Iterable<String> keys);
 
 	String statementForRelationshipFullTextIndex(String name, Iterable<RelationshipType> types, Iterable<String> keys);
 
-	String statementForConstraint(String label, Iterable<String> keys);
+	String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExist);
 
 	String statementForCleanUp(int batchSize);
 

--- a/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -33,12 +33,12 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	}
 
 	@Override
-	public String statementForIndex(String label, Iterable<String> key) {
+	public String statementForIndex(String label, Iterable<String> key, boolean ifNotExist) {
 		return "";
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> key) {
+	public String statementForConstraint(String label, Iterable<String> key, boolean ifNotExists) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -24,6 +24,7 @@ public class ExportConfig {
     public static final String DEFAULT_ARRAY_DELIM = ";";
     public static final String DEFAULT_QUOTES = ALWAYS_QUOTES;
     private final boolean streamStatements;
+    private final boolean ifNotExists;
 
     private int batchSize;
     private boolean silent;
@@ -97,6 +98,7 @@ public class ExportConfig {
         this.config = config;
         this.streamStatements = toBoolean(config.get("streamStatements")) || toBoolean(config.get("stream"));
         this.writeNodeProperties = toBoolean(config.get("writeNodeProperties"));
+        this.ifNotExists = toBoolean(config.get("ifNotExists"));
         exportQuotes(config);
         this.optimizations = (Map<String, Object>) config.getOrDefault("useOptimizations", Collections.emptyMap());
         this.optimizationType = OptimizationType.valueOf(optimizations.getOrDefault("type", OptimizationType.UNWIND_BATCH.toString()).toString().toUpperCase());
@@ -207,4 +209,7 @@ public class ExportConfig {
         return sampling;
     }
     
+    public boolean ifNotExists() {
+        return ifNotExists;
+    }
 }

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -778,8 +778,8 @@ public class ExportCypherTest {
                 "COMMIT%n");
 
         static final String EXPECTED_SCHEMA = String.format("BEGIN%n" +
-                "CREATE INDEX ON :Bar(first_name,last_name);%n" +
-                "CREATE INDEX ON :Foo(name);%n" +
+                "CREATE INDEX FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
+                "CREATE INDEX FOR (node:Foo) ON (node.name);%n" +
                 "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
                 "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
                 "COMMIT%n" +
@@ -817,8 +817,8 @@ public class ExportCypherTest {
                 "COMMIT%n");
 
         static final String EXPECTED_ONLY_SCHEMA_NEO4J_SHELL = String.format("BEGIN%n" +
-                "CREATE INDEX ON :Bar(first_name,last_name);%n" +
-                "CREATE INDEX ON :Foo(name);%n" +
+                "CREATE INDEX FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
+                "CREATE INDEX FOR (node:Foo) ON (node.name);%n" +
                 "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
                 "COMMIT%n" +
                 "SCHEMA AWAIT%n");
@@ -828,7 +828,7 @@ public class ExportCypherTest {
                 "CREATE (:Bar:`UNIQUE IMPORT LABEL` {place3d:point({x: 12.78, y: 56.7, z: 100.0, crs: 'wgs-84-3d'}), `UNIQUE IMPORT ID`:4});%n" +
                 "COMMIT%n" +
                 "BEGIN%n" +
-                "CREATE INDEX ON :Bar(first_name,last_name);%n" +
+                "CREATE INDEX FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
                 "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
                 "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
                 "COMMIT%n" +
@@ -848,7 +848,7 @@ public class ExportCypherTest {
                 "CREATE (:Bar:`UNIQUE IMPORT LABEL` {datetime:datetime('2018-10-30T12:50:35.556Z'), `UNIQUE IMPORT ID`:4});%n" +
                 "COMMIT%n" +
                 "BEGIN%n" +
-                "CREATE INDEX ON :Bar(first_name,last_name);%n" +
+                "CREATE INDEX FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
                 "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
                 "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
                 "COMMIT%n" +
@@ -868,7 +868,7 @@ public class ExportCypherTest {
                 "CREATE (:Bar:`UNIQUE IMPORT LABEL` {datetime:datetime('2018-10-30T12:50:35.556+01:00'), `UNIQUE IMPORT ID`:4});%n" +
                 "COMMIT%n" +
                 "BEGIN%n" +
-                "CREATE INDEX ON :Bar(first_name,last_name);%n" +
+                "CREATE INDEX FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
                 "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
                 "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
                 "COMMIT%n" +
@@ -888,7 +888,7 @@ public class ExportCypherTest {
                 "CREATE (:Bar:`UNIQUE IMPORT LABEL` {duration:duration('P5M1DT12H'), `UNIQUE IMPORT ID`:4});%n" +
                 "COMMIT%n" +
                 "BEGIN%n" +
-                "CREATE INDEX ON :Bar(first_name,last_name);%n" +
+                "CREATE INDEX FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
                 "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
                 "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
                 "COMMIT%n" +
@@ -918,8 +918,8 @@ public class ExportCypherTest {
                 "COMMIT%n");
 
         static final String EXPECTED_SCHEMA_OPTIMIZED = String.format("BEGIN%n" +
-                "CREATE INDEX ON :Bar(first_name,last_name);%n" +
-                "CREATE INDEX ON :Foo(name);%n" +
+                "CREATE INDEX FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
+                "CREATE INDEX FOR (node:Foo) ON (node.name);%n" +
                 "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
                 "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
                 "COMMIT%n" +
@@ -1094,8 +1094,8 @@ public class ExportCypherTest {
                 "MATCH (end:Bar{name: row.end.name})%n" +
                 "CREATE (start)-[r:KNOWS]->(end)  SET r += row.properties;%n");
 
-        static final String EXPECTED_UPDATE_ALL_UNWIND = String.format("CREATE INDEX ON :Bar(first_name,last_name);%n" +
-                "CREATE INDEX ON :Foo(name);%n" +
+        static final String EXPECTED_UPDATE_ALL_UNWIND = String.format("CREATE INDEX FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
+                "CREATE INDEX FOR (node:Foo) ON (node.name);%n" +
                 "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
                 "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
                 "UNWIND [{_id:3, properties:{age:12}}] AS row%n" +

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -396,6 +396,18 @@ public class ExportCypherTest {
     }
 
     @Test
+    public void testExportAllCypherDefaultSeparatedFiles1Optimized() throws Exception {
+        String fileName = "allDefaultOptimized.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($file, $config)",
+                map("file", fileName, "config", map("ifNotExists", true, "separateFiles", true, "format", "neo4j-shell")),
+                (r) -> assertResultsOptimized(fileName, r));
+        assertEquals(EXPECTED_SCHEMA_OPTIMIZED_WITH_IF_NOT_EXISTS, readFile("allDefaultOptimized.schema.cypher"));
+        assertEquals(EXPECTED_NODES_OPTIMIZED, readFile("allDefaultOptimized.nodes.cypher"));
+        assertEquals(EXPECTED_RELATIONSHIPS_OPTIMIZED, readFile("allDefaultOptimized.relationships.cypher"));
+        assertEquals(EXPECTED_CLEAN_UP, readFile("allDefaultOptimized.cleanup.cypher"));
+    }
+
+    @Test
     public void testExportAllCypherCypherShellWithUnwindBatchSizeOptimized() throws Exception {
         String fileName = "allCypherShellOptimized.cypher";
         TestUtil.testCall(db, "CALL apoc.export.cypher.all($file,{format:'cypher-shell', useOptimizations: {type: 'unwind_batch'}})",
@@ -913,6 +925,14 @@ public class ExportCypherTest {
                 "COMMIT%n" +
                 "SCHEMA AWAIT%n");
 
+        static final String EXPECTED_SCHEMA_OPTIMIZED_WITH_IF_NOT_EXISTS = String.format("BEGIN%n" +
+                "CREATE INDEX IF NOT EXISTS FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
+                "CREATE INDEX IF NOT EXISTS FOR (node:Foo) ON (node.name);%n" +
+                "CREATE CONSTRAINT IF NOT EXISTS ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n" +
+                "SCHEMA AWAIT%n");
+
         static final String EXPECTED_NODES_OPTIMIZED_BATCH_SIZE = String.format("BEGIN%n" +
                 "UNWIND [{_id:3, properties:{age:12}}] AS row%n" +
                 "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar;%n" +
@@ -1078,6 +1098,27 @@ public class ExportCypherTest {
                 "CREATE INDEX ON :Foo(name);%n" +
                 "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
                 "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "UNWIND [{_id:3, properties:{age:12}}] AS row%n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar;%n" +
+                "UNWIND [{_id:2, properties:{age:12}}] AS row%n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar:Person;%n" +
+                "UNWIND [{_id:0, properties:{born:date('2018-10-31'), name:\"foo\"}}, {_id:4, properties:{born:date('2017-09-29'), name:\"foo2\"}}] AS row%n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;%n" +
+                "UNWIND [{name:\"bar\", properties:{age:42}}, {name:\"bar2\", properties:{age:44}}] AS row%n" +
+                "MERGE (n:Bar{name: row.name}) SET n += row.properties;%n" +
+                "UNWIND [{_id:6, properties:{age:99}}] AS row%n" +
+                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties;%n" +
+                "UNWIND [{start: {_id:0}, end: {name:\"bar\"}, properties:{since:2016}}, {start: {_id:4}, end: {name:\"bar2\"}, properties:{since:2015}}] AS row%n" +
+                "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})%n" +
+                "MATCH (end:Bar{name: row.end.name})%n" +
+                "MERGE (start)-[r:KNOWS]->(end) SET r += row.properties;%n" +
+                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
+                "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n");
+
+        static final String EXPECTED_UPDATE_ALL_UNWIND_WITH_IF_NOT_EXISTS = String.format("CREATE INDEX IF NOT EXISTS ON :Bar(first_name,last_name);%n" +
+                "CREATE INDEX IF NOT EXISTS ON :Foo(name);%n" +
+                "CREATE CONSTRAINT IF NOT EXISTS ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT IF NOT EXISTS ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
                 "UNWIND [{_id:3, properties:{age:12}}] AS row%n" +
                 "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar;%n" +
                 "UNWIND [{_id:2, properties:{age:12}}] AS row%n" +

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -396,15 +396,15 @@ public class ExportCypherTest {
     }
 
     @Test
-    public void testExportAllCypherDefaultSeparatedFiles1Optimized() throws Exception {
-        String fileName = "allDefaultOptimized.cypher";
+    public void testExportAllCypherWithIfNotExistsFalseOptimized() throws Exception {
+        String fileName = "ifNotExists.cypher";
         TestUtil.testCall(db, "CALL apoc.export.cypher.all($file, $config)",
                 map("file", fileName, "config", map("ifNotExists", true, "separateFiles", true, "format", "neo4j-shell")),
                 (r) -> assertResultsOptimized(fileName, r));
-        assertEquals(EXPECTED_SCHEMA_OPTIMIZED_WITH_IF_NOT_EXISTS, readFile("allDefaultOptimized.schema.cypher"));
-        assertEquals(EXPECTED_NODES_OPTIMIZED, readFile("allDefaultOptimized.nodes.cypher"));
-        assertEquals(EXPECTED_RELATIONSHIPS_OPTIMIZED, readFile("allDefaultOptimized.relationships.cypher"));
-        assertEquals(EXPECTED_CLEAN_UP, readFile("allDefaultOptimized.cleanup.cypher"));
+        assertEquals(EXPECTED_SCHEMA_OPTIMIZED_WITH_IF_NOT_EXISTS, readFile("ifNotExists.schema.cypher"));
+        assertEquals(EXPECTED_NODES_OPTIMIZED, readFile("ifNotExists.nodes.cypher"));
+        assertEquals(EXPECTED_RELATIONSHIPS_OPTIMIZED, readFile("ifNotExists.relationships.cypher"));
+        assertEquals(EXPECTED_CLEAN_UP, readFile("ifNotExists.cleanup.cypher"));
     }
 
     @Test

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -929,7 +929,7 @@ public class ExportCypherTest {
                 "CREATE INDEX IF NOT EXISTS FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
                 "CREATE INDEX IF NOT EXISTS FOR (node:Foo) ON (node.name);%n" +
                 "CREATE CONSTRAINT IF NOT EXISTS ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
-                "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT IF NOT EXISTS ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
                 "COMMIT%n" +
                 "SCHEMA AWAIT%n");
 
@@ -1098,27 +1098,6 @@ public class ExportCypherTest {
                 "CREATE INDEX FOR (node:Foo) ON (node.name);%n" +
                 "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
                 "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
-                "UNWIND [{_id:3, properties:{age:12}}] AS row%n" +
-                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar;%n" +
-                "UNWIND [{_id:2, properties:{age:12}}] AS row%n" +
-                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar:Person;%n" +
-                "UNWIND [{_id:0, properties:{born:date('2018-10-31'), name:\"foo\"}}, {_id:4, properties:{born:date('2017-09-29'), name:\"foo2\"}}] AS row%n" +
-                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Foo;%n" +
-                "UNWIND [{name:\"bar\", properties:{age:42}}, {name:\"bar2\", properties:{age:44}}] AS row%n" +
-                "MERGE (n:Bar{name: row.name}) SET n += row.properties;%n" +
-                "UNWIND [{_id:6, properties:{age:99}}] AS row%n" +
-                "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties;%n" +
-                "UNWIND [{start: {_id:0}, end: {name:\"bar\"}, properties:{since:2016}}, {start: {_id:4}, end: {name:\"bar2\"}, properties:{since:2015}}] AS row%n" +
-                "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})%n" +
-                "MATCH (end:Bar{name: row.end.name})%n" +
-                "MERGE (start)-[r:KNOWS]->(end) SET r += row.properties;%n" +
-                "MATCH (n:`UNIQUE IMPORT LABEL`)  WITH n LIMIT 20000 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;%n" +
-                "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n");
-
-        static final String EXPECTED_UPDATE_ALL_UNWIND_WITH_IF_NOT_EXISTS = String.format("CREATE INDEX IF NOT EXISTS ON :Bar(first_name,last_name);%n" +
-                "CREATE INDEX IF NOT EXISTS ON :Foo(name);%n" +
-                "CREATE CONSTRAINT IF NOT EXISTS ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
-                "CREATE CONSTRAINT IF NOT EXISTS ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
                 "UNWIND [{_id:3, properties:{age:12}}] AS row%n" +
                 "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Bar;%n" +
                 "UNWIND [{_id:2, properties:{age:12}}] AS row%n" +

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.cypher.all.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.cypher.all.adoc
@@ -25,4 +25,5 @@ The procedure support the following config parameters:
 * `UNWIND_BATCH` - exports the file by batching the entities with the `UNWIND` method as explained in Michael Hunger's article on https://medium.com/neo4j/5-tips-tricks-for-fast-batched-updates-of-graph-structures-with-neo4j-and-cypher-73c7f693c8cc[fast batched writes^].
 * `UNWIND_BATCH_PARAMS` - similar to `UNWIND_BATCH`, but also uses parameters where appropriate
 | awaitForIndexes | Long | 300 | Timeout to use for `db.awaitIndexes` when using `format: "cypher-shell"`
+| ifNotExists | boolean | false | If true adds the keyword `IF NOT EXISTS` to constraints and indexes
 |===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.cypher.data.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.cypher.data.adoc
@@ -25,4 +25,5 @@ The procedure support the following config parameters:
 * `UNWIND_BATCH` - exports the file by batching the entities with the `UNWIND` method as explained in Michael Hunger's article on https://medium.com/neo4j/5-tips-tricks-for-fast-batched-updates-of-graph-structures-with-neo4j-and-cypher-73c7f693c8cc[fast batched writes^].
 * `UNWIND_BATCH_PARAMS` - similar to `UNWIND_BATCH`, but also uses parameters where appropriate
 | awaitForIndexes | Long | 300 | Timeout to use for `db.awaitIndexes` when using `format: "cypher-shell"`
+| ifNotExists | boolean | false | If true adds the keyword `IF NOT EXISTS` to constraints and indexes
 |===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.cypher.query.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.cypher.query.adoc
@@ -25,4 +25,5 @@ The procedure support the following config parameters:
 * `UNWIND_BATCH` - exports the file by batching the entities with the `UNWIND` method as explained in Michael Hunger's article on https://medium.com/neo4j/5-tips-tricks-for-fast-batched-updates-of-graph-structures-with-neo4j-and-cypher-73c7f693c8cc[fast batched writes^].
 * `UNWIND_BATCH_PARAMS` - similar to `UNWIND_BATCH`, but also uses parameters where appropriate
 | awaitForIndexes | Long | 300 | Timeout to use for `db.awaitIndexes` when using `format: "cypher-shell"`
+| ifNotExists | boolean | false | If true adds the keyword `IF NOT EXISTS` to constraints and indexes
 |===


### PR DESCRIPTION
Fixes neo4j-contrib#2037
Fixes neo4j-contrib#2073

Changed index creation with new syntax 