### PR TITLE
Fixes #2384: Add Scraper procedures to apoc.load.html

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/import/html.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/html.adoc
@@ -34,6 +34,7 @@ Config param is optional, the default value is an empty map.
 |===
 |charset | Default: UTF-8
 |baserUri | Default: "", it is use to resolve relative paths
+|htmlString | Default: false, to use an HTML string instead of an url as 1st parameter
 |===
 
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.load.html.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.load.html.adoc
@@ -225,3 +225,84 @@ a|
 }
 ----
 |===
+
+We can also pass an HTML string into the 1st parameter by putting as a config parameter `htmlString: true`, for example:
+
+[source,cypher]
+----
+CALL apoc.load.html("<!DOCTYPE html> <html> <body> <p class='firstClass'>My first paragraph.</p> </body> </html>",{metadata:"meta", h2:"h2"}, {htmlString: true});
+----
+
+The jsoup class https://jsoup.org/apidocs/org/jsoup/nodes/Element.html[org.jsoup.nodes.Element]
+provides a set of functions that can be used. 
+Anyway, we can emulate all of them using the appropriate css/jQuery selectors in these ways 
+(except for the last one, we can substitute the `*` with a tag name to search into it instead of everywhere. Furthermore, by removing the `*` selector will be returned the same result):
+
+
+[opts="header"]
+|===
+| jsoup function | css/jQuery selector | description
+| `getElementById(id)` | `#id` | Find an element by ID, including or under this element.
+| `getElementsByTag(tag)`  | `tag` | Finds elements, including and recursively under this element, with the specified tag name.
+| `getElementsByClass(className)` | `.className`  | Find elements that have this class, including or under this element.
+| `getElementsByAttribute(key)` | `[key]`  | Find elements that have a named attribute set.
+| `getElementsByAttributeStarting(keyPrefix)` | `*[^keyPrefix]`  | Find elements that have an attribute name starting with the supplied prefix. Use data | to find elements that have HTML5 datasets.
+| `getElementsByAttributeValue(key,value)`  | `*[key=value]` | Find elements that have an attribute with the specific value.
+| `getElementsByAttributeValueContaining(key,match)` |`*[key*=match]` | Find elements that have attributes whose value contains the match string.
+| `getElementsByAttributeValueEnding(key,valueSuffix)` | `*[class$="test"]` | Find elements that have attributes that end with the value suffix.
+| `getElementsByAttributeValueMatching(key,regex)` |`*[id~=content]` | Find elements that have attributes whose values match the supplied regular expression.
+| `getElementsByAttributeValueNot(key,value)` |`*:not([key="value"])` | Find elements that either do not have this attribute, or have it with a different value.
+| `getElementsByAttributeValueStarting(key,valuePrefix)` |`*[key^=valuePrefix]` | Find elements that have attributes that start with the value prefix.
+| `getElementsByIndexEquals(index)` |`*:nth-child(index)` | Find elements whose sibling index is equal to the supplied index.
+| `getElementsByIndexGreaterThan(index)` |`*:gt(index)` | Find elements whose sibling index is greater than the supplied index.
+| `getElementsByIndexLessThan(index)` |`*:lt(index)` | Find elements whose sibling index is less than the supplied index.
+| `getElementsContainingOwnText(searchText)` |`*:containsOwn(searchText)` | Find elements that directly contain the specified string.
+| `getElementsContainingText(searchText)` |`*:contains('searchText')` | Find elements that contain the specified string.
+| `getElementsMatchingOwnText(regex)` |`*:matches(regex)` | Find elements whose text matches the supplied regular expression.
+| `getElementsMatchingText(pattern)` |`*:matchesOwn(pattern)` | Find elements whose text matches the supplied regular expression.
+| `getAllElements()` |`*` | Find all elements under document (including self, and children of children).
+|===
+
+For example, we can execute:
+
+[source,cypher]
+----
+CALL apoc.load.html($url, {nameKey: '#idName'})
+----
+
+.Results
+[opts="header"]
+|===
+| Output
+a|
+[source,json]
+----
+{
+  "h6": [
+    {
+      "attributes": {
+        "id": "idName"
+      },
+      "text": "test",
+      "tagName": "h6"
+    }
+  ]
+}
+----
+|===
+
+== Html plain text representation
+
+Using the same syntax and logic as `apoc.load.html`, 
+we can get a plain text representation of the whole document, using the `apoc.load.htmlPlainText(URL_OR_TEXT, QUERY_MAP, CONFIG_MAP)` procedure, for example:
+
+[source,cypher]
+----
+CALL apoc.load.htmlPlainText($urlOrString, {nameKey: 'body'})
+----
+
+or of some elements, with a selector:
+[source,cypher]
+----
+CALL apoc.load.htmlPlainText($urlOrString, {nameKey: 'div'})
+----

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.html.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.load.html.adoc
@@ -7,4 +7,5 @@ The procedure support the following config parameters:
 | charset | String | "UTF-8" | the character set of the page being scraped
 | baseUri | String | "" | Base URI used to resolve relative paths
 | failSilently | Enum [FALSE, WITH_LOG, WITH_LIST] | FALSE | If the parse fails with one or more elements, using `FALSE` it throws a `RuntimeException`, using `WITH_LOG` a `log.warn` is created for each incorrect item and using `WITH_LIST` an `errorList` key is added to the result with the failed tags.
+|htmlString | boolean |  true | to use a string instead of an url as 1st parameter
 |===

--- a/full/src/main/java/apoc/load/HtmlResultInterface.java
+++ b/full/src/main/java/apoc/load/HtmlResultInterface.java
@@ -1,0 +1,26 @@
+package apoc.load;
+
+import org.jsoup.nodes.Document;
+import org.neo4j.logging.Log;
+
+import java.util.List;
+import java.util.Map;
+
+public interface HtmlResultInterface {
+    
+    enum Type {
+        DEFAULT(new SelectElement()), 
+        PLAIN_TEXT(new PlainText());
+
+        private final HtmlResultInterface resultInterface;
+        Type(HtmlResultInterface resultInterface) {
+            this.resultInterface = resultInterface;
+        }
+
+        public HtmlResultInterface get() {
+            return resultInterface;
+        }
+    }
+
+    Object getResult(Document document, String selector, Map<String, Object> config, List<String> errorList, Log log);
+}

--- a/full/src/main/java/apoc/load/PlainText.java
+++ b/full/src/main/java/apoc/load/PlainText.java
@@ -1,0 +1,101 @@
+package apoc.load;
+
+import apoc.util.Util;
+import org.apache.commons.lang3.StringUtils;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
+import org.jsoup.nodes.TextNode;
+import org.jsoup.select.Elements;
+import org.jsoup.select.NodeTraversor;
+import org.jsoup.select.NodeVisitor;
+import org.neo4j.logging.Log;
+
+import java.util.List;
+import java.util.Map;
+
+import static apoc.load.LoadHtml.withError;
+
+public class PlainText implements HtmlResultInterface {
+
+    @Override
+    public String getResult(Document document, String selector, Map<String, Object> config, List<String> errorList, Log log) {
+        LoadHtml.FailSilently failConfig = LoadHtml.FailSilently.valueOf((String) config.getOrDefault("failSilently", "FALSE"));
+        StringBuilder plainText = new StringBuilder();
+        Elements elements = document.select(selector);
+        for (Element element : elements) {
+            final String result = getResult(config, errorList, log, failConfig, element);
+            plainText.append(result);
+        }
+        return plainText.toString();
+    }
+
+    private String getResult(Map<String, Object> config, List<String> errorList, Log log, LoadHtml.FailSilently failConfig, Element element) {
+        return withError(element, errorList, failConfig, log, () -> getPlainText(element, config));
+    }
+
+    public String getPlainText(Element element, Map<String, Object> config) {
+        FormattingVisitor formatter = new FormattingVisitor(config);
+        NodeTraversor.traverse(formatter, element);
+        return formatter.toString();
+    }
+
+    private static class FormattingVisitor implements NodeVisitor {
+        private int width;
+        private final int textSize;
+        private final StringBuilder builder;
+
+        private FormattingVisitor(Map<String, Object> config) {
+            this.width = 0;
+            this.builder = new StringBuilder();
+            this.textSize = Util.toInteger(config.getOrDefault("textSize", 80));
+        }
+
+        public void head(Node node, int depth) {
+            String name = node.nodeName();
+            if (node instanceof TextNode) {
+                this.append(((TextNode)node).text());
+            } else if (name.equals("li")) {
+                this.append("\n - ");
+            } else if (name.equals("dt")) {
+                builder.append("  ");
+            } else {
+                final CharSequence[] charSequences = {"p", "h1", "h2", "h3", "h4", "h5", "tr"};
+                if (StringUtils.containsAny(name, charSequences)) {
+                    this.append("\n");
+                }
+            }
+        }
+
+        public void tail(Node node, int depth) {
+            final CharSequence[] charSequences = {"br", "dd", "dt", "p", "h1", "h2", "h3", "h4", "h5"};
+            if (StringUtils.containsAny(node.nodeName(), charSequences)) {
+                this.append("\n");
+            }
+        }
+
+        private void append(String text) {
+            if (text.startsWith("\n")) {
+                this.builder.append(text);
+                this.width = 0;
+                return;
+            }
+
+            if (!StringUtils.isBlank(text)) {
+                for (String word: text.split("\\s+")) {
+                    if (word.length() + this.width > textSize) {
+                        this.builder.append("\n");//.append(word);
+                        this.width = word.length();
+                    } else {
+                        this.width += word.length();
+                    }
+                    this.builder.append(word).append(" ");
+                }
+            }
+        }
+
+        public String toString() {
+            return this.builder.toString();
+        }
+    }
+}

--- a/full/src/main/java/apoc/load/SelectElement.java
+++ b/full/src/main/java/apoc/load/SelectElement.java
@@ -1,0 +1,20 @@
+package apoc.load;
+
+
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
+import org.neo4j.logging.Log;
+
+import java.util.List;
+import java.util.Map;
+
+import static apoc.load.LoadHtml.getElements;
+
+public class SelectElement implements HtmlResultInterface {
+
+    @Override
+    public List<Map<String, Object>> getResult(Document document, String selector, Map<String, Object> config, List<String> errorList, Log log) {
+        final Elements select = document.select(selector);
+        return getElements(select, config, errorList, log);
+    }
+}

--- a/full/src/main/resources/extended.txt
+++ b/full/src/main/resources/extended.txt
@@ -66,6 +66,7 @@ apoc.load.directory.async.remove
 apoc.load.directory.async.removeAll
 apoc.load.driver
 apoc.load.html
+apoc.load.htmlPlainText
 apoc.load.jdbc
 apoc.load.jdbcParams
 apoc.load.jdbcUpdate

--- a/full/src/test/java/apoc/load/LoadHtmlTest.java
+++ b/full/src/test/java/apoc/load/LoadHtmlTest.java
@@ -47,6 +47,14 @@ public class LoadHtmlTest {
     private static final String INVALID_PATH_ABSOLUTE = new File("src/test/resources/wikipedia1.html").getName();
     private static final String VALID_PATH = new File("src/test/resources/wikipedia.html").toURI().toString();
     private static final String INVALID_CHARSET = "notValid";
+    
+    private static final String HTML_TEXT = "<!DOCTYPE html> <html> <body> " +
+            "<h1>My First Heading</h1> " +
+            "<p class='firstClass'>My first paragraph.</p> " +
+            "<p class='secondClass'>My second paragraph.</p> " +
+            "<p class='thirdClass'>My third paragraph. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.</p> " +
+            "<ul><li>Coffee</li><li>Tea</li><li>Milk</li></ul>  " +
+            "</body> </html>";
 
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule()
@@ -86,6 +94,170 @@ public class LoadHtmlTest {
                     Map<String, Object> row = result.next();
                     assertEquals(map("metadata",asList(RESULT_QUERY_METADATA)).toString().trim(), row.get("value").toString().trim());
                     assertFalse(result.hasNext());
+                });
+    }
+
+    @Test
+    public void testQueryMetadataWithGetElementById() {
+        Map<String, Object> query = map("siteSubElement", "#siteSub");
+
+        testCall(db, "CALL apoc.load.html($url,$query)", 
+                map("url", new File("src/test/resources/wikipedia.html").toURI().toString(), "query", query),
+                row -> {
+                    final List<Map<String, Object>> expected = asList(map("attributes", map("id", "siteSub", "class", "noprint"),
+                            "text", "From Wikipedia, the free encyclopedia",
+                            "tagName", "div"));
+                    final Object actual = ((Map<String, Object>) row.get("value")).get("siteSubElement");
+                    assertEquals(expected, actual);
+                });
+    }
+    
+    @Test
+    public void shouldEmulateJsoupFunctions() {
+        // getElementsByTag
+        loadHtmlWithSelector(48, "div");
+        
+        // getElementsByAttribute
+        loadHtmlWithSelector(10, "[type]");
+        
+        // getElementsByAttributeStarting
+        loadHtmlWithSelector(15, "[^ro]");
+        
+        // getElementsByAttributeValue
+        loadHtmlWithSelector(1, "*[role=button]");
+        
+        // getElementsByAttributeValueContaining
+        loadHtmlWithSelector(1, "[role*=utto]");
+        
+        // getElementsByAttributeValueEnding
+        loadHtmlWithSelector(4, "*[class$=editsection]");
+        
+        // getElementsByAttributeValueNot
+        loadHtmlWithSelector(426, "*:not([class=\"mw-editsection\"])");
+        
+        // getElementsByAttributeValueStarting
+        loadHtmlWithSelector(2, "div[id^=site]");
+        
+        // getElementsByAttributeValueMatching
+        loadHtmlWithSelector(3, "div[id~=content]");
+        
+        // getElementsByIndexEquals
+        loadHtmlWithSelector(3, "*:nth-child(12)");
+        
+        // getElementsByIndexGreaterThan
+        loadHtmlWithSelector(12, "*:gt(12)");
+        
+        // getElementsByIndexLessThan
+        loadHtmlWithSelector(47, "div:lt(12)");
+        
+        // getElementsContainingOwnText
+        loadHtmlWithSelector(5, "i:containsOwn(Kaa)");
+        
+        // getElementsContainingText
+        loadHtmlWithSelector(6, "i:contains(Kaa)");
+        
+        // getElementsContainingText
+        loadHtmlWithSelector(6, "i:matches((?i)kaa)");
+        
+        // getElementsContainingText
+        loadHtmlWithSelector(5, "i:matchesOwn((?i)kaa)");
+        
+        // getAllElements
+        loadHtmlWithSelector(430, "*");
+    }
+
+    private void loadHtmlWithSelector(int expected, String selector) {
+        final String urlFile = new File("src/test/resources/wikipedia.html").toURI().toString();
+        testCall(db, "CALL apoc.load.html($url,$query, {failSilently: 'WITH_LOG'})",
+                map("url", urlFile, "query", map("selector", selector)),
+                row -> {
+                    final List actual = (List) ((Map) row.get("value")).get("selector");
+                    assertEquals(expected, actual.size());
+                });
+    }
+
+    @Test
+    public void testQueryMetadataWithGetLinks() {
+        Map<String, Object> query = map("links", "a[href]");
+
+        testCall(db, "CALL apoc.load.html($url,$query)", 
+                map("url", new File("src/test/resources/wikipedia.html").toURI().toString(), "query", query),
+                row -> {
+                    final List<Map<String, Object>> actual = (List) ((Map) row.get("value")).get("links");
+                    assertEquals(106, actual.size());
+                    assertTrue(actual.stream().allMatch(i -> i.get("tagName").equals("a")));
+                });
+    }
+
+    @Test
+    public void testQueryMetadataWithGetElementsByClassAndHtmlString() {
+        Map<String, Object> query = map("firstClass", ".firstClass",
+                "secondClass", ".secondClass");
+
+        testCall(db, "CALL apoc.load.html($html, $query, $config)", 
+                map("html", HTML_TEXT, 
+                        "query", query,
+                        "config", map("htmlString", true)),
+                row -> {
+                    final Map<String, List<Map<String, Object>>> value = (Map) row.get("value");
+                    final List firstClass = value.get("firstClass");
+                    assertEquals(map("attributes", map("class", "firstClass"), "text", "My first paragraph.", "tagName", "p"), firstClass.get(0));
+                    final List secondClass = value.get("secondClass");
+                    assertEquals(map("attributes", map("class", "secondClass"), "text", "My second paragraph.", "tagName", "p"), secondClass.get(0));
+                    System.out.println("LoadHtmlTest.testQueryMetadataWithGetElementsByClass");
+                });
+    }
+
+    @Test
+    public void testQueryMetadataWithGetElementsByClass() {
+        Map<String, Object> query = map("siteSubElement", ".toclevel-1");
+
+        testCall(db, "CALL apoc.load.html($url,$query)", 
+                map("url", new File("src/test/resources/wikipedia.html").toURI().toString(), "query", query),
+                row -> {
+                    final List<Map<String, Object>> actual = (List) ((Map) row.get("value")).get("siteSubElement");
+                    assertEquals(4, actual.size());
+                    assertTrue(actual.stream().allMatch(item -> item.get("tagName").equals("li")));
+                });
+    }
+
+    @Test
+    public void testQueryMetadataPlainText() {
+        final String secondPar = "\nMy second paragraph. \n";
+        
+        final String thirdPar = "\nMy third paragraph. Lorem Ipsum is simply dummy text of the printing and typesetting industry. \n" +
+                "Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown \n" +
+                "printer took a galley of type and scrambled it to make a type specimen book. \n";
+
+        testCall(db, "CALL apoc.load.htmlPlainText($url, $query, {htmlString: true})", 
+                map("url", HTML_TEXT, "query", map("siteSubElement", "body")),
+                row -> {
+                    String expected = "\nMy First Heading \n" +
+                            "\nMy first paragraph. \n" +
+                            secondPar +
+                            thirdPar +
+                            "\n" +
+                            " - Coffee \n" +
+                            " - Tea \n" +
+                            " - Milk ";
+                    final String actual = (String) ((Map) row.get("value")).get("siteSubElement");
+                    assertEquals(expected, actual);
+                });
+
+        testCall(db, "CALL apoc.load.htmlPlainText($url, $query, {htmlString: true})",
+                map("url", HTML_TEXT, "query", 
+                        map("thirdClass", ".thirdClass", "secondClass", ".secondClass")),
+                row -> {
+                    final Map<String, Object> actual = (Map) row.get("value");
+                    assertEquals(secondPar, actual.get("secondClass"));
+                    assertEquals(thirdPar, actual.get("thirdClass"));
+                });
+        
+        testCall(db, "CALL apoc.load.htmlPlainText($url,$query, {htmlString: true, textSize: 9999})",
+                map("url", HTML_TEXT, "query", map("thirdClass", ".thirdClass")),
+                row -> {
+                    String expected = "\nMy third paragraph. Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. \n";
+                    assertEquals(expected, ((Map) row.get("value")).get("thirdClass"));
                 });
     }
 


### PR DESCRIPTION
Fixes #2384

- Added documentation to explain how to emulate the functions provided by https://github.com/szenyo/neo4jscraperproc with the custom jsoup selectors
- Added `htmlText` configuration to pass an html string as 1st parameter
- Added procedure `apoc.load.htmlPlainText`, with the same syntax as apoc.load.html, to retrieve the plain text similarly to `scraper.getPlainText()` in https://github.com/szenyo/neo4jscraperproc