### PR TITLE
Checks full API listings and archives more test results. No AUTO cherry-pick

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -32,7 +32,7 @@ jobs:
         run: git diff --exit-code full/src/main/resources/extended.txt || (echo "extended.txt file does not contain all changes" && exit -1)
       - name: Archive test results
         uses: actions/upload-artifact@v2
-        if: ${{ always() }}
+        if: always()
         with:
           name: test-results
           path: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -28,3 +28,16 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew build
+      - name: Check procedures included in apoc full
+        run: git diff --exit-code full/src/main/resources/extended.txt || (echo "extended.txt file does not contain all changes" && exit -1)
+      - name: Archive test results
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: test-results
+          path: |
+            core/build/reports/tests/test/
+            full/build/reports/tests/test/
+            processor/build/reports/tests/test/
+            test-startup/build/reports/tests/test/
+            test-utils/build/reports/tests/test/

--- a/full/src/main/resources/extended.txt
+++ b/full/src/main/resources/extended.txt
@@ -78,6 +78,12 @@ apoc.metrics.get
 apoc.metrics.list
 apoc.metrics.storage
 apoc.model.jdbc
+apoc.mongo.aggregate
+apoc.mongo.count
+apoc.mongo.delete
+apoc.mongo.find
+apoc.mongo.insert
+apoc.mongo.update
 apoc.mongodb.count
 apoc.mongodb.delete
 apoc.mongodb.find
@@ -137,6 +143,7 @@ apoc.static.get
 apoc.static.list
 apoc.static.set
 apoc.systemdb.execute
+apoc.systemdb.export.metadata
 apoc.systemdb.graph
 apoc.ttl.expire
 apoc.ttl.expireIn
@@ -150,9 +157,3 @@ apoc.static.getAll
 apoc.trigger.nodesByLabel
 apoc.trigger.propertiesByKey
 apoc.ttl.config
-apoc.mongo.aggregate
-apoc.mongo.count
-apoc.mongo.find
-apoc.mongo.insert
-apoc.mongo.update
-apoc.mongo.delete


### PR DESCRIPTION
## What
Checks full API listings and archives more test results.

## Why
There's a file called `full/src/main/resources/extended.txt` that contains the procedures and functions included in apoc full. It's important this file is up to date in the PRs cause it will be used to package apoc, and if not updated, the `apoc.help` method indicate something is in core while it's not (cause it uses that `extended.txt` file internally).

It is bad practice as that file is kept up to date by a test: `./gradlew test --tests HelpExtendedTest`, but that's a different problem.

This PR ensures we archive all tests from all projects but also that the aforementioned file is kept up to date.