### PR TITLE
Make PathExpander return ResourceIterable in readiness for Core API changes

### DIFF
--- a/core/src/main/java/apoc/path/RelationshipSequenceExpander.java
+++ b/core/src/main/java/apoc/path/RelationshipSequenceExpander.java
@@ -1,14 +1,21 @@
 package apoc.path;
 
-import org.neo4j.graphdb.*;
-import org.neo4j.graphdb.traversal.BranchState;
-import org.neo4j.internal.helpers.collection.Iterators;
-import org.neo4j.internal.helpers.collection.NestingIterator;
-import org.neo4j.internal.helpers.collection.Pair;
-
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
+
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.PathExpander;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.traversal.BranchState;
+import org.neo4j.internal.helpers.collection.AbstractResourceIterable;
+import org.neo4j.internal.helpers.collection.NestingResourceIterator;
+import org.neo4j.internal.helpers.collection.Pair;
+import org.neo4j.internal.helpers.collection.ResourceClosingIterator;
 
 /**
  * An expander for repeating sequences of relationships. The sequence provided should be a string consisting of
@@ -22,9 +29,9 @@ import java.util.List;
  * The remaining relationship steps will be used as the repeating relationship sequence.
  */
 public class RelationshipSequenceExpander implements PathExpander {
+
     private final List<List<Pair<RelationshipType, Direction>>> relSequences = new ArrayList<>();
     private List<Pair<RelationshipType, Direction>> initialRels = null;
-
 
     public RelationshipSequenceExpander(String relSequenceString, boolean beginSequenceAtStart) {
         int index = 0;
@@ -71,7 +78,7 @@ public class RelationshipSequenceExpander implements PathExpander {
     }
 
     @Override
-    public Iterable<Relationship> expand( Path path, BranchState state ) {
+    public ResourceIterable<Relationship> expand( Path path, BranchState state ) {
         final Node node = path.endNode();
         int depth = path.length();
         List<Pair<RelationshipType, Direction>> stepRels;
@@ -82,25 +89,27 @@ public class RelationshipSequenceExpander implements PathExpander {
             stepRels = relSequences.get((initialRels == null ? depth : depth - 1) % relSequences.size());
         }
 
-        return Iterators.asList(
-         new NestingIterator<Relationship, Pair<RelationshipType, Direction>>(
-                stepRels.iterator() )
-        {
+        return new AbstractResourceIterable<>() {
             @Override
-            protected Iterator<Relationship> createNestedIterator(
-                    Pair<RelationshipType, Direction> entry )
-            {
-                RelationshipType type = entry.first();
-                Direction dir = entry.other();
-                if (type != null) {
-                    return ((dir == Direction.BOTH) ? node.getRelationships(type) :
-                            node.getRelationships(dir, type)).iterator();
-                } else {
-                    return ((dir == Direction.BOTH) ? node.getRelationships() :
-                            node.getRelationships(dir)).iterator();
-                }
+            protected ResourceIterator<Relationship> newIterator() {
+                return new NestingResourceIterator<>(stepRels.iterator()) {
+                    @Override
+                    protected ResourceIterator<Relationship> createNestedIterator( Pair<RelationshipType, Direction> entry ) {
+                        RelationshipType type = entry.first();
+                        Direction dir = entry.other();
+
+                        ResourceIterable<Relationship> relationships;
+                        if (type == null) {
+                            relationships = (dir == Direction.BOTH) ? node.getRelationships() : node.getRelationships(dir);
+                        } else {
+                            relationships = (dir == Direction.BOTH) ? node.getRelationships(type) : node.getRelationships(dir, type);
+                        }
+
+                        return ResourceClosingIterator.fromResourceIterable(relationships);
+                    }
+                };
             }
-        });
+        };
     }
 
     @Override


### PR DESCRIPTION
The public API for PathExpanders will be changing to return a ResourceIterable instead of a simple Iterable.

This will allow the path expansions to be closed and the underlying resources to be released. Currently, any iterators
created during the traversal are not closed and resources could potentially be leaked. The ResourceIterable returned
in this commit will track any iterators created and close them when it is itself closed.

The change needs to be made in APOC first to allow the main neo4j build to proceed.