### PR TITLE
Simplify APOC auto-cherry-picking (4.2)

### DIFF
--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         target-branch: [
-          {name: '4.1', comment: '824917901'},
           {name: '4.3', comment: '824917996'}
         ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Stop to auto cherry-pick 4.2 PRs to 4.1

4.1 is not supported anymore