### PR TITLE
Fixes #2607: apoc.export.json.data JSON format missing brace

### DIFF
--- a/core/src/main/java/apoc/export/json/JsonFormat.java
+++ b/core/src/main/java/apoc/export/json/JsonFormat.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
+
 public class JsonFormat implements Format {
     enum Format {JSON_LINES, ARRAY_JSON, JSON, JSON_ID_AS_KEYS}
     private final GraphDatabaseService db;
@@ -49,11 +50,9 @@ public class JsonFormat implements Format {
             consumer.accept(jsonGenerator);
             jsonGenerator.flush();
             tx.commit();
-            reporter.done();
-            return reporter.getTotal();
-        } finally {
-            writer.close();
         }
+        reporter.done();
+        return reporter.getTotal();
     }
 
     @Override

--- a/core/src/test/java/apoc/export/json/ExportJsonTest.java
+++ b/core/src/test/java/apoc/export/json/ExportJsonTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import static apoc.util.MapUtil.map;
 import static org.junit.Assert.*;
+import static apoc.export.json.JsonFormat.Format;
 
 public class ExportJsonTest {
 
@@ -87,6 +88,23 @@ public class ExportJsonTest {
                     assertStreamEquals(filename, r.get("data").toString());
                 }
         );
+    }
+
+    @Test
+    public void testExportAllJsonStreamWithFormatConfig() {
+        Map.of(Format.JSON_LINES.name(), "all.json", 
+                Format.JSON.name(), "all_fields.json",
+                Format.ARRAY_JSON.name(), "all_array.json",
+                Format.JSON_ID_AS_KEYS.name(), "all_id_as_keys.json").forEach((jsonFormat, fileName) -> {
+
+            TestUtil.testCall(db, "CALL apoc.export.json.all(null, $config)",
+                    map("config", map("jsonFormat", jsonFormat, "stream", true)),
+                    (r) -> {
+                        assertStreamResults(r, "database");
+                        assertStreamEquals(fileName, r.get("data").toString());
+                    }
+            );   
+        });
     }
 
     @Test


### PR DESCRIPTION
Fixes #2607

`reporter.done()` and `reporter.getTotal()` have to be executed after `jsonGenerator.close()`

