### PR TITLE
Uses service account token when cherry-picking

### DIFF
--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v1
+        with:
+          token: ${{ secrets.NEO4J_OSS_BUILD_GH_TOKEN }}
       - name: Create PR to branch ${{ matrix.target-branch.name }}
         uses: conker84/github-action-cherry-pick@0.1.1
         with:

--- a/.github/workflows/auto-cherry-pick.yml
+++ b/.github/workflows/auto-cherry-pick.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           pr_branch: ${{ matrix.target-branch.name }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NEO4J_OSS_BUILD_GH_TOKEN }}
           #          GITBOT_EMAIL: <BOT_EMAIL>
           DRY_RUN: false
       - name: Add commit-id to comment in case the previous step fails


### PR DESCRIPTION
This was approved in #2741 but it made the cherry-pick fail due to having a different token on checkout and on cherry-pick. This should have been solved in 3639255.

## What
Uses a personal access token for the service account https://github.com/neo4j-oss-build  when cherry picking.

## Why
That should trigger the CI for us automatically when creating the automatic cherry-picks PR, according to the solutions proposed in https://github.com/peter-evans/create-pull-request/issues/48, contrary to what's happening at the moment.

