### PR TITLE
Fixes #2037: apoc.export.cypher.all to generate constraints with IF NOT EXISTS (4.4)

### DIFF
--- a/core/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/core/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -142,7 +142,7 @@ public class ExportCypher {
         MultiStatementCypherSubGraphExporter exporter = new MultiStatementCypherSubGraphExporter(graph, c, db);
 
         if (onlySchema)
-            exporter.exportOnlySchema(cypherFileManager);
+            exporter.exportOnlySchema(cypherFileManager, c);
         else
             exporter.export(c, reporter, cypherFileManager);
     }

--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -104,12 +104,12 @@ public class MultiStatementCypherSubGraphExporter {
         switch (useOptimizations) {
             case NONE:
                 exportNodes(nodesWriter, reporter, batchSize);
-                exportSchema(schemaWriter);
+                exportSchema(schemaWriter, config);
                 exportRelationships(relationshipsWriter, reporter, batchSize);
                 break;
             default:
                 artificialUniques += countArtificialUniques(graph.getNodes());
-                exportSchema(schemaWriter);
+                exportSchema(schemaWriter, config);
                 exportNodesUnwindBatch(nodesWriter, reporter);
                 exportRelationshipsUnwindBatch(relationshipsWriter, reporter);
                 break;
@@ -124,9 +124,9 @@ public class MultiStatementCypherSubGraphExporter {
         reporter.done();
     }
 
-    public void exportOnlySchema(ExportFileManager cypherFileManager) {
+    public void exportOnlySchema(ExportFileManager cypherFileManager, ExportConfig config) {
         PrintWriter schemaWriter = cypherFileManager.getPrintWriter("schema");
-        exportSchema(schemaWriter);
+        exportSchema(schemaWriter, config);
         schemaWriter.close();
     }
 
@@ -205,7 +205,7 @@ public class MultiStatementCypherSubGraphExporter {
 
     // ---- Schema ----
 
-    private void exportSchema(PrintWriter out) {
+    private void exportSchema(PrintWriter out, ExportConfig config) {
         List<String> indexesAndConstraints = new ArrayList<>();
         indexesAndConstraints.addAll(exportIndexes());
         indexesAndConstraints.addAll(exportConstraints());
@@ -215,7 +215,7 @@ public class MultiStatementCypherSubGraphExporter {
             out.println(index);
         }
         if (artificialUniques > 0) {
-            String cypher = this.cypherFormat.statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP));
+            String cypher = this.cypherFormat.statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP), config.ifNotExists());
             if (cypher != null && !"".equals(cypher)) {
                 out.println(cypher);
             }
@@ -258,10 +258,11 @@ public class MultiStatementCypherSubGraphExporter {
                     }
                     // "normal" schema index
                     String tokenName = tokenNames.get(0);
+                    final boolean ifNotExist = exportConfig.ifNotExists();
                     if (isNode) {
-                        return this.cypherFormat.statementForNodeIndex(tokenName, props);
+                        return this.cypherFormat.statementForNodeIndex(tokenName, props, ifNotExist);
                     } else {
-                        return this.cypherFormat.statementForIndexRelationship(tokenName, props);
+                        return this.cypherFormat.statementForIndexRelationship(tokenName, props, ifNotExist);
                     }
 
                 })
@@ -304,7 +305,7 @@ public class MultiStatementCypherSubGraphExporter {
                 .map(index -> {
                     String label = Iterables.single(index.getLabels()).name();
                     Iterable<String> props = index.getPropertyKeys();
-                    return this.cypherFormat.statementForConstraint(label, props);
+                    return this.cypherFormat.statementForConstraint(label, props, exportConfig.ifNotExists());
                 })
                 .filter(StringUtils::isNotBlank)
                 .collect(Collectors.toList());
@@ -324,7 +325,8 @@ public class MultiStatementCypherSubGraphExporter {
                 artificialUniques -= batchSize;
             }
             begin(out);
-            String cypher = this.cypherFormat.statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP)).replaceAll("^CREATE", "DROP");
+            String cypher = this.cypherFormat.statementForConstraint(UNIQUE_ID_LABEL, Collections.singleton(UNIQUE_ID_PROP), false)
+                    .replaceAll("^CREATE", "DROP");
             if (cypher != null && !"".equals(cypher)) {
                 out.println(cypher);
             }

--- a/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -33,17 +33,17 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
-	public String statementForNodeIndex(String label, Iterable<String> key) {
+	public String statementForNodeIndex(String label, Iterable<String> key, boolean ifNotExist) {
 		return "";
 	}
 	
 	@Override
-	public String statementForIndexRelationship(String type, Iterable<String> key) {
+	public String statementForIndexRelationship(String type, Iterable<String> key, boolean ifNotExists) {
 		return "";
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> keys) {
+	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -19,15 +19,15 @@ public interface CypherFormatter {
 
 	String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties);
 
-	String statementForNodeIndex(String label, Iterable<String> keys);
+	String statementForNodeIndex(String label, Iterable<String> keys, boolean ifNotExist);
 
-	String statementForIndexRelationship(String type, Iterable<String> keys);
+	String statementForIndexRelationship(String type, Iterable<String> keys, boolean ifNotExist);
 
 	String statementForNodeFullTextIndex(String name, Iterable<Label> labels, Iterable<String> keys);
 
 	String statementForRelationshipFullTextIndex(String name, Iterable<RelationshipType> types, Iterable<String> keys);
 
-	String statementForConstraint(String label, Iterable<String> keys);
+	String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExist);
 
 	String statementForCleanUp(int batchSize);
 

--- a/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -33,17 +33,17 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	}
 
 	@Override
-	public String statementForNodeIndex(String label, Iterable<String> key) {
+	public String statementForNodeIndex(String label, Iterable<String> key, boolean ifNotExist) {
 		return "";
 	}
 
 	@Override
-	public String statementForIndexRelationship(String type, Iterable<String> key) {
+	public String statementForIndexRelationship(String type, Iterable<String> key, boolean ifNotExists) {
 		return "";
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> key) {
+	public String statementForConstraint(String label, Iterable<String> key, boolean ifNotExists) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -25,6 +25,7 @@ public class ExportConfig extends CompressionConfig {
     public static final String DEFAULT_ARRAY_DELIM = ";";
     public static final String DEFAULT_QUOTES = ALWAYS_QUOTES;
     private final boolean streamStatements;
+    private final boolean ifNotExists;
 
     private int batchSize;
     private boolean silent;
@@ -99,6 +100,7 @@ public class ExportConfig extends CompressionConfig {
         this.config = config;
         this.streamStatements = toBoolean(config.get("streamStatements")) || toBoolean(config.get("stream"));
         this.writeNodeProperties = toBoolean(config.get("writeNodeProperties"));
+        this.ifNotExists = toBoolean(config.get("ifNotExists"));
         exportQuotes(config);
         this.optimizations = (Map<String, Object>) config.getOrDefault("useOptimizations", Collections.emptyMap());
         this.optimizationType = OptimizationType.valueOf(optimizations.getOrDefault("type", OptimizationType.UNWIND_BATCH.toString()).toString().toUpperCase());
@@ -209,4 +211,7 @@ public class ExportConfig extends CompressionConfig {
         return sampling;
     }
     
+    public boolean ifNotExists() {
+        return ifNotExists;
+    }
 }

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.cypher.all.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.cypher.all.adoc
@@ -25,4 +25,5 @@ The procedure support the following config parameters:
 * `UNWIND_BATCH` - exports the file by batching the entities with the `UNWIND` method as explained in Michael Hunger's article on https://medium.com/neo4j/5-tips-tricks-for-fast-batched-updates-of-graph-structures-with-neo4j-and-cypher-73c7f693c8cc[fast batched writes^].
 * `UNWIND_BATCH_PARAMS` - similar to `UNWIND_BATCH`, but also uses parameters where appropriate
 | awaitForIndexes | Long | 300 | Timeout to use for `db.awaitIndexes` when using `format: "cypher-shell"`
+| ifNotExists | boolean | false | If true adds the keyword `IF NOT EXISTS` to constraints and indexes
 |===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.cypher.data.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.cypher.data.adoc
@@ -25,4 +25,5 @@ The procedure support the following config parameters:
 * `UNWIND_BATCH` - exports the file by batching the entities with the `UNWIND` method as explained in Michael Hunger's article on https://medium.com/neo4j/5-tips-tricks-for-fast-batched-updates-of-graph-structures-with-neo4j-and-cypher-73c7f693c8cc[fast batched writes^].
 * `UNWIND_BATCH_PARAMS` - similar to `UNWIND_BATCH`, but also uses parameters where appropriate
 | awaitForIndexes | Long | 300 | Timeout to use for `db.awaitIndexes` when using `format: "cypher-shell"`
+| ifNotExists | boolean | false | If true adds the keyword `IF NOT EXISTS` to constraints and indexes
 |===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.cypher.query.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.cypher.query.adoc
@@ -25,4 +25,5 @@ The procedure support the following config parameters:
 * `UNWIND_BATCH` - exports the file by batching the entities with the `UNWIND` method as explained in Michael Hunger's article on https://medium.com/neo4j/5-tips-tricks-for-fast-batched-updates-of-graph-structures-with-neo4j-and-cypher-73c7f693c8cc[fast batched writes^].
 * `UNWIND_BATCH_PARAMS` - similar to `UNWIND_BATCH`, but also uses parameters where appropriate
 | awaitForIndexes | Long | 300 | Timeout to use for `db.awaitIndexes` when using `format: "cypher-shell"`
+| ifNotExists | boolean | false | If true adds the keyword `IF NOT EXISTS` to constraints and indexes
 |===


### PR DESCRIPTION
Fixes #2037

Cherry-pick: `7a99cad24f869db67d436a0896f4e2c611e27268`