### PR TITLE
Remove usage of CoordinateReferenceSystem

### DIFF
--- a/core/src/main/java/apoc/export/util/PointSerializer.java
+++ b/core/src/main/java/apoc/export/util/PointSerializer.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import org.neo4j.graphdb.spatial.Point;
-import org.neo4j.values.storable.CoordinateReferenceSystem;
 
 import java.io.IOException;
 import java.util.List;
@@ -16,7 +15,7 @@ public class PointSerializer extends JsonSerializer<Point> {
         String crsType = value.getCRS().getType();
         List<Double> coordinate = value.getCoordinate().getCoordinate();
 
-        if (crsType.startsWith(CoordinateReferenceSystem.Cartesian.toString())) {
+        if (crsType.startsWith("cartesian")) {
             if (coordinate.size() == 3) {
                 jsonGenerator.writeObject(new PointCartesian(crsType, coordinate.get(0), coordinate.get(1), coordinate.get(2)));
             } else {


### PR DESCRIPTION
`CoordinateReferenceSystem` is not listed as `@PublicAPI`. This usage was found in an internal Neo4j failing build.
A pending internal PR is changing some constant names to fit with internal naming conventions. Rather than fix it to use the new (still internal) name; this change explicitly checks for the string, minimising direct use, and assumptions, of internals.