### PR TITLE
Fix var tests dev

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -100,7 +100,6 @@ dependencies {
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
 
     testImplementation group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
     implementation group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
     implementation group: 'com.opencsv', name: 'opencsv', version: '4.6'
     implementation group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
@@ -119,7 +118,7 @@ dependencies {
     testImplementation group: 'org.xmlunit', name: 'xmlunit-core', version: '2.2.1'
     testImplementation group: 'com.github.adejanovski', name: 'cassandra-jdbc-wrapper', version: '3.1.0'
 
-    testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: '2.9.7'
+    testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: '2.13.1'
     testImplementation group: 'org.skyscreamer', name: 'jsonassert', version: '1.5.0'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.13.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.2.0'

--- a/core/src/main/java/apoc/util/FileUtils.java
+++ b/core/src/main/java/apoc/util/FileUtils.java
@@ -282,7 +282,7 @@ public class FileUtils {
 //            "dbms.directories.metrics",  // metrics is only in EE
             "dbms.directories.plugins",
             "dbms.directories.run",
-            "dbms.directories.tx_log",
+            "dbms.directories.transaction.logs.root", // in Neo4j 5.0 GraphDatabaseSettings.transaction_logs_root_path changed from tx_log to this config
             "unsupported.dbms.directories.neo4j_home"
     );
 

--- a/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
+++ b/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
@@ -5,6 +5,7 @@ import apoc.util.TestUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.neo4j.driver.Record;
@@ -93,7 +94,7 @@ public class SchemasEnterpriseFeaturesTest {
             assertEquals(1, result.size());
             Map<String, Object> firstResult = result.get(0).asMap();
             assertThat( (String) firstResult.get( "createStatement" ) )
-                    .contains( "CREATE CONSTRAINT", "FOR (foo:`Foo`) REQUIRE (foo.`foo`, foo.`bar`) IS NODE KEY" );
+                    .contains( "CREATE CONSTRAINT", "FOR (n:`Foo`) REQUIRE (n.`foo`, n.`bar`) IS NODE KEY" );
             tx.commit();
             return null;
         });
@@ -131,8 +132,8 @@ public class SchemasEnterpriseFeaturesTest {
                     .map(record -> (String) record.asMap().get("createStatement"))
                     .collect(Collectors.toList());
             List<String> expectedDescriptions = List.of(
-                    "FOR (foo:`Foo`) REQUIRE (foo.`foo`, foo.`bar`) IS NODE KEY",
-                    "FOR (foo:`Foo`) REQUIRE (foo.`bar`, foo.`foo`) IS NODE KEY" );
+                    "FOR (n:`Foo`) REQUIRE (n.`foo`, n.`bar`) IS NODE KEY",
+                    "FOR (n:`Foo`) REQUIRE (n.`bar`, n.`foo`) IS NODE KEY" );
             assertMatchesAll( expectedDescriptions, actualDescriptions );
             tx.commit();
             return null;
@@ -162,8 +163,8 @@ public class SchemasEnterpriseFeaturesTest {
                     .map(record -> (String) record.asMap().get("createStatement"))
                     .collect(Collectors.toList());
             List<String> expectedDescriptions = List.of(
-                    "FOR (galileo:`Galileo`) REQUIRE (galileo.`newton`, galileo.`tesla`) IS NODE KEY",
-                    "FOR ( galileo:`Galileo` ) REQUIRE (galileo.`curie`) IS UNIQUE");
+                    "FOR (n:`Galileo`) REQUIRE (n.`newton`, n.`tesla`) IS NODE KEY",
+                    "FOR (n:`Galileo`) REQUIRE (n.`curie`) IS UNIQUE");
             assertMatchesAll( expectedDescriptions, actualDescriptions );
             tx.commit();
             return null;
@@ -206,7 +207,7 @@ public class SchemasEnterpriseFeaturesTest {
             assertEquals(1, result.size());
             Map<String, Object> firstResult = result.get(0).asMap();
             assertThat( (String) firstResult.get( "createStatement" ) )
-                    .contains( "CREATE CONSTRAINT", "FOR (foo:`Foo`) REQUIRE (foo.`baa`, foo.`baz`) IS NODE KEY" );
+                    .contains( "CREATE CONSTRAINT", "FOR (n:`Foo`) REQUIRE (n.`baa`, n.`baz`) IS NODE KEY" );
             tx.commit();
             return null;
         });

--- a/core/src/test/java/apoc/trigger/TriggerTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerTest.java
@@ -129,8 +129,6 @@ public class TriggerTest {
         });
     }
 
-    // TODO NC:Why is this failing?
-    @Ignore
     @Test
     public void testTxIdAfterAsync() throws Exception {
         db.executeTransactionally("CALL apoc.trigger.add('txinfo','UNWIND $createdNodes AS n SET n.txId = $transactionId, n.txTime = $commitTime',{phase:'afterAsync'})");

--- a/core/src/test/java/apoc/trigger/TriggerTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerTest.java
@@ -132,7 +132,7 @@ public class TriggerTest {
     // TODO NC:Why is this failing?
     @Ignore
     @Test
-    public void testTxId1() throws Exception {
+    public void testTxIdAfterAsync() throws Exception {
         db.executeTransactionally("CALL apoc.trigger.add('txinfo','UNWIND $createdNodes AS n SET n.txId = $transactionId, n.txTime = $commitTime',{phase:'afterAsync'})");
         db.executeTransactionally("CREATE (f:Bar)");
         org.neo4j.test.assertion.Assert.assertEventually(() ->

--- a/docs/asciidoc/modules/ROOT/pages/background-operations/triggers.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/background-operations/triggers.adoc
@@ -63,6 +63,17 @@ You can use these helper functions to extract nodes or relationships by label/re
 | apoc.trigger.propertiesByKey($assignedNodeProperties,'key') | function to filter propertyEntries by property-key, to be used within a trigger statement with $assignedNode/RelationshipProperties and $removedNode/RelationshipProperties. Returns [{old,[new],key,node,relationship}]
 |===
 
+[WARNING]
+====
+Unlike Neo4j up to 4, with Neo4j 5 it's not possible to modify an entity created in phase: "after". 
+For example this query will throw an Exception with message `can't acquire ExclusiveLock...`:
+```
+CALL apoc.trigger.add('name','UNWIND $createdNodes AS n SET n.txId = $transactionId',{phase:'after'});
+CREATE (f:Baz);
+```
+
+Instead, it's necessary to put another phase or perform only reading operations.
+====
 
 == Triggers Examples
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/draft/apoc.trigger.add.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/draft/apoc.trigger.add.adoc
@@ -27,7 +27,7 @@ CALL apoc.trigger.add(
    WITH prop.node as n
    MATCH(n)-[]-(a)
    SET a.surname = n.surname',
-  {phase:'after'}
+  {phase:'afterAsync'}
 );
 ----
 
@@ -38,7 +38,7 @@ CALL apoc.trigger.add(
 | "setAllConnectedNodes" | "UNWIND apoc.trigger.propertiesByKey($assignedNodeProperties,\"surname\") as prop
 WITH prop.node as n
 MATCH(n)-[]-(a)
-SET a.surname = n.surname" | {phase: "after"} | {}     | TRUE      | FALSE
+SET a.surname = n.surname" | {phase: "afterAsync"} | {}     | TRUE      | FALSE
 |===
 
 

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -119,7 +119,6 @@ dependencies {
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
 
     testImplementation group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.10.5.1'
     implementation group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
     implementation group: 'com.opencsv', name: 'opencsv', version: '4.6'
     implementation group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
@@ -138,7 +137,7 @@ dependencies {
     testImplementation group: 'com.github.adejanovski', name: 'cassandra-jdbc-wrapper', version: '3.1.0'
 
 
-    testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: '2.9.7'
+    testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: '2.13.1'
     testImplementation group: 'org.skyscreamer', name: 'jsonassert', version: '1.5.0'
     testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.13.2'
 


### PR DESCRIPTION
Fix var tests dev.
- Updated `com.fasterxml.jackson.dataformat` to fix some `ExportCsvTest` java.
- Fixed trigger tests (see `background-operations/triggers.adoc` note)
- Fixed Schemas enterprise tests (due to `SHOW CONSTRAINTS YIELD createStatement` instead of `db. constraints()`, with a different resutl)
- Fixed Metric test 
- Removed unused `jackson-databind`

same as #2647 as @vga91 doesn't have the rights to push on neo4j-contrib repo