### PR TITLE
Fixes #2748: apoc.temporal.toZonedTemporal missing in temporal docs page

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/temporal/datetime-conversions.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/temporal/datetime-conversions.adoc
@@ -273,7 +273,7 @@ This function parses a date string in a specified format and converts it to a Ne
 
 [NOTE]
 ====
-This function has been renamed to `apoc.temporal.toZonedTemporal` and moved to the temporal section.
+This function has been deprecated by `apoc.temporal.toZonedTemporal`, therefore it's recommended to use this one instead.
 See xref::temporal/temporal-conversions.adoc[].
 ====
 

--- a/docs/asciidoc/modules/ROOT/pages/temporal/datetime-conversions.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/temporal/datetime-conversions.adoc
@@ -273,7 +273,7 @@ This function parses a date string in a specified format and converts it to a Ne
 
 [NOTE]
 ====
-This function has been deprecated by `apoc.temporal.toZonedTemporal`, therefore it's recommended to use this one instead.
+This function has been deprecated by `apoc.temporal.toZonedTemporal`, therefore it's recommended to use that one instead.
 See xref::temporal/temporal-conversions.adoc[].
 ====
 

--- a/docs/asciidoc/modules/ROOT/pages/temporal/datetime-conversions.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/temporal/datetime-conversions.adoc
@@ -273,7 +273,7 @@ This function parses a date string in a specified format and converts it to a Ne
 
 [NOTE]
 ====
-This function has been renamed to `apoc.temporal.toZonedDateTime` and moved to the temporal section.
+This function has been renamed to `apoc.temporal.toZonedTemporal` and moved to the temporal section.
 See xref::temporal/temporal-conversions.adoc[].
 ====
 

--- a/docs/asciidoc/modules/ROOT/pages/temporal/temporal-conversions.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/temporal/temporal-conversions.adoc
@@ -119,3 +119,39 @@ RETURN apoc.temporal.format( duration.between( datetime.transaction(), datetime.
 | Output
 | "00:00:00.0110"
 |===
+
+== To ZonedDateTime
+
+You can pass a string to be converted as a 1st parameter,
+a pattern to convert the string into a `ZonedDateTime` as a 2nd parameter  (default: 'yyyy-MM-dd HH:mm:ss'),
+and the timezone as a 3rd parameter (default: 'UTC').
+
+
+For example, using the default pattern and timezone:
+
+[source,cypher]
+----
+RETURN apoc.temporal.toZonedTemporal('2015-12-23 23:59:59') AS output;
+----
+
+.Results
+[opts="header",cols="1"]
+|===
+| Output
+| "2015-12-23T23:59:59[UTC]"
+|===
+
+or:
+
+[source,cypher]
+----
+RETURN apoc.temporal.toZonedTemporal('2012-12-23T23:59:59', "yyyy-MM-dd'T'HH:mm:ss", "Asia/Tokyo") AS output;
+----
+
+.Results
+[opts="header",cols="1"]
+|===
+| Output
+| "2012-12-23T23:59:59[Asia/Tokyo]"
+
+|===

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.nodes.cycles.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.nodes.cycles.adoc
@@ -48,7 +48,7 @@ Furthermore, we can specify a `maxDepth` to consider cycles with only `n` interm
 MATCH (m1:Start) WITH collect(m1) as nodes CALL apoc.nodes.cycles(nodes, {maxDepth: 1}) YIELD path RETURN path
 ----
 
-image::cycles_max_depth_1.png
+image::cycles_max_depth_1.png[width=800]
 
 
 


### PR DESCRIPTION
Fixes #2748

Other docs fixes:
- image in `apoc.nodes.cycles.adoc`
