### PR TITLE
Fixes #2190: apoc.convert.toTree reorders paths

### DIFF
--- a/core/src/main/java/apoc/convert/ConvertConfig.java
+++ b/core/src/main/java/apoc/convert/ConvertConfig.java
@@ -1,5 +1,7 @@
 package apoc.convert;
 
+import apoc.util.Util;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -14,8 +16,10 @@ public class ConvertConfig {
 
     private Map<String, List<String>> nodes;
     private Map<String, List<String>> rels;
+    private final boolean sortPaths;
 
     public ConvertConfig(Map<String,Object> config) {
+        this.sortPaths = Util.toBoolean(config.getOrDefault("sortPaths", true));
 
         this.nodes = (Map<String, List<String>>) config.getOrDefault("nodes", Collections.EMPTY_MAP);
         this.rels = (Map<String, List<String>>) config.getOrDefault("rels", Collections.EMPTY_MAP);
@@ -30,6 +34,10 @@ public class ConvertConfig {
 
     public Map<String, List<String>> getRels() {
         return rels;
+    }
+
+    public boolean isSortPaths() {
+        return sortPaths;
     }
 
     private void validateListProperties(List<String> list) {

--- a/core/src/main/java/apoc/convert/Json.java
+++ b/core/src/main/java/apoc/convert/Json.java
@@ -143,7 +143,11 @@ public class Json {
 
         Map<Long, Map<String, Object>> maps = new HashMap<>(paths.size() * 100);
 
-        paths.stream().sorted(Comparator.comparingInt(Path::length).reversed()).forEach(path -> {
+        Stream<Path> stream = paths.stream();
+        if (conf.isSortPaths()) {
+            stream = stream.sorted(Comparator.comparingInt(Path::length).reversed());
+        }
+        stream.forEach(path -> {
             Iterator<Entity> it = path.iterator();
             while (it.hasNext()) {
                 Node n = (Node) it.next();

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.convert.toTree.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.convert.toTree.adoc
@@ -6,4 +6,5 @@ The procedure support the following config parameters:
 | name | type | default | description
 | nodes | Map<String, List<String>> | {}| properties to include for each node label e.g. `{Movie: ['title']}` or to exclude (e.g. `{Movie: ['-title']}`).
 | rels | Map<String, List<String>> | {} | properties to include for each relationship type e.g. `{`ACTED_IN`: ["roles"]}`  or to exclude (e.g. `{`ACTED_IN`: ["-roles"]}`).
+| sortPaths | boolean | true | to sort the result by path length
 |===


### PR DESCRIPTION
Fixes #2190

Added `sortPaths` config
