### PR TITLE
Fixes #2325: added property filters

### DIFF
--- a/core/src/main/java/apoc/export/json/ImportJsonConfig.java
+++ b/core/src/main/java/apoc/export/json/ImportJsonConfig.java
@@ -6,9 +6,13 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 public class ImportJsonConfig extends CompressionConfig {
+    public static final String WILDCARD_PROPS = "_all";
+    private final Map<String, List<String>> nodePropFilter;
+    private final Map<String, List<String>> relPropFilter;
 
     private final Map<String, Map<String, String>> nodePropertyMappings;
     private final Map<String, Map<String, String>> relPropertyMappings;
@@ -29,6 +33,8 @@ public class ImportJsonConfig extends CompressionConfig {
         this.txBatchSize = Util.toInteger(config.getOrDefault("txBatchSize", 5000));
         this.importIdName = (String) config.getOrDefault("importIdName", "neo4jImportId");
         this.cleanup = Util.toBoolean(config.get("cleanup"));
+        this.nodePropFilter = (Map<String, List<String>>) config.getOrDefault("nodePropFilter", Collections.emptyMap());
+        this.relPropFilter = (Map<String, List<String>>) config.getOrDefault("relPropFilter", Collections.emptyMap());
     }
 
     public String typeForNode(Collection<String> labels, String property) {
@@ -57,5 +63,13 @@ public class ImportJsonConfig extends CompressionConfig {
 
     public boolean isCleanup() {
         return cleanup;
+    }
+
+    public Map<String, List<String>> getNodePropFilter() {
+        return nodePropFilter;
+    }
+
+    public Map<String, List<String>> getRelPropFilter() {
+        return relPropFilter;
     }
 }

--- a/core/src/main/java/apoc/export/json/JsonImporter.java
+++ b/core/src/main/java/apoc/export/json/JsonImporter.java
@@ -25,9 +25,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import static apoc.export.json.ImportJsonConfig.WILDCARD_PROPS;
 
 public class JsonImporter implements Closeable {
     private static final String UNWIND = "UNWIND $rows AS row ";
@@ -68,18 +71,33 @@ public class JsonImporter implements Closeable {
 
         manageEntityType(type);
 
+        final List<String> labels;
+        final Map<String, List<String>> propFilter;
         switch (type) {
             case "node":
                 manageNode(param);
+                labels = lastLabels;
+                propFilter = importJsonConfig.getNodePropFilter();
                 break;
             case "relationship":
                 manageRelationship(param);
+                labels = Collections.singletonList((String) lastRelTypes.get("label"));
+                propFilter = importJsonConfig.getRelPropFilter();
                 break;
             default:
                 throw new IllegalArgumentException("Current type not supported: " + type);
         }
 
         final Map<String, Object> properties = (Map<String, Object>) param.getOrDefault("properties", Collections.emptyMap());
+
+        final List<String> defaultProps = propFilter.getOrDefault(WILDCARD_PROPS, Collections.emptyList());
+        
+        properties.keySet()
+                .removeIf(name -> {
+                    final Predicate<String> nameInPropFilter = (i) -> propFilter.getOrDefault(i, defaultProps).contains(name);
+                    return labels.stream().anyMatch(nameInPropFilter);
+                });
+
         updateReporter(type, properties);
         param.put("properties", convertProperties(type, properties, null));
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.json.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.json.adoc
@@ -1,7 +1,7 @@
 This procedure supports the following config parameters:
 
 .Config parameters
-[opts=header]
+[opts=header, cols='1a,1a,1a,3a']
 |===
 | name | type |default | description
 | unwindBatchSize | Integer | `5000` | the batch size of the unwind
@@ -12,6 +12,13 @@ This procedure supports the following config parameters:
 | compression | `Enum[NONE, BYTES, GZIP, BZIP2, DEFLATE, BLOCK_LZ4, FRAMED_SNAPPY]` | `null` | Allow taking binary data, either not compressed (value: `NONE`) or compressed (other values)
 See the xref::overview/apoc.load/apoc.load.csv.adoc#_binary_file[Binary file example]
 | cleanup | boolean | false | To remove the "id" field present into the json, if present. Note that in this way we cannot import relationship, because we leverage on "id" field to connect the nodes.
+| nodePropFilter | Map<String, List<String>> | `{}` | A map with key the labels, and value the list of properties keys to filter during the import. 
+For example `{ User: ['name', 'surname'], Another: ['foo']}` will skip the properties name and surname of nodes with label User, the property foo of (:Another) nodes. +
+Note that if a node has multiple labels, in this example (:User:Another {}), will be filtered all properties of both labels, that is 'name', 'surname' and 'foo'. +
+We can also pass a key `_all` to filter properties of all nodes, for example `{_all: ['myProp']}`
+| relPropFilter | Map<String, List<String>> | `{}` | A map with key the rel-types, and value the list of properties keys to filter during the import.  
+For example `{ MY_REL: ['foo', 'baz'] }` will skip the properties name and surname of nodes with label User, the properties foo and baz of [:MY_REL] relationship. +
+We can also pass a key `_all` to filter properties of all relationships, for example `{_all: ['myProp']}`
 |===
 
 `nodePropertyMappings` and `relPropertyMappings` support the following Neo4j types:

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.json.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.json.adoc
@@ -12,12 +12,12 @@ This procedure supports the following config parameters:
 | compression | `Enum[NONE, BYTES, GZIP, BZIP2, DEFLATE, BLOCK_LZ4, FRAMED_SNAPPY]` | `null` | Allow taking binary data, either not compressed (value: `NONE`) or compressed (other values)
 See the xref::overview/apoc.load/apoc.load.csv.adoc#_binary_file[Binary file example]
 | cleanup | boolean | false | To remove the "id" field present into the json, if present. Note that in this way we cannot import relationship, because we leverage on "id" field to connect the nodes.
-| nodePropFilter | Map<String, List<String>> | `{}` | A map with key the labels, and value the list of properties keys to filter during the import. 
-For example `{ User: ['name', 'surname'], Another: ['foo']}` will skip the properties name and surname of nodes with label User, the property foo of (:Another) nodes. +
-Note that if a node has multiple labels, in this example (:User:Another {}), will be filtered all properties of both labels, that is 'name', 'surname' and 'foo'. +
+| nodePropFilter | Map<String, List<String>> | `{}` | A map with the labels as keys, and the list of property keys to filter during the import as values. 
+For example `{ User: ['name', 'surname'], Another: ['foo']}` will skip the properties 'name' and 'surname' of nodes with label 'User' and the property 'foo' of (:Another) nodes. +
+Note that if a node has multiple labels, in this example `(:User:Another {})`, all properties of both labels will be filtered, that is 'name', 'surname', and 'foo'. +
 We can also pass a key `_all` to filter properties of all nodes, for example `{_all: ['myProp']}`
-| relPropFilter | Map<String, List<String>> | `{}` | A map with key the rel-types, and value the list of properties keys to filter during the import.  
-For example `{ MY_REL: ['foo', 'baz'] }` will skip the properties name and surname of nodes with label User, the properties foo and baz of [:MY_REL] relationship. +
+| relPropFilter | Map<String, List<String>> | `{}` | A map with the relationship types as keys, and the list of property keys to filter during the import as values.  
+For example `{ MY_REL: ['foo', 'baz'] }` will skip the properties 'foo' and 'baz' of '[:MY_REL]' relationship. +
 We can also pass a key `_all` to filter properties of all relationships, for example `{_all: ['myProp']}`
 |===
 


### PR DESCRIPTION
Fixes #2325

Added `nodePropFilter` and `relPropFilter`, 
with key the label / rel-type consistently with `nodePropertyMappings` and `relPropertyMappings`.

The values are the property keys to be filtered.

Resolve the linked issue together with the #2592