### PR TITLE
Fixes #2405: The apoc.schema.assert procedure fails with multi-label fulltext index

### DIFF
--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -168,6 +168,8 @@ public class Schemas {
                 continue;
             if (definition.isConstraintIndex())
                 continue;
+            if (definition.isMultiTokenIndex())
+                continue;
 
             Object label = getLabelForAssert(definition, definition.isNodeIndex());
             List<String> keys = new ArrayList<>();

--- a/core/src/test/java/apoc/schema/SchemasTest.java
+++ b/core/src/test/java/apoc/schema/SchemasTest.java
@@ -132,6 +132,7 @@ public class SchemasTest {
     @Test
     public void testDropIndexWhenUsingDropExisting() throws Exception {
         db.executeTransactionally("CREATE INDEX ON :Foo(bar)");
+        db.executeTransactionally("CREATE FULLTEXT INDEX titlesAndDescriptions FOR (n:Movie|Book) ON EACH [n.title, n.description]");
         testCall(db, "CALL apoc.schema.assert(null,null)", (r) -> {
             assertEquals("Foo", r.get("label"));
             assertEquals("bar", r.get("key"));
@@ -140,7 +141,8 @@ public class SchemasTest {
         });
         try (Transaction tx = db.beginTx()) {
             List<IndexDefinition> indexes = Iterables.asList(tx.schema().getIndexes());
-            assertEquals(0, indexes.size());
+            // the multi-token idx remains
+            assertEquals(1, indexes.size());
         }
     }
 
@@ -541,18 +543,6 @@ public class SchemasTest {
         testResult(db, "CALL apoc.schema.assert({Bar:[['foo','bar']]}, {One:['two']}) " +
                 "YIELD label, key, keys, unique, action RETURN * ORDER BY label", (result) -> {
             Map<String, Object> r = result.next();
-            assertEquals(expectedKeys("Moon", "Blah"), r.get("label"));
-            assertEquals(expectedKeys("weightProp", "anotherProp"), r.get("keys"));
-            assertEquals(false, r.get("unique"));
-            assertEquals("DROPPED", r.get("action"));
-
-            r = result.next();
-            assertEquals(expectedKeys("TYPE_1", "TYPE_2"), r.get("label"));
-            assertEquals(expectedKeys("alpha", "beta"), r.get("keys"));
-            assertEquals(false, r.get("unique"));
-            assertEquals("DROPPED", r.get("action"));
-
-            r = result.next();
             assertEquals("Asd", r.get("label"));
             assertEquals(expectedKeys("uno", "due"), r.get("keys"));
             assertEquals(false, r.get("unique"));
@@ -573,7 +563,7 @@ public class SchemasTest {
         });
         try (Transaction tx = db.beginTx()) {
             List<IndexDefinition> indexes = Iterables.asList(tx.schema().getIndexes());
-            assertEquals(2, indexes.size());
+            assertEquals(4, indexes.size());
             List<ConstraintDefinition> constraints = Iterables.asList(tx.schema().getConstraints());
             assertEquals(1, constraints.size());
         }

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.schema.assert.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.schema.assert.adoc
@@ -19,7 +19,7 @@ We can create a uniqueness constraint on `:Person(name)` and an index on `:Perso
 
 We can drop all constraints and indexes, by running the following query.
 Note that the cancellation mechanism doesn't consider indexes of type `LOOKUP` and multi-token indexes, that is indexes applicable to multiple rel-types or multiple labels, 
-for example `CREATE FULLTEXT INDEX titlesAndDescriptions FOR (n:Movie|Book) ON EACH [n.title, n.description]` or `CALL db.index.fulltext.createRelationshipIndex('fullIdxRel', ['TYPE_1', 'TYPE_2'], ['alpha', 'beta'])`. 
+for example `CREATE FULLTEXT INDEX titlesAndDescriptions FOR (n:Movie|Book) ON EACH [n.title, n.description]` or `CREATE FULLTEXT INDEX fullIdxRel FOR ()-[r:TYPE_1|TYPE_2]-() ON EACH [r.alpha, r.beta]`. 
 This because they cannot be re-created by the `apoc.schema.assert` procedure:
 
 [source,cypher]

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.schema.assert.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.schema.assert.adoc
@@ -17,7 +17,8 @@ We can create a uniqueness constraint on `:Person(name)` and an index on `:Perso
 | "Person" | "name" | ["name"] | TRUE   | "CREATED"
 |===
 
-We can drop all constraints and indexes by running the following query:
+We can drop all constraints and indexes, except for `LOOKUP`s, index constraints and multi-token indexes (because they cannot be re-created by the `apoc.schema.assert` procedure),
+by running the following query:
 
 [source,cypher]
 ----

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.schema.assert.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.schema.assert.adoc
@@ -17,8 +17,10 @@ We can create a uniqueness constraint on `:Person(name)` and an index on `:Perso
 | "Person" | "name" | ["name"] | TRUE   | "CREATED"
 |===
 
-We can drop all constraints and indexes, except for `LOOKUP`s, index constraints and multi-token indexes (because they cannot be re-created by the `apoc.schema.assert` procedure),
-by running the following query:
+We can drop all constraints and indexes, by running the following query.
+Note that the cancellation mechanism doesn't consider indexes of type `LOOKUP` and multi-token indexes, that is indexes applicable to multiple rel-types or multiple labels, 
+for example `CREATE FULLTEXT INDEX titlesAndDescriptions FOR (n:Movie|Book) ON EACH [n.title, n.description]` or `CALL db.index.fulltext.createRelationshipIndex('fullIdxRel', ['TYPE_1', 'TYPE_2'], ['alpha', 'beta'])`. 
+This because they cannot be re-created by the `apoc.schema.assert` procedure:
 
 [source,cypher]
 ----


### PR DESCRIPTION
Fixes #2405

The bug is solved via https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/23443afd6a928c72351206bb03f9e971f6bb20df.
 
Anyway, we skip the multi-token idxs, similarly to lookups and constraint index,
because we cannot create them with `apoc.assert.schema`