### PR TITLE
Uses TeamCity as artifactory

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
       - uses: actions/cache@v2
         with:
@@ -24,7 +24,21 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+      - name: Force a fresh version of neo4j (not the cached one)
+        run: (find ~/.gradle/caches -name "*neo4j*" -exec rm -rf {} \;) || echo "All neo4j files cleaned"
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
+        env:
+          TEAMCITY_DEV_URL: ${{ secrets.TEAMCITY_DEV_URL }}
+          TEAMCITY_USER: ${{ secrets.TEAMCITY_USER }}
+          TEAMCITY_PASSWORD: ${{ secrets.TEAMCITY_PASSWORD }}
         run: ./gradlew build --continue
+      - name: Clean neo4j from the cache
+        run: (find ~/.gradle/caches -name "*neo4j*" -exec rm -rf {} \;) || echo "All neo4j files cleaned"
+      - name: Archive test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results
+          path: /home/runner/work/apoc-private/apoc-private/core/build/reports/tests/test/index.html
+

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -32,11 +32,14 @@ jobs:
           TEAMCITY_USER: ${{ secrets.TEAMCITY_USER }}
           TEAMCITY_PASSWORD: ${{ secrets.TEAMCITY_PASSWORD }}
         run: ./gradlew build --continue
-      - name: Clean neo4j from the cache
-        run: (find ~/.gradle/caches -name "*neo4j*" -exec rm -rf {} \;) || echo "All neo4j files cleaned"
-      - name: Archive test results
-        uses: actions/upload-artifact@v2
+      - name: Test Report
+        uses: dorny/test-reporter@v1
+        if: success() || failure() # run this step even if previous step failed
         with:
-          name: test-results
-          path: /home/runner/work/apoc-private/apoc-private/core/build/reports/tests/test/index.html
+          name: JEST Tests
+          path: TEST-*.xml
+          reporter: jest-junit
+      - name: Clean neo4j from the cache
+        if: success() || failure() # run this step even if previous step failed
+        run: (find ~/.gradle/caches -name "*neo4j*" -exec rm -rf {} \;) || echo "All neo4j files cleaned"
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -24,8 +24,6 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-      - name: Force a fresh version of neo4j (not the cached one)
-        run: (find ~/.gradle/caches -name "*neo4j*" -exec rm -rf {} \;) || echo "All neo4j files cleaned"
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -32,14 +32,13 @@ jobs:
           TEAMCITY_USER: ${{ secrets.TEAMCITY_USER }}
           TEAMCITY_PASSWORD: ${{ secrets.TEAMCITY_PASSWORD }}
         run: ./gradlew build --continue
-      - name: Test Report
-        uses: dorny/test-reporter@v1
-        if: success() || failure() # run this step even if previous step failed
-        with:
-          name: JEST Tests
-          path: TEST-*.xml
-          reporter: jest-junit
       - name: Clean neo4j from the cache
         if: success() || failure() # run this step even if previous step failed
         run: (find ~/.gradle/caches -name "*neo4j*" -exec rm -rf {} \;) || echo "All neo4j files cleaned"
-
+      - name: Archive test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: test-results
+          path: |
+            core/build/reports/tests/test/
+            full/build/reports/tests/test/

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ allprojects {
 }
 
 apply plugin: 'java-library'
+apply from: 'teamcity-repository.gradle'
 
 repositories {
 
@@ -51,8 +52,8 @@ subprojects {
 
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     task mySourcesJar(type: Jar) {
@@ -70,8 +71,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country ' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:4.3.0-drop03.0-enterprise',
-                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:4.3.0-drop03.0'
+                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.0.0-enterprise',
+                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:5.0.0'
 
         maxHeapSize = "8G"
         forkEvery = 50
@@ -116,7 +117,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "4.3.0-drop03.0"
+    neo4jVersion = "5.0.0-dev"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.16.2'

--- a/build.gradle
+++ b/build.gradle
@@ -72,8 +72,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country ' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.0.0-enterprise',
-                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:5.0.0'
+                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.0-enterprise',
+                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:5.0'
 
         maxHeapSize = "8G"
         forkEvery = 50

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,8 @@ allprojects {
 }
 
 apply plugin: 'java-library'
-apply from: 'teamcity-repository.gradle'
+if (System.getenv("CI") == "true")
+    apply from: 'teamcity-repository.gradle'
 
 repositories {
 

--- a/build.gradle
+++ b/build.gradle
@@ -118,8 +118,10 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.0.0-dev"
+    neo4jVersion = "5.0.0"
+    // This should be removed when the version is stable and released
+    neo4jInDevVersion = (System.getenv("CI") == "true") ? neo4jVersion + "-dev" : neo4jVersion + "-SNAPSHOT"
     // instead we apply the override logic here
-    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
+    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jInDevVersion
     testContainersVersion = '1.16.2'
 }

--- a/teamcity-repository.gradle
+++ b/teamcity-repository.gradle
@@ -1,0 +1,17 @@
+allprojects {
+    plugins.withType(JavaLibraryPlugin) {
+        repositories {
+            maven {
+                name = 'teamcity-neo4j-dev'
+                url =  System.getenv('TEAMCITY_DEV_URL')
+                credentials {
+                    username System.getenv('TEAMCITY_USER')
+                    password System.getenv('TEAMCITY_PASSWORD')
+                }
+                authentication {
+                    basic(BasicAuthentication)
+                }
+            }
+        }
+    }
+}

--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -48,7 +48,7 @@ public class TestContainerUtil {
         importFolder.mkdirs();
 
         // read neo4j version from build.gradle and use this as default
-        String neo4jDockerImageVersion = System.getProperty("neo4jDockerImage", "neo4j:4.3.0-drop03.0-enterprise");
+        String neo4jDockerImageVersion = System.getProperty("neo4jDockerImage", "neo4j:5.0.0-enterprise");
 
         // use a separate folder for mounting plugins jar - build/libs might contain other jars as well.
         File pluginsFolder = new File(baseDir, "build/plugins");

--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -48,7 +48,7 @@ public class TestContainerUtil {
         importFolder.mkdirs();
 
         // read neo4j version from build.gradle and use this as default
-        String neo4jDockerImageVersion = System.getProperty("neo4jDockerImage", "neo4j:5.0.0-enterprise");
+        String neo4jDockerImageVersion = System.getProperty("neo4jDockerImage", "neo4j:5.0-enterprise");
 
         // use a separate folder for mounting plugins jar - build/libs might contain other jars as well.
         File pluginsFolder = new File(baseDir, "build/plugins");


### PR DESCRIPTION
## What
Uses TeamCity as artifactory. Only PRs from branches internal to the repo (that means only members of neo4j) will have a green CI, due to them having access to the secrets. If we receive a PR from a fork against dev, the CI will be red.

Note the CI of this same PR is already being run with neo4j 5.0.0 SNAPSHOT.

## Why
So we can develop in this repo with confidence we are not breaking things against the latest version of the database.