### PR TITLE
Update expected systemdb content

### DIFF
--- a/full/src/test/java/apoc/systemdb/SystemDbTest.java
+++ b/full/src/test/java/apoc/systemdb/SystemDbTest.java
@@ -14,6 +14,7 @@ import org.neo4j.internal.helpers.collection.MapUtil;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -58,8 +59,8 @@ public class SystemDbTest {
             List<Map<String, Object>> rows = Iterators.asList(result.columnAs("row"));
             // removed key "systemDefault"
             org.hamcrest.MatcherAssert.assertThat(rows, Matchers.containsInAnyOrder(
-                    MapUtil.map("name", "system", "default", false, "currentStatus", "online", "role", "standalone", "requestedStatus", "online", "error", "", "address", "localhost:7687"),
-                    MapUtil.map("name", "neo4j", "default", true, "currentStatus", "online", "role", "standalone", "requestedStatus", "online", "error", "", "address", "localhost:7687")
+                    MapUtil.map( "name", "system", "default", false, "currentStatus", "online", "role", "standalone", "requestedStatus", "online", "error", "", "address", "localhost:7687", "aliases", Collections.EMPTY_LIST, "access", "read-write", "home", false),
+                    MapUtil.map("name", "neo4j", "default", true, "currentStatus", "online", "role", "standalone", "requestedStatus", "online", "error", "", "address", "localhost:7687", "aliases", Collections.EMPTY_LIST, "access", "read-write", "home", true)
             ));
         });
     }

--- a/full/src/test/java/apoc/systemdb/SystemDbTest.java
+++ b/full/src/test/java/apoc/systemdb/SystemDbTest.java
@@ -39,15 +39,16 @@ public class SystemDbTest {
             Map<String, Object> map = Iterators.single(result);
             List<Node> nodes = (List<Node>) map.get("nodes");
             List<Relationship> relationships = (List<Relationship>) map.get("relationships");
-            assertEquals(5, nodes.size());
+            assertEquals(6, nodes.size());
             assertEquals(2, nodes.stream().filter( node -> "Database".equals(Iterables.single(node.getLabels()).name())).count());
+            assertEquals(2, nodes.stream().filter( node -> "DatabaseName".equals(Iterables.single(node.getLabels()).name())).count());
             assertEquals(1, nodes.stream().filter( node -> "User".equals(Iterables.single(node.getLabels()).name())).count());
             assertEquals(1, nodes.stream().filter( node -> "Version".equals(Iterables.single(node.getLabels()).name())).count());
-            assertEquals(1, nodes.stream().filter( node -> "DbmsRuntime".equals(Iterables.single(node.getLabels()).name())).count());
             Set<String> names = nodes.stream().map(node -> (String)node.getProperty("name")).filter(Objects::nonNull).collect(Collectors.toSet());
             org.hamcrest.MatcherAssert.assertThat( names, Matchers.containsInAnyOrder("neo4j", "system"));
 
-            assertTrue(relationships.isEmpty());
+            assertEquals( 2, relationships.size() );
+            assertEquals( 2, relationships.stream().filter( rel -> "TARGETS".equals( rel.getType().name() ) ).count() );
         });
     }
 


### PR DESCRIPTION
The initial content of the system database has changed, updating tests to reflect this
`SHOW DATABASES` have added columns to the output
