### PR TITLE
Fixes #2325: added config cleanup

### DIFF
--- a/core/src/main/java/apoc/export/json/ImportJsonConfig.java
+++ b/core/src/main/java/apoc/export/json/ImportJsonConfig.java
@@ -17,6 +17,8 @@ public class ImportJsonConfig extends CompressionConfig {
     private final int txBatchSize;
 
     private final String importIdName;
+    
+    private final boolean cleanup;
 
     public ImportJsonConfig(Map<String, Object> config) {
         super(config);
@@ -26,6 +28,7 @@ public class ImportJsonConfig extends CompressionConfig {
         this.unwindBatchSize = Util.toInteger(config.getOrDefault("unwindBatchSize", 5000));
         this.txBatchSize = Util.toInteger(config.getOrDefault("txBatchSize", 5000));
         this.importIdName = (String) config.getOrDefault("importIdName", "neo4jImportId");
+        this.cleanup = Util.toBoolean(config.get("cleanup"));
     }
 
     public String typeForNode(Collection<String> labels, String property) {
@@ -50,5 +53,9 @@ public class ImportJsonConfig extends CompressionConfig {
 
     public String getImportIdName() {
         return importIdName;
+    }
+
+    public boolean isCleanup() {
+        return cleanup;
     }
 }

--- a/core/src/main/java/apoc/export/json/JsonImporter.java
+++ b/core/src/main/java/apoc/export/json/JsonImporter.java
@@ -8,10 +8,8 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.Schema;
-import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.storable.DurationValue;
 import org.neo4j.values.storable.PointValue;
-import org.neo4j.values.storable.Values;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -34,7 +32,7 @@ import java.util.stream.StreamSupport;
 public class JsonImporter implements Closeable {
     private static final String UNWIND = "UNWIND $rows AS row ";
     private static final String CREATE_NODE = UNWIND +
-            "CREATE (n%s {%s: row.id}) SET n += row.properties";
+            "CREATE (n%s {%s}) SET n += row.properties";
     private static final String CREATE_RELS = UNWIND +
             "MATCH (s%s {%s: row.start.id}) " +
             "MATCH (e%s {%2$s: row.end.id}) " +
@@ -308,7 +306,10 @@ public class JsonImporter implements Closeable {
         String query;
         switch (type) {
             case "node":
-                query = String.format(CREATE_NODE, getLabelString(lastLabels), importJsonConfig.getImportIdName());
+                final String importId = importJsonConfig.isCleanup() 
+                        ? StringUtils.EMPTY
+                        : importJsonConfig.getImportIdName() + ": row.id";
+                query = String.format(CREATE_NODE, getLabelString(lastLabels), importId);
                 break;
             case "relationship":
                 String rel = (String) lastRelTypes.get("label");

--- a/core/src/test/java/apoc/export/json/ImportJsonTest.java
+++ b/core/src/test/java/apoc/export/json/ImportJsonTest.java
@@ -39,6 +39,7 @@ import org.neo4j.values.storable.Values;
 import java.io.File;
 import java.io.IOException;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -73,11 +74,20 @@ public class ImportJsonTest {
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db, ImportJson.class, Schemas.class, Utils.class);
     }
+    
+    @Test
+    public void shouldImportAllJsonWithoutImportId() {
+        shouldImportAllCommon(map("cleanup", true), 8, false, 0L);
+    }
 
     @Test
     public void shouldImportAllJson() throws Exception {
+        shouldImportAllCommon(Collections.emptyMap(), 9, true, 1L);
+    }
+
+    private void shouldImportAllCommon(Map<String, Object> config, int expectedPropSize, boolean hasImportId, long relCount) {
         db.executeTransactionally("CREATE CONSTRAINT ON (n:User) assert n.neo4jImportId IS UNIQUE");
-        
+
         // given
         String filename = "all.json";
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.json.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.json.adoc
@@ -11,6 +11,7 @@ This procedure supports the following config parameters:
 | relPropertyMappings | Map | `{}` | The mapping rel type/property name/property type for Custom Neo4j types (point date). I.e. { KNOWS: { since: 'Datetime' } }
 | compression | `Enum[NONE, BYTES, GZIP, BZIP2, DEFLATE, BLOCK_LZ4, FRAMED_SNAPPY]` | `null` | Allow taking binary data, either not compressed (value: `NONE`) or compressed (other values)
 See the xref::overview/apoc.load/apoc.load.csv.adoc#_binary_file[Binary file example]
+| cleanup | boolean | false | To remove the "id" field present into the json, if present. Note that in this way we cannot import relationship, because we leverage on "id" field to connect the nodes.
 |===
 
 `nodePropertyMappings` and `relPropertyMappings` support the following Neo4j types:


### PR DESCRIPTION
Fixes #2325

Added a cleanup config to remove `neo4jImportId`
