### PR TITLE
4.2 update dependencies

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -67,7 +67,7 @@ dependencies {
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
     testCompile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
 
-    testCompile group: 'org.reflections', name: 'reflections', version: '0.9.11', { exclude group: 'com.google.guava', module: 'guava' }
+    testCompile group: 'org.reflections', name: 'reflections', version: '0.9.12'
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
     testCompile group: 'org.neo4j.test', name: 'neo4j-harness', version: neo4jVersionEffective
@@ -130,7 +130,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
 
-    compile group: 'com.google.guava', name: 'guava', version: '27.0-jre'
+    compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
 
     compile group: 'xerces', name: 'xercesImpl', version: '2.12.1'
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -99,7 +99,7 @@ dependencies {
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
 
     testCompile group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.1'
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
     compile group: 'com.opencsv', name: 'opencsv', version: '4.6'
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'

--- a/extra-dependencies/gradle/wrapper/gradle-wrapper.properties
+++ b/extra-dependencies/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/extra-dependencies/nlp/build.gradle
+++ b/extra-dependencies/nlp/build.gradle
@@ -19,8 +19,8 @@ jar {
 
 dependencies {
     compile group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
-    compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.10.3'
-    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71'
+    compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.1'
+    compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0'
 }
 
 

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
     testCompile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
 
-    testCompile group: 'org.reflections', name: 'reflections', version: '0.9.11', { exclude group: 'com.google.guava', module: 'guava' }
+    testCompile group: 'org.reflections', name: 'reflections', version: '0.9.12'
 
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
     testCompile group: 'org.neo4j.test', name: 'neo4j-harness', version: neo4jVersionEffective

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -7,7 +7,7 @@ plugins {
     id 'maven-publish'
     id 'antlr'
     id "org.sonarqube"
-    id "org.jetbrains.kotlin.jvm" version "1.3.71"
+    id "org.jetbrains.kotlin.jvm" version "1.6.0"
 }
 
 archivesBaseName = "apoc"
@@ -107,11 +107,11 @@ dependencies {
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
     compileOnly group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
 
-    compileOnly group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.10.3'
-    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71'
+    compileOnly group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.1'
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0'
 
-    testCompile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.10.3'
-    testCompile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71'
+    testCompile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.1'
+    testCompile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0'
 
     testCompile 'org.mock-server:mockserver-netty:5.6.0'
     testCompile 'org.mock-server:mockserver-client-java:5.6.0'
@@ -120,7 +120,7 @@ dependencies {
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
 
     testCompile group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.1'
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
     compile group: 'com.opencsv', name: 'opencsv', version: '4.6'
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compile group: 'org.neo4j', name: 'neo4j-kernel', version: neo4jVersionEffective, classifier: "tests"
     compile group: 'org.neo4j', name: 'neo4j-io', version: neo4jVersionEffective, classifier: "tests"
 
-    compile group: 'com.google.guava', name: 'guava', version: '27.0-jre'
+    compile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
 
     compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.2.0'
 

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.2.0'
 
-    compile group: 'org.gradle', name: 'gradle-tooling-api', version: '6.0.1'
+    compile group: 'org.gradle', name: 'gradle-tooling-api', version: '6.1.1'
 
     def withoutServers = {
         exclude group: 'org.eclipse.jetty'


### PR DESCRIPTION
Fixes CVE-2020-25649

Upgrading some dependencies to mitigate CVE-2020-25649 and another vulnerability

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Upgrade org.reflections from 0.9.11 to 0.9.12
  - Upgrade guava from 27.0 to 31.0.1
  - Upgrade jackson-databind and jackson-module-kotlin to 2.13.1
  - Upgrade kotlin from 1.3.71 to 1.6.0
  - Upgrade gradle from 6.0.1 to 6.1.1
