### PR TITLE
apoc.meta.stats() displays incorrect relationship counts with multi-label nodes

### DIFF
--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -441,12 +441,14 @@ public class Meta {
             }
 
             public void rel(int typeId, String typeName, long count) {
-                if (count > 0) relStats.put("()-[:" + typeName + "]->()", count);
+                if (count > 0) {
+                    relStatsCount.merge(typeName, count, Long::sum);
+                    relStats.put("()-[:" + typeName + "]->()", count);
+                }
             }
 
             public void rel(int typeId, String typeName, int labelId, String labelName, long out, long in) {
                 if (out > 0) {
-                    relStatsCount.put(typeName, relStatsCount.getOrDefault(typeName, 0L) + out);
                     relStats.put("(:" + labelName + ")-[:" + typeName + "]->()", out);
                 }
                 if (in > 0) {

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -1211,7 +1211,7 @@ public class MetaTest {
             assertEquals(5L, row.get("nodeCount"));
             assertEquals(4L, row.get("labelCount"));
             
-            assertEquals(map("REL", 4L, "ANOTHER", 1L), row.get("relTypesCount"));
+            assertEquals(map("REL", 2L, "ANOTHER", 1L), row.get("relTypesCount"));
             assertEquals(2L, row.get("relTypeCount"));
             assertEquals(3L, row.get("relCount"));
             Map<String, Object> expectedRelTypes = map("(:A)-[:ANOTHER]->()", 1L,
@@ -1230,7 +1230,7 @@ public class MetaTest {
             assertEquals(3L, row.get("nodeCount"));
             assertEquals(2L, row.get("labelCount"));
             
-            assertEquals(map("REL", 4L), row.get("relTypesCount"));
+            assertEquals(map("REL", 2L), row.get("relTypesCount"));
             assertEquals(1L, row.get("relTypeCount"));
             assertEquals(2L, row.get("relCount"));
             Map<String, Object> expectedRelTypes = map("()-[:REL]->(:Node)", 2L,

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.stats.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.stats.adoc
@@ -41,4 +41,4 @@ CALL apoc.meta.stats();
 |===
 
 
-Note that the `relTypesCount` field return, for each relationship type, the `MATCH ()-[r:RELATIONSHIP_TYPE]->() RETURN count(r)`.
+Note that the `relTypesCount` field returns a count equal to `MATCH ()-[r:RELATIONSHIP_TYPE]->() RETURN count(r)` for each relationship type (unique relationships versus unique patterns).

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.stats.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.meta.stats.adoc
@@ -41,13 +41,4 @@ CALL apoc.meta.stats();
 |===
 
 
-Note that the `relTypesCount` field counts unique patterns (from single label to single label)
-so multi-label nodes will be counted as separate paths.
-For example, with the following dataset with multiple labels `Node` and `Test`:
-
-[source,cypher]
-----
-CREATE (:Node:Test)-[:REL {a: 'b'}]->(:Node {c: 'd'})<-[:REL]-(:Node:Test)
-----
-
-`relTypesCount` will be `{REL: 4}`, otherwise, without label `Test`, it would be `{REL: 2}`.
+Note that the `relTypesCount` field return, for each relationship type, the `MATCH ()-[r:RELATIONSHIP_TYPE]->() RETURN count(r)`.


### PR DESCRIPTION
apoc.meta.stats() displays incorrect relationship counts with multi-label nodes

Related Trello card: https://trello.com/c/EMTTTZY4/862-apoc-apocmetastats-displays-incorrect-relationship-counts

Changed rel count handling via `MATCH ()-[r:RELATIONSHIP_TYPE]->() RETURN count(r)`
instead of previous `MATCH (:LabelName)-[r:RELATIONSHIP_TYPE]->() RETURN count(r)` 
(the 2nd count returns the count of rels multiplied by the number of start-node labels)
