### PR TITLE
Simplify APOC auto-cherry-picking (dev)

### DIFF
--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         target-branch: [
-          {name: '4.3', comment: '824917996'}
+          {name: '4.4', comment: '961175996'}
         ]
     runs-on: ubuntu-latest
     name: cherry-pick


### PR DESCRIPTION
Auto cherry-pick dev PRs to 4.4 instead of 4.3
