### PR TITLE
NO AUTO Ignores test failures only in TeamCity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,9 +78,16 @@ subprojects {
         forkEvery = 50
         maxParallelForks = 1 //Runtime.runtime.availableProcessors().intdiv(2) + 1
 
+        // This would apply only to GitHub Actions
         if (System.env.CI != null) {
             minHeapSize = "128m"
             maxHeapSize = "512m"
+        }
+
+        // This would apply only to TeamCity
+        // We need to ignore the failures because we may have tests muted
+        if (System.env.TEAMCITY_VERSION != null) {
+            ignoreFailures(true)
         }
 
         filter {


### PR DESCRIPTION
Cherry-picks #2743 

## What
It ignores the test failures in TeamCity

## Why
Because we may have tests muted there and we don't want to see `Process exited with code 1 (Step: gen-artifacts (Gradle))` there in those cases.
