### PR TITLE
distance has been replaced with point.distance

### DIFF
--- a/core/src/test/java/apoc/spatial/SpatialTest.java
+++ b/core/src/test/java/apoc/spatial/SpatialTest.java
@@ -116,7 +116,7 @@ public class SpatialTest {
                 "MATCH (a:Event) \n" +
                 "WHERE exists(a.address)\n" +
                 "CALL apoc.spatial.geocodeOnce(a.address) YIELD location \n" +
-                "WITH location, distance(point({latitude: location.latitude, longitude:location.longitude}), eiffel) AS distance\n" +
+                "WITH location, point.distance(point({latitude: location.latitude, longitude:location.longitude}), eiffel) AS distance\n" +
                 "WHERE distance < 5000\n" +
                 "RETURN location.description AS description, distance\n" +
                 "ORDER BY distance\n" +
@@ -136,7 +136,7 @@ public class SpatialTest {
         String query = "WITH point({latitude: 48.8582532, longitude: 2.294287}) AS eiffel\n" +
                 "MATCH (a:Event) \n" +
                 "WHERE exists(a.latitude) AND exists(a.longitude)\n" +
-                "WITH a, distance(point(a), eiffel) AS distance\n" +
+                "WITH a, point.distance(point(a), eiffel) AS distance\n" +
                 "WHERE distance < 5000\n" +
                 "RETURN a.name AS event, distance\n" +
                 "ORDER BY distance\n" +
@@ -153,7 +153,7 @@ public class SpatialTest {
                 "WITH apoc.date.parse(e.datetime,'h') as hours, e, due_date, eiffel\n" +
                 "CALL apoc.spatial.geocodeOnce(e.address) YIELD location\n" +
                 "WITH e, location,\n" +
-                "     distance(point({longitude: location.longitude, latitude:location.latitude}), eiffel) as distance,\n" +
+                "     point.distance(point({longitude: location.longitude, latitude:location.latitude}), eiffel) as distance,\n" +
                 "     (due_date - hours)/24.0 as days_before_due\n" +
                 "WHERE distance < 5000 AND days_before_due < 14 AND hours < due_date\n" +
                 "RETURN e.name as event, e.datetime as date,\n" +

--- a/docs/asciidoc/modules/ROOT/pages/misc/spatial.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/misc/spatial.adoc
@@ -129,7 +129,7 @@ RETURN location.latitude AS latitude, location.longitude AS longitude, location.
 == Calculating distance between locations
 
 If we wish to calculate the distance between addresses, we need to use the point() function to convert
-latitude and longitude to Cyper Point types, and then use the distance() function to calculate the distance:
+latitude and longitude to Cyper Point types, and then use the point.distance() function to calculate the distance:
 
 [source,cypher]
 ----
@@ -137,7 +137,7 @@ WITH point({latitude: 48.8582532, longitude: 2.294287}) AS eiffel
 MATCH (a:Place)
 WHERE exists(a.address)
 CALL apoc.spatial.geocodeOnce(a.address) YIELD location
-WITH location, distance(point(location), eiffel) AS distance
+WITH location, point.distance(point(location), eiffel) AS distance
 WHERE distance < 5000
 RETURN location.description AS description, distance
 ORDER BY distance
@@ -208,7 +208,7 @@ Now make use of the results in distance queries
 WITH point({latitude: 48.8582532, longitude: 2.294287}) AS eiffel
 MATCH (a:Place)
 WHERE exists(a.latitude) AND exists(a.longitude)
-WITH a, distance(point(a), eiffel) AS distance
+WITH a, point.distance(point(a), eiffel) AS distance
 WHERE distance < 5000
 RETURN a.name, distance
 ORDER BY distance

--- a/docs/guide.html
+++ b/docs/guide.html
@@ -3896,7 +3896,7 @@ RETURN location.latitude AS latitude, location.longitude AS longitude, location.
     <div>
       <div class="paragraph">
 <p>If we wish to calculate the distance between addresses, we need to use the point() function to convert
-latitude and longitude to Cyper Point types, and then use the distance() function to calculate the distance:</p>
+latitude and longitude to Cyper Point types, and then use the point.distance() function to calculate the distance:</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -3904,7 +3904,7 @@ latitude and longitude to Cyper Point types, and then use the distance() functio
 MATCH (a:Place)
 WHERE exists(a.address)
 CALL apoc.spatial.geocodeOnce(a.address) YIELD location
-WITH location, distance(point(location), eiffel) AS distance
+WITH location, point.distance(point(location), eiffel) AS distance
 WHERE distance &lt; 5000
 RETURN location.description AS description, distance
 ORDER BY distance
@@ -3999,7 +3999,7 @@ Two good reasons:</p>
 <pre mode="cypher"  class="highlight pre-scrollable programlisting cm-s-neo code runnable standalone-example ng-binding" data-lang="cypher" lang="cypher"><!--code class="cypher language-cypher"-->WITH point({latitude: 48.8582532, longitude: 2.294287}) AS eiffel
 MATCH (a:Place)
 WHERE exists(a.latitude) AND exists(a.longitude)
-WITH a, distance(point(a), eiffel) AS distance
+WITH a, point.distance(point(a), eiffel) AS distance
 WHERE distance &lt; 5000
 RETURN a.name, distance
 ORDER BY distance

--- a/docs/index.html
+++ b/docs/index.html
@@ -5104,7 +5104,7 @@ RETURN location.latitude AS latitude, location.longitude AS longitude, location.
 <h4 id="_calculating_distance_between_locations"><a class="link" href="#_calculating_distance_between_locations">Calculating distance between locations</a></h4>
 <div class="paragraph">
 <p>If we wish to calculate the distance between addresses, we need to use the point() function to convert
-latitude and longitude to Cyper Point types, and then use the distance() function to calculate the distance:</p>
+latitude and longitude to Cyper Point types, and then use the point.distance() function to calculate the distance:</p>
 </div>
 <div class="listingblock">
 <div class="content">
@@ -5112,7 +5112,7 @@ latitude and longitude to Cyper Point types, and then use the distance() functio
 MATCH (a:Place)
 WHERE exists(a.address)
 CALL apoc.spatial.geocodeOnce(a.address) YIELD location
-WITH location, distance(point(location), eiffel) AS distance
+WITH location, point.distance(point(location), eiffel) AS distance
 WHERE distance &lt; 5000
 RETURN location.description AS description, distance
 ORDER BY distance
@@ -5198,7 +5198,7 @@ Two good reasons:</p>
 <pre class="highlight"><code class="language-cypher" data-lang="cypher">WITH point({latitude: 48.8582532, longitude: 2.294287}) AS eiffel
 MATCH (a:Place)
 WHERE exists(a.latitude) AND exists(a.longitude)
-WITH a, distance(point(a), eiffel) AS distance
+WITH a, point.distance(point(a), eiffel) AS distance
 WHERE distance &lt; 5000
 RETURN a.name, distance
 ORDER BY distance


### PR DESCRIPTION
The `distance` function has been moved to `point.distance` in 5.0. This changes all usages to reflect the change. 