### PR TITLE
Use 4.2 index syntax

### DIFF
--- a/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
+++ b/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
@@ -392,7 +392,7 @@ public class SchemasEnterpriseFeaturesTest {
         
         testResult(session, "CALL apoc.schema.relationships()", (result) -> {
             Map<String, Object> r = result.next();
-            assertEquals("CONSTRAINT ON ()-[liked:LIKED]-() ASSERT (liked.day) IS NOT NULL", r.get("name"));
+            assertEquals("CONSTRAINT ON ()-[liked:LIKED]-() ASSERT exists(liked.day)", r.get("name"));
             assertEquals("RELATIONSHIP_PROPERTY_EXISTENCE", r.get("type"));
             assertEquals(asList("day"), r.get("properties"));
             assertEquals(StringUtils.EMPTY, r.get("status"));


### PR DESCRIPTION
Fixes a failing test due to too new index syntax.
