### PR TITLE
Fixes #2334: apoc.load.directory() fails on Windows

### DIFF
--- a/core/src/main/java/apoc/util/FileUtils.java
+++ b/core/src/main/java/apoc/util/FileUtils.java
@@ -337,7 +337,7 @@ public class FileUtils {
     }
 
     public static Path getPathFromUrlString(String urlDir) {
-        return Paths.get(URI.create(urlDir).getPath());
+        return Paths.get(URI.create(urlDir));
     }
 
     // to exclude cases like 'testload.tar.gz?raw=true'

--- a/full/src/main/java/apoc/load/LoadDirectory.java
+++ b/full/src/main/java/apoc/load/LoadDirectory.java
@@ -19,6 +19,8 @@ import org.neo4j.procedure.Name;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Collection;
 import java.util.stream.Stream;
@@ -110,9 +112,12 @@ public class LoadDirectory {
 
     // visible for test purpose
     public static String checkIfUrlBlankAndGetFileUrl(String urlDir) throws IOException {
-        return StringUtils.isBlank(urlDir)
-                ? encodePath(getDirImport())
-                : FileUtils.changeFileUrlIfImportDirectoryConstrained(urlDir.replace("?", "%3F"));
+        if (StringUtils.isBlank(urlDir)) {
+            final Path pathImport = Paths.get(getDirImport()).toAbsolutePath();
+            // with replaceAll we remove final "/" from path
+            return pathImport.toUri().toString().replaceAll(".$", "");
+        }
+        return FileUtils.changeFileUrlIfImportDirectoryConstrained(urlDir.replace("?", "%3F"));
     }
 
 }

--- a/full/src/test/java/apoc/load/LoadDirectoryTest.java
+++ b/full/src/test/java/apoc/load/LoadDirectoryTest.java
@@ -55,9 +55,9 @@ public class LoadDirectoryTest {
     public static TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     private static GraphDatabaseService db;
-    private static File importFolder;
+    private static String importPath;
 
-    private static final String IMPORT_DIR = "import";
+    private static final String IMPORT_DIR = "impo rt";
     private static final String SUBFOLDER_1 = "sub1";
     private static final String INNER_SUBFOLDER = "innerSub1";
     private static final String SUBFOLDER_2 = "sub2";
@@ -77,7 +77,8 @@ public class LoadDirectoryTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        importFolder = new File(temporaryFolder.getRoot() + File.separator + IMPORT_DIR);
+        File importFolder = new File(temporaryFolder.getRoot() + File.separator + IMPORT_DIR);
+        importPath = encodePath(FILE_PROTOCOL + importFolder.getPath());
         DatabaseManagementService databaseManagementService = new TestDatabaseManagementServiceBuilder(importFolder.toPath()).build();
         db = databaseManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
 
@@ -295,7 +296,7 @@ public class LoadDirectoryTest {
             Map<String, Object> mapTestOne = result.next();
             assertThat(mapTestOne.get("name"), isOneOf("testOne", "testTwo"));
             assertThat(mapTestOne.get("pattern"), isOneOf("*.csv", "*.json"));
-            assertEquals(encodePath(importFolder.getPath()), mapTestOne.get("urlDir"));
+            assertEquals(importPath, mapTestOne.get("urlDir"));
             assertEquals("CREATE (n:Test)", mapTestOne.get("cypher"));
             assertEquals(defaultConfig, mapTestOne.get("config"));
             assertEquals(LoadDirectoryItem.Status.RUNNING.name(), mapTestOne.get("status"));
@@ -303,7 +304,7 @@ public class LoadDirectoryTest {
             Map<String, Object> mapTestTwo = result.next();
             assertThat(mapTestTwo.get("name"), isOneOf("testOne", "testTwo"));
             assertThat(mapTestTwo.get("pattern"), isOneOf("*.csv", "*.json"));
-            assertEquals(encodePath(importFolder.getPath()), mapTestTwo.get("urlDir"));
+            assertEquals(importPath, mapTestTwo.get("urlDir"));
             assertEquals("CREATE (n:Test)", mapTestTwo.get("cypher"));
             assertEquals(defaultConfig, mapTestTwo.get("config"));
             assertEquals(LoadDirectoryItem.Status.RUNNING.name(), mapTestTwo.get("status"));
@@ -315,7 +316,7 @@ public class LoadDirectoryTest {
             // remains 2nd listener
             assertEquals("testTwo", result.get("name"));
             assertEquals("*.json", result.get("pattern"));
-            assertEquals(encodePath(importFolder.getPath()), result.get("urlDir"));
+            assertEquals(importPath, result.get("urlDir"));
             assertEquals("CREATE (n:Test)", result.get("cypher"));
             assertEquals(defaultConfig, result.get("config"));
             assertEquals(LoadDirectoryItem.Status.RUNNING.name(), result.get("status"));
@@ -345,7 +346,7 @@ public class LoadDirectoryTest {
         testCall(db, "CALL apoc.load.directory.async.add('test','CREATE (n:Test {file: $fileName})','*.json')", result -> {
             assertEquals("test", result.get("name"));
             assertEquals("*.json", result.get("pattern"));
-            assertEquals(encodePath(importFolder.getPath()), result.get("urlDir"));
+            assertEquals(importPath, result.get("urlDir"));
             assertEquals("CREATE (n:Test {file: $fileName})", result.get("cypher"));
             assertEquals(defaultConfig, result.get("config"));
             assertEquals(LoadDirectoryItem.Status.CREATED.name(), result.get("status"));
@@ -476,7 +477,7 @@ public class LoadDirectoryTest {
             // remain 1st listener
             assertEquals("testTwo", result.get("name"));
             assertEquals("*.json", result.get("pattern"));
-            assertEquals(encodePath(importFolder.getPath()), result.get("urlDir"));
+            assertEquals(importPath, result.get("urlDir"));
             assertEquals("CREATE (n:TestTwo)", result.get("cypher"));
             assertEquals("CREATE (n:TestTwo)", result.get("cypher"));
         });


### PR DESCRIPTION
Fixes #2334 (cherry-pick of https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/1973, same cause).

This solves https://trello.com/c/PCtmfQod/861-apocloaddirectory-not-working-in-apoc-4300 issue too.
