### PR TITLE
Update Neo4j Logging API usage

### DIFF
--- a/core/src/main/java/apoc/RegisterComponentFactory.java
+++ b/core/src/main/java/apoc/RegisterComponentFactory.java
@@ -1,25 +1,24 @@
 package apoc;
 
-import apoc.trigger.TriggerHandler;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 import org.neo4j.kernel.api.procedure.GlobalProcedures;
 import org.neo4j.kernel.extension.ExtensionFactory;
 import org.neo4j.kernel.extension.ExtensionType;
 import org.neo4j.kernel.extension.context.ExtensionContext;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
-import org.neo4j.logging.Log;
+import org.neo4j.logging.InternalLog;
 import org.neo4j.logging.internal.LogService;
 import org.neo4j.service.Services;
-
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * NOTE: this is a GLOBAL component, so only once per DBMS
  */
 public class RegisterComponentFactory extends ExtensionFactory<RegisterComponentFactory.Dependencies> {
 
-    private Log log;
+    private InternalLog log;
     private GlobalProcedures globalProceduresRegistry;
 
     public RegisterComponentFactory() {

--- a/core/src/test/java/apoc/ApocConfigTest.java
+++ b/core/src/test/java/apoc/ApocConfigTest.java
@@ -10,7 +10,7 @@ import org.neo4j.configuration.Config;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.logging.AssertableLogProvider;
-import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.InternalLogProvider;
 import org.neo4j.logging.internal.SimpleLogService;
 import org.neo4j.procedure.impl.GlobalProceduresRegistry;
 
@@ -26,7 +26,7 @@ public class ApocConfigTest {
 
     @Before
     public void setup() {
-        LogProvider logProvider = new AssertableLogProvider();
+        InternalLogProvider logProvider = new AssertableLogProvider();
 
         Config neo4jConfig = mock(Config.class);
         when(neo4jConfig.getDeclaredSettings()).thenReturn(Collections.emptyMap());

--- a/core/src/test/java/org/neo4j/test/rule/ImpermanentDbmsRule.java
+++ b/core/src/test/java/org/neo4j/test/rule/ImpermanentDbmsRule.java
@@ -1,6 +1,7 @@
 package org.neo4j.test.rule;
 
 import org.neo4j.dbms.api.DatabaseManagementServiceBuilder;
+import org.neo4j.logging.ExternalLogProviderWrapper;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 
@@ -43,6 +44,6 @@ public class ImpermanentDbmsRule extends DbmsRule
 
     protected final TestDatabaseManagementServiceBuilder maybeSetInternalLogProvider( TestDatabaseManagementServiceBuilder factory )
     {
-        return ( internalLogProvider == null ) ? factory : factory.setInternalLogProvider( internalLogProvider );
+        return ( internalLogProvider == null ) ? factory : factory.setInternalLogProvider( new ExternalLogProviderWrapper( internalLogProvider ) );
     }
 }

--- a/test-utils/src/main/java/org/neo4j/test/rule/ImpermanentDbmsRule.java
+++ b/test-utils/src/main/java/org/neo4j/test/rule/ImpermanentDbmsRule.java
@@ -1,6 +1,7 @@
 package org.neo4j.test.rule;
 
 import org.neo4j.dbms.api.DatabaseManagementServiceBuilder;
+import org.neo4j.logging.ExternalLogProviderWrapper;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 
@@ -43,6 +44,6 @@ public class ImpermanentDbmsRule extends DbmsRule
 
     protected final TestDatabaseManagementServiceBuilder maybeSetInternalLogProvider( TestDatabaseManagementServiceBuilder factory )
     {
-        return ( internalLogProvider == null ) ? factory : factory.setInternalLogProvider( internalLogProvider );
+        return ( internalLogProvider == null ) ? factory : factory.setInternalLogProvider( new ExternalLogProviderWrapper( internalLogProvider ) );
     }
 }


### PR DESCRIPTION
A few methods have moved to the InternalLogProvider and this will fix all related compilation errors.
