### PR TITLE
Simplify APOC auto-cherry-picking (4.3)

### DIFF
--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -10,10 +10,8 @@ jobs:
       fail-fast: false
       matrix:
         target-branch: [
-          {name: '4.1', comment: '824917901'},
           {name: '4.2', comment: '824917952'},
-          {name: '4.4', comment: '961175996'},
-          {name: 'dev', comment: '854451009'}
+          {name: '4.4', comment: '961175996'}
         ]
     runs-on: ubuntu-latest
     name: cherry-pick


### PR DESCRIPTION
Stop to auto cherry-pick 4.3 PRs to 4.1 and dev

4.1 is not supported anymore and dev will happen through 4.4.
