### PR TITLE
Fixes #2015: Various bugs with Neo4j 4.3 indexes

### DIFF
--- a/core/src/main/java/apoc/export/util/NodesAndRelsSubGraph.java
+++ b/core/src/main/java/apoc/export/util/NodesAndRelsSubGraph.java
@@ -103,6 +103,14 @@ public class NodesAndRelsSubGraph implements SubGraph {
     }
 
     @Override
+    public Iterable<IndexDefinition> getIndexes(RelationshipType type) {
+        if (!types.contains(type.name())) {
+            return Collections.emptyList();
+        }
+        return tx.schema().getIndexes(type);
+    }
+
+    @Override
     public Iterable<RelationshipType> getAllRelationshipTypesInUse() {
         return types.stream()
                 .map(RelationshipType::withName)

--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -610,21 +610,18 @@ public class Meta {
 
         Set<RelationshipType> types = Iterables.asSet(graph.getAllRelationshipTypesInUse());
         Map<String, Iterable<ConstraintDefinition>> relConstraints = new HashMap<>(20);
+        Map<String, Set<String>> relIndexes = new HashMap<>();
         for (RelationshipType type : graph.getAllRelationshipTypesInUse()) {
             metaData.put(type.name(), new LinkedHashMap<>(10));
             relConstraints.put(type.name(),graph.getConstraints(type));
+            relIndexes.put(type.name(), getIndexedProperties(graph.getIndexes(type)));
         }
         for (Label label : graph.getAllLabelsInUse()) {
             Map<String,MetaResult> nodeMeta = new LinkedHashMap<>(50);
             String labelName = label.name();
             metaData.put(labelName, nodeMeta);
             Iterable<ConstraintDefinition> constraints = graph.getConstraints(label);
-            Set<String> indexed = new LinkedHashSet<>();
-            for (IndexDefinition index : graph.getIndexes(label)) {
-                for (String prop : index.getPropertyKeys()) {
-                    indexed.add(prop);
-                }
-            }
+            Set<String> indexed = getIndexedProperties(graph.getIndexes(label));
             long labelCount = graph.countsForNode(label);
             long sample = getSampleForLabelCount(labelCount, config.getSample());
             Iterator<Node> nodes = graph.findNodes(label);
@@ -632,12 +629,19 @@ public class Meta {
             while (nodes.hasNext()) {
                 Node node = nodes.next();
                 if(count++ % sample == 0) {
-                    addRelationships(metaData, nodeMeta, labelName, node, relConstraints, types);
+                    addRelationships(metaData, nodeMeta, labelName, node, relConstraints, types, relIndexes);
                     addProperties(nodeMeta, labelName, constraints, indexed, node, node);
                 }
             }
         }
         return metaData;
+    }
+
+    private Set<String> getIndexedProperties(Iterable<IndexDefinition> indexes) {
+        return Iterables.stream(indexes)
+                .map(IndexDefinition::getPropertyKeys)
+                .flatMap(Iterables::stream)
+                .collect(Collectors.toSet());
     }
 
     private Map<String, Long> getLabelCountStore() {
@@ -754,7 +758,8 @@ public class Meta {
                     entityProperties.put(entityDataKey, MapUtil.map(
                             "type", metaResult.type,
                             "array", metaResult.array,
-                            "existence", metaResult.existence));
+                            "existence", metaResult.existence,
+                            "indexed", metaResult.index));
                 }
             }
             if (isRelationship) {
@@ -782,7 +787,9 @@ public class Meta {
                                   String labelName,
                                   Node node,
                                   Map<String, Iterable<ConstraintDefinition>> relConstraints,
-                                  Set<RelationshipType> types) {
+                                  Set<RelationshipType> types,
+            Map<String, Set<String >> relIndexes
+    ) {
         StreamSupport.stream(node.getRelationshipTypes().spliterator(), false)
                 .filter(type -> types.contains(type))
                 .forEach(type -> {
@@ -792,17 +799,19 @@ public class Meta {
                     String typeName = type.name();
 
                     Iterable<ConstraintDefinition> constraints = relConstraints.get(typeName);
+                    Set<String> indexes = relIndexes.get(typeName);
                     if (!nodeMeta.containsKey(typeName)) nodeMeta.put(typeName, new MetaResult(labelName,typeName));
 //            int in = node.getDegree(type, Direction.INCOMING);
 
                     Map<String, MetaResult> typeMeta = metaData.get(typeName);
                     if (!typeMeta.containsKey(labelName)) typeMeta.put(labelName,new MetaResult(typeName,labelName));
                     MetaResult relMeta = nodeMeta.get(typeName);
-                    addOtherNodeInfo(node, labelName, out, type, relMeta , typeMeta, constraints);
+                    addOtherNodeInfo(node, labelName, out, type, relMeta , typeMeta, constraints, indexes);
                 });
     }
 
-    private void addOtherNodeInfo(Node node, String labelName, int out, RelationshipType type, MetaResult relMeta, Map<String, MetaResult> typeMeta, Iterable<ConstraintDefinition> relConstraints) {
+    private void addOtherNodeInfo(Node node, String labelName, int out, RelationshipType type, MetaResult relMeta, Map<String, MetaResult> typeMeta,
+                                  Iterable<ConstraintDefinition> relConstraints, Set<String> indexes) {
         MetaResult relNodeMeta = typeMeta.get(labelName);
         relMeta.elementType(Types.of(node).name());
         for (Relationship rel : node.getRelationships(Direction.OUTGOING, type)) {
@@ -811,7 +820,7 @@ public class Meta {
             int in = endNode.getDegree(type, Direction.INCOMING);
             relMeta.inc().other(labels).rel(out , in);
             relNodeMeta.inc().other(labels).rel(out,in);
-            addProperties(typeMeta, type.name(), relConstraints, Collections.emptySet(), rel, node);
+            addProperties(typeMeta, type.name(), relConstraints, indexes, rel, node);
             relNodeMeta.elementType(Types.RELATIONSHIP.name());
         }
     }

--- a/core/src/main/java/apoc/result/IndexConstraintRelationshipInfo.java
+++ b/core/src/main/java/apoc/result/IndexConstraintRelationshipInfo.java
@@ -5,7 +5,7 @@ import java.util.List;
 /**
  * Created by alberto.delazzari on 04/07/17.
  */
-public class ConstraintRelationshipInfo {
+public class IndexConstraintRelationshipInfo {
 
     public final String name;
 
@@ -15,7 +15,7 @@ public class ConstraintRelationshipInfo {
 
     public final String status;
 
-    public ConstraintRelationshipInfo(String name, String type, List<String> properties, String status) {
+    public IndexConstraintRelationshipInfo(String name, String type, List<String> properties, String status) {
         this.name = name;
         this.type = type;
         this.properties = properties;

--- a/core/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
@@ -206,6 +206,13 @@ public class CypherResultSubGraph implements SubGraph
     }
 
     @Override
+    public Iterable<IndexDefinition> getIndexes(RelationshipType type) {
+        return indexes.stream()
+                .filter(idx -> StreamSupport.stream(idx.getRelationshipTypes().spliterator(), false).anyMatch(lb -> lb.equals(type)))
+                .collect(Collectors.toSet());
+    }
+
+    @Override
     public Iterable<RelationshipType> getAllRelationshipTypesInUse() {
         return Collections.unmodifiableCollection(types);
     }

--- a/core/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
@@ -208,7 +208,8 @@ public class CypherResultSubGraph implements SubGraph
     @Override
     public Iterable<IndexDefinition> getIndexes(RelationshipType type) {
         return indexes.stream()
-                .filter(idx -> StreamSupport.stream(idx.getRelationshipTypes().spliterator(), false).anyMatch(lb -> lb.equals(type)))
+                .filter(idx -> StreamSupport.stream(idx.getRelationshipTypes().spliterator(), false)
+                        .anyMatch(relType -> relType.name().equals(type.name())))
                 .collect(Collectors.toSet());
     }
 

--- a/core/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
@@ -73,6 +73,11 @@ public class DatabaseSubGraph implements SubGraph
     }
 
     @Override
+    public Iterable<IndexDefinition> getIndexes(RelationshipType type) {
+        return transaction.schema().getIndexes(type);
+    }
+
+    @Override
     public Iterable<RelationshipType> getAllRelationshipTypesInUse() {
         return transaction.getAllRelationshipTypesInUse();
     }

--- a/core/src/main/java/org/neo4j/cypher/export/SubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/SubGraph.java
@@ -35,6 +35,8 @@ public interface SubGraph
 
     Iterable<IndexDefinition> getIndexes(Label label);
 
+    Iterable<IndexDefinition> getIndexes(RelationshipType label);
+
     Iterable<RelationshipType> getAllRelationshipTypesInUse();
 
     Iterable<Label> getAllLabelsInUse();


### PR DESCRIPTION
Fixes #2015

- Implemented `getIndexes(RelationshipType type)` in `SubGraph.java`
- Added `relIndexes` in `Meta.java`
- Added lookup index handling