### PR TITLE
Adds tests for regressions that happened in the 4.x versions

### DIFF
--- a/src/test/java/apoc/cypher/CypherTest.java
+++ b/src/test/java/apoc/cypher/CypherTest.java
@@ -289,7 +289,11 @@ public class CypherTest {
 
     @Test
     public void testRunFilesMultiple() throws Exception {
-        testResult(db, "CALL apoc.cypher.runFiles(['src/test/resources/create.cypher', 'src/test/resources/create_delete.cypher'])",
+        // The execution of both these files should happen sequentially
+        // There was a bug in the 4.x versions at some point that made
+        // both executions to interleave and at some point we were
+        // seeing nodesDeleted = 4
+        testResult(db, "CALL apoc.cypher.runFiles(['src/test/resources/create_with_sleep.cypher', 'src/test/resources/create_delete_with_sleep.cypher'])",
                 r -> {
                     Map<String, Object> row = r.next();
                     assertEquals(row.get("row"),((Map)row.get("result")).get("id"));

--- a/src/test/resources/create_delete_with_sleep.cypher
+++ b/src/test/resources/create_delete_with_sleep.cypher
@@ -1,0 +1,6 @@
+CREATE (n:Node {id:1});
+
+CALL apoc.util.sleep(2000)
+
+MATCH (n)
+DELETE n;

--- a/src/test/resources/create_with_sleep.cypher
+++ b/src/test/resources/create_with_sleep.cypher
@@ -1,0 +1,7 @@
+UNWIND RANGE(0,2) as id
+CREATE (n:Node {id:id})
+RETURN n.id as id;
+
+CALL apoc.util.sleep(1000)
+
+MATCH (n) DELETE n;


### PR DESCRIPTION
## What
Adds tests to ensure `cypher.runFiles` happens sequentiatially.

## Why
Because in 4.x versions there were regressions that made them to run in parallel. See https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/2707 for context.