### PR TITLE
MultiThreadedGlobalGraphOperations is storage-agnostic

### DIFF
--- a/core/src/main/java/apoc/util/kernel/MultiThreadedGlobalGraphOperations.java
+++ b/core/src/main/java/apoc/util/kernel/MultiThreadedGlobalGraphOperations.java
@@ -1,90 +1,66 @@
 package apoc.util.kernel;
 
-import org.neo4j.common.DependencyResolver;
-import org.neo4j.graphdb.Transaction;
-import org.neo4j.internal.kernel.api.CursorFactory;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import org.neo4j.internal.kernel.api.EntityCursor;
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.Read;
 import org.neo4j.internal.kernel.api.RelationshipScanCursor;
-import org.neo4j.internal.recordstorage.RecordStorageEngine;
+import org.neo4j.internal.kernel.api.Scan;
+import org.neo4j.internal.kernel.api.security.AccessMode;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
-import org.neo4j.kernel.impl.store.CommonAbstractStore;
-import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.BiConsumer;
-import java.util.function.Supplier;
-
 public class MultiThreadedGlobalGraphOperations {
-
-    public enum GlobalOperationsTypes { NODES, RELATIONSHIPS }
-
-    public static BatchJobResult forAllNodes(GraphDatabaseAPI db, ExecutorService executorService, int batchSize, BiConsumer<KernelTransaction, NodeCursor> consumer) {
-        return forAll(db, executorService, batchSize, GlobalOperationsTypes.NODES, consumer);
+    public static BatchJobResult forAllNodes(GraphDatabaseAPI db, ExecutorService executorService, int batchSize, BiConsumer<KernelTransaction,
+            NodeCursor> consumer) {
+        return forAll(db, executorService, batchSize, consumer, Read::allNodesScan, ktx -> ktx.cursors().allocateNodeCursor( ktx.cursorContext() ));
     }
 
-    public static BatchJobResult forAllRelationships(GraphDatabaseAPI db, ExecutorService executorService, int batchSize, BiConsumer<KernelTransaction, RelationshipScanCursor> consumer) {
-        return forAll(db, executorService, batchSize, GlobalOperationsTypes.RELATIONSHIPS, consumer);
+    public static BatchJobResult forAllRelationships(GraphDatabaseAPI db, ExecutorService executorService, int batchSize, BiConsumer<KernelTransaction,
+            RelationshipScanCursor> consumer) {
+        return forAll( db, executorService, batchSize, consumer, Read::allRelationshipsScan,
+                ktx -> ktx.cursors().allocateRelationshipScanCursor( ktx.cursorContext() ) );
     }
 
-    private static BatchJobResult forAll(GraphDatabaseAPI db, ExecutorService executorService, int batchSize, GlobalOperationsTypes type, BiConsumer consumer) {
-        try {
-            DependencyResolver dependencyResolver = db.getDependencyResolver();
-            long maxId = getHighestIdInUseForStore(dependencyResolver, type);
-
-            List<BatchJob> taskList = new ArrayList<>();
-            BatchJobResult result = new BatchJobResult();
-
+    private static <C extends EntityCursor> BatchJobResult forAll( GraphDatabaseAPI db, ExecutorService executorService, int batchSize,
+            BiConsumer<KernelTransaction,C> consumer, Function<Read, Scan<C>> scanFunction, Function<KernelTransaction,C> cursorAllocator ) {
+        BatchJobResult result = new BatchJobResult();
+        AtomicInteger processing = new AtomicInteger();
+        try ( InternalTransaction tx = db.beginTransaction( KernelTransaction.Type.EXPLICIT, LoginContext.AUTH_DISABLED ) ) {
+            KernelTransaction ktx = tx.kernelTransaction();
+            Scan<C> scan = scanFunction.apply( ktx.dataRead() );
             result.startStopWatch();
-            for (long batchStart = 0; batchStart < maxId; batchStart += batchSize) {
-                taskList.add(new BatchJob(type, batchStart, batchSize, db, consumer, result));
+            executorService.submit( new BatchJob<>( scan, batchSize, db, consumer, result, cursorAllocator, executorService, processing ) );
+        }
+
+        try {
+            while ( processing.get() > 0 ) {
+                Thread.sleep( 10 );
             }
-            executorService.invokeAll(taskList);
             result.stopStopWatch();
-            result.setBatches(taskList.size());
-            return result;
-
         } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+            Thread.currentThread().interrupt();
         }
-    }
-
-    public static long getHighestIdInUseForStore(DependencyResolver dependencyResolver, GlobalOperationsTypes type) {
-        NeoStores neoStores = dependencyResolver.resolveDependency(RecordStorageEngine.class).testAccessNeoStores();
-        CommonAbstractStore store;
-        switch (type) {
-            case NODES:
-                store = neoStores.getNodeStore();
-                break;
-            case RELATIONSHIPS:
-                store = neoStores.getRelationshipStore();
-                break;
-            default:
-                throw new IllegalArgumentException("invalid type " + type);
-        }
-        return store.getHighId();
+        return result;
     }
 
     public static class BatchJobResult {
-        final AtomicLong succeeded = new AtomicLong(0);
-        final AtomicLong missing = new AtomicLong( 0);
-        final AtomicLong failures = new AtomicLong(0);
+        final AtomicInteger batches = new AtomicInteger();
+        final AtomicLong succeeded = new AtomicLong();
+        final AtomicLong failures = new AtomicLong();
         private long started;
         private long duration;
-        private int batches;
 
         public void incrementSuceeded() {
             succeeded.incrementAndGet();
-        }
-
-        public void incrementMissing() {
-            missing.incrementAndGet();
         }
 
         public void incrementFailures() {
@@ -93,10 +69,6 @@ public class MultiThreadedGlobalGraphOperations {
 
         public long getSucceeded() {
             return succeeded.get();
-        }
-
-        public long getMissing() {
-            return missing.get();
         }
 
         public long getFailures() {
@@ -115,85 +87,67 @@ public class MultiThreadedGlobalGraphOperations {
             duration = System.currentTimeMillis() - started;
         }
 
-        public void setBatches(int batches) {
-            this.batches = batches;
-        }
-
         public int getBatches() {
-            return batches;
+            return batches.get();
         }
     }
 
-    private static class BatchJob implements Callable<Void> {
-        private final GlobalOperationsTypes type;
-        private final long batchStart;
+    private static class BatchJob<C extends EntityCursor> implements Callable<Void> {
+        private final Scan<C> scan;
         private final int batchSize;
         private final GraphDatabaseAPI db;
-        private final BiConsumer consumer;
+        private final BiConsumer<KernelTransaction,C> consumer;
         private final BatchJobResult result;
+        private final Function<KernelTransaction,C> cursorAllocator;
+        private final ExecutorService executorService;
+        private final AtomicInteger processing;
 
-        public BatchJob(GlobalOperationsTypes type, long batchStart, int batchSize, GraphDatabaseAPI db, BiConsumer consumer, BatchJobResult result) {
-            this.type = type;
-            this.batchStart = batchStart;
+        public BatchJob(Scan<C> scan, int batchSize, GraphDatabaseAPI db, BiConsumer<KernelTransaction,C> consumer,
+                BatchJobResult result, Function<KernelTransaction,C> cursorAllocator, ExecutorService executorService, AtomicInteger processing ) {
+            this.scan = scan;
             this.batchSize = batchSize;
             this.db = db;
             this.consumer = consumer;
             this.result = result;
+            this.cursorAllocator = cursorAllocator;
+            this.executorService = executorService;
+            this.processing = processing;
+            processing.incrementAndGet();
         }
 
         @Override
         public Void call() {
-            try (Transaction tx = db.beginTx()) {
-                KernelTransaction ktx = ((InternalTransaction)tx).kernelTransaction();
-                CursorFactory cursors = ktx.cursors();
-                Read read = ktx.dataRead();
-
-                switch (type) {
-                    case NODES:
-                        iterateForNodes(ktx, read, cursors, result);
-                        break;
-                    case RELATIONSHIPS:
-                        iterateForRelationships(ktx, read, cursors, result);
-                        break;
-                    default:
-                        throw new IllegalArgumentException("dunno how to deal with type " + type);
-
+            try (InternalTransaction tx = db.beginTransaction(KernelTransaction.Type.EXPLICIT, LoginContext.AUTH_DISABLED)) {
+                KernelTransaction ktx = tx.kernelTransaction();
+                try (C cursor = cursorAllocator.apply( ktx )) {
+                    if (scan.reserveBatch( cursor, batchSize, ktx.cursorContext(), AccessMode.Static.FULL )) {
+                        // Branch out so that all available threads will get saturated
+                        executorService.submit( new BatchJob<>( scan, batchSize, db, consumer, result, cursorAllocator, executorService, processing ) );
+                        executorService.submit( new BatchJob<>( scan, batchSize, db, consumer, result, cursorAllocator, executorService, processing ) );
+                        while (processAndReport(ktx, cursor)) {
+                            // just continue processing...
+                        }
+                    }
                 }
                 tx.commit();
                 return null;
+            } finally {
+                result.batches.incrementAndGet();
+                processing.decrementAndGet();
             }
         }
 
-        private void iterateForNodes(KernelTransaction ktx, Read read, CursorFactory cursors, BatchJobResult result) {
-            try (NodeCursor cursor = cursors.allocateNodeCursor(ktx.cursorContext())) {
-                for (long id = batchStart; id < batchStart + batchSize; id++) {
-                    read.singleNode(id, cursor);
-                    processAndReport(ktx, cursor::next, consumer, cursor, result);
-                }
-            }
-        }
-
-        private void iterateForRelationships(KernelTransaction ktx, Read read, CursorFactory cursors, BatchJobResult result) {
-            try (RelationshipScanCursor cursor = cursors.allocateRelationshipScanCursor(ktx.cursorContext())) {
-                for (long id = batchStart; id < batchStart + batchSize; id++) {
-                    read.singleRelationship(id, cursor);
-                    processAndReport(ktx, cursor::next, consumer, cursor, result);
-                }
-            }
-        }
-
-        private void processAndReport(KernelTransaction ktx, Supplier<Boolean> nextMethod, BiConsumer consumer, Object parameter, BatchJobResult result) {
-            if (nextMethod.get()) {
+        private boolean processAndReport(KernelTransaction ktx, C cursor) {
+            if (cursor.next()) {
                 try {
-                    consumer.accept(ktx, parameter);
+                    consumer.accept(ktx, cursor);
                     result.incrementSuceeded();
                 } catch (Exception e) {
                     result.incrementFailures();
                 }
-            } else {
-                result.incrementMissing();
+                return true;
             }
+            return false;
         }
-
     }
 }

--- a/core/src/test/java/apoc/util/kernel/MultiThreadedGlobalGraphOperationsTest.java
+++ b/core/src/test/java/apoc/util/kernel/MultiThreadedGlobalGraphOperationsTest.java
@@ -4,15 +4,16 @@ import apoc.util.TestUtil;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.neo4j.test.rule.DbmsRule;
-import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static apoc.util.kernel.MultiThreadedGlobalGraphOperations.*;
-import static apoc.util.kernel.MultiThreadedGlobalGraphOperations.GlobalOperationsTypes.NODES;
-import static apoc.util.kernel.MultiThreadedGlobalGraphOperations.GlobalOperationsTypes.RELATIONSHIPS;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import static apoc.util.kernel.MultiThreadedGlobalGraphOperations.BatchJobResult;
+import static apoc.util.kernel.MultiThreadedGlobalGraphOperations.forAllNodes;
+import static apoc.util.kernel.MultiThreadedGlobalGraphOperations.forAllRelationships;
 import static org.junit.Assert.assertEquals;
 
 public class MultiThreadedGlobalGraphOperationsTest {
@@ -33,16 +34,13 @@ public class MultiThreadedGlobalGraphOperationsTest {
     public void shouldforAllNodesWork() {
         AtomicInteger counter = new AtomicInteger();
         BatchJobResult result = forAllNodes(db, Executors.newFixedThreadPool(4), 10,
-                (ktx,nodeCursor) -> counter.incrementAndGet());
+                (ktx,nodeCursor) -> counter.incrementAndGet() );
         assertEquals(1001, counter.get());
-        final long highestIdInUse = getHighestIdInUseForStore(db.getDependencyResolver(), NODES);
-        assertEquals(Double.valueOf(Math.ceil(highestIdInUse / 10.0)).longValue() , result.getBatches());
-        assertEquals( 1001, result.getSucceeded());
+        assertEquals(1001, result.getSucceeded());
 
         long countOfNodes = TestUtil.singleResultFirstColumn(db, "match (n) return count(n) as count");
 
-        assertEquals( 9, result.getMissing()); // TODO: why do we get 9 missings ?
-        assertEquals( 0, result.getFailures());
+        assertEquals(0, result.getFailures());
     }
 
     @Test
@@ -51,10 +49,7 @@ public class MultiThreadedGlobalGraphOperationsTest {
         BatchJobResult result = forAllRelationships(db, Executors.newFixedThreadPool(4), 10,
                 (ktx, relationshipScanCursor) -> counter.incrementAndGet());
         assertEquals(1000, counter.get());
-        final long highestIdInUse = getHighestIdInUseForStore(db.getDependencyResolver(), RELATIONSHIPS);
-        assertEquals(Double.valueOf(Math.ceil(highestIdInUse / 10.0)).longValue(), result.getBatches());
-        assertEquals( 1000, result.getSucceeded());
-        assertEquals( 0, result.getMissing());
-        assertEquals( 0, result.getFailures());
+        assertEquals(1000, result.getSucceeded());
+        assertEquals(0, result.getFailures());
     }
 }


### PR DESCRIPTION
Storage engine agnostic MultiThreadedGlobalGraphOperations implementation

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - MultiThreadedGlobalGraphOperations was accessing record storage specific classes and methods, which won't work with other storage engines going forward. Changed it to use the cursor scan concept and tries to keep the same multi-threaded functionality of it.