### PR TITLE
Fixes #2612: Confusing behavior with map as a custom functions

### DIFF
--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -396,17 +396,10 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                             List<String> cols = result.columns();
                             if (cols.isEmpty()) return null;
                             if (!forceSingle && outType instanceof Neo4jTypes.ListType) {
-                                Neo4jTypes.ListType listType = (Neo4jTypes.ListType) outType;
-                                Neo4jTypes.AnyType innerType = listType.innerType();
-                                // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
-                                if (innerType.getClass().equals(Neo4jTypes.MapType.class))
-                                    return ValueUtils.of(result.stream().collect(Collectors.toList()));
                                 if (cols.size() == 1)
                                     return ValueUtils.of(result.stream().map(row -> row.get(cols.get(0))).collect(Collectors.toList()));
                             } else {
                                 Map<String, Object> row = result.next();
-                                // We wrap the result only if we have a "true" map, and not NodeType or RelationshipType that extends MapType
-                                if (outType.getClass().equals(Neo4jTypes.MapType.class)) return ValueUtils.of(row);
                                 if (cols.size() == 1) return ValueUtils.of(row.get(cols.get(0)));
                             }
                             throw new IllegalStateException("Result mismatch " + cols + " output type is " + outType);

--- a/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -69,13 +69,13 @@ public class CypherProceduresStorageTest {
     @Test
     public void registerSimpleFunctionWithDotInName() {
         db.executeTransactionally("call apoc.custom.asFunction('foo.bar.baz','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
             assertEquals("foo.bar.baz", row.get("name"));
             assertEquals("function", row.get("type"));
         });
         restartDb();
-        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
             assertEquals("foo.bar.baz", row.get("name"));
             assertEquals("function", row.get("type"));
@@ -137,9 +137,9 @@ public class CypherProceduresStorageTest {
     @Test
     public void registerSimpleStatementFunction() {
         db.executeTransactionally("call apoc.custom.asFunction('answer','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, (((List)row.get("row"))).get(0)));
         restartDb();
-        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, (((List)row.get("row"))).get(0)));
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
             assertEquals("answer", row.get("name"));
             assertEquals("function", row.get("type"));
@@ -149,13 +149,13 @@ public class CypherProceduresStorageTest {
     @Test
     public void registerSimpleStatementFunctionWithDotInName() {
         db.executeTransactionally("call apoc.custom.asFunction('foo.bar.baz','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
             assertEquals("foo.bar.baz", row.get("name"));
             assertEquals("function", row.get("type"));
         });
         restartDb();
-        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.foo.bar.baz() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
             assertEquals("foo.bar.baz", row.get("name"));
             assertEquals("function", row.get("type"));

--- a/full/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -257,7 +257,7 @@ public class CypherProceduresTest  {
     @Test
     public void registerSimpleStatementFunction() throws Exception {
         db.executeTransactionally("call apoc.custom.asFunction('answer','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
         db.executeTransactionally("CALL apoc.custom.declareFunction('answer2() :: STRING','RETURN 42 as answer')");
         TestUtil.testCall(db, "return custom.answer2() as row", (row) -> assertEquals(42L, row.get("row")));
     }
@@ -265,7 +265,7 @@ public class CypherProceduresTest  {
     @Test
     public void registerSimpleStatementFunctionWithOneChar() throws Exception {
         db.executeTransactionally("call apoc.custom.asFunction('a','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.a() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.a() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
         final String procedureSignature = "b() :: STRING";
         assertProcedureFails(String.format(SIGNATURE_SYNTAX_ERROR, procedureSignature),
                 "CALL apoc.custom.declareFunction('" + procedureSignature + "','RETURN 42 as answer')");
@@ -323,7 +323,7 @@ public class CypherProceduresTest  {
         db.executeTransactionally("call apoc.custom.asFunction('answer','RETURN 42 as answer', '', null, false, 'Answer to the Ultimate Question of Life, the Universe, and Everything')");
 
         // when
-        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.answer() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
 
         // then
         TestUtil.testCall(db, "call apoc.custom.list()", row -> {
@@ -405,10 +405,10 @@ public class CypherProceduresTest  {
 
         // given
         db.executeTransactionally("CALL apoc.custom.asFunction('a.b.c','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
         db.executeTransactionally("call db.clearQueryCaches()");
         db.executeTransactionally("CALL apoc.custom.asFunction('a.b.c','RETURN 43 as answer')");
-        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(43L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(43L, ((List)row.get("row")).get(0)));
         db.executeTransactionally("call db.clearQueryCaches()");
 
         // when
@@ -450,7 +450,7 @@ public class CypherProceduresTest  {
 
         // given
         db.executeTransactionally("CALL apoc.custom.asFunction('a.b.c','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.a.b.c() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
 
         // when
         db.executeTransactionally("call apoc.custom.removeFunction('a.b.c')");
@@ -484,16 +484,16 @@ public class CypherProceduresTest  {
 
         // given
         db.executeTransactionally("call apoc.custom.asFunction('a.b.name','RETURN 42 as answer')");
-        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(42L, ((List)row.get("row")).get(0)));
         db.executeTransactionally("call db.clearQueryCaches()");
 
         db.executeTransactionally("call apoc.custom.asFunction('a.b.name','RETURN 34 as answer')");
-        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(34L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(34L, (((List)row.get("row")).get(0))));
         db.executeTransactionally("call db.clearQueryCaches()");
 
         db.executeTransactionally("call apoc.custom.asFunction('x.z.name','RETURN 12 as answer')");
-        TestUtil.testCall(db, "return custom.x.z.name() as row", (row) -> assertEquals(12L, ((Map)((List)row.get("row")).get(0)).get("answer")));
-        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(34L, ((Map)((List)row.get("row")).get(0)).get("answer")));
+        TestUtil.testCall(db, "return custom.x.z.name() as row", (row) -> assertEquals(12L, ((List)row.get("row")).get(0)));
+        TestUtil.testCall(db, "return custom.a.b.name() as row", (row) -> assertEquals(34L, ((List)row.get("row")).get(0)));
         db.executeTransactionally("call db.clearQueryCaches()");
 
         TestUtil.testResult(db, "call apoc.custom.list", (row) -> {

--- a/full/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -190,15 +190,16 @@ public class CypherProceduresTest  {
             assertEquals(2L, node.getProperty("value"));
         });
         TestUtil.testResult(db, "RETURN custom.ret_map(3) AS val", (result) -> {
-            Map<String, Map<String, Object>> map = result.<Map<String, Map<String, Object>>>columnAs("val").next();
+            Map<String, Object> map = result.<Map<String, Object>>columnAs("val").next();
             assertEquals(1, map.size());
-            assertEquals(3L, map.get("value").get("value"));
+            assertEquals(3L, map.get("value"));
         });
         TestUtil.testResult(db, "RETURN custom.ret_map_list(4) AS val", (result) -> {
-            List<Map<String, List<Map<String, Object>>>> list = result.<List<Map<String, List<Map<String, Object>>>>>columnAs("val").next();
+            List<List<Map<String, Object>>> list = result.<List<List<Map<String, Object>>>>columnAs("val").next();
             assertEquals(1, list.size());
-            assertEquals(1, list.get(0).size());
-            assertEquals(4L, list.get(0).get("value").get(0).get("value"));
+            List<Map<String, Object>> map = list.get(0);
+            assertEquals(1, map.size());
+            assertEquals(4L, map.get(0).get("value"));
         });
     }
 
@@ -226,18 +227,16 @@ public class CypherProceduresTest  {
             assertEquals(2L, t.getProperty("value"));
         });
         TestUtil.testResult(db, "RETURN custom.ret_map(3) AS val", (result) -> {
-            Map<String,Node> map = result.<Map<String, Node>>columnAs("val").next();
-            assertEquals(1, map.size());
-            Node t = map.get("t");
-            assertTrue(t.hasLabel(Label.label("Target")));
-            assertEquals(3L, t.getProperty("value"));
+            Node node = result.<Node>columnAs("val").next();
+            assertTrue(node.hasLabel(Label.label("Target")));
+            assertEquals(3L, node.getProperty("value"));
         });
         TestUtil.testResult(db, "RETURN custom.ret_map_list(4) AS val", (result) -> {
-            List<Map<String, Node>> nodes = result.<List<Map<String, Node>>>columnAs("val").next();
+            List<Node> nodes = result.<List<Node>>columnAs("val").next();
             assertEquals(1, nodes.size());
-            Node t = nodes.get(0).get("t");
-            assertTrue(t.hasLabel(Label.label("Target")));
-            assertEquals(4L, t.getProperty("value"));
+            Node node = nodes.get(0);
+            assertTrue(node.hasLabel(Label.label("Target")));
+            assertEquals(4L, node.getProperty("value"));
         });
     }
 


### PR DESCRIPTION
Fixes #2612

Related community issue: https://community.neo4j.com/t/why-do-functions-created-with-apoc-custom-declarefunction-or-asfunction-behave-differently-when-returning-a-map-value-vs-other-types/52095/2

The user ask why the map is wrapped with an `answer` key and the only way is to do this change.

However, this is a breaking-change so it is to be understood if it might be worth.
