### PR TITLE
Exclude module-info.class from fat jar on 3.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,8 @@ configurations {
 }
 
 shadowJar {
-    classifier = 'all'  
+    classifier = 'all'
+    exclude 'module-info.class'
 }
 
 compileJava {


### PR DESCRIPTION
module-info.class is not compatible with JDK 1.8