### PR TITLE
Fixes #1376: apoc.load.csv cannot parse files with backslash character in the data

### DIFF
--- a/core/src/main/java/apoc/load/util/LoadCsvConfig.java
+++ b/core/src/main/java/apoc/load/util/LoadCsvConfig.java
@@ -14,6 +14,7 @@ public class LoadCsvConfig {
     public static final char DEFAULT_ARRAY_SEP = ';';
     public static final char DEFAULT_SEP = ',';
     public static final char DEFAULT_QUOTE_CHAR = '"';
+    // this is the same value as ICSVParser.DEFAULT_ESCAPE_CHARACTER
     public static final char DEFAULT_ESCAPE_CHAR = '\\';
 
     private final boolean ignoreErrors;

--- a/core/src/main/java/apoc/load/util/LoadCsvConfig.java
+++ b/core/src/main/java/apoc/load/util/LoadCsvConfig.java
@@ -14,11 +14,13 @@ public class LoadCsvConfig {
     public static final char DEFAULT_ARRAY_SEP = ';';
     public static final char DEFAULT_SEP = ',';
     public static final char DEFAULT_QUOTE_CHAR = '"';
+    public static final char DEFAULT_ESCAPE_CHAR = '\\';
 
     private final boolean ignoreErrors;
     private char separator;
     private char arraySep;
     private char quoteChar;
+    private char escapeChar;
     private long skip;
     private boolean hasHeader;
     private long limit;
@@ -41,6 +43,7 @@ public class LoadCsvConfig {
         separator = parseCharFromConfig(config, "sep", DEFAULT_SEP);
         arraySep = parseCharFromConfig(config, "arraySep", DEFAULT_ARRAY_SEP);
         quoteChar = parseCharFromConfig(config,"quoteChar", DEFAULT_QUOTE_CHAR);
+        escapeChar = parseCharFromConfig(config,"escapeChar", DEFAULT_ESCAPE_CHAR);
         long skip = (long) config.getOrDefault("skip", 0L);
         this.skip = skip > -1 ? skip : 0L;
         hasHeader = (boolean) config.getOrDefault("header", true);
@@ -116,6 +119,10 @@ public class LoadCsvConfig {
 
     public char getQuoteChar() {
         return quoteChar;
+    }
+
+    public char getEscapeChar() {
+        return escapeChar;
     }
 
     public boolean getIgnoreErrors() {

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -827,6 +827,9 @@ public class Util {
         if ("TAB".equals(separator)) {
             return '\t';
         }
+        if ("NONE".equals(separator)) {
+            return '\0';
+        }
         return separator.charAt(0);
     }
 

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -827,6 +827,8 @@ public class Util {
         if ("TAB".equals(separator)) {
             return '\t';
         }
+        // "NONE" is used to resolve cases like issue #1376. 
+        // That is, when I have a line like "VER: AX\GEARBOX\ASSEMBLY" and I don't want to convert it in "VER: AXGEARBOXASSEMBLY"
         if ("NONE".equals(separator)) {
             return '\0';
         }

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.csv.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.csv.adoc
@@ -9,6 +9,7 @@ The procedure support the following config parameters:
 | header | booelan | true | indicates if file has a header
 | sep | String | ',' | separator character or 'TAB'
 | quoteChar | String | '"' | the char to use for quoted elements
+| escapeChar | String | '\' | the char to use for escape elements. Use `"NONE"` if you don't want to use any characters
 | arraySep | String |  ';' | array separator
 | ignore | List<String> | [] | which columns to ignore
 | nullValues | List<String> | [] | which values to treat as null, e.g. `['na',false]`

--- a/full/src/main/java/apoc/load/LoadCsv.java
+++ b/full/src/main/java/apoc/load/LoadCsv.java
@@ -60,6 +60,7 @@ public class LoadCsv {
 
         CSVReader csv = new CSVReaderBuilder(reader)
                 .withCSVParser(new CSVParserBuilder()
+                        .withEscapeChar(config.getEscapeChar())
                         .withQuoteChar(config.getQuoteChar())
                         .withIgnoreQuotations( config.isIgnoreQuotations() )
                         .withSeparator(config.getSeparator())

--- a/full/src/test/java/apoc/load/LoadCsvTest.java
+++ b/full/src/test/java/apoc/load/LoadCsvTest.java
@@ -179,7 +179,7 @@ RETURN m.col_1,m.col_2,m.col_3
         testResult(db, "CALL apoc.load.csv($url,$config)",
                 map("url", url.toString(), "config", map("results", results, "escapeChar", "NONE")),
                 (r) -> {
-                    assertRow(r, 0L,"name", "Narut\\o", "surname","Uzu\\maki");
+                    assertRow(r, 0L,"name", "Narut\\o\\", "surname","Uzu\\maki");
                     assertRow(r, 1L,"name", "Minat\\o", "surname","Nami\\kaze");
                     assertFalse(r.hasNext());
                 });

--- a/full/src/test/java/apoc/load/LoadCsvTest.java
+++ b/full/src/test/java/apoc/load/LoadCsvTest.java
@@ -165,6 +165,26 @@ RETURN m.col_1,m.col_2,m.col_3
                 });
     }
 
+    @Test 
+    public void testLoadCsvEscape() { 
+        URL url = getUrlFileName("test-escape.csv");
+        final List<String> results = List.of("map", "list", "stringMap", "strings");
+        testResult(db, "CALL apoc.load.csv($url, $config)", 
+                map("url", url.toString(), "config", map("results", results)),
+                (r) -> {
+                    assertRow(r, 0L,"name", "Naruto", "surname","Uzumaki");
+                    assertRow(r, 1L,"name", "Minato", "surname","Namikaze");
+                    assertFalse(r.hasNext());
+                });
+        testResult(db, "CALL apoc.load.csv($url,$config)",
+                map("url", url.toString(), "config", map("results", results, "escapeChar", "NONE")),
+                (r) -> {
+                    assertRow(r, 0L,"name", "Narut\\o", "surname","Uzu\\maki");
+                    assertRow(r, 1L,"name", "Minat\\o", "surname","Nami\\kaze");
+                    assertFalse(r.hasNext());
+                });
+    }
+
     @Test public void testLoadCsvNoHeader() throws Exception {
         URL url = getUrlFileName("test-no-header.csv");
         testResult(db, "CALL apoc.load.csv($url,{header:false,results:['map','list','stringMap','strings']})", map("url",url.toString()), // 'file:test.csv'

--- a/full/src/test/resources/test-escape.csv
+++ b/full/src/test/resources/test-escape.csv
@@ -1,0 +1,3 @@
+name,surname
+Narut\o,Uzu\maki
+Minat\o,Nami\kaze

--- a/full/src/test/resources/test-escape.csv
+++ b/full/src/test/resources/test-escape.csv
@@ -1,3 +1,3 @@
 name,surname
-Narut\o,Uzu\maki
+Narut\o\,Uzu\maki
 Minat\o,Nami\kaze


### PR DESCRIPTION
Fixes #1376

Added `escapeChar` config