### PR TITLE
Added slotted=runtime to apoc.cypher.runMany

### DIFF
--- a/core/src/main/java/apoc/cypher/CypherFunctions.java
+++ b/core/src/main/java/apoc/cypher/CypherFunctions.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static apoc.cypher.Cypher.withParamMapping;
+import static apoc.util.Util.slottedRuntime;
 
 /**
  * Created by lyonwj on 9/29/17.
@@ -28,8 +29,7 @@ public class CypherFunctions {
     public Object runFirstColumn(@Name("cypher") String statement, @Name("params") Map<String, Object> params, @Name(value = "expectMultipleValues",defaultValue = "true") boolean expectMultipleValues) {
         if (params == null) params = Collections.emptyMap();
         String resolvedStatement = withParamMapping(statement, params.keySet());
-        if (!resolvedStatement.contains(" runtime")) resolvedStatement = "cypher runtime=slotted " + resolvedStatement;
-        try (Result result = tx.execute(resolvedStatement, params)) {
+        try (Result result = tx.execute(slottedRuntime(resolvedStatement), params)) {
 
         String firstColumn = result.columns().get(0);
         try (ResourceIterator<Object> iter = result.columnAs(firstColumn)) {

--- a/core/src/main/java/apoc/periodic/Periodic.java
+++ b/core/src/main/java/apoc/periodic/Periodic.java
@@ -27,15 +27,14 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static apoc.util.Util.merge;
+import static apoc.util.Util.prependQueryOption;
+import static apoc.util.Util.slottedRuntime;
 
 public class Periodic {
     
     enum Planner {DEFAULT, COST, IDP, DP }
 
     public static final Pattern PLANNER_PATTERN = Pattern.compile("\\bplanner\\s*=\\s*[^\\s]*", Pattern.CASE_INSENSITIVE);
-    public static final Pattern RUNTIME_PATTERN = Pattern.compile("\\bruntime\\s*=", Pattern.CASE_INSENSITIVE);
-    public static final Pattern CYPHER_PREFIX_PATTERN = Pattern.compile("^\\s*\\bcypher\\b", Pattern.CASE_INSENSITIVE);
-    public static final String CYPHER_RUNTIME_SLOTTED = " runtime=slotted ";
     final static Pattern LIMIT_PATTERN = Pattern.compile("\\slimit\\s", Pattern.CASE_INSENSITIVE);
 
     @Context public GraphDatabaseService db;
@@ -278,14 +277,6 @@ public class Periodic {
         }
     }
 
-    static String slottedRuntime(String cypherIterate) {
-        if (RUNTIME_PATTERN.matcher(cypherIterate).find()) {
-            return cypherIterate;
-        }
-        
-        return prependQueryOption(cypherIterate, CYPHER_RUNTIME_SLOTTED);
-    }
-
     public static String applyPlanner(String query, Planner planner) {
         if(planner.equals(Planner.DEFAULT)) {
             return query;
@@ -296,14 +287,6 @@ public class Periodic {
             return matcher.replaceFirst(cypherPlanner);
         }
         return prependQueryOption(query, cypherPlanner);
-    }
-
-    private static String prependQueryOption(String query, String cypherOption) {
-        String cypherPrefix = "cypher";
-        String completePrefix = cypherPrefix + cypherOption;
-        return CYPHER_PREFIX_PATTERN.matcher(query).find()
-                ? query.replaceFirst("(?i)" + cypherPrefix, completePrefix)
-                : completePrefix + query;
     }
 
 

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -78,6 +78,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
@@ -980,6 +981,27 @@ public class Util {
     
     private static Object getOrDefault(Map<String, Object> firstMap, Map<String, Object> secondMap, String key) {
         return firstMap.getOrDefault(key, secondMap.get(key));
+    }
+
+    public static String slottedRuntime(String cypherIterate) {
+        final String CYPHER_RUNTIME_SLOTTED = " runtime=slotted ";
+        final Pattern RUNTIME_PATTERN = Pattern.compile("\\bruntime\\s*=", Pattern.CASE_INSENSITIVE);
+
+        if (RUNTIME_PATTERN.matcher(cypherIterate).find()) {
+            return cypherIterate;
+        }
+
+        return prependQueryOption(cypherIterate, CYPHER_RUNTIME_SLOTTED);
+    }
+
+
+    public static String prependQueryOption(String query, String cypherOption) {
+        final Pattern CYPHER_PREFIX_PATTERN = Pattern.compile("^\\s*\\bcypher\\b", Pattern.CASE_INSENSITIVE);
+        String cypherPrefix = "cypher";
+        String completePrefix = cypherPrefix + cypherOption;
+        return CYPHER_PREFIX_PATTERN.matcher(query).find()
+                ? query.replaceFirst("(?i)" + cypherPrefix, completePrefix)
+                : completePrefix + query;
     }
 
     public static String toCypherMap(Map<String, Object> map) {

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -2,6 +2,7 @@ package apoc.periodic;
 
 import apoc.util.MapUtil;
 import apoc.util.TestUtil;
+import apoc.util.Util;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -120,18 +121,6 @@ public class PeriodicTest {
                 applyPlanner("cypher planner=cost MATCH (n) RETURN n", Periodic.Planner.COST));
     }
 
-    @Test
-    public void testSlottedRuntime() throws Exception {
-        assertEquals("cypher runtime=slotted MATCH (n:cypher) RETURN n", Periodic.slottedRuntime("MATCH (n:cypher) RETURN n"));
-        assertTrue(Periodic.slottedRuntime("MATCH (n) RETURN n").contains("cypher runtime=slotted "));
-        assertFalse(Periodic.slottedRuntime(" cypher runtime=compiled MATCH (n) RETURN n").contains("cypher runtime=slotted "));
-        assertFalse(Periodic.slottedRuntime("cypher runtime=compiled MATCH (n) RETURN n").contains("cypher runtime=slotted cypher"));
-        assertTrue(Periodic.slottedRuntime(" cypher 3.1 MATCH (n) RETURN n").contains(" runtime=slotted "));
-        assertFalse(Periodic.slottedRuntime("cypher 3.1 MATCH (n) RETURN n").contains(" runtime=slotted cypher "));
-        assertTrue(Periodic.slottedRuntime("cypher expressionEngine=compiled MATCH (n) RETURN n").contains(" runtime=slotted "));
-        assertFalse(Periodic.slottedRuntime("cypher expressionEngine=compiled MATCH (n) RETURN n").contains(" runtime=slotted cypher"));
-
-    }
     @Test
     public void testTerminateCommit() throws Exception {
         PeriodicTestUtils.testTerminatePeriodicQuery(db, "CALL apoc.periodic.commit('UNWIND range(0,1000) as id WITH id CREATE (:Foo {id: id})', {})");

--- a/core/src/test/java/apoc/util/UtilTest.java
+++ b/core/src/test/java/apoc/util/UtilTest.java
@@ -16,9 +16,11 @@ import java.util.List;
 import java.util.Map;
 
 import static apoc.util.MapUtil.map;
+import static apoc.util.Util.slottedRuntime;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -113,5 +115,18 @@ public class UtilTest {
         } finally {
             db.executeTransactionally("MATCH (n:Test) DETACH DELETE n");
         }
+    }
+    
+    @Test
+    public void testSlottedRuntime() throws Exception {
+        assertEquals("cypher runtime=slotted MATCH (n:cypher) RETURN n", slottedRuntime("MATCH (n:cypher) RETURN n"));
+        assertTrue(slottedRuntime("MATCH (n) RETURN n").contains("cypher runtime=slotted "));
+        assertFalse(slottedRuntime(" cypher runtime=compiled MATCH (n) RETURN n").contains("cypher runtime=slotted "));
+        assertFalse(slottedRuntime("cypher runtime=compiled MATCH (n) RETURN n").contains("cypher runtime=slotted cypher"));
+        assertTrue(slottedRuntime(" cypher 3.1 MATCH (n) RETURN n").contains(" runtime=slotted "));
+        assertFalse(slottedRuntime("cypher 3.1 MATCH (n) RETURN n").contains(" runtime=slotted cypher "));
+        assertTrue(slottedRuntime("cypher expressionEngine=compiled MATCH (n) RETURN n").contains(" runtime=slotted "));
+        assertFalse(slottedRuntime("cypher expressionEngine=compiled MATCH (n) RETURN n").contains(" runtime=slotted cypher"));
+
     }
 }


### PR DESCRIPTION

Added `slotted=runtime` to `apoc.cypher.runMany`.

Reused `slottedRuntime()` method present in `Periodic.java` (now moved in `Util.java`)

----

I'm not sure it's the best way to proceed,
I opened the pr to discuss it together.
Should it be done via config or is it okay to force `cypher runtime=slotted` as a prefix, if not present?