### PR TITLE
Upgrade dependencies to mitigate vulnerabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,7 +128,7 @@ dependencies {
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
     testCompile group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
 
-    testCompile group: 'org.reflections', name: 'reflections', version: '0.9.11', { exclude group: 'com.google.guava', module: 'guava' }
+    testCompile group: 'org.reflections', name: 'reflections', version: '0.9.12'
     testCompile group: 'junit', name: 'junit', version: '4.13.2'
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
     testCompile group: 'org.neo4j.test', name: 'neo4j-harness', version: neo4jVersionEffective
@@ -159,11 +159,11 @@ dependencies {
         exclude group: 'org.apache.hive', module: 'hive-service'
     }
 
-    compileOnly group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '2.7.5', withoutServers
-    testCompile group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '2.7.5', withoutServers
-    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '2.7.5', withoutServers
-    testCompile group: 'org.apache.hadoop', name: 'hadoop-common', version: '2.7.5', withoutServers
-    testCompile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '2.7.5', withoutServers
+    compileOnly group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.1', withoutServers
+    testCompile group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.1', withoutServers
+    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.1', withoutServers
+    testCompile group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.1', withoutServers
+    testCompile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.3.1', withoutServers
 
     compileOnly 'org.mongodb:mongodb-driver:3.2.2'
     testCompile 'org.mongodb:mongodb-driver:3.2.2'
@@ -172,7 +172,7 @@ dependencies {
     testCompile group: 'com.couchbase.client', name: 'java-client', version: '2.7.2'
 
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.10.8'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.1'
     compile group: 'com.opencsv', name: 'opencsv', version: '4.2' 
     compileOnly group: 'org.ow2.asm', name: 'asm', version: '5.0.2'
     compile group: 'com.github.javafaker', name: 'javafaker', version: '0.10'
@@ -212,8 +212,9 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
 
-    // there is a compatibility problem between the Guava Library used by HDFS, Google Cloud Storage and Reflections; the only version that fits for all is the following
-    testCompile group: 'com.google.guava', name: 'guava', version: '20.0'
+    testCompile group: 'com.google.guava', name: 'guava', version: '31.0.1-jre'
+
+    testCompile group: 'xerces', name: 'xercesImpl', version: '2.12.1'
 
     // force last version of beanutils as transitive dependency due to CVE https://www.cvedetails.com/cve/CVE-2019-10086/
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'

--- a/build.gradle
+++ b/build.gradle
@@ -172,7 +172,6 @@ dependencies {
     testCompile group: 'com.couchbase.client', name: 'java-client', version: '2.7.2'
 
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.13.1'
     compile group: 'com.opencsv', name: 'opencsv', version: '4.2' 
     compileOnly group: 'org.ow2.asm', name: 'asm', version: '5.0.2'
     compile group: 'com.github.javafaker', name: 'javafaker', version: '0.10'

--- a/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -166,7 +166,7 @@ public class ExportCsvTest {
 
     @Test
     public void testExportAllCsvHDFS() throws Exception {
-        String hdfsUrl = String.format("hdfs://localhost:12345/user/%s/all.csv", System.getProperty("user.name"));
+        String hdfsUrl = String.format("%s/user/%s/all.csv", miniDFSCluster.getURI().toString(), System.getProperty("user.name"));
         TestUtil.testCall(db, "CALL apoc.export.csv.all({file},null)", map("file", hdfsUrl),
                 (r) -> {
                     try {

--- a/src/test/java/apoc/load/LoadHdfsTest.java
+++ b/src/test/java/apoc/load/LoadHdfsTest.java
@@ -48,8 +48,9 @@ public class LoadHdfsTest {
     }
 
     @Test public void testLoadCsvFromHDFS() throws Exception {
-        testResult(db, "CALL apoc.load.csv({url},{results:['map','list','stringMap','strings']})", map("url", String.format("hdfs://localhost:12345/user/%s/%s",
-        		System.getProperty("user.name"), "test.csv")), // 'hdfs://localhost:12345/user/<sys_user_name>/test.csv'
+        testResult(db, "CALL apoc.load.csv($url,{results:['map','list','stringMap','strings']})", map("url", String.format("%s/user/%s/%s",
+                        miniDFSCluster.getURI().toString(),
+                        System.getProperty("user.name"), "test.csv")), // 'hdfs://localhost:12345/user/<sys_user_name>/test.csv'
                 (r) -> {
                     assertRow(r,0L,"name","Selma","age","8");
                     assertRow(r,1L,"name","Rana","age","11");

--- a/src/test/java/apoc/load/relative/LoadRelativePathTest.java
+++ b/src/test/java/apoc/load/relative/LoadRelativePathTest.java
@@ -7,13 +7,13 @@ import apoc.util.TestUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mortbay.util.StringMap;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Result;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -63,7 +63,7 @@ public class LoadRelativePathTest {
         Map<String, Object> row = r.next();
         Map<String, Object> map = map(data);
         List<Object> values = new ArrayList<>(map.values());
-        StringMap stringMap = new StringMap();
+        Map<String, Object> stringMap = new HashMap<>();
         stringMap.putAll(map);
         assertEquals(map, row.get("map"));
         assertEquals(values, row.get("list"));

--- a/src/test/java/apoc/util/HdfsTestUtils.java
+++ b/src/test/java/apoc/util/HdfsTestUtils.java
@@ -5,6 +5,8 @@ import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
 
 public class HdfsTestUtils {
 
@@ -31,16 +33,24 @@ public class HdfsTestUtils {
             return windowsLibDir.getAbsolutePath();
         }
     }
+
+    private static int getFreePort() throws IOException
+    {
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+            return serverSocket.getLocalPort();
+        }
+    }
     
     public static MiniDFSCluster getLocalHDFSCluster() throws Exception {
     	setHadoopHomeWindows();
     	Configuration conf = new HdfsConfiguration();
     	conf.set("fs.defaultFS", "hdfs://localhost");
 		File hdfsPath = new File(System.getProperty("user.dir") + File.separator + "hadoop" + File.separator + "hdfs");
-		conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, hdfsPath.getAbsolutePath());
+        hdfsPath.setWritable(true);
+        conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, hdfsPath.getAbsolutePath());
 		MiniDFSCluster miniDFSCluster = new MiniDFSCluster.Builder(conf)
-                .nameNodePort(12345)
-                .nameNodeHttpPort(12341)
+                .nameNodePort(getFreePort())
+//                .nameNodeHttpPort(12341)
                 .numDataNodes(1)
                 .storagesPerDatanode(2)
                 .format(true)


### PR DESCRIPTION
Fixes CVE-2020-25649

Upgrading some dependencies to mitigate CVE-2020-25649 and another vulnerability

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Upgrade org.reflections from 0.9.11 to 0.9.12
  - Upgrade guava from 20.0 to 31.0.1
  - Upgrade jackson-databind and to 2.13.1