### PR TITLE
Fixes the Cypher files execution not happening sequentially

### DIFF
--- a/full/src/main/java/apoc/cypher/CypherExtended.java
+++ b/full/src/main/java/apoc/cypher/CypherExtended.java
@@ -88,19 +88,19 @@ public class CypherExtended {
         return runFiles(fileNames, config, parameters, schemaOperation);
     }
 
+    // This runs the files sequentially
     private Stream<RowResult> runFiles(List<String> fileNames, Map<String, Object> config, Map<String, Object> parameters, boolean schemaOperation) {
         boolean addStatistics = Util.toBoolean(config.getOrDefault("statistics",true));
         int timeout = Util.toInteger(config.getOrDefault("timeout",10));
         int queueCapacity = Util.toInteger(config.getOrDefault("queueCapacity",100));
-        List<Stream<RowResult>> result = new ArrayList<>();
-        for (final String fileName : fileNames) {
+        var result = fileNames.stream().flatMap(fileName -> {
             final Reader reader = readerForFile(fileName);
             final Scanner scanner = createScannerFor(reader);
-            final Stream<RowResult> stream = runManyStatements(scanner, parameters, schemaOperation, addStatistics, timeout, queueCapacity)
+            return runManyStatements(scanner, parameters, schemaOperation, addStatistics, timeout, queueCapacity)
                     .onClose(() -> Util.close(scanner, (e) -> log.info("Cannot close the scanner for file " + fileName + " because the following exception", e)));
-            result.add(stream);
-        }
-        return result.stream().reduce(Stream::concat).orElse(Stream.empty());
+        });
+
+        return result;
     }
 
     @Procedure(mode=Mode.SCHEMA)

--- a/full/src/test/java/apoc/cypher/CypherExtendedTest.java
+++ b/full/src/test/java/apoc/cypher/CypherExtendedTest.java
@@ -196,7 +196,10 @@ public class CypherExtendedTest {
 
     @Test
     public void testRunFilesMultiple() throws Exception {
-        testResult(db, "CALL apoc.cypher.runFiles(['create.cypher', 'create_delete.cypher'])",
+        // The execution of both these files should happen sequentially
+        // There was a bug before that made both executions to
+        // interleave and at some point we were seeing nodesDeleted = 4
+        testResult(db, "CALL apoc.cypher.runFiles(['create_with_sleep.cypher', 'create_delete_with_sleep.cypher'])",
                 r -> {
                     Map<String, Object> row = r.next();
                     assertEquals(row.get("row"),((Map)row.get("result")).get("id"));

--- a/full/src/test/resources/create_delete_with_sleep.cypher
+++ b/full/src/test/resources/create_delete_with_sleep.cypher
@@ -1,0 +1,6 @@
+CREATE (n:Node {id:1});
+
+CALL apoc.util.sleep(2000)
+
+MATCH (n)
+DELETE n;

--- a/full/src/test/resources/create_with_sleep.cypher
+++ b/full/src/test/resources/create_with_sleep.cypher
@@ -1,0 +1,7 @@
+UNWIND RANGE(0,2) as id
+CREATE (n:Node {id:id})
+RETURN n.id as id;
+
+CALL apoc.util.sleep(1000)
+
+MATCH (n) DELETE n;


### PR DESCRIPTION
## What
Fixes `runFiles` so that the execution happens sequentially, rather than in parallel. 

It wasn't working because of two reasons:

* We were creating a list with streams produced by `runManyStatements`, which starts a thread. Which means all threads were started effectively at the same time for the different files it receives as input.
* `Stream.reduce` doesn't have good semantics to achieve the sequential execution either. On the one hand it's eager (or terminal as they call it in the docs), which means the threads are fired when we call the reduce phase and not when the stream is consumed. On the other hand it asks for associativity, which means we could group operations like (read the `+` as in execute the operation, not just concatenating them, since we have said it's eager):

```
a + b + c + d
as
(a + b) + (c + d)
```

`flatMap` on the other hand is an intermediate operation (it creates a lazy stream) and the threads will not be fired until the Stream is consumed.

## Why

`apoc.cypher.runFiles` and `apoc.cypher.runSchemaFile` were not being executed sequentially.

That was a problem creating flakiness in the modified `testRunFilesMultiple` test.

It was reproducible doing `apoc.cypher.runFiles` with the following (added in the PR to the test) files:

```
UNWIND RANGE(0,2) as id
CREATE (n:Node {id:id})
RETURN n.id as id;

CALL apoc.util.sleep(2000)

MATCH (n) DELETE n; // The files definitely run in parallel cause I see 4 deleted here
```

and

```
UNWIND RANGE(0,2) as id
CREATE (n:Node {id:id})
RETURN n.id as id;

CALL apoc.util.sleep(1000)

MATCH (n) DELETE n;
```