### PR TITLE
Apoc.schema.assert should drops only indexes not included in the 1st parameter

### DIFF
--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -175,16 +175,21 @@ public class Schemas {
             definition.getPropertyKeys().forEach(keys::add);
 
             AssertSchemaResult info = new AssertSchemaResult(label, keys);
-            if(indexes.containsKey(label)) {
-                if (keys.size() > 1) {
-                    indexes.get(label).remove(keys);
-                } else if (keys.size() == 1) {
-                    indexes.get(label).remove(keys.get(0));
-                } else
-                    throw new IllegalArgumentException("Label given with no keys.");
-            }
 
-            if (dropExisting) {
+            final boolean included = Optional.ofNullable(indexes.get(label))
+                    .map(lbl -> {
+                        if (keys.size() > 1) {
+                            return lbl.remove(keys);
+                        }
+                        if (keys.size() == 1) {
+                            return lbl.remove(keys.get(0));
+                        }
+                        // todo - it shouldn't be needed. only LOOKUP indexes, absent in 4.2 and previous and filtered for 4.3+, can be without keys
+                        throw new IllegalArgumentException("Label given with no keys.");
+                    })
+                    .orElse(false);
+
+            if (dropExisting && !included) {
                 definition.drop();
                 info.dropped();
             }
@@ -192,8 +197,6 @@ public class Schemas {
             result.add(info);
         }
 
-        if (dropExisting)
-            indexes = copyMapOfObjects(indexes0);
 
         for (Map.Entry<String, List<Object>> index : indexes.entrySet()) {
             for (Object key : index.getValue()) {

--- a/core/src/test/java/apoc/schema/SchemasTest.java
+++ b/core/src/test/java/apoc/schema/SchemasTest.java
@@ -258,20 +258,32 @@ public class SchemasTest {
 
     @Test
     public void testKeepIndex() throws Exception {
-        db.executeTransactionally("CREATE INDEX ON :Foo(bar)");
-        testResult(db, "CALL apoc.schema.assert({Foo:['bar', 'foo']},null,false)", (result) -> { 
-            Map<String, Object> r = result.next();
-            assertEquals("Foo", r.get("label"));
-            assertEquals("bar", r.get("key"));
-            assertEquals(false, r.get("unique"));
-            assertEquals("KEPT", r.get("action"));
+        keepIndexCommon(false);
+    }
 
-            r = result.next();
-            assertEquals("Foo", r.get("label"));
-            assertEquals("foo", r.get("key"));
-            assertEquals(false, r.get("unique"));
-            assertEquals("CREATED", r.get("action"));
-        });
+    @Test
+    public void testKeepIndexWithDropExisting() throws Exception {
+        keepIndexCommon(true);
+    }
+
+    private void keepIndexCommon(boolean dropExisting) {
+        db.executeTransactionally("CREATE INDEX ON :Foo(bar)");
+        testResult(db, "CALL apoc.schema.assert({Foo:['bar', 'foo']}, null, $drop)",
+                Map.of("drop", dropExisting),
+                (result) -> {
+                    Map<String, Object> r = result.next();
+                    assertEquals("Foo", r.get("label"));
+                    assertEquals("bar", r.get("key"));
+                    assertEquals(false, r.get("unique"));
+                    assertEquals("KEPT", r.get("action"));
+
+                    r = result.next();
+                    assertEquals("Foo", r.get("label"));
+                    assertEquals("foo", r.get("key"));
+                    assertEquals(false, r.get("unique"));
+                    assertEquals("CREATED", r.get("action"));
+                });
+
         try (Transaction tx = db.beginTx()) {
             List<IndexDefinition> indexes = Iterables.asList(tx.schema().getIndexes());
             assertEquals(2, indexes.size());
@@ -427,13 +439,11 @@ public class SchemasTest {
     public void testDropCompoundIndexAndRecreateWithDropExisting() throws Exception {
         db.executeTransactionally("CREATE INDEX ON :Foo(bar,baa)");
         awaitIndexesOnline();
-        testResult(db, "CALL apoc.schema.assert({Foo:[['bar','baa']]},null,true)", (result) -> {
-            Map<String, Object> r = result.next();
+        testCall(db, "CALL apoc.schema.assert({Foo:[['bar','baa']]},null,true)", (r) -> {
             assertEquals("Foo", r.get("label"));
             assertEquals(expectedKeys("bar", "baa"), r.get("keys"));
             assertEquals(false, r.get("unique"));
-            assertEquals("DROPPED", r.get("action"));
-            result.close();
+            assertEquals("KEPT", r.get("action"));
         });
         try (Transaction tx = db.beginTx()) {
             List<IndexDefinition> indexes = Iterables.asList(tx.schema().getIndexes());
@@ -462,9 +472,20 @@ public class SchemasTest {
     */
     @Test
     public void testKeepCompoundIndex() throws Exception {
+        testKeepCompoundCommon(false);
+    }
+    
+    @Test
+    public void testKeepCompoundIndexWithDropExisting() throws Exception {
+        testKeepCompoundCommon(true);
+    }
+
+    private void testKeepCompoundCommon(boolean dropExisting) {
         db.executeTransactionally("CREATE INDEX ON :Foo(bar,baa)");
         awaitIndexesOnline();
-        testResult(db, "CALL apoc.schema.assert({Foo:[['bar','baa'], ['foo','faa']]},null,false)", (result) -> {
+        testResult(db, "CALL apoc.schema.assert({Foo:[['bar','baa'], ['foo','faa']]},null,$drop)", 
+                Map.of("drop", dropExisting), 
+                (result) -> {
             Map<String, Object> r = result.next();
             assertEquals("Foo", r.get("label"));
             assertEquals(expectedKeys("bar", "baa"), r.get("keys"));
@@ -477,6 +498,7 @@ public class SchemasTest {
             assertEquals(false, r.get("unique"));
             assertEquals("CREATED", r.get("action"));
         });
+        
         try (Transaction tx = db.beginTx()) {
             List<IndexDefinition> indexes = Iterables.asList(tx.schema().getIndexes());
             assertEquals(2, indexes.size());
@@ -510,18 +532,11 @@ public class SchemasTest {
     public void testDropCompoundIndexAndCreateCompoundIndexWhenUsingDropExisting() throws Exception {
         db.executeTransactionally("CREATE INDEX ON :Foo(bar,baa)");
         awaitIndexesOnline();
-        testResult(db, "CALL apoc.schema.assert({Foo:[['bar','baa']]},null)", (result) -> {
-            Map<String, Object> r = result.next();
+        testCall(db, "CALL apoc.schema.assert({Foo:[['bar','baa']]},null)", (r) -> {
             assertEquals("Foo", r.get("label"));
             assertEquals(expectedKeys("bar","baa"), r.get("keys"));
             assertEquals(false, r.get("unique"));
-            assertEquals("DROPPED", r.get("action"));
-
-            r = result.next();
-            assertEquals("Foo", r.get("label"));
-            assertEquals(expectedKeys("bar", "baa"), r.get("keys"));
-            assertEquals(false, r.get("unique"));
-            assertEquals("CREATED", r.get("action"));
+            assertEquals("KEPT", r.get("action"));
         });
         try (Transaction tx = db.beginTx()) {
             List<IndexDefinition> indexes = Iterables.asList(tx.schema().getIndexes());


### PR DESCRIPTION
Related Trello card: https://trello.com/c/rmXko1UQ/914-s4-enedis-hdr-project-behaviour-of-apocschemaassert-in-42

Drop existing should drops only OTHER indexes, consistent with the documentation and with constraint behaviour.
Instead currently drop also indexes included in the 1st parameter of `apoc.schema.assert()`, and subsequently recreates them.