### PR TITLE
Fixes #1674: Manage utf8 file with BOM properly

### DIFF
--- a/core/src/main/java/apoc/export/util/CountingInputStream.java
+++ b/core/src/main/java/apoc/export/util/CountingInputStream.java
@@ -1,5 +1,7 @@
 package apoc.export.util;
 
+import org.apache.commons.io.input.BOMInputStream;
+
 import java.io.*;
 
 /**
@@ -13,12 +15,17 @@ public class CountingInputStream extends FilterInputStream implements SizeCounte
     private long newLines;
 
     public CountingInputStream(File file) throws FileNotFoundException {
-        super(new BufferedInputStream(new FileInputStream(file), BUFFER_SIZE));
+        super(toBufferedStream(new FileInputStream(file)));
         this.total = file.length();
     }
     public CountingInputStream(InputStream stream, long total) throws FileNotFoundException {
-        super(new BufferedInputStream(stream, BUFFER_SIZE));
+        super(toBufferedStream(stream));
         this.total = total;
+    }
+
+    private static BufferedInputStream toBufferedStream(InputStream stream) {
+        final BOMInputStream bomInputStream = new BOMInputStream(stream);
+        return new BufferedInputStream(bomInputStream, BUFFER_SIZE);
     }
 
     @Override

--- a/full/src/test/java/apoc/load/LoadCsvTest.java
+++ b/full/src/test/java/apoc/load/LoadCsvTest.java
@@ -220,6 +220,19 @@ RETURN m.col_1,m.col_2,m.col_3
                     assertEquals(asList("Selina", asList("Cola")), r.next().get("list"));
                 });
     }
+    
+    @Test
+    public void testLoadCsvWithBom() {
+        String url = "taxonomy.csv";
+        testCall(db, "CALL apoc.load.csv($url) YIELD map return map['smth1'] as first, map['ceva'] as second",
+                map("url",url),
+                (row) -> {
+                    final Object first = row.get("first");
+                    final Object second = row.get("second");
+                    assertEquals("Taxonomy", first);
+                    assertEquals("1", second);
+                });
+    }
 
     @Test public void testMapping() throws Exception {
         String url = "test-mapping.csv";

--- a/full/src/test/resources/taxonomy.csv
+++ b/full/src/test/resources/taxonomy.csv
@@ -1,0 +1,2 @@
+﻿ceva,Tree Level,Tree Path,Id,Code,Description,Long Description,smth,smth1,Active,Code Valid from,Node Valid from,Node Valid to
+1,1,(Root Code),31102727,Something,SomethingElse,,Something,Taxonomy,A,31/01/2020,,


### PR DESCRIPTION
Fixes #1674

Wrapped `InputStream` into `BOMInputStream`.

---

I tried to overwrite BOM with null charachter `\ 0`, but it does not work, because the null character is different from "empty character ".

Also, I tried to assign the `cbuf` array with another cleaned and then re-read the portion,
but it doesn't work as well, because the `BufferedReader` under the hood takes the starting array with the BOM (`cb`) and replaces the other cleaned array -> `System.arraycopy(cb, nextChar, cbuf, off, n); `.

Because of this, I opted for the `BOMInputStream`.




