### PR TITLE
Fixes #2285: apoc.bolt.load from neo4j 4.3.6 to 3.5.29 does not work

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/database-integration/bolt-neo4j.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/bolt-neo4j.adoc
@@ -12,6 +12,7 @@ Bolt procedures allows to accessing other databases via bolt protocol.
 ¦Qualified Name¦Type¦Release
 include::example$generated-documentation/apoc.bolt.execute.adoc[]
 include::example$generated-documentation/apoc.bolt.load.adoc[]
+include::example$generated-documentation/apoc.bolt.load.fromLocal.adoc[]
 |===
 
 **urlOrKey** param allows users to decide if send url by apoc or if put it into apoc.conf file.
@@ -65,6 +66,13 @@ Config available are:
 
 * `statistics`: possible values are true/false, the default value is false. This config print the execution statistics;
 * `virtual`: possible values are true/false, the default value is false. This config return result in virtual format and not in map format, in apoc.bolt.load.
+* `databaseName`: the database instance name on the remote Neo4j instance. The default value is 'neo4j'. Put `null` to connect through protocol which not support database name (for neo4j before 4.x).
+
+
+In addition, the `apoc.bolt.load.fromLocal` can have:
+* `streamStatements`: if true and used in combination with the cypher export procedures it streams the statement from local to remote database.
+* `readOnly`: default false. To execute or not, read-only statements.  
+* `localParams`: to put optional parameters to local cypher statement
 
 == Driver configuration
 

--- a/full/src/main/java/apoc/bolt/BoltConfig.java
+++ b/full/src/main/java/apoc/bolt/BoltConfig.java
@@ -84,8 +84,11 @@ public class BoltConfig {
     }
 
     public SessionConfig getSessionConfig() {
-        return SessionConfig.builder()
-                .withDatabase(this.databaseName)
+        final SessionConfig.Builder builder = SessionConfig.builder();
+        if (this.databaseName != null) {
+            builder.withDatabase(this.databaseName);
+        }
+        return builder
                 .withDefaultAccessMode(readOnly ? AccessMode.READ : AccessMode.WRITE)
                 .build();
     }

--- a/full/src/test/java/apoc/bolt/BoltTest.java
+++ b/full/src/test/java/apoc/bolt/BoltTest.java
@@ -7,6 +7,7 @@ import apoc.util.TestContainerUtil;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.junit.AfterClass;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -67,6 +68,15 @@ public class BoltTest {
         if (neo4jContainer != null && neo4jContainer.isRunning()) {
             neo4jContainer.close();
         }
+    }
+    
+    @Test
+    public void testNeo4jBolt() {
+        final String uriDbBefore4 = System.getenv("URI_DB_BEFORE_4");
+        Assume.assumeNotNull(uriDbBefore4);
+        TestUtil.testCall(db, "CALL apoc.bolt.load($uri, 'RETURN 1', {}, {databaseName: null})", 
+                Map.of("uri", uriDbBefore4),
+                r -> assertEquals(Map.of("1", 1L), r.get("row")));
     }
 
     @Test


### PR DESCRIPTION
Fixes #2285

Small fixes adoc