### PR TITLE
Use CALL {} IN TRANSACTIONS instead of PERIODIC COMMIT in test

### DIFF
--- a/full/src/main/java/apoc/cypher/CypherExtended.java
+++ b/full/src/main/java/apoc/cypher/CypherExtended.java
@@ -224,7 +224,7 @@ public class CypherExtended {
         return stmt.matches("(?is).*(create|drop)\\s+(index|constraint).*");
     }
     private boolean isPeriodicOperation(String stmt) {
-        return stmt.matches("(?is).*using\\s+periodic.*");
+        return stmt.matches("(?is).*using\\s+periodic.*") || stmt.matches("(?is).*in\\s+transactions.*");
     }
 
     private Map<String, Object> toMap(QueryStatistics stats, long time, long rows) {

--- a/full/src/test/java/apoc/cypher/CypherExtendedTest.java
+++ b/full/src/test/java/apoc/cypher/CypherExtendedTest.java
@@ -110,8 +110,8 @@ public class CypherExtendedTest {
                 });
     }
     @Test
-    public void testRunWithPeriodic() throws Exception {
-        testResult(db, "CALL apoc.cypher.runFile('periodic.cypher')",
+    public void testRunFileWithCallInTransactions() throws Exception {
+        testResult(db, "CALL apoc.cypher.runFile('call_in_transactions.cypher')",
                 r -> {
                     Map<String, Object> row = r.next();
                     assertEquals(-1L, row.get("row"));

--- a/full/src/test/resources/call_in_transactions.cypher
+++ b/full/src/test/resources/call_in_transactions.cypher
@@ -1,0 +1,6 @@
+LOAD CSV WITH HEADERS FROM "file:///test.dsv" AS row FIELDTERMINATOR ":"
+CALL {
+    WITH row
+    CREATE (n:Person {name:row.name, age:row.age})
+} IN TRANSACTIONS OF 1 ROW;
+

--- a/full/src/test/resources/periodic.cypher
+++ b/full/src/test/resources/periodic.cypher
@@ -1,3 +1,0 @@
-USING PERIODIC COMMIT 1
-LOAD CSV WITH HEADERS FROM "file:///test.dsv" AS row FIELDTERMINATOR ":"
-CREATE (n:Person {name:row.name, age:row.age});


### PR DESCRIPTION
Fixes test that will start failing when `PERIODIC COMMIT` is removed in neo4j