### PR TITLE
Fixes #2223: Add config option for schema exports to retain the index and/or constraint names

### DIFF
--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -264,7 +264,7 @@ public class MultiStatementCypherSubGraphExporter {
                         return new AbstractMap.SimpleEntry<>(FULL, fullTextIndex);
                     }
                     // "normal" schema index
-                    String idxName = getIdxName(name, config.isSaveIndexNames());
+                    String idxName = getIdxName(name, config.shouldSaveIndexNames());
                     String tokenName = tokenNames.get(0);
                     return new AbstractMap.SimpleEntry<>(NORMAL, this.cypherFormat.statementForIndex(tokenName, props, exportConfig.ifNotExists(), idxName));
 
@@ -308,7 +308,7 @@ public class MultiStatementCypherSubGraphExporter {
         return StreamSupport.stream(graph.getIndexes().spliterator(), false)
                 .filter(index -> index.isConstraintIndex())
                 .map(index -> {
-                    String name = getIdxName(index.getName(), config.isSaveConstraintNames());
+                    String name = getIdxName(index.getName(), config.shouldSaveConstraintNames());
                     String label = Iterables.single(index.getLabels()).name();
                     Iterable<String> props = index.getPropertyKeys();
                     return this.cypherFormat.statementForConstraint(label, props, exportConfig.ifNotExists(), name);

--- a/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -31,7 +31,7 @@ import static apoc.export.cypher.formatter.CypherFormatterUtils.quote;
  */
 abstract class AbstractCypherFormatter implements CypherFormatter {
 
-	private static final String STATEMENT_CONSTRAINTS = "CREATE CONSTRAINT%s ON (node:%s) ASSERT (%s) %s;";
+	private static final String STATEMENT_CONSTRAINTS = "CREATE CONSTRAINT%s%s ON (node:%s) ASSERT (%s) %s;";
 
 	private static final String STATEMENT_NODE_FULLTEXT_IDX = "CALL db.index.fulltext.createNodeIndex('%s',[%s],[%s]);";
 	private static final String STATEMENT_REL_FULLTEXT_IDX = "CALL db.index.fulltext.createRelationshipIndex('%s',[%s],[%s]);";
@@ -45,8 +45,9 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 	}
 
 	@Override
-	public String statementForIndex(String label, Iterable<String> keys, boolean ifNotExists) {
-		return String.format("CREATE INDEX%s FOR (node:%s) ON (%s);", 
+	public String statementForIndex(String label, Iterable<String> keys, boolean ifNotExists, String idxName) {
+		return String.format("CREATE INDEX%s%s FOR (node:%s) ON (%s);", 
+				idxName,
 				getIfNotExists(ifNotExists),
 				Util.quote(label),
 				getPropertiesQuoted(keys));
@@ -81,10 +82,10 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists) {
+	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists, String name) {
 		String keysString = getPropertiesQuoted(keys);
 
-		return String.format(STATEMENT_CONSTRAINTS, getIfNotExists(ifNotExists), Util.quote(label), keysString, Iterables.count(keys) > 1 ? "IS NODE KEY" : "IS UNIQUE");
+		return String.format(STATEMENT_CONSTRAINTS, name, getIfNotExists(ifNotExists), Util.quote(label), keysString, Iterables.count(keys) > 1 ? "IS NODE KEY" : "IS UNIQUE");
 	}
 
 	private String getIfNotExists(boolean ifNotExists) {

--- a/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -33,12 +33,12 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
-	public String statementForIndex(String label, Iterable<String> key, boolean ifNotExist) {
+	public String statementForIndex(String label, Iterable<String> key, boolean ifNotExist, String idxName) {
 		return "";
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists) {
+	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists, String name) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -19,13 +19,13 @@ public interface CypherFormatter {
 
 	String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties);
 
-	String statementForIndex(String label, Iterable<String> keys, boolean ifNotExist);
+	String statementForIndex(String label, Iterable<String> keys, boolean ifNotExist, String idxName);
 
 	String statementForNodeFullTextIndex(String name, Iterable<Label> labels, Iterable<String> keys);
 
 	String statementForRelationshipFullTextIndex(String name, Iterable<RelationshipType> types, Iterable<String> keys);
 
-	String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExist);
+	String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExist, String name);
 
 	String statementForCleanUp(int batchSize);
 

--- a/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -33,12 +33,12 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	}
 
 	@Override
-	public String statementForIndex(String label, Iterable<String> key, boolean ifNotExist) {
+	public String statementForIndex(String label, Iterable<String> key, boolean ifNotExist, String idxName) {
 		return "";
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> key, boolean ifNotExists) {
+	public String statementForConstraint(String label, Iterable<String> key, boolean ifNotExists, String name) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -32,6 +32,8 @@ public class ExportConfig extends CompressionConfig {
 
     private int batchSize;
     private boolean silent;
+    private boolean saveIndexNames;
+    private boolean saveConstraintNames;
     private boolean bulkImport = false;
     private boolean sampling;
     private String delim;
@@ -91,6 +93,8 @@ public class ExportConfig extends CompressionConfig {
         super(config);
         config = config != null ? config : Collections.emptyMap();
         this.silent = toBoolean(config.getOrDefault("silent",false));
+        this.saveIndexNames = toBoolean(config.getOrDefault("saveIndexNames",false));
+        this.saveConstraintNames = toBoolean(config.getOrDefault("saveConstraintNames",false));
         this.delim = delim(config.getOrDefault("delim", DEFAULT_DELIM).toString());
         this.arrayDelim = delim(config.getOrDefault("arrayDelim", DEFAULT_ARRAY_DELIM).toString());
         this.useTypes = toBoolean(config.get("useTypes"));
@@ -216,5 +220,13 @@ public class ExportConfig extends CompressionConfig {
     
     public boolean ifNotExists() {
         return ifNotExists;
+    }
+
+    public boolean isSaveIndexNames() {
+        return saveIndexNames;
+    }
+
+    public boolean isSaveConstraintNames() {
+        return saveConstraintNames;
     }
 }

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -222,11 +222,11 @@ public class ExportConfig extends CompressionConfig {
         return ifNotExists;
     }
 
-    public boolean isSaveIndexNames() {
+    public boolean shouldSaveIndexNames() {
         return saveIndexNames;
     }
 
-    public boolean isSaveConstraintNames() {
+    public boolean shouldSaveConstraintNames() {
         return saveConstraintNames;
     }
 }

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -17,6 +17,7 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -28,6 +29,7 @@ import static apoc.util.BinaryTestUtil.getDecompressedData;
 import static apoc.util.Util.map;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.*;
+import static org.testcontainers.shaded.org.apache.commons.lang.StringUtils.EMPTY;
 
 /**
  * @author mh
@@ -57,9 +59,9 @@ public class ExportCypherTest {
     public void setUp() throws Exception {
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
         TestUtil.registerProcedure(db, ExportCypher.class, Graphs.class);
-        db.executeTransactionally("CREATE INDEX ON :Bar(first_name, last_name)");
-        db.executeTransactionally("CREATE INDEX ON :Foo(name)");
-        db.executeTransactionally("CREATE CONSTRAINT ON (b:Bar) ASSERT b.name IS UNIQUE");
+        db.executeTransactionally("CREATE INDEX barIndex FOR (n:Bar) ON (n.first_name, n.last_name)");
+        db.executeTransactionally("CREATE INDEX fooIndex FOR (n:Foo) ON (n.name)");
+        db.executeTransactionally("CREATE CONSTRAINT consBar ON (n:Bar) ASSERT (n.name) IS UNIQUE");
         if (testName.getMethodName().endsWith(OPTIMIZED)) {
             db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})-[:KNOWS {since:2016}]->(b:Bar {name:'bar',age:42}),(c:Bar:Person {age:12}),(d:Bar {age:12})," +
                     " (t:Foo {name:'foo2', born:date('2017-09-29')})-[:KNOWS {since:2015}]->(e:Bar {name:'bar2',age:44}),({age:99})");
@@ -214,6 +216,30 @@ public class ExportCypherTest {
     }
 
     @Test
+    public void testExportAllCypherSchemaWithSaveIdxNames() throws Exception {
+        final Map<String, Object> config = new HashMap<>(ExportCypherTest.exportConfig);
+        config.put("saveIndexNames", true);
+        String fileName = "all.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($file,$config)", 
+                map("file", fileName, "config", config),
+                (r) -> assertResults(fileName, r, "database"));
+        final String expectedFile = String.format(EXPECTED_SCHEMA_WITH_NAMES, " barIndex", " fooIndex", EMPTY);
+        assertEquals(expectedFile, readFile("all.schema.cypher"));
+    }
+
+    @Test
+    public void testExportAllCypherSchemaWithSaveConstraintNames() throws Exception {
+        final Map<String, Object> config = new HashMap<>(ExportCypherTest.exportConfig);
+        config.put("saveConstraintNames", true);
+        String fileName = "all.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($file,$config)", 
+                map("file", fileName, "config", config),
+                (r) -> assertResults(fileName, r, "database"));
+        final String expectedFile = String.format(EXPECTED_SCHEMA_WITH_NAMES, EMPTY, EMPTY, " consBar");
+        assertEquals(expectedFile, readFile("all.schema.cypher"));
+    }
+
+    @Test
     public void testExportAllCypherCleanUp() throws Exception {
         String fileName = "all.cypher";
         TestUtil.testCall(db, "CALL apoc.export.cypher.all($file,$exportConfig)", map("file", fileName, "exportConfig", exportConfig),
@@ -320,6 +346,16 @@ public class ExportCypherTest {
         TestUtil.testCall(db, "CALL apoc.export.cypher.schema($file,$exportConfig)", map("file", fileName, "exportConfig", exportConfig), (r) -> {
         });
         assertEquals(EXPECTED_ONLY_SCHEMA_NEO4J_SHELL, readFile(fileName));
+    }
+
+    @Test
+    public void testExportSchemaCypherWithIdxAndConsNames() throws Exception {
+        final Map<String, Object> config = new HashMap<>(ExportCypherTest.exportConfig);
+        config.putAll(map("saveConstraintNames", true, "saveIndexNames", true));
+        String fileName = "onlySchema.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.schema($file,$config)", 
+                map("file", fileName, "config", config), (r) -> {});
+        assertEquals(EXPECTED_ONLY_SCHEMA_NEO4J_SHELL_WITH_NAMES, readFile(fileName));
     }
 
     @Test
@@ -842,6 +878,14 @@ public class ExportCypherTest {
                 "COMMIT%n" +
                 "SCHEMA AWAIT%n");
 
+        static final String EXPECTED_SCHEMA_WITH_NAMES = "BEGIN%n" +
+                "CREATE INDEX%s FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
+                "CREATE INDEX%s FOR (node:Foo) ON (node.name);%n" +
+                "CREATE CONSTRAINT%s ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n" +
+                "SCHEMA AWAIT%n";
+
         static final String EXPECTED_SCHEMA_EMPTY = String.format("BEGIN%n" +
                 "COMMIT%n" +
                 "SCHEMA AWAIT%n");
@@ -879,6 +923,13 @@ public class ExportCypherTest {
                 "CREATE CONSTRAINT ON (node:Bar) ASSERT (node.name) IS UNIQUE;%n" +
                 "COMMIT%n" +
                 "SCHEMA AWAIT%n");
+
+        static final String EXPECTED_ONLY_SCHEMA_NEO4J_SHELL_WITH_NAMES = "BEGIN\n" +
+                "CREATE INDEX barIndex FOR (node:Bar) ON (node.first_name, node.last_name);\n" +
+                "CREATE INDEX fooIndex FOR (node:Foo) ON (node.name);\n" +
+                "CREATE CONSTRAINT consBar ON (node:Bar) ASSERT (node.name) IS UNIQUE;\n" +
+                "COMMIT\n" +
+                "SCHEMA AWAIT\n";
 
         static final String EXPECTED_CYPHER_POINT = String.format("BEGIN%n" +
                 "CREATE (:Test:`UNIQUE IMPORT LABEL` {name:\"foo\", place2d:point({x: 2.3, y: 4.5, crs: 'cartesian'}), place3d1:point({x: 2.3, y: 4.5, z: 1.2, crs: 'cartesian-3d'}), `UNIQUE IMPORT ID`:3});%n" +

--- a/docs/asciidoc/modules/ROOT/pages/export/cypher.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/export/cypher.adoc
@@ -63,6 +63,8 @@ The procedures support the following config parameters:
 * `UNWIND_BATCH` - exports the file by batching the entities with the `UNWIND` method as explained in Michael Hunger's article on https://medium.com/neo4j/5-tips-tricks-for-fast-batched-updates-of-graph-structures-with-neo4j-and-cypher-73c7f693c8cc[fast batched writes^].
 * `UNWIND_BATCH_PARAMS` - similar to `UNWIND_BATCH`, but also uses parameters where appropriate
 | awaitForIndexes | Long | 300 | Timeout to use for `db.awaitIndexes` when using `format: "cypher-shell"`
+| saveIndexNames | boolean | false | Save name indexes on export
+| saveConstraintNames | boolean | false | Save name constraints on export
 |===
 
 [[export-cypher-file-export]]


### PR DESCRIPTION
Fixes #2223

Added configs `saveIndexNames` and `saveConstraintNames`