### PR TITLE
Fixes #2468: APOC uses Jackson version prior to 2.11 not compatible with latest spring-boot

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -91,7 +91,6 @@ dependencies {
     }
 
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
-    compileOnly group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
 
     testCompile 'org.mock-server:mockserver-netty:5.6.0'
     testCompile 'org.mock-server:mockserver-client-java:5.6.0'
@@ -100,7 +99,6 @@ dependencies {
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
 
     testCompile group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
-    compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
     compile group: 'com.opencsv', name: 'opencsv', version: '4.6'
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
     compileOnly group: 'org.ow2.asm', name: 'asm', version: '5.0.2'

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -105,7 +105,6 @@ dependencies {
     testCompile group: 'io.lettuce', name: 'lettuce-core', version: '6.1.1.RELEASE'
 
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
-    compileOnly group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
 
     compileOnly group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.1'
     compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0'
@@ -119,8 +118,6 @@ dependencies {
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
 
-    testCompile group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
-    compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
     compile group: 'com.opencsv', name: 'opencsv', version: '4.6'
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
     compileOnly group: 'org.ow2.asm', name: 'asm', version: '5.0.2'


### PR DESCRIPTION
Fixes #2468

Removed `jackson-mapper-asl`, not used (old jackson-databind package)

Removed duplicated  `compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'`

