### PR TITLE
Fixes #558: Check for neo4j version being compatible with neo version

### DIFF
--- a/core/src/main/java/apoc/RegisterComponentFactory.java
+++ b/core/src/main/java/apoc/RegisterComponentFactory.java
@@ -1,11 +1,10 @@
 package apoc;
 
-import apoc.trigger.TriggerHandler;
+import org.neo4j.annotations.service.ServiceProvider;
 import org.neo4j.kernel.api.procedure.GlobalProcedures;
 import org.neo4j.kernel.extension.ExtensionFactory;
 import org.neo4j.kernel.extension.ExtensionType;
 import org.neo4j.kernel.extension.context.ExtensionContext;
-import org.neo4j.kernel.internal.Version;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
@@ -18,14 +17,14 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * NOTE: this is a GLOBAL component, so only once per DBMS
  */
+@ServiceProvider
 public class RegisterComponentFactory extends ExtensionFactory<RegisterComponentFactory.Dependencies> {
 
     private Log log;
     private GlobalProcedures globalProceduresRegistry;
 
     public RegisterComponentFactory() {
-        super(ExtensionType.GLOBAL,
-                "ApocRegisterComponent");
+        super(ExtensionType.GLOBAL, "ApocRegisterComponent");
     }
 
     @Override
@@ -55,14 +54,6 @@ public class RegisterComponentFactory extends ExtensionFactory<RegisterComponent
 
         @Override
         public void init() throws Exception {
-            final String kernelFullVersion = Version.getKernelVersion();
-            final String kernelVersion = getMajorMinVersion(kernelFullVersion);
-            final String apocFullVersion = apoc.version.Version.class.getPackage().getImplementationVersion();
-            if (kernelVersion != null && !kernelVersion.equals(getMajorMinVersion(apocFullVersion))) {
-                log.warn("The apoc version (%s) and the Neo4j version (%s) are incompatible. \n" +
-                        "See the compatibility matrix in https://neo4j.com/labs/apoc/4.4/installation/ to see the correct version",
-                        apocFullVersion, kernelFullVersion);
-            }
 
             for (ApocGlobalComponents c: Services.loadAll(ApocGlobalComponents.class)) {
                 for (Class clazz: c.getContextClasses()) {
@@ -80,14 +71,6 @@ public class RegisterComponentFactory extends ExtensionFactory<RegisterComponent
                         return instance;
                     }, true)
             );
-        }
-
-        private String getMajorMinVersion(String completeVersion) {
-            if (completeVersion == null) {
-                return null;
-            }
-            final String[] split = completeVersion.split("\\.");
-            return split[0] + "." + split[1];
         }
 
     }

--- a/core/src/main/java/apoc/RegisterComponentFactory.java
+++ b/core/src/main/java/apoc/RegisterComponentFactory.java
@@ -5,6 +5,7 @@ import org.neo4j.kernel.api.procedure.GlobalProcedures;
 import org.neo4j.kernel.extension.ExtensionFactory;
 import org.neo4j.kernel.extension.ExtensionType;
 import org.neo4j.kernel.extension.context.ExtensionContext;
+import org.neo4j.kernel.internal.Version;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
@@ -54,6 +55,14 @@ public class RegisterComponentFactory extends ExtensionFactory<RegisterComponent
 
         @Override
         public void init() throws Exception {
+            final String kernelFullVersion = Version.getKernelVersion();
+            final String kernelVersion = getMajorMinVersion(kernelFullVersion);
+            final String apocFullVersion = apoc.version.Version.class.getPackage().getImplementationVersion();
+            if (kernelVersion != null && !kernelVersion.equals(getMajorMinVersion(apocFullVersion))) {
+                log.warn("The apoc version (%s) and the Neo4j version (%s) are incompatible. \n" +
+                        "See the compatibility matrix in https://neo4j.com/labs/apoc/4.4/installation/ to see the correct version",
+                        apocFullVersion, kernelFullVersion);
+            }
 
             for (ApocGlobalComponents c: Services.loadAll(ApocGlobalComponents.class)) {
                 for (Class clazz: c.getContextClasses()) {
@@ -71,6 +80,14 @@ public class RegisterComponentFactory extends ExtensionFactory<RegisterComponent
                         return instance;
                     }, true)
             );
+        }
+
+        private String getMajorMinVersion(String completeVersion) {
+            if (completeVersion == null) {
+                return null;
+            }
+            final String[] split = completeVersion.split("\\.");
+            return split[0] + "." + split[1];
         }
 
     }

--- a/core/src/main/java/apoc/cypher/CypherInitializer.java
+++ b/core/src/main/java/apoc/cypher/CypherInitializer.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 
 public class CypherInitializer implements AvailabilityListener {
@@ -91,9 +92,11 @@ public class CypherInitializer implements AvailabilityListener {
         }).start();
     }
 
-    // only for testing purpose
+    // the visibility is public only for testing purpose, it could be private otherwise
     public static boolean isVersionDifferent(List<String> versions, String apocFullVersion) {
-        return versions.stream().noneMatch(apocFullVersion::startsWith);
+        return Optional.ofNullable(apocFullVersion)
+                .map(v -> versions.stream().noneMatch(v::startsWith))
+                .orElse(true);
     }
 
     private Collection<String> collectInitializers(boolean isSystemDatabase, Configuration config) {

--- a/core/src/test/java/apoc/cypher/CypherIsVersionDifferentTest.java
+++ b/core/src/test/java/apoc/cypher/CypherIsVersionDifferentTest.java
@@ -1,0 +1,20 @@
+package apoc.cypher;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CypherIsVersionDifferentTest {
+
+    @Test
+    public void shouldReturnFalseOnlyWithCompatibleVersion() {
+        assertTrue(CypherInitializer.isVersionDifferent(List.of("3.5"), "4.4.0.2"));
+        assertTrue(CypherInitializer.isVersionDifferent(List.of("5_0"), "4.4.0.2"));
+
+        // we expect that APOC versioning is always consistent to Neo4j versioning
+        assertFalse(CypherInitializer.isVersionDifferent(List.of("5_0"), "5_0_0_1"));
+    }
+}

--- a/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
@@ -58,6 +58,12 @@ The version compatibility matrix explains the mapping between Neo4j and APOC ver
 
 // end::version-matrix[]
 
+If by mistake a jar not compatible with the neo4j version is inserted, a `log.warn` like this will appear in `neo4j.log`:
+```
+The apoc version (<APOC_VERSION>) and the Neo4j DBMS versions [NEO4J_VERSION] are incompatible. 
+See the compatibility matrix in https://neo4j.com/labs/apoc/4.4/installation/ to see the correct version
+```
+
 [[docker]]
 == Docker
 


### PR DESCRIPTION
Fixes #558

Added a check between neo4j and apoc version. If versions are different, a log warn will be returned.


![reg](https://user-images.githubusercontent.com/25103389/161757313-aee6dcec-bfec-48b9-9051-ba895ac17eaf.gif)

