### PR TITLE
Improve performance apoc.meta.stats 4.x

### DIFF
--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -476,30 +476,25 @@ public class    Meta {
     private void collectStats(SubGraph subGraph, Collection<String> labelNames, Collection<String> relTypeNames, StatsCallback cb) {
         TokenRead tokenRead = kernelTx.tokenRead();
 
-        Map<String, Integer> labelMap = subGraph.labelsInUse(tokenRead, labelNames);
-        Map<String, Integer> typeMap = subGraph.relTypesInUse(tokenRead, relTypeNames);
-
-        Iterable<Label> labels = CollectionUtils.isNotEmpty(labelNames)
-                ? labelNames.stream().map(Label::label).collect(Collectors.toList()) : subGraph.getAllLabelsInUse();
-        Iterable<RelationshipType> types = CollectionUtils.isNotEmpty(relTypeNames)
-                ? relTypeNames.stream().map(RelationshipType::withName).collect(Collectors.toList()) : subGraph.getAllRelationshipTypesInUse();
+        Iterable<Label> labels = subGraph.labelsInUse(labelNames);
+        Iterable<RelationshipType> types = subGraph.relTypesInUse(relTypeNames);
 
         labels.forEach(label -> {
             long count = subGraph.countsForNode(label);
             if (count > 0) {
                 String name = label.name();
-                int id = labelMap.get(name);
+                int id = tokenRead.nodeLabel(name);
                 cb.label(id, name, count);
                 types.forEach(type -> {
                     long relCountOut = subGraph.countsForRelationship(label, type);
                     long relCountIn = subGraph.countsForRelationship(type, label);
-                    cb.rel(typeMap.get(type.name()), type.name(), id, name, relCountOut, relCountIn);
+                    cb.rel(tokenRead.relationshipType(type.name()), type.name(), id, name, relCountOut, relCountIn);
                 });
             }
         });
         types.forEach(type -> {
             String name = type.name();
-            int id = typeMap.get(name);
+            int id = tokenRead.relationshipType(name);
             cb.rel(id, name, subGraph.countsForRelationship(type));
         });
     }
@@ -1043,15 +1038,13 @@ public class    Meta {
     private Stream<GraphResult> metaGraph(SubGraph subGraph, Collection<String> labelNames, Collection<String> relTypeNames, boolean removeMissing, MetaConfig metaConfig) {
         TokenRead tokenRead = kernelTx.tokenRead();
 
-        Map<String, Integer> typeMap = subGraph.relTypesInUse(tokenRead, relTypeNames);
+        Iterable<RelationshipType> types = subGraph.relTypesInUse(relTypeNames);
         Iterable<Label> labels = CollectionUtils.isNotEmpty(labelNames)
                 ? labelNames.stream().map(Label::label).collect(Collectors.toList()) : subGraph.getAllLabelsInUse();
-        Iterable<RelationshipType> types = CollectionUtils.isNotEmpty(relTypeNames)
-                ? relTypeNames.stream().map(RelationshipType::withName).collect(Collectors.toList()) : subGraph.getAllRelationshipTypesInUse();
 
 
         Map<String, Node> vNodes = new TreeMap<>();
-        Map<Pattern, Relationship> vRels = new HashMap<>(typeMap.size() * 2);
+        Map<Pattern, Relationship> vRels = new HashMap<>((int) Iterables.count(types) * 2);
 
         labels.forEach(label -> {
             long count = subGraph.countsForNode(label);

--- a/core/src/main/java/org/neo4j/cypher/export/SubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/SubGraph.java
@@ -12,10 +12,10 @@ import org.neo4j.internal.kernel.api.TokenRead;
 
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.Map;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static java.util.stream.Collectors.toMap;
 
 public interface SubGraph
 {
@@ -41,24 +41,20 @@ public interface SubGraph
 
     Iterator<Node> findNodes(Label label);
 
-    default Map<String, Integer> relTypesInUse(TokenRead ops, Collection<String> relTypeNames) {
+    default List<RelationshipType> relTypesInUse(Collection<String> relTypeNames) {
         Stream<RelationshipType> stream = Iterables.stream(this.getAllRelationshipTypesInUse());
         if (CollectionUtils.isNotEmpty(relTypeNames)) {
             stream = stream.filter(rel -> relTypeNames.contains(rel.name()));
         }
-        return stream
-                .map(RelationshipType::name)
-                .collect(toMap(t -> t, ops::relationshipType));
+        return stream.collect(Collectors.toList());
     }
 
-    default Map<String, Integer> labelsInUse(TokenRead ops, Collection<String> labelNames) {
+    default List<Label> labelsInUse(Collection<String> labelNames) {
         Stream<Label> stream = Iterables.stream(this.getAllLabelsInUse());
         if (CollectionUtils.isNotEmpty(labelNames)) {
             stream = stream.filter(rel -> labelNames.contains(rel.name()));
         }
-        return stream
-                .map(Label::name)
-                .collect(toMap(t -> t, ops::nodeLabel));
+        return stream.collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
Improve performance apoc.meta.stats 4.x

Changed implementation to leverage on `org.neo4j.internal.kernel.api.TokenRead`,
much faster than "classic" count(n) queries because of planner overhead