### PR TITLE
apoc.refactor.mergeNodes is not producing desired output

### DIFF
--- a/core/src/main/java/apoc/refactor/util/PropertiesManager.java
+++ b/core/src/main/java/apoc/refactor/util/PropertiesManager.java
@@ -2,6 +2,7 @@ package apoc.refactor.util;
 
 import apoc.util.ArrayBackedList;
 import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.Relationship;
 
 import java.lang.reflect.Array;
 import java.util.LinkedHashSet;
@@ -20,7 +21,7 @@ public class PropertiesManager {
     public static void mergeProperties(Map<String, Object> properties, Entity target, RefactorConfig refactorConfig) {
         for (Map.Entry<String, Object> prop : properties.entrySet()) {
             String key = prop.getKey();
-            String mergeMode = refactorConfig.getMergeMode(key);
+            String mergeMode = refactorConfig.getMergeMode(key, target instanceof Relationship);
             mergeProperty(target, refactorConfig, prop, key, mergeMode);
         }
     }

--- a/core/src/main/java/apoc/refactor/util/RefactorConfig.java
+++ b/core/src/main/java/apoc/refactor/util/RefactorConfig.java
@@ -37,7 +37,9 @@ public class RefactorConfig {
 	private final RelationshipSelectionStrategy relationshipSelectionStrategy;
 
 	public RefactorConfig(Map<String,Object> config) {
-
+		if (config == null) {
+			config = Collections.emptyMap();
+		}
 		this.mergeRelsAllowed = toBoolean(config.get("mergeRels"));
 		this.mergeVirtualRels = toBoolean(config.getOrDefault("mergeRelsVirtual", true));
 		this.selfRel = toBoolean(config.get("selfRel"));
@@ -56,12 +58,14 @@ public class RefactorConfig {
 			this.propertiesManagement = Collections.singletonMap(MATCH_ALL, value.toString());
 		} else if (value instanceof Map) {
 			this.propertiesManagement = (Map<String,String>)value;
-		} else if (mergeRelsAllowed && !hasProperties) {
-			this.propertiesManagement = Collections.singletonMap(MATCH_ALL, COMBINE);
 		}
 	}
 
-	public String getMergeMode(String name){
+	public String getMergeMode(String name, boolean isRel) {
+		// coherently with https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/1051
+		if (!hasProperties && isRel) {
+			return COMBINE;
+		}
 		for (String key : propertiesManagement.keySet()) {
 			if (!key.equals(MATCH_ALL) && name.matches(key)) {
 				return propertiesManagement.get(key);

--- a/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -1026,6 +1026,57 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
     }
 
     @Test
+    public void shouldAlwaysOverrideNodePropsIfNotSetAndCombineRelPropsIfPropertyIsNull() {
+        // test case from https://trello.com/c/7yO7mniS/924-s2cast-softwareapocrefactormergenodes-is-not-producing-desired-output
+        final String query = "CREATE (n1:Test:Obj {Name:1})\n" +
+                "CREATE (n2:Test:Obj {Name:2})\n" +
+                "CREATE (t:Test:Tran {Name:'t'})\n" +
+                "MERGE (t)-[:Contains {isReduced:true}]->(n1)\n" +
+                "MERGE (t)-[:Contains {isReduced:false, onlyForn2:true}]->(n2)\n" +
+                "WITH collect(n1) + collect(n2) AS nodes\n" +
+                "CALL apoc.refactor.mergeNodes(nodes, $config)\n" +
+                "YIELD node WITH node\n" +
+                "MATCH (node)-[r]-(t:Test:Tran) RETURN node, collect(r) AS rels";
+        
+        testCall(db, query, map("config", map()), r -> {
+            assertOverrideNode(r);
+            final List<Relationship> rels = (List<Relationship>) r.get("rels");
+            assertEquals(2, rels.size());
+        });
+        
+        testCall(db, query, map("config", 
+                map("mergeRels", true, "produceSelfRel", false, "properties", null)
+        ), r -> {
+            assertOverrideNode(r);
+            final List<Relationship> rels = (List<Relationship>) r.get("rels");
+            assertEquals(1, rels.size());
+            assertArrayEquals(new boolean[] {true, false}, (boolean[]) rels.get(0).getProperty("isReduced"));
+        });
+
+        testCall(db, query, map("config", 
+                map("properties", map())
+        ), r -> {
+            assertOverrideNode(r);
+            final List<Relationship> rels = (List<Relationship>) r.get("rels");
+            assertEquals(2, rels.size());
+        });
+
+        testCall(db, query, map("config", 
+                map("mergeRels", true, "properties", map())
+        ), r -> {
+            assertOverrideNode(r);
+            final List<Relationship> rels = (List<Relationship>) r.get("rels");
+            assertEquals(1, rels.size());
+            assertEquals(false, rels.get(0).getProperty("isReduced"));
+        });
+    }
+
+    private void assertOverrideNode(Map<String, Object> r) {
+        final Node node = (Node) r.get("node");
+        assertEquals(2L, node.getProperty("Name"));
+    }
+
+    @Test
     public void testMergeNodeShouldNotCreateSelfRelationshipsAndCancelThePreExistingSelfRelAfterMerge() {
         db.executeTransactionally("CREATE (a:TestNode {a:'a'})-[:TEST_REL]->(b:TestNode {a:'b'})-[:TEST_REL]->(c:TestNode {a:'c'})\n" +
                 "WITH a, c CREATE (a)-[:TEST_REL {prop: 'one'}]->(a), (a)-[:TEST_REL {prop: 'two'}]->(a) WITH c CREATE (c)-[:TEST_REL]->(c);");

--- a/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/merge-nodes.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/merge-nodes.adoc
@@ -47,9 +47,11 @@ In addition, mergeNodes supports the following config properties:
 | singleElementAsArray | false/true: if is `false` (default) and `type` is `combine` in case the merge of two arrays is a new array with size 1 it extracts the single value.
 |===
 
-Relationships properties are managed with the same nodes' method. 
-If properties parameter is null, entity properties are combined.
-Instead, if properties parameter is a map, properties with a name not included in parameter map are overridden.
+If properties parameter is a map, properties with a name not included in parameter map are overridden.
+
+Relationships properties are managed with the same nodes' method,
+except when the properties parameter is null, in this case entity properties are combined.
+
 
 //If relationships have same start and end nodes will be merged into one, and properties managed by the properties config.
 //If relationships have different start/end nodes (related to direction), relationships will be maintained and properties will be combine in all relationship.

--- a/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/merge-nodes.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/graph-updates/graph-refactoring/merge-nodes.adoc
@@ -47,7 +47,9 @@ In addition, mergeNodes supports the following config properties:
 | singleElementAsArray | false/true: if is `false` (default) and `type` is `combine` in case the merge of two arrays is a new array with size 1 it extracts the single value.
 |===
 
-Relationships properties are managed with the same nodes' method, if properties parameter isn't set relationships properties are combined.
+Relationships properties are managed with the same nodes' method. 
+If properties parameter is null, entity properties are combined.
+Instead, if properties parameter is a map, properties with a name not included in parameter map are overridden.
 
 //If relationships have same start and end nodes will be merged into one, and properties managed by the properties config.
 //If relationships have different start/end nodes (related to direction), relationships will be maintained and properties will be combine in all relationship.


### PR DESCRIPTION
Trello issue: https://trello.com/c/7yO7mniS/924-s2cast-softwareapocrefactormergenodes-is-not-producing-desired-output


Added clearer documentation and fixed `mergeRels:true` bug (it should combine also rel-prop):

If properties is a map, properties with a name not included in parameter map are overridden (with an empty map too).

Instead, if properties is null, relationship properties are combined and node properties are overridden (coherently with https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/1051)

