### PR TITLE
Upgrade dependencies to mitigate vulnerabilities

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -65,7 +65,7 @@ dependencies {
     implementation group: 'com.github.seancfoley', name: 'ipaddress', version: '5.3.3'
 
     testImplementation 'net.sourceforge.jexcelapi:jxl:2.6.12'
-    
+
     implementation(group: 'org.apache.commons', name: 'commons-lang3') {
         version {
             strictly '3.12.0'
@@ -75,7 +75,7 @@ dependencies {
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
 
-    testImplementation group: 'org.reflections', name: 'reflections', version: '0.9.11', { exclude group: 'com.google.guava', module: 'guava' }
+    testImplementation group: 'org.reflections', name: 'reflections', version: '0.9.12'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
     testImplementation group: 'org.neo4j.test', name: 'neo4j-harness', version: neo4jVersionEffective
@@ -135,7 +135,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
 
-    implementation group: 'com.google.guava', name: 'guava', version: '27.0-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
 
     implementation group: 'org.apache.arrow', name: 'arrow-vector', version: '6.0.0'
     implementation group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '6.0.0'

--- a/extra-dependencies/nlp/build.gradle
+++ b/extra-dependencies/nlp/build.gradle
@@ -19,8 +19,8 @@ jar {
 
 dependencies {
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.11.683'
-    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.10.3'
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.71'
+    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.1'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0'
 }
 
 

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
 
-    testImplementation group: 'org.reflections', name: 'reflections', version: '0.9.11', { exclude group: 'com.google.guava', module: 'guava' }
+    testImplementation group: 'org.reflections', name: 'reflections', version: '0.9.12'
 
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
     testImplementation group: 'org.neo4j.test', name: 'neo4j-harness', version: neo4jVersionEffective
@@ -106,11 +106,11 @@ dependencies {
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
     compileOnly group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
 
-    compileOnly group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.0'
-    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31'
+    compileOnly group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.1'
+    compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0'
 
-    testImplementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.0'
-    testImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31'
+    testImplementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.1'
+    testImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0'
 
     testImplementation 'org.mock-server:mockserver-netty:5.6.0'
     testImplementation 'org.mock-server:mockserver-client-java:5.6.0'

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     implementation group: 'org.neo4j', name: 'neo4j-kernel', version: neo4jVersionEffective, classifier: "tests"
     implementation group: 'org.neo4j', name: 'neo4j-io', version: neo4jVersionEffective, classifier: "tests"
 
-    implementation group: 'com.google.guava', name: 'guava', version: '27.0-jre'
+    implementation group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
 
     api group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.0.0'
 


### PR DESCRIPTION
Fixes CVE-2020-25649

Upgrading some dependencies to mitigate CVE-2020-25649 and another vulnerability

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Upgrade org.reflections from 0.9.11 to 0.9.12
  - Upgrade guava from 20.0 to 31.0.1
  - Upgrade jackson-module-kotlin to 2.13.1
  - Upgrade kotlin from 1.3.71 to 1.6.0
