### PR TITLE
Uses TLS 2.1 in JDBC tests. No AUTO cherry-pick

### DIFF
--- a/full/src/test/java/apoc/model/ModelTest.java
+++ b/full/src/test/java/apoc/model/ModelTest.java
@@ -29,6 +29,8 @@ public class ModelTest {
 
     public static JdbcDatabaseContainer mysql;
 
+    private static String mysqlUrl;
+
     @BeforeClass
     public static void setUpContainer() {
         assumeFalse(isRunningInCI());
@@ -38,6 +40,7 @@ public class ModelTest {
         },Exception.class);
         assumeNotNull("MySQL container has to exist", mysql);
         assumeTrue("MySQL must be running", mysql.isRunning());
+        mysqlUrl = mysql.getJdbcUrl() + "?enabledTLSProtocols=TLSv1.2";
     }
 
     @AfterClass
@@ -59,7 +62,7 @@ public class ModelTest {
     @Test
     public void testLoadJdbcSchema() {
         testCall(db, "CALL apoc.model.jdbc($url, $config)",
-                Util.map("url", mysql.getJdbcUrl(),
+                Util.map("url", mysqlUrl,
                         "config", Util.map("schema", "test",
                                 "credentials", Util.map("user", mysql.getUsername(), "password", mysql.getPassword()))),
                 (row) -> {
@@ -111,7 +114,7 @@ public class ModelTest {
     @Test
     public void testLoadJdbcSchemaWithWriteOperation() {
         db.executeTransactionally("CALL apoc.model.jdbc($url, $config)",
-                Util.map("url", mysql.getJdbcUrl(),
+                Util.map("url", mysqlUrl,
                         "config", Util.map("schema", "test",
                                 "write", true,
                                 "credentials", Util.map("user", mysql.getUsername(), "password", mysql.getPassword()))),
@@ -165,7 +168,7 @@ public class ModelTest {
     @Test
     public void testLoadJdbcSchemaWithFiltering() {
         testCall(db, "CALL apoc.model.jdbc($url, $config)",
-                Util.map("url", mysql.getJdbcUrl(),
+                Util.map("url", mysqlUrl,
                         "config", Util.map("schema", "test",
                                 "credentials", Util.map("user", mysql.getUsername(), "password", mysql.getPassword()),
                                 "filters", Util.map("tables", Arrays.asList("country\\w*"), "columns", Arrays.asList("(?i)code", "(?i)name", "(?i)Language")))),


### PR DESCRIPTION
## What
Forces TLS 2.1 in the JDBC tests

## Why
We have tests failing in our internal build system due to SSL exceptions:

```
org.neo4j.graphdb.QueryExecutionException: Failed to invoke procedure `apoc.model.jdbc`: Caused by: javax.net.ssl.SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate)
	at app//org.neo4j.kernel.impl.query.QueryExecutionKernelException.asUserException(QueryExecutionKernelException.java:35)
	at app//org.neo4j.cypher.internal.javacompat.ResultSubscriber.converted(ResultSubscriber.java:426)
	at app//org.neo4j.cypher.internal.javacompat.ResultSubscriber.fetchResults(ResultSubscriber.java:369)
	at app//org.neo4j.cypher.internal.javacompat.ResultSubscriber.materialize(ResultSubscriber.java:92)
	at app//org.neo4j.cypher.internal.result.StandardInternalExecutionResult.initiate(StandardInternalExecutionResult.scala:65)
	at app//org.neo4j.cypher.internal.result.ClosingExecutionResult.$anonfun$initiate$1(ClosingExecutionResult.scala:58)
	at app//scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at app//org.neo4j.cypher.internal.result.ClosingExecutionResult.safely(ClosingExecutionResult.scala:99)
	at app//org.neo4j.cypher.internal.result.ClosingExecutionResult.initiate(ClosingExecutionResult.scala:58)
	at app//org.neo4j.cypher.internal.result.ClosingExecutionResult$.wrapAndInitiate(ClosingExecutionResult.scala:183)
	at app//org.neo4j.cypher.internal.CypherCurrentCompiler$CypherExecutableQuery.innerExecute(CypherCurrentCompiler.scala:412)
	at app//org.neo4j.cypher.internal.CypherCurrentCompiler$CypherExecutableQuery.execute(CypherCurrentCompiler.scala:349)
	at app//org.neo4j.cypher.internal.ExecutionEngine.doExecute(ExecutionEngine.scala:189)
	at app//org.neo4j.cypher.internal.ExecutionEngine.$anonfun$executeSubquery$1(ExecutionEngine.scala:150)
	at app//org.neo4j.cypher.internal.ExecutionEngine.closing(ExecutionEngine.scala:155)
	at app//org.neo4j.cypher.internal.ExecutionEngine.executeSubquery(ExecutionEngine.scala:147)
	at app//org.neo4j.cypher.internal.ExecutionEngine.execute(ExecutionEngine.scala:97)
	at app//org.neo4j.cypher.internal.javacompat.ExecutionEngine.executeQuery(ExecutionEngine.java:124)
	at app//org.neo4j.cypher.internal.javacompat.ExecutionEngine.executeQuery(ExecutionEngine.java:112)
	at app//org.neo4j.kernel.impl.coreapi.TransactionImpl.execute(TransactionImpl.java:301)
	at app//org.neo4j.kernel.impl.coreapi.TransactionImpl.execute(TransactionImpl.java:290)
	at app//apoc.util.TestUtil.testResult(TestUtil.java:109)
	at app//apoc.util.TestUtil.testCall(TestUtil.java:39)
	at app//apoc.model.ModelTest.testLoadJdbcSchema(ModelTest.java:61)
	at java.base@17.0.2/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base@17.0.2/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base@17.0.2/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base@17.0.2/java.lang.reflect.Method.invoke(Method.java:568)
	...
```

According to [this](https://stackoverflow.com/questions/67332909/why-can-java-not-connect-to-mysql-5-7-after-the-latest-jdk-update-and-how-should) StackOverflow answer the error could be cause newer JDK versions disallow less safe TLS protocols by default.

## Open questions
* At first glance from the stacktrace above it is unclear why we have these two lines mixing different Java versions?:

```
	at app//scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
	at java.base@17.0.2/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
```
* Why the differences between our internal builds and GH Actions if both are using jdk 17?