### PR TITLE
Update S3 dependency versions in docs to eliminate CVEs

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/import/web-apis.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/web-apis.adoc
@@ -43,11 +43,11 @@ apoc.load.json("https://github.com/neo4j-contrib/neo4j-apoc-procedures/tree/3.4/
 
 When using the S3 protocol we need to download and copy the following jars into the plugins directory:
 
-* aws-java-sdk-core-1.11.250.jar (https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-core/1.11.250)
-* aws-java-sdk-s3-1.11.250.jar (https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-s3/1.11.250)
-* httpclient-4.4.8.jar (https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient/4.5.4)
-* httpcore-4.5.4.jar (https://mvnrepository.com/artifact/org.apache.httpcomponents/httpcore/4.4.8)
-* joda-time-2.9.9.jar (https://mvnrepository.com/artifact/joda-time/joda-time/2.9.9)
+* aws-java-sdk-core-1.12.136.jar (https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-core/1.12.136)
+* aws-java-sdk-s3-1.12.136.jar (https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-s3/1.12.136)
+* httpclient-4.5.13.jar (https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient/4.5.13)
+* httpcore-4.4.15.jar (https://mvnrepository.com/artifact/org.apache.httpcomponents/httpcore/4.4.15)
+* joda-time-2.10.13.jar (https://mvnrepository.com/artifact/joda-time/joda-time/2.10.13)
 
 Once those files have been copied we'll need to restart the database.
 


### PR DESCRIPTION

Fixes #2424

The com.amazonaws:aws-java-sdk-core:1.11.250 dependency in particular, which dates back to 2017, was riddled with vulnerabilities.

## Proposed Changes

Use the following dependencies:
- com.amazonaws:aws-java-sdk-core:1.12.136 (CVE's are test dependencies, not compile)
- com.amazonaws:aws-java-sdk-s3:1.12.136 (no CVE's)
- org.apache.httpcomponents:httpclient:4.5.13 (CVE's are test dependencies, not compile)
- org.apache.httpcomponents:httpcore:4.4.15 (CVE's are test dependencies, not compile)
- joda-time:joda-time:2.10.13 (no CVE's)

  -
  -
  -
