### PR TITLE
Update cypher-based-procedures-functions.adoc

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/cypher-execution/cypher-based-procedures-functions.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/cypher-execution/cypher-based-procedures-functions.adoc
@@ -73,7 +73,7 @@ The default values are parsed as JSON.
 ----
 CALL apoc.custom.asProcedure('neighbours',
   'MATCH (n:Person {name:$name})-->(nb) RETURN nb as neighbour','read',
-  [['neighbour','NODE']],[['name','STRING'], 'get neighbours of a person']);
+  [['neighbour','NODE']],[['name','STRING']], 'get neighbours of a person');
 
 CALL custom.neighbours('Keanu Reeves') YIELD neighbour;
 ----


### PR DESCRIPTION
Line 76 closes the list after the description 'get neighbors of a person']. 
It needs to be after [['name','STRING']

Fixes #<Replace with the number of the issue, Mandatory>

One sentence summary of the change.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  -
  -
  -
