### PR TITLE
Fixes #2336: Error when restoring a backup with cypher-shell (≥ 4.3)

### DIFF
--- a/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -33,9 +33,8 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 
 	private static final String STATEMENT_CONSTRAINTS = "CREATE CONSTRAINT ON (node:%s) ASSERT (%s) %s;";
 
-	private static final String STATEMENT_NODE_FULLTEXT_IDX = "CALL db.index.fulltext.createNodeIndex('%s',[%s],[%s]);";
-	private static final String STATEMENT_REL_FULLTEXT_IDX = "CALL db.index.fulltext.createRelationshipIndex('%s',[%s],[%s]);";
-	public static final String PROPERTY_QUOTING_FORMAT = "'%s'";
+	private static final String STATEMENT_NODE_FULLTEXT_IDX = "CREATE FULLTEXT INDEX %s FOR (n:%s) ON EACH [%s];";
+	private static final String STATEMENT_REL_FULLTEXT_IDX = "CREATE FULLTEXT INDEX %s FOR ()-[rel:%s]-() ON EACH [%s];";
 
 	@Override
 	public String statementForCleanUp(int batchSize) {
@@ -59,12 +58,9 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 		String label = StreamSupport.stream(labels.spliterator(), false)
 				.map(Label::name)
 				.map(Util::quote)
-				.map(s -> String.format(PROPERTY_QUOTING_FORMAT, s))
-				.collect(Collectors.joining(","));
-		String key = StreamSupport.stream(keys.spliterator(), false)
-				.map(Util::quote)
-				.map(s -> String.format(PROPERTY_QUOTING_FORMAT, s))
-				.collect(Collectors.joining(","));
+				.collect(Collectors.joining("|"));
+		String key = getPropertiesQuoted(keys, "n.");
+
 		return String.format(STATEMENT_NODE_FULLTEXT_IDX, name, label, key);
 	}
 
@@ -73,12 +69,9 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 		String type = StreamSupport.stream(types.spliterator(), false)
 				.map(RelationshipType::name)
 				.map(Util::quote)
-				.map(s -> String.format(PROPERTY_QUOTING_FORMAT, s))
-				.collect(Collectors.joining(","));
-		String key = StreamSupport.stream(keys.spliterator(), false)
-				.map(Util::quote)
-				.map(s -> String.format(PROPERTY_QUOTING_FORMAT, s))
-				.collect(Collectors.joining(","));
+				.collect(Collectors.joining("|"));
+		String key = getPropertiesQuoted(keys, "rel.");
+		
 		return String.format(STATEMENT_REL_FULLTEXT_IDX, name, type, key);
 	}
 

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -555,20 +555,20 @@ public class ExportCypherTest {
     @Test
     public void exportMultiTokenIndex() {
         // given
-        db.executeTransactionally("CREATE (n:TempNode {value:'value'})");
-        db.executeTransactionally("CREATE (n:TempNode2 {value:'value'})");
-        db.executeTransactionally("CALL db.index.fulltext.createNodeIndex('MyCoolNodeFulltextIndex',['TempNode', 'TempNode2'],['value'])");
+        db.executeTransactionally("CREATE (n:TempNode {value:'value', value2:'value'})");
+        db.executeTransactionally("CREATE (n:TempNode2 {value:'value', value:'value2'})");
+        db.executeTransactionally("CALL db.index.fulltext.createNodeIndex('MyCoolNodeFulltextIndex',['TempNode', 'TempNode2'],['value', 'value2'])");
 
         String query = "MATCH (t:TempNode) return t";
         String file = null;
         Map<String, Object> config = map("awaitForIndexes", 3000);
         String expected = String.format(":begin%n" +
-                "CALL db.index.fulltext.createNodeIndex('MyCoolNodeFulltextIndex',['TempNode','TempNode2'],['value']);%n" +
+                "CREATE FULLTEXT INDEX MyCoolNodeFulltextIndex FOR (n:TempNode|TempNode2) ON EACH [n.value, n.value2];%n" +
                 "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
                 ":commit%n" +
                 "CALL db.awaitIndexes(3000);%n" +
                 ":begin%n" +
-                "UNWIND [{_id:3, properties:{value:\"value\"}}] AS row%n" +
+                "UNWIND [{_id:3, properties:{value2:\"value\", value:\"value\"}}] AS row%n" +
                 "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:TempNode;%n" +
                 ":commit%n" +
                 ":begin%n" +


### PR DESCRIPTION
Fixes #2336 (≥ 4.3)

New syntax. This also fixes the bug.
 
It's not possible to create test for the fulltext relationship due to `https://github.com/neo4j/neo4j/issues/12304`