### PR TITLE
Fixes #2225: Missing documentation for the input parameter of apoc.meta.schema

### DIFF
--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.schema.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.schema.adoc
@@ -46,19 +46,15 @@ RETURN key, value[key] AS value;
 |===
 
 
+Because the count stores return an incomplete picture of the data, we have to cross check the results with the actual data to filter out false positives.
 
-We can only take a limited set of data to analyze by specifying the `sample` parameter (1000 by default).
-Through this parameter, for each label we split data into batches of (total / sample) ± rand
-where `total` is the total number of nodes and `rand` is a number between `0` and `total / sample / 10`
+We use a subset of the data to analyze by specifying the `sample` parameter (1000 by default).
 
-So, we pick a percentage of nodes of ABOUT `sample / total * 100`%.
+Through this parameter, for each label we split data for each node-label into batches of `(total / sample) ± rand` where `total` is the total number of nodes with that label and `rand` is a number between `0` and `total / sample / 10`
 
-Therefore, we pick the first node of each batch and we analyze the properties and the relationships.
+So, we pick a percentage of nodes with that label of roughly `sample / total * 100`% to check against.
 
-However, with `sample` parameter, we have to look at the actual data,
-because the count stores return an incomplete picture of the data 
-and we have to cross the results with the actual data to filter out false positives.
-
+We pick the first node of each batch and we analyze the properties and the relationships.
 
 For example, given the following graph:
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.schema.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.schema.adoc
@@ -153,10 +153,11 @@ YIELD value RETURN value["Other"] as value;
 }
 ----
 |===
-Otherwise, with `sample: 1`:
+Otherwise, with `sample: 2` we obtain (the result can change):
+
 [source,cypher]
 ----
-CALL apoc.meta.schema({sample: 1})
+CALL apoc.meta.schema({sample: 2})
 YIELD value RETURN value["Other"] as value
 ----
 .Results
@@ -167,30 +168,28 @@ YIELD value RETURN value["Other"] as value
 [source,json]
 ----
 {
-"count": 8,
-"relationships": {
-"REL_3": {
-"count": 1,
-"properties": {
-
-            },
-            "direction": "out",
-            "labels": [
-                "Other",
-                "Other"
-            ]
-        }
-    },
-    "type": "node",
-    "properties": {
-        "foo": {
-            "existence": false,
-            "type": "STRING",
-            "indexed": false,
-            "unique": false
-        }
-    },
-    "labels": []
+  "count": 8,
+  "relationships": {
+    "REL_1": {
+      "count": 1,
+      "properties": {},
+      "direction": "out",
+      "labels": [
+        "Other",
+        "Other"
+      ]
+    }
+  },
+  "type": "node",
+  "properties": {
+    "alpha": {
+      "existence": false,
+      "type": "STRING",
+      "indexed": false,
+      "unique": false
+    }
+  },
+  "labels": []
 }
 ----
 |===

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.schema.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.schema.adoc
@@ -45,3 +45,139 @@ RETURN key, value[key] AS value;
 | "Person"   | {count: 2, relationships: {ACTED_IN: {count: 9, properties: {roles: {existence: FALSE, type: "LIST", array: TRUE}}, direction: "out", labels: ["Movie"]}}, type: "node", properties: {name: {existence: FALSE, type: "STRING", indexed: FALSE, unique: FALSE}, born: {existence: FALSE, type: "INTEGER", indexed: FALSE, unique: FALSE}}, labels: []}
 |===
 
+
+We can control the number of entities to analyze by specifying the `sample` parameter.
+For example, given the following graph:
+
+[source,cypher]
+----
+CREATE (:Foo), (:Other)-[:REL_0]->(:Other), (:Other)-[:REL_1]->(:Other)<-[:REL_2 {baz: 'baa'}]-(:Other), (:Other {alpha: 'beta'}), (:Other {foo:'bar'})-[:REL_3]->(:Other)
+----
+
+Without `sample` parameter we receive:
+
+[source,cypher]
+----
+CALL apoc.meta.schema()
+YIELD value RETURN value["Other"] as value;
+----
+
+.Results
+[opts="header",cols="a"]
+|===
+| value
+|
+[source,json]
+----
+{
+    "count": 8,
+    "relationships": {
+        "REL_2": {
+            "count": 1,
+            "properties": {
+                "baz": {
+                    "existence": false,
+                    "type": "STRING",
+                    "array": false
+                }
+            },
+            "direction": "out",
+            "labels": [
+                "Other",
+                "Other"
+            ]
+        },
+        "REL_3": {
+            "count": 1,
+            "properties": {
+
+            },
+            "direction": "out",
+            "labels": [
+                "Other",
+                "Other"
+            ]
+        },
+        "REL_0": {
+            "count": 1,
+            "properties": {
+
+            },
+            "direction": "out",
+            "labels": [
+                "Other",
+                "Other"
+            ]
+        },
+        "REL_1": {
+            "count": 1,
+            "properties": {
+
+            },
+            "direction": "out",
+            "labels": [
+                "Other",
+                "Other"
+            ]
+        }
+    },
+    "type": "node",
+    "properties": {
+        "alpha": {
+            "existence": false,
+            "type": "STRING",
+            "indexed": false,
+            "unique": false
+        },
+        "foo": {
+            "existence": false,
+            "type": "STRING",
+            "indexed": false,
+            "unique": false
+        }
+    },
+    "labels": []
+}
+----
+|===
+Otherwise, with `sample: 1`:
+[source,cypher]
+----
+CALL apoc.meta.schema({sample: 1})
+YIELD value RETURN value["Other"] as value
+----
+.Results
+[opts="header",cols="a"]
+|===
+| value
+|
+[source,json]
+----
+{
+"count": 8,
+"relationships": {
+"REL_3": {
+"count": 1,
+"properties": {
+
+            },
+            "direction": "out",
+            "labels": [
+                "Other",
+                "Other"
+            ]
+        }
+    },
+    "type": "node",
+    "properties": {
+        "foo": {
+            "existence": false,
+            "type": "STRING",
+            "indexed": false,
+            "unique": false
+        }
+    },
+    "labels": []
+}
+----
+|===

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.schema.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.schema.adoc
@@ -46,7 +46,20 @@ RETURN key, value[key] AS value;
 |===
 
 
-We can control the number of entities to analyze by specifying the `sample` parameter.
+
+We can only take a limited set of data to analyze by specifying the `sample` parameter (1000 by default).
+Through this parameter, for each label we split data into batches of (total / sample) ± rand
+where `rand` is a number between `0` and `total / sample / 10`
+
+So, we pick a percentage of nodes of ABOUT `sample / total * 100`%.
+
+Therefore, we pick the first node of each batch and we analyze the properties and the relationships.
+
+However, with `sample` parameter, we have to look at the actual data,
+because the count stores return an incomplete picture of the data 
+and we have to cross the results with the actual data to filter out false positives.
+
+
 For example, given the following graph:
 
 [source,cypher]

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.schema.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.schema.adoc
@@ -49,7 +49,7 @@ RETURN key, value[key] AS value;
 
 We can only take a limited set of data to analyze by specifying the `sample` parameter (1000 by default).
 Through this parameter, for each label we split data into batches of (total / sample) ± rand
-where `rand` is a number between `0` and `total / sample / 10`
+where `total` is the total number of nodes and `rand` is a number between `0` and `total / sample / 10`
 
 So, we pick a percentage of nodes of ABOUT `sample / total * 100`%.
 


### PR DESCRIPTION
Fixes #2225

Only `sample` config. Other `MetaConfig` are not used.