### PR TITLE
Exports tests

### DIFF
--- a/core/import/testCypherShellWithCompoundConstraint.cypher
+++ b/core/import/testCypherShellWithCompoundConstraint.cypher
@@ -1,5 +1,5 @@
 :begin
-CREATE CONSTRAINT FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;
+CREATE CONSTRAINT PersonRequiresNamesConstraint FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;
 :commit
 CALL db.awaitIndexes(300);
 :begin

--- a/core/import/testNeo4jShellWithCompoundConstraint.cypher
+++ b/core/import/testNeo4jShellWithCompoundConstraint.cypher
@@ -1,5 +1,5 @@
 BEGIN
-CREATE CONSTRAINT FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;
+CREATE CONSTRAINT PersonRequiresNamesConstraint FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;
 COMMIT
 SCHEMA AWAIT
 BEGIN

--- a/core/import/testPlainFormatWithCompoundConstraint.cypher
+++ b/core/import/testPlainFormatWithCompoundConstraint.cypher
@@ -1,4 +1,4 @@
-CREATE CONSTRAINT FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;
+CREATE CONSTRAINT PersonRequiresNamesConstraint FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;
 UNWIND [{surname:"Snow", name:"John", properties:{}}, {surname:"Jackson", name:"Matt", properties:{}}, {surname:"White", name:"Jenny", properties:{}}, {surname:"Brown", name:"Susan", properties:{}}, {surname:"Taylor", name:"Tom", properties:{}}] AS row
 CREATE (n:Person{surname: row.surname, name: row.name}) SET n += row.properties;
 UNWIND [{start: {name:"John", surname:"Snow"}, end: {name:"Matt", surname:"Jackson"}, properties:{}}] AS row

--- a/core/src/test/java/apoc/export/cypher/ExportCypherEnterpriseFeaturesTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherEnterpriseFeaturesTest.java
@@ -9,18 +9,13 @@ import org.junit.Test;
 import org.neo4j.driver.Session;
 
 import java.io.File;
-import java.util.Map;
 import java.util.stream.Stream;
 
 import static apoc.export.cypher.ExportCypherTest.ExportCypherResults.*;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestContainerUtil.*;
-import static apoc.util.TestUtil.isRunningInCI;
 import static apoc.util.TestUtil.readFileToString;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeFalse;
-import static org.junit.Assume.assumeNotNull;
-import static org.junit.Assume.assumeTrue;
 
 /**
  * @author as
@@ -35,23 +30,14 @@ public class ExportCypherEnterpriseFeaturesTest {
 
     @BeforeClass
     public static void beforeAll() {
-        assumeFalse(isRunningInCI());
-        TestUtil.ignoreException(() -> {
-            // We build the project, the artifact will be placed into ./build/libs
-            neo4jContainer = createEnterpriseDB(!TestUtil.isRunningInCI())
-                    .withInitScript("init_neo4j_export_csv.cypher");
-            neo4jContainer.start();
-        }, Exception.class);
-        assumeNotNull(neo4jContainer);
-        assumeTrue("Neo4j Instance should be up-and-running", neo4jContainer.isRunning());
+        neo4jContainer = createEnterpriseDB(!TestUtil.isRunningInCI()).withInitScript("init_neo4j_export_csv.cypher");
+        neo4jContainer.start();
         session = neo4jContainer.getSession();
     }
 
     @AfterClass
     public static void afterAll() {
-        if (neo4jContainer != null && neo4jContainer.isRunning()) {
-            neo4jContainer.close();
-        }
+        neo4jContainer.close();
     }
 
     private static void beforeTwoLabelsWithOneCompoundConstraintEach() {
@@ -87,7 +73,7 @@ public class ExportCypherEnterpriseFeaturesTest {
         String fileName = "testCypherShellWithCompoundConstraint.cypher";
         testCall(session, "CALL apoc.export.cypher.all($file, $config)",
                 map("file", fileName, "config", Util.map("format", "cypher-shell")), (r) -> {
-                    assertExportStatement(EXPECTED_CYPHER_SHELL_WITH_COMPOUND_CONSTRAINT, r, fileName);
+                    assertExportStatement(EXPECTED_CYPHER_SHELL_WITH_COMPOUND_CONSTRAINT, fileName);
                 });
     }
 
@@ -96,7 +82,7 @@ public class ExportCypherEnterpriseFeaturesTest {
         String fileName = "testPlainFormatWithCompoundConstraint.cypher";
         testCall(session, "CALL apoc.export.cypher.all($file, $config)",
                 map("file", fileName, "config", Util.map("format", "plain")),
-                (r) -> assertExportStatement(EXPECTED_PLAIN_FORMAT_WITH_COMPOUND_CONSTRAINT, r, fileName));
+                (r) -> assertExportStatement(EXPECTED_PLAIN_FORMAT_WITH_COMPOUND_CONSTRAINT, fileName));
     }
 
     @Test
@@ -104,7 +90,7 @@ public class ExportCypherEnterpriseFeaturesTest {
         String fileName = "testNeo4jShellWithCompoundConstraint.cypher";
         testCall(session, "CALL apoc.export.cypher.all($file, $config)",
                 map("file", fileName, "config", Util.map("format", "neo4j-shell")),
-                (r) -> assertExportStatement(EXPECTED_NEO4J_SHELL_WITH_COMPOUND_CONSTRAINT, r, fileName));
+                (r) -> assertExportStatement(EXPECTED_NEO4J_SHELL_WITH_COMPOUND_CONSTRAINT, fileName));
     }
 
     @Test
@@ -141,7 +127,7 @@ public class ExportCypherEnterpriseFeaturesTest {
         }
     }
 
-    private void assertExportStatement(String expectedStatement, Map<String, Object> result, String fileName) {
-        assertEquals(expectedStatement, isRunningInCI() ? result.get("cypherStatements") : readFileToString(new File(directory, fileName)));
+    private void assertExportStatement(String expectedStatement, String fileName) {
+        assertEquals(expectedStatement, readFileToString(new File(directory, fileName)));
     }
 }

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -1250,28 +1250,8 @@ public class ExportCypherTest {
         static final String EXPECTED_ONLY_SCHEMA_CYPHER_SHELL = EXPECTED_ONLY_SCHEMA_NEO4J_SHELL.replace(NEO4J_SHELL.begin(), CYPHER_SHELL.begin())
                 .replace(NEO4J_SHELL.commit(), CYPHER_SHELL.commit()).replace(NEO4J_SHELL.schemaAwait(), CYPHER_SHELL.schemaAwait()) + EXPECTED_INDEXES_AWAIT;
 
-
-        static final String EXPECTED_NODES_COMPOUND_CONSTRAINT = String.format("BEGIN%n" +
-                "CREATE (:`Person` {`name`:\"John\", `surname`:\"Snow\"});%n" +
-                "CREATE (:`Person` {`name`:\"Matt\", `surname`:\"Jackson\"});%n" +
-                "CREATE (:`Person` {`name`:\"Jenny\", `surname`:\"White\"});%n" +
-                "CREATE (:`Person` {`name`:\"Susan\", `surname`:\"Brown\"});%n" +
-                "CREATE (:`Person` {`name`:\"Tom\", `surname`:\"Taylor\"});%n" +
-                "COMMIT%n");
-
-        static final String EXPECTED_SCHEMA_COMPOUND_CONSTRAINT = String.format("BEGIN%n" +
-                "CREATE CONSTRAINT uniqueConstraint FOR (node:`Person`) REQUIRE (node.`name`, node.`surname`) IS NODE KEY;%n" +
-                "COMMIT%n" +
-                "SCHEMA AWAIT%n");
-
-        static final String EXPECTED_RELATIONSHIP_COMPOUND_CONSTRAINT = String.format(("BEGIN%n" +
-                "MATCH (n1:`Person`{`surname`:\"Snow\", `name`:\"John\"}), (n2:`Person`{`surname`:\"Jackson\", `name`:\"Matt\"}) CREATE (n1)-[r:`KNOWS`]->(n2);%n" +
-                "COMMIT%n"));
-
-        static final String EXPECTED_INDEX_AWAIT_COMPOUND_CONSTRAINT =  String.format("CALL db.awaitIndex(':`Person`(`name`,`surname`)');%n");
-
         static final String EXPECTED_NEO4J_SHELL_WITH_COMPOUND_CONSTRAINT = String.format("BEGIN%n" +
-                "CREATE CONSTRAINT uniqueConstraint FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;%n" +
+                "CREATE CONSTRAINT PersonRequiresNamesConstraint FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;%n" +
                 "COMMIT%n" +
                 "SCHEMA AWAIT%n" +
                 "BEGIN%n" +
@@ -1286,7 +1266,7 @@ public class ExportCypherTest {
                 "COMMIT%n");
 
         static final String EXPECTED_CYPHER_SHELL_WITH_COMPOUND_CONSTRAINT = String.format(":begin%n" +
-                "CREATE CONSTRAINT uniqueConstraint FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;%n" +
+                "CREATE CONSTRAINT PersonRequiresNamesConstraint FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;%n" +
                 ":commit%n" +
                 "CALL db.awaitIndexes(300);%n" +
                 ":begin%n" +
@@ -1300,7 +1280,7 @@ public class ExportCypherTest {
                 "CREATE (start)-[r:KNOWS]->(end) SET r += row.properties;%n" +
                 ":commit%n");
 
-        static final String EXPECTED_PLAIN_FORMAT_WITH_COMPOUND_CONSTRAINT = String.format("CREATE CONSTRAINT uniqueConstraint FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;%n" +
+        static final String EXPECTED_PLAIN_FORMAT_WITH_COMPOUND_CONSTRAINT = String.format("CREATE CONSTRAINT PersonRequiresNamesConstraint FOR (node:Person) REQUIRE (node.name, node.surname) IS NODE KEY;%n" +
                 "UNWIND [{surname:\"Snow\", name:\"John\", properties:{}}, {surname:\"Jackson\", name:\"Matt\", properties:{}}, {surname:\"White\", name:\"Jenny\", properties:{}}, {surname:\"Brown\", name:\"Susan\", properties:{}}, {surname:\"Taylor\", name:\"Tom\", properties:{}}] AS row%n" +
                 "CREATE (n:Person{surname: row.surname, name: row.name}) SET n += row.properties;%n" +
                 "UNWIND [{start: {name:\"John\", surname:\"Snow\"}, end: {name:\"Matt\", surname:\"Jackson\"}, properties:{}}] AS row%n" +

--- a/core/src/test/resources/init_neo4j_export_csv.cypher
+++ b/core/src/test/resources/init_neo4j_export_csv.cypher
@@ -1,4 +1,4 @@
-CREATE CONSTRAINT FOR (t:Person) REQUIRE (t.name, t.surname) IS NODE KEY;
+CREATE CONSTRAINT PersonRequiresNamesConstraint FOR (t:Person) REQUIRE (t.name, t.surname) IS NODE KEY;
 
 CREATE (a:Person {name: 'John', surname: 'Snow'})
 CREATE (b:Person {name: 'Matt', surname: 'Jackson'})


### PR DESCRIPTION
Fix ExportFeatureTests

## Proposed Changes

  - Providing constraint names explicitly so that we can check the export contains those explicit names
  - In the CI, stop comparing the response's CypherStatement against our expectations: apoc.export.all populates a file and does not return a CypherStatement