### PR TITLE
Apoc.schema.assert should drops only indexes not included in the 1st parameter (#2523)

### DIFF
--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -155,16 +155,21 @@ public class Schemas {
             definition.getPropertyKeys().forEach(keys::add);
 
             AssertSchemaResult info = new AssertSchemaResult(label, keys);
-            if(indexes.containsKey(label)) {
-                if (keys.size() > 1) {
-                    indexes.get(label).remove(keys);
-                } else if (keys.size() == 1) {
-                    indexes.get(label).remove(keys.get(0));
-                } else
-                    throw new IllegalArgumentException("Label given with no keys.");
-            }
 
-            if (dropExisting) {
+            final boolean included = Optional.ofNullable(indexes.get(label))
+                    .map(lbl -> {
+                        if (keys.size() > 1) {
+                            return lbl.remove(keys);
+                        }
+                        if (keys.size() == 1) {
+                            return lbl.remove(keys.get(0));
+                        }
+                        // todo - it shouldn't be needed. only LOOKUP indexes, absent in 4.2 and previous and filtered for 4.3+, can be without keys
+                        throw new IllegalArgumentException("Label given with no keys.");
+                    })
+                    .orElse(false);
+
+            if (dropExisting && !included) {
                 definition.drop();
                 info.dropped();
             }
@@ -172,8 +177,6 @@ public class Schemas {
             result.add(info);
         }
 
-        if (dropExisting)
-            indexes = copyMapOfObjects(indexes0);
 
         for (Map.Entry<String, List<Object>> index : indexes.entrySet()) {
             for (Object key : index.getValue()) {


### PR DESCRIPTION
Cherry pick for 4.2 https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/5886f7b53a2c629888bac5af257bd54a6347f903