### PR TITLE
Missing ^ in the example for ascending order

### DIFF
--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.coll.sortNodes.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.coll.sortNodes.adoc
@@ -29,7 +29,7 @@ The following sorts a collection of nodes by the `name` property in ascending or
 ----
 MATCH (person:Person)
 WITH collect(person) AS people
-RETURN apoc.coll.sortNodes(people, 'name') AS output;
+RETURN apoc.coll.sortNodes(people, '^name') AS output;
 ----
 
 .Results


### PR DESCRIPTION
Missing ^ in the documentation for sortNodes ascendingOrder.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added ^ in the example for the sortNodes function - ascending order
