### PR TITLE
Deprecating apoc.warmup.run procedure

### DIFF
--- a/core/src/main/java/apoc/warmup/Warmup.java
+++ b/core/src/main/java/apoc/warmup/Warmup.java
@@ -62,6 +62,7 @@ public class Warmup {
         return sb.toString();
     }
 
+    @Deprecated
     @Procedure
     @Description("apoc.warmup.run(loadProperties=false,loadDynamicProperties=false,loadIndexes=false) - quickly loads all nodes and rels into memory by skipping one page at a time")
     public Stream<WarmupResult> run(@Name(value = "loadProperties", defaultValue = "false") boolean loadProperties, @Name(value = "loadDynamicProperties", defaultValue = "false") boolean loadDynamicProperties, @Name(value = "loadIndexes", defaultValue = "false") boolean loadIndexes) throws IOException {

--- a/core/src/main/java/apoc/warmup/Warmup.java
+++ b/core/src/main/java/apoc/warmup/Warmup.java
@@ -63,7 +63,8 @@ public class Warmup {
     }
 
     @Deprecated
-    @Procedure
+    @Procedure( deprecatedBy = "Firstly, the procedure duplicates functionality of page cache warm up which is a part of the DBMS. " +
+            "Secondly, the API of this procedure is very specific to Record storage engine." )
     @Description("apoc.warmup.run(loadProperties=false,loadDynamicProperties=false,loadIndexes=false) - quickly loads all nodes and rels into memory by skipping one page at a time")
     public Stream<WarmupResult> run(@Name(value = "loadProperties", defaultValue = "false") boolean loadProperties, @Name(value = "loadDynamicProperties", defaultValue = "false") boolean loadDynamicProperties, @Name(value = "loadIndexes", defaultValue = "false") boolean loadIndexes) throws IOException {
         PageCache pageCache = db.getDependencyResolver().resolveDependency(PageCache.class);

--- a/core/src/test/java/apoc/warmup/WarmupTest.java
+++ b/core/src/test/java/apoc/warmup/WarmupTest.java
@@ -8,6 +8,7 @@ import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 /**
  * @author Sascha Peukert
@@ -37,9 +38,9 @@ public class WarmupTest {
     public void testWarmup() throws Exception {
         TestUtil.testCall(db, "CALL apoc.warmup.run()", r -> {
             assertEquals(4L, r.get("nodesTotal"));
-            assertEquals(2L, r.get("nodePages"));
+            assertNotEquals(0L, r.get("nodePages"));
             assertEquals(2L, r.get("relsTotal"));
-            assertEquals(2L, r.get("relPages"));
+            assertNotEquals(0L, r.get("relPages"));
         });
     }
 
@@ -47,7 +48,7 @@ public class WarmupTest {
     public void testWarmupProperties() throws Exception {
         TestUtil.testCall(db, "CALL apoc.warmup.run(true)", r -> {
             assertEquals(true, r.get("propertiesLoaded"));
-            assertEquals(5L, r.get("propPages"));
+            assertNotEquals(0L, r.get("propPages"));
         });
     }
 
@@ -56,7 +57,7 @@ public class WarmupTest {
         TestUtil.testCall(db, "CALL apoc.warmup.run(true,true)", r -> {
             assertEquals(true, r.get("propertiesLoaded"));
             assertEquals(true, r.get("dynamicPropertiesLoaded"));
-            assertEquals(5L, r.get("arrayPropPages"));
+            assertNotEquals(0L, r.get("arrayPropPages"));
         });
     }
 
@@ -64,7 +65,7 @@ public class WarmupTest {
     public void testWarmupIndexes() throws Exception {
         TestUtil.testCall(db, "CALL apoc.warmup.run(true,true,true)", r -> {
             assertEquals(true, r.get("indexesLoaded"));
-            assertEquals(6L, r.get("indexPages"));
+            assertNotEquals( 0L, r.get("indexPages") );
         });
     }
 }


### PR DESCRIPTION
Also changing tests of the procedure not to assert
the exact number of loaded pages as this is extremely
kernel-internals specific
