### PR TITLE
Fixes #2405: The apoc.schema.assert procedure fails with multi-label fulltext index

### DIFF
--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -169,6 +169,8 @@ public class Schemas {
                 continue;
             if (definition.isConstraintIndex())
                 continue;
+            if (definition.isMultiTokenIndex())
+                continue;
 
             String label = Iterables.single(definition.getLabels()).name();
             List<String> keys = new ArrayList<>();

--- a/core/src/test/java/apoc/schema/SchemasTest.java
+++ b/core/src/test/java/apoc/schema/SchemasTest.java
@@ -129,6 +129,7 @@ public class SchemasTest {
     @Test
     public void testDropIndexWhenUsingDropExisting() throws Exception {
         db.executeTransactionally("CREATE INDEX ON :Foo(bar)");
+        db.executeTransactionally("CREATE FULLTEXT INDEX titlesAndDescriptions FOR (n:Movie|Book) ON EACH [n.title, n.description]");
         testCall(db, "CALL apoc.schema.assert(null,null)", (r) -> {
             assertEquals("Foo", r.get("label"));
             assertEquals("bar", r.get("key"));
@@ -137,7 +138,8 @@ public class SchemasTest {
         });
         try (Transaction tx = db.beginTx()) {
             List<IndexDefinition> indexes = Iterables.asList(tx.schema().getIndexes());
-            assertEquals(0, indexes.size());
+            // the multi-token idx remains
+            assertEquals(1, indexes.size());
         }
     }
 


### PR DESCRIPTION
Fixes #2405