### PR TITLE
Run core tests in ci

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,11 +75,10 @@ subprojects {
                 'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.0.0-dev-enterprise',
                 'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:5.0.0-dev'
 
-        maxHeapSize = "8G"
         forkEvery = 50
         maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
-        minHeapSize = "128m"
-        maxHeapSize = "512m"
+        minHeapSize = "512m"
+        maxHeapSize = "1024m"
 
         // This would apply only to TeamCity
         // We need to ignore the failures because we may have tests muted

--- a/build.gradle
+++ b/build.gradle
@@ -77,13 +77,9 @@ subprojects {
 
         maxHeapSize = "8G"
         forkEvery = 50
-        maxParallelForks = 1 //Runtime.runtime.availableProcessors().intdiv(2) + 1
-
-        // This would apply only to GitHub Actions
-        if (System.env.CI != null) {
-            minHeapSize = "128m"
-            maxHeapSize = "512m"
-        }
+        maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+        minHeapSize = "128m"
+        maxHeapSize = "512m"
 
         // This would apply only to TeamCity
         // We need to ignore the failures because we may have tests muted

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -148,21 +148,6 @@ dependencies {
     }
 }
 
-
-// tweaks for CI
-if (System.env.CI == 'true') {
-  allprojects {
-    tasks.withType(GroovyCompile) {
-      groovyOptions.fork = false
-    }
-    tasks.withType(Test) {
-      // containers (currently) have 2 dedicated cores and 4GB of memory
-      maxParallelForks = 2
-      minHeapSize = '128m'
-    }
-  }
-}
-
 task copyRuntimeLibs(type: Copy) {
     into "lib"
     from configurations.testRuntimeClasspath

--- a/core/src/test/java/apoc/agg/CollAggregationTest.java
+++ b/core/src/test/java/apoc/agg/CollAggregationTest.java
@@ -1,6 +1,7 @@
 package apoc.agg;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -19,6 +20,11 @@ public class CollAggregationTest {
     @BeforeClass
     public static void setUp() {
         TestUtil.registerProcedure(db, CollAggregation.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/agg/GraphAggregationTest.java
+++ b/core/src/test/java/apoc/agg/GraphAggregationTest.java
@@ -1,6 +1,7 @@
 package apoc.agg;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -28,6 +29,11 @@ public class GraphAggregationTest {
     @BeforeClass public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, apoc.agg.Graph.class);
         db.executeTransactionally("CREATE (a:A {id:'a'})-[:AB {id:'ab'}]->(b:B {id:'b'})-[:BC {id:'bc'}]->(c:C {id:'c'}),(a)-[:AC {id:'ac'}]->(c)");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/agg/MaxAndMinItemsAggregationTest.java
+++ b/core/src/test/java/apoc/agg/MaxAndMinItemsAggregationTest.java
@@ -17,7 +17,6 @@ import static apoc.util.TestUtil.testCall;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
-
 public class MaxAndMinItemsAggregationTest {
 
     @ClassRule

--- a/core/src/test/java/apoc/agg/MedianTest.java
+++ b/core/src/test/java/apoc/agg/MedianTest.java
@@ -1,6 +1,7 @@
 package apoc.agg;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -17,6 +18,11 @@ public class MedianTest {
 
     @BeforeClass public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, Median.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/agg/PercentilesTest.java
+++ b/core/src/test/java/apoc/agg/PercentilesTest.java
@@ -1,6 +1,7 @@
 package apoc.agg;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -21,6 +22,11 @@ public class PercentilesTest {
 
     @BeforeClass public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, Percentiles.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/agg/ProductAggregationTest.java
+++ b/core/src/test/java/apoc/agg/ProductAggregationTest.java
@@ -1,6 +1,7 @@
 package apoc.agg;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -17,6 +18,11 @@ public class ProductAggregationTest {
 
     @BeforeClass public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, Product.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/agg/StatisticsTest.java
+++ b/core/src/test/java/apoc/agg/StatisticsTest.java
@@ -1,6 +1,7 @@
 package apoc.agg;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -21,6 +22,11 @@ public class StatisticsTest {
     @BeforeClass
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, Statistics.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/algo/CoverTest.java
+++ b/core/src/test/java/apoc/algo/CoverTest.java
@@ -1,6 +1,7 @@
 package apoc.algo;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -22,6 +23,11 @@ public class CoverTest {
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, Cover.class);
         db.executeTransactionally("CREATE (a)-[:X]->(b)-[:X]->(c)-[:X]->(d)");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/algo/PathFindingTest.java
+++ b/core/src/test/java/apoc/algo/PathFindingTest.java
@@ -1,13 +1,11 @@
 package apoc.algo;
 
 import apoc.util.TestUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
-import org.neo4j.graphdb.Result;
-import org.neo4j.internal.helpers.collection.Iterables;
 import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -58,6 +56,10 @@ public class PathFindingTest {
    		TestUtil.registerProcedure(db, PathFinding.class);
    	}
 
+    @After
+    public void tearDown() {
+        db.shutdown();
+    }
     @Test
     public void testAStar() {
         db.executeTransactionally(SETUP_GEO);

--- a/core/src/test/java/apoc/atomic/AtomicTest.java
+++ b/core/src/test/java/apoc/atomic/AtomicTest.java
@@ -3,6 +3,7 @@ package apoc.atomic;
 import apoc.util.TestUtil;
 import org.apache.commons.lang.ArrayUtils;
 import org.hamcrest.Matchers;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,6 +34,11 @@ public class AtomicTest {
 	@Before public void setUp() throws Exception {
 		TestUtil.registerProcedure(db, Atomic.class);
 	}
+
+    @After
+    public void tearDown() {
+        db.shutdown();
+    }
 
 	@Test
 	public void testAddAndSubInteger(){

--- a/core/src/test/java/apoc/bitwise/BitwiseOperationsTest.java
+++ b/core/src/test/java/apoc/bitwise/BitwiseOperationsTest.java
@@ -1,6 +1,7 @@
 package apoc.bitwise;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -25,6 +26,11 @@ public class BitwiseOperationsTest {
     @BeforeClass
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, BitwiseOperations.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     public void testOperation(String op, long expected) {

--- a/core/src/test/java/apoc/coll/CollTest.java
+++ b/core/src/test/java/apoc/coll/CollTest.java
@@ -2,6 +2,7 @@ package apoc.coll;
 
 import apoc.convert.Json;
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -28,6 +29,11 @@ public class CollTest {
 
     @BeforeClass public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, Coll.class, Json.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/coll/EqualityTest.java
+++ b/core/src/test/java/apoc/coll/EqualityTest.java
@@ -2,6 +2,7 @@ package apoc.coll;
 
 import apoc.util.ArrayBackedIterator;
 import apoc.util.ArrayBackedList;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.graphalgo.impl.util.PathImpl;
@@ -24,6 +25,11 @@ public class EqualityTest {
 
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule();
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
+    }
 
     @Test
     public void testSpecial() throws Exception {

--- a/core/src/test/java/apoc/convert/ConvertJsonTest.java
+++ b/core/src/test/java/apoc/convert/ConvertJsonTest.java
@@ -47,6 +47,11 @@ public class ConvertJsonTest {
 	@Before public void setUp() throws Exception {
         TestUtil.registerProcedure(db, Json.class);
     }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
+    }
     
 	@After 
     public void clear() {

--- a/core/src/test/java/apoc/convert/ConvertTest.java
+++ b/core/src/test/java/apoc/convert/ConvertTest.java
@@ -1,6 +1,7 @@
 package apoc.convert;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -27,6 +28,11 @@ public class ConvertTest {
 
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule();
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
+    }
 
     @BeforeClass
     public static void initDb() throws Exception {

--- a/core/src/test/java/apoc/create/CreateTest.java
+++ b/core/src/test/java/apoc/create/CreateTest.java
@@ -3,6 +3,7 @@ package apoc.create;
 import apoc.path.Paths;
 import apoc.util.TestUtil;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -38,6 +39,11 @@ public class CreateTest {
 
     @Before public void setUp() throws Exception {
         TestUtil.registerProcedure(db,Create.class, Paths.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/cypher/CypherTest.java
+++ b/core/src/test/java/apoc/cypher/CypherTest.java
@@ -6,6 +6,7 @@ import apoc.util.Util;
 import apoc.util.Utils;
 import org.hamcrest.Matchers;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -72,6 +73,11 @@ public class CypherTest {
             tx.schema().getIndexes().forEach(IndexDefinition::drop);
             tx.commit();
         }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/data/ExtractTest.java
+++ b/core/src/test/java/apoc/data/ExtractTest.java
@@ -1,6 +1,7 @@
 package apoc.data;
 
 import apoc.util.TestUtil;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -21,6 +22,11 @@ public class ExtractTest {
     @Before
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db, Extract.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/data/url/ExtractURLTest.java
+++ b/core/src/test/java/apoc/data/url/ExtractURLTest.java
@@ -1,6 +1,7 @@
 package apoc.data.url;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -55,6 +56,11 @@ public class ExtractURLTest {
                 "protocol","neo4j", "user", null, "host","graphapps", "port",null, "path","/neo4j-browser", "file","/neo4j-browser?cmd=play&arg=cypher", "query","cmd=play&arg=cypher", "anchor",null)
         );
 
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/date/DateTest.java
+++ b/core/src/test/java/apoc/date/DateTest.java
@@ -1,6 +1,7 @@
 package apoc.date;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -53,6 +54,11 @@ public class DateTest {
 	public static void sUp() throws Exception {
 		TestUtil.registerProcedure(db, Date.class);
 	}
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
+    }
 
 	@Test public void testToDays() throws Exception {
 		testCall(db,

--- a/core/src/test/java/apoc/diff/DiffTest.java
+++ b/core/src/test/java/apoc/diff/DiffTest.java
@@ -2,6 +2,7 @@ package apoc.diff;
 
 import apoc.create.Create;
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -50,6 +51,11 @@ public class DiffTest {
             node3.setProperty("prop4", "for");
             tx.commit();
         }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/example/ExamplesTest.java
+++ b/core/src/test/java/apoc/example/ExamplesTest.java
@@ -1,6 +1,7 @@
 package apoc.example;
 
 import apoc.util.TestUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -21,6 +22,11 @@ public class ExamplesTest {
     @Before
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db,Examples.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
+++ b/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
@@ -12,6 +12,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
@@ -52,6 +53,11 @@ public class ExportCoreSecurityTest {
     @BeforeClass
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, ExportCSV.class, ExportJson.class, ExportGraphML.class, ExportCypher.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Before

--- a/core/src/test/java/apoc/export/ExportS3PerformanceTest.java
+++ b/core/src/test/java/apoc/export/ExportS3PerformanceTest.java
@@ -11,6 +11,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.Ignore;
@@ -68,6 +69,11 @@ public class ExportS3PerformanceTest {
             S3_BUCKET_NAME = getEnvVar("S3_BUCKET_NAME");
         }
         TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/arrow/ArrowTest.java
+++ b/core/src/test/java/apoc/export/arrow/ArrowTest.java
@@ -7,6 +7,7 @@ import apoc.meta.Meta;
 import apoc.util.JsonUtil;
 import apoc.util.TestUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -95,6 +96,11 @@ public class ArrowTest {
     public static void beforeClass() {
         db.executeTransactionally("CREATE (f:User {name:'Adam',age:42,male:true,kids:['Sam','Anna','Grace'], born:localdatetime('2015-05-18T19:32:24.000'), place:point({latitude: 13.1, longitude: 33.46789, height: 100.0})})-[:KNOWS {since: 1993, bffSince: duration('P5M1.5D')}]->(b:User {name:'Jim',age:42})");
         TestUtil.registerProcedure(db, ExportArrow.class, LoadArrow.class, Graphs.class, Meta.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     private byte[] extractByteArray(Result result) {

--- a/core/src/test/java/apoc/export/csv/ExportCsvIT.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvIT.java
@@ -13,10 +13,8 @@ import java.util.List;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestContainerUtil.createEnterpriseDB;
 import static apoc.util.TestContainerUtil.testCall;
-import static apoc.util.TestUtil.isRunningInCI;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 
@@ -31,7 +29,6 @@ public class ExportCsvIT {
 
     @BeforeClass
     public static void beforeAll() {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() -> {
             neo4jContainer = createEnterpriseDB(true);
             neo4jContainer.start();

--- a/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
@@ -6,6 +6,7 @@ import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -90,6 +91,11 @@ public class ExportCsvNeo4jAdminTest {
         db.executeTransactionally("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})");
         db.executeTransactionally("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})");
         db.executeTransactionally("CREATE (a:Types {date: date('2018-10-30'), localDateTime: localdatetime('20181030T19:32:24'), dateTime: datetime('2018-10-30T12:50:35.556+0100'), localtime: localtime('12:50:35.556'), duration: duration('P5M1DT12H'), time: time('125035.556+0100'), born_2D: point({ x: 2.3, y: 4.5 }), born_3D:point({ longitude: 56.7, latitude: 12.78, height: 100 })})");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -5,6 +5,7 @@ import apoc.graph.Graphs;
 import apoc.meta.Meta;
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -115,6 +116,11 @@ public class ExportCsvTest {
         TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class, Meta.class);
         db.executeTransactionally("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})");
         db.executeTransactionally("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     private String readFile(String fileName) {

--- a/core/src/test/java/apoc/export/csv/ImportCsvLdbcTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvLdbcTest.java
@@ -4,6 +4,7 @@ import apoc.ApocSettings;
 import apoc.util.TestUtil;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
@@ -128,6 +129,11 @@ public class ImportCsvLdbcTest {
         }
 
         TestUtil.registerProcedure(db, ImportCsv.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -6,6 +6,7 @@ import apoc.util.TestUtil;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
@@ -159,6 +160,11 @@ public class ImportCsvTest {
         }
 
         TestUtil.registerProcedure(db, ImportCsv.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/cypher/ExportCypherEnterpriseFeaturesTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherEnterpriseFeaturesTest.java
@@ -16,6 +16,8 @@ import static apoc.util.MapUtil.map;
 import static apoc.util.TestContainerUtil.*;
 import static apoc.util.TestUtil.readFileToString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeNotNull;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * @author as
@@ -30,14 +32,20 @@ public class ExportCypherEnterpriseFeaturesTest {
 
     @BeforeClass
     public static void beforeAll() {
-        neo4jContainer = createEnterpriseDB(!TestUtil.isRunningInCI()).withInitScript("init_neo4j_export_csv.cypher");
-        neo4jContainer.start();
+        TestUtil.ignoreException(() -> {
+            neo4jContainer = createEnterpriseDB(!TestUtil.isRunningInCI()).withInitScript("init_neo4j_export_csv.cypher");
+            neo4jContainer.start();
+        }, Exception.class );
+        assumeNotNull(neo4jContainer);
+        assumeTrue("Neo4j Instance should be up-and-running", neo4jContainer.isRunning());
         session = neo4jContainer.getSession();
     }
 
     @AfterClass
     public static void afterAll() {
-        neo4jContainer.close();
+        if (neo4jContainer != null && neo4jContainer.isRunning()) {
+            neo4jContainer.close();
+        }
     }
 
     private static void beforeTwoLabelsWithOneCompoundConstraintEach() {

--- a/core/src/test/java/apoc/export/cypher/ExportCypherS3Test.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherS3Test.java
@@ -4,6 +4,7 @@ import apoc.graph.Graphs;
 import apoc.util.TestUtil;
 import apoc.util.s3.S3TestUtil;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.Ignore;
@@ -93,6 +94,11 @@ public class ExportCypherS3Test {
         } else {
             db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})-[:KNOWS {since:2016}]->(b:Bar {name:'bar',age:42}),(c:Bar {age:12})");
         }
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     // -- Whole file test -- //

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -4,6 +4,7 @@ import apoc.graph.Graphs;
 import apoc.util.TestUtil;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -75,6 +76,11 @@ public class ExportCypherTest {
         } else {
             db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})-[:KNOWS {since:2016}]->(b:Bar {name:'bar',age:42}),(c:Bar {age:12})");
         }
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLS3Test.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLS3Test.java
@@ -5,6 +5,7 @@ import apoc.graph.Graphs;
 import apoc.util.TestUtil;
 import apoc.util.s3.S3TestUtil;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.Ignore;
@@ -151,6 +152,11 @@ public class ExportGraphMLS3Test {
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, Boolean.toString(!testName.getMethodName().endsWith(TEST_WITH_NO_IMPORT)));
 
         db.executeTransactionally("CREATE (f:Foo:Foo2:Foo0 {name:'foo', born:Date('2018-10-10'), place:point({ longitude: 56.7, latitude: 12.78, height: 100 })})-[:KNOWS]->(b:Bar {name:'bar',age:42, place:point({ longitude: 56.7, latitude: 12.78})}),(c:Bar {age:12,values:[1,2,3]})");
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -200,6 +201,7 @@ public class ExportGraphMLTest {
         TestUtil.testCall(db, "MATCH  (c:Bar {age: 12, values: [1,2,3]}) RETURN COUNT(c) AS c", null, (r) -> assertEquals(1L, r.get("c")));
     }
 
+    @Ignore
     @Test
     public void testImportGraphMLLargeFile() {
         db.executeTransactionally("MATCH (n) DETACH DELETE n");

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -37,13 +37,11 @@ import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
 import static apoc.util.BinaryTestUtil.fileToBinary;
 import static apoc.util.MapUtil.map;
-import static apoc.util.TestUtil.isRunningInCI;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
 import static org.neo4j.configuration.GraphDatabaseSettings.TransactionStateMemoryAllocation.OFF_HEAP;
 import static org.neo4j.configuration.SettingValueParsers.BYTES;
 import static org.xmlunit.diff.ElementSelectors.byName;
@@ -198,7 +196,6 @@ public class ExportGraphMLTest {
 
     @Test
     public void testImportGraphMLLargeFile() {
-        assumeFalse(isRunningInCI());
         db.executeTransactionally("MATCH (n) DETACH DELETE n");
 
         final String file = ClassLoader.getSystemResource("largeFile.graphml").toString();

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -8,6 +8,7 @@ import junit.framework.TestCase;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -177,6 +178,11 @@ public class ExportGraphMLTest {
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, Boolean.toString(!testName.getMethodName().endsWith(TEST_WITH_NO_IMPORT)));
 
         db.executeTransactionally("CREATE (f:Foo:Foo2:Foo0 {name:'foo', born:Date('2018-10-10'), place:point({ longitude: 56.7, latitude: 12.78, height: 100 })})-[:KNOWS]->(b:Bar {name:'bar',age:42, place:point({ longitude: 56.7, latitude: 12.78})}),(c:Bar {age:12,values:[1,2,3]})");
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/json/ExportJsonS3Test.java
+++ b/core/src/test/java/apoc/export/json/ExportJsonS3Test.java
@@ -6,6 +6,7 @@ import apoc.util.JsonUtil;
 import apoc.util.TestUtil;
 import apoc.util.s3.S3TestUtil;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.Ignore;
@@ -66,6 +67,11 @@ public class ExportJsonS3Test {
 
         TestUtil.registerProcedure(db, ExportJson.class, Graphs.class);
         db.executeTransactionally("CREATE (f:User {name:'Adam',age:42,male:true,kids:['Sam','Anna','Grace'], born:localdatetime('2015185T19:32:24'), place:point({latitude: 13.1, longitude: 33.46789})})-[:KNOWS {since: 1993, bffSince: duration('P5M1.5D')}]->(b:User {name:'Jim',age:42}),(c:User {age:12})");
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/json/ExportJsonTest.java
+++ b/core/src/test/java/apoc/export/json/ExportJsonTest.java
@@ -5,6 +5,7 @@ import apoc.graph.Graphs;
 import apoc.util.JsonUtil;
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,6 +38,11 @@ public class ExportJsonTest {
     public void setup() {
         TestUtil.registerProcedure(db, ExportJson.class, Graphs.class);
         db.executeTransactionally("CREATE (f:User {name:'Adam',age:42,male:true,kids:['Sam','Anna','Grace'], born:localdatetime('2015185T19:32:24'), place:point({latitude: 13.1, longitude: 33.46789})})-[:KNOWS {since: 1993, bffSince: duration('P5M1.5D')}]->(b:User {name:'Jim',age:42}),(c:User {age:12})");
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/json/ImportJsonTest.java
+++ b/core/src/test/java/apoc/export/json/ImportJsonTest.java
@@ -11,6 +11,7 @@ import junit.framework.TestCase;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import apoc.util.Utils;
 import org.junit.Assert;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -62,6 +63,11 @@ public class ImportJsonTest {
     @Before
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db, ImportJson.class, Schemas.class, Utils.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/export/util/FormatUtilsTest.java
+++ b/core/src/test/java/apoc/export/util/FormatUtilsTest.java
@@ -2,6 +2,7 @@ package apoc.export.util;
 
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.After;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
@@ -18,6 +19,11 @@ public class FormatUtilsTest {
 
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
+
+    @After
+    public void tearDown() {
+        db.shutdown();
+    }
 
     @Test
     public void formatString() throws Exception {

--- a/core/src/test/java/apoc/graph/GraphsTest.java
+++ b/core/src/test/java/apoc/graph/GraphsTest.java
@@ -7,11 +7,11 @@ import apoc.util.Util;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.configuration.SettingImpl;
 import org.neo4j.configuration.SettingValueParsers;
-import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Relationship;
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -65,6 +64,11 @@ public class GraphsTest {
                     result.stream().forEach(m -> graph.putAll(m));
                     return null;
                 });
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/hashing/FingerprintingTest.java
+++ b/core/src/test/java/apoc/hashing/FingerprintingTest.java
@@ -6,6 +6,7 @@ import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.graphdb.QueryExecutionException;
@@ -34,6 +35,11 @@ public class FingerprintingTest  {
     @Before
     public void setup() {
         TestUtil.registerProcedure(db, Fingerprinting.class, Graphs.class, Coll.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/help/HelpTest.java
+++ b/core/src/test/java/apoc/help/HelpTest.java
@@ -4,6 +4,7 @@ import apoc.bitwise.BitwiseOperations;
 import apoc.coll.Coll;
 import apoc.util.TestUtil;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.test.rule.DbmsRule;
@@ -24,6 +25,11 @@ public class HelpTest {
     @Before
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db, Help.class, BitwiseOperations.class,Coll.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/index/SchemaIndexTest.java
+++ b/core/src/test/java/apoc/index/SchemaIndexTest.java
@@ -2,6 +2,7 @@ package apoc.index;
 
 import apoc.util.TestUtil;
 import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.graphdb.Result;
@@ -61,6 +62,11 @@ SchemaIndexTest {
             tx.schema().awaitIndexesOnline(2,TimeUnit.SECONDS);
             tx.commit();
         }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/label/LabelTest.java
+++ b/core/src/test/java/apoc/label/LabelTest.java
@@ -2,6 +2,7 @@ package apoc.label;
 
 import apoc.util.TestUtil;
 import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.test.rule.DbmsRule;
@@ -18,6 +19,11 @@ public class LabelTest {
     @BeforeClass
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, Label.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/load/LoadCoreSecurityTest.java
+++ b/core/src/test/java/apoc/load/LoadCoreSecurityTest.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
@@ -55,6 +56,11 @@ public class LoadCoreSecurityTest {
     @BeforeClass
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, LoadJson.class, Xml.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Before

--- a/core/src/test/java/apoc/load/XmlTest.java
+++ b/core/src/test/java/apoc/load/XmlTest.java
@@ -6,6 +6,7 @@ import apoc.util.TestUtil;
 import apoc.xml.XmlTestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,6 +47,11 @@ public class XmlTest {
     @Before
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db, Xml.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/load/relative/LoadRelativePathTest.java
+++ b/core/src/test/java/apoc/load/relative/LoadRelativePathTest.java
@@ -5,6 +5,7 @@ import apoc.load.LoadJson;
 import apoc.load.Xml;
 import apoc.util.TestUtil;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
@@ -36,6 +37,11 @@ public class LoadRelativePathTest {
 
     @Before public void setUp() throws Exception {
         TestUtil.registerProcedure(db, LoadJson.class, Xml.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     //JSON

--- a/core/src/test/java/apoc/lock/LockTest.java
+++ b/core/src/test/java/apoc/lock/LockTest.java
@@ -2,6 +2,7 @@ package apoc.lock;
 
 import apoc.util.TestUtil;
 import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
@@ -28,6 +29,11 @@ public class LockTest {
     @BeforeClass
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, Lock.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/log/Neo4jLogStreamTest.java
+++ b/core/src/test/java/apoc/log/Neo4jLogStreamTest.java
@@ -2,6 +2,7 @@ package apoc.log;
 
 import apoc.util.TestUtil;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.dbms.api.DatabaseManagementService;
@@ -20,16 +21,22 @@ import static org.junit.Assert.assertTrue;
 public class Neo4jLogStreamTest {
     
     private GraphDatabaseService db;
+    private DatabaseManagementService dbManagementService;
 
     @Before
     public void setUp() throws Exception {
-        DatabaseManagementService dbManagementService = new TestDatabaseManagementServiceBuilder(
+        dbManagementService = new TestDatabaseManagementServiceBuilder(
                 Paths.get("target", UUID.randomUUID().toString()).toAbsolutePath()).build();
         apocConfig().setProperty("dbms.directories.logs", "");
         db = dbManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
         TestUtil.registerProcedure(db, Neo4jLogStream.class);
     }
-    
+
+    @After
+    public void tearDown() {
+        dbManagementService.shutdown();
+    }
+
     @Test
     public void testLogStream() {
         testResult(db, "CALL apoc.log.stream('debug.log')", res -> {

--- a/core/src/test/java/apoc/map/MapsTest.java
+++ b/core/src/test/java/apoc/map/MapsTest.java
@@ -2,6 +2,7 @@ package apoc.map;
 
 import apoc.util.TestUtil;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.graphdb.Node;
@@ -30,6 +31,11 @@ public class MapsTest {
     @Before
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db,Maps.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/math/MathsTest.java
+++ b/core/src/test/java/apoc/math/MathsTest.java
@@ -2,6 +2,7 @@ package apoc.math;
 
 import apoc.util.TestUtil;
 import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.test.rule.DbmsRule;
@@ -21,6 +22,11 @@ public class MathsTest {
 
     @BeforeClass public static void setUp() throws Exception {
         TestUtil.registerProcedure(db,Maths.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test public void testRoundMode() throws Exception {

--- a/core/src/test/java/apoc/math/RegressionTest.java
+++ b/core/src/test/java/apoc/math/RegressionTest.java
@@ -3,6 +3,7 @@ package apoc.math;
 import apoc.util.TestUtil;
 import org.apache.commons.math3.stat.regression.SimpleRegression;
 import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.test.rule.DbmsRule;
@@ -16,11 +17,16 @@ import static org.junit.Assert.assertEquals;
 public class RegressionTest {
 
     @ClassRule
-public static DbmsRule db = new ImpermanentDbmsRule();
+    public static DbmsRule db = new ImpermanentDbmsRule();
 
     @BeforeClass
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, Regression.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/merge/MergeTest.java
+++ b/core/src/test/java/apoc/merge/MergeTest.java
@@ -3,6 +3,7 @@ package apoc.merge;
 import apoc.util.MapUtil;
 import apoc.util.TestUtil;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.graphdb.*;
@@ -21,10 +22,14 @@ public class MergeTest {
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
 
-
     @Before
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db, Merge.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/meta/CollEnterpriseTest.java
+++ b/core/src/test/java/apoc/meta/CollEnterpriseTest.java
@@ -8,9 +8,7 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.neo4j.driver.Session;
 
 import static apoc.util.TestContainerUtil.createEnterpriseDB;
-import static apoc.util.TestUtil.isRunningInCI;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 
@@ -21,7 +19,6 @@ public class CollEnterpriseTest {
 
     @BeforeAll
     public static void beforeAll() {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() -> {
             // We build the project, the artifact will be placed into ./build/libs
             neo4jContainer = createEnterpriseDB(!TestUtil.isRunningInCI());

--- a/core/src/test/java/apoc/meta/MetaEnterpriseFeaturesTest.java
+++ b/core/src/test/java/apoc/meta/MetaEnterpriseFeaturesTest.java
@@ -16,9 +16,7 @@ import java.util.function.Predicate;
 
 import static apoc.util.TestContainerUtil.createEnterpriseDB;
 import static apoc.util.TestContainerUtil.testResult;
-import static apoc.util.TestUtil.isRunningInCI;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 
@@ -33,7 +31,6 @@ public class MetaEnterpriseFeaturesTest {
 
     @BeforeClass
     public static void beforeAll() {
-        assumeFalse(isRunningInCI());
 //        executeGradleTasks("clean", "shadow");
         TestUtil.ignoreException(() -> {
             // We build the project, the artifact will be placed into ./build/libs

--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -6,6 +6,7 @@ import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.assertj.core.api.Assertions;
 import org.junit.Assert;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -70,6 +71,11 @@ public class MetaTest {
     @Before
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db, Meta.class, Graphs.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     public static boolean hasRecordMatching(List<Map<String,Object>> records, Map<String,Object> record) {

--- a/core/src/test/java/apoc/neighbors/NeighborsTest.java
+++ b/core/src/test/java/apoc/neighbors/NeighborsTest.java
@@ -2,6 +2,7 @@ package apoc.neighbors;
 
 import apoc.util.TestUtil;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.graphdb.Node;
@@ -30,6 +31,11 @@ public class NeighborsTest {
                 "(b)-[:KNOWS]->(a), " +
                 "(b)-[:KNOWS]->(c), " +
                 "(c)-[:KNOWS]->(d) ");
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/nodes/GroupingTest.java
+++ b/core/src/test/java/apoc/nodes/GroupingTest.java
@@ -1,6 +1,7 @@
 package apoc.nodes;
 
 import apoc.util.TestUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,6 +30,11 @@ public class GroupingTest {
     @Before
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db, Grouping.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     public void createGraph() {

--- a/core/src/test/java/apoc/nodes/NodesTest.java
+++ b/core/src/test/java/apoc/nodes/NodesTest.java
@@ -6,6 +6,7 @@ import apoc.result.VirtualRelationship;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.junit.Before;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
@@ -59,6 +60,11 @@ public class NodesTest {
     @Before
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db, Nodes.class, Create.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/number/ArabicRomanTest.java
+++ b/core/src/test/java/apoc/number/ArabicRomanTest.java
@@ -2,6 +2,7 @@ package apoc.number;
 
 import apoc.util.TestUtil;
 import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.test.rule.DbmsRule;
@@ -15,10 +16,14 @@ public class ArabicRomanTest {
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule();
 
-
     @BeforeClass
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, ArabicRoman.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/number/NumbersTest.java
+++ b/core/src/test/java/apoc/number/NumbersTest.java
@@ -2,6 +2,7 @@ package apoc.number;
 
 import apoc.util.TestUtil;
 import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,6 +29,11 @@ public class NumbersTest {
     @BeforeClass
     public static void sUp() throws Exception {
         TestUtil.registerProcedure(db, Numbers.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/number/exact/ExactTest.java
+++ b/core/src/test/java/apoc/number/exact/ExactTest.java
@@ -2,6 +2,7 @@ package apoc.number.exact;
 
 import apoc.util.TestUtil;
 import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,6 +29,11 @@ public class ExactTest {
 	@BeforeClass public static void sUp() throws Exception {
 		TestUtil.registerProcedure(db, Exact.class);
 	}
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
+    }
 
 	@Test
 	public void testAdd(){

--- a/core/src/test/java/apoc/path/ExpandPathTest.java
+++ b/core/src/test/java/apoc/path/ExpandPathTest.java
@@ -5,6 +5,7 @@ import apoc.util.Util;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -42,6 +43,11 @@ public class ExpandPathTest {
 			tx.execute(bigbrother);
 			tx.commit();
 		 }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @After

--- a/core/src/test/java/apoc/path/LabelSequenceTest.java
+++ b/core/src/test/java/apoc/path/LabelSequenceTest.java
@@ -1,6 +1,7 @@
 package apoc.path;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -26,6 +27,11 @@ public class LabelSequenceTest {
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, PathExplorer.class);
         db.executeTransactionally("create (s:Start{name:'start'})-[:REL]->(:A{name:'a'})-[:REL]->(:B{name:'b'})-[:REL]->(:A:C{name:'ac'})-[:REL]->(:B:A{name:'ba'})-[:REL]->(:D:A{name:'da'})");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/path/NodeFilterTest.java
+++ b/core/src/test/java/apoc/path/NodeFilterTest.java
@@ -4,6 +4,7 @@ import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.junit.After;
 import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.graphdb.Node;
@@ -36,6 +37,11 @@ public class NodeFilterTest {
             tx.execute(movies);
             tx.commit();
         }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @After

--- a/core/src/test/java/apoc/path/PathsTest.java
+++ b/core/src/test/java/apoc/path/PathsTest.java
@@ -2,6 +2,7 @@ package apoc.path;
 
 import apoc.util.TestUtil;
 import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.graphdb.*;
@@ -26,6 +27,11 @@ public class PathsTest {
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, Paths.class);
         db.executeTransactionally("CREATE (a:A)-[:NEXT]->(b:B)-[:NEXT]->(c:C)-[:NEXT]->(d:D)");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/path/RelSequenceTest.java
+++ b/core/src/test/java/apoc/path/RelSequenceTest.java
@@ -2,6 +2,7 @@ package apoc.path;
 
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -34,6 +35,11 @@ public class RelSequenceTest {
             tx.execute(additionalLink);
             tx.commit();
         }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/path/SequenceTest.java
+++ b/core/src/test/java/apoc/path/SequenceTest.java
@@ -3,6 +3,7 @@ package apoc.path;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.junit.BeforeClass;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.graphdb.Transaction;
@@ -31,6 +32,11 @@ public class SequenceTest {
             tx.execute(additionalLink);
             tx.commit();
         }
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/path/SubgraphTest.java
+++ b/core/src/test/java/apoc/path/SubgraphTest.java
@@ -8,6 +8,7 @@ import apoc.util.Util;
 import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -54,6 +55,11 @@ public class SubgraphTest {
 			fullGraphCount = (Long) row.get("graphCount");
 		}
 	}
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
+    }
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();

--- a/core/src/test/java/apoc/periodic/PeriodicTest.java
+++ b/core/src/test/java/apoc/periodic/PeriodicTest.java
@@ -2,6 +2,7 @@ package apoc.periodic;
 
 import apoc.util.MapUtil;
 import apoc.util.TestUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,6 +56,11 @@ public class PeriodicTest {
     public void initDb() throws Exception {
         TestUtil.registerProcedure(db, Periodic.class);
         db.executeTransactionally("call apoc.periodic.list() yield name call apoc.periodic.cancel(name) yield name as name2 return count(*)");
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
+++ b/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
@@ -1,6 +1,7 @@
 package apoc.schema;
 
 import apoc.util.Neo4jContainerExtension;
+import apoc.util.TestUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -22,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeNotNull;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * @author as
@@ -34,15 +37,21 @@ public class SchemasEnterpriseFeaturesTest {
 
     @BeforeClass
     public static void beforeAll() {
-        neo4jContainer = createEnterpriseDB(true);
-        neo4jContainer.start();
+        TestUtil.ignoreException( () -> {
+          neo4jContainer = createEnterpriseDB( true );
+          neo4jContainer.start();
+        }, Exception.class);
+        assumeNotNull(neo4jContainer);
+        assumeTrue("Neo4j Instance should be up-and-running", neo4jContainer.isRunning());
         session = neo4jContainer.getSession();
     }
 
     @AfterClass
     public static void afterAll() {
-        session.close();
-        neo4jContainer.close();
+        if (neo4jContainer != null && neo4jContainer.isRunning()) {
+            session.close();
+            neo4jContainer.close();
+        }
     }
 
     // coherently with SchemasTest we remove all indexes/constraints before (e.g. to get rid of lookup indexes)

--- a/core/src/test/java/apoc/spatial/GeocodeTest.java
+++ b/core/src/test/java/apoc/spatial/GeocodeTest.java
@@ -22,7 +22,6 @@ public class GeocodeTest {
 
     @Before
     public void initDb() throws Exception {
-        assumeRunningInCI();
         apocConfig().setProperty("apoc.spatial.geocode.provider", "opencage");
         apocConfig().setProperty("apoc.spatial.geocode.opencage.key", "<YOUR_API_KEY>");
         apocConfig().setProperty("apoc.spatial.geocode.opencage.url", "https://api.opencagedata.com/geocode/v1/json?q=PLACE&key=KEY");
@@ -30,11 +29,6 @@ public class GeocodeTest {
 
 //        List<String> strings = Iterators.asList(apocConfig().getConfig().getKeys("apoc.spatial.geocode.opencage"));
         TestUtil.registerProcedure(db, Geocode.class);
-    }
-
-    @Before
-    public void setUp() throws Exception {
-        assumeRunningInCI();
     }
 
     @Test

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -160,20 +160,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
-// tweaks for CI
-if (System.env.CI == 'true') {
-    allprojects {
-        tasks.withType(GroovyCompile) {
-            groovyOptions.fork = false
-        }
-        tasks.withType(Test) {
-            // containers (currently) have 2 dedicated cores and 4GB of memory
-            maxParallelForks = 2
-            minHeapSize = '128m'
-        }
-    }
-}
-
 publishing {
     repositories {
         maven {

--- a/full/src/test/java/DocsTest.java
+++ b/full/src/test/java/DocsTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import org.junit.jupiter.api.AfterAll;
 import org.reflections.Reflections;
 import org.reflections.scanners.SubTypesScanner;
 import org.reflections.scanners.TypeAnnotationsScanner;
@@ -50,6 +52,11 @@ public class DocsTest {
         new File(GENERATED_DOCUMENTATION_DIR).mkdirs();
         new File(GENERATED_PARTIALS_DOCUMENTATION_DIR).mkdirs();
         new File(GENERATED_OVERVIEW_DIR).mkdirs();
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/algo/PathFindingFullTest.java
+++ b/full/src/test/java/apoc/algo/PathFindingFullTest.java
@@ -1,6 +1,7 @@
 package apoc.algo;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -15,12 +16,16 @@ public class PathFindingFullTest {
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule();
 
-
     @BeforeClass
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, PathFindingFull.class);
     }
-    
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
+    }
+
     @Test
     public void testAStarWithPoint() {
         db.executeTransactionally(SETUP_GEO);

--- a/full/src/test/java/apoc/bolt/BoltTest.java
+++ b/full/src/test/java/apoc/bolt/BoltTest.java
@@ -27,7 +27,6 @@ import static apoc.util.TestUtil.isRunningInCI;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 import static org.neo4j.driver.Values.isoDuration;
@@ -47,7 +46,6 @@ public class BoltTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() -> {
             neo4jContainer = TestContainerUtil.createEnterpriseDB(isRunningInCI())
                     .withInitScript("init_neo4j_bolt.cypher")

--- a/full/src/test/java/apoc/cache/StaticTest.java
+++ b/full/src/test/java/apoc/cache/StaticTest.java
@@ -5,6 +5,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ProvideSystemProperty;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -34,6 +36,11 @@ public class StaticTest {
     public  void setUp() throws Exception {
         TestUtil.registerProcedure(db, Static.class);
         Static.clear();
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/config/ConfigTest.java
+++ b/full/src/test/java/apoc/config/ConfigTest.java
@@ -6,6 +6,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ProvideSystemProperty;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -27,6 +29,11 @@ public class ConfigTest {
     @Before
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db, Config.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/couchbase/CouchbaseIT.java
+++ b/full/src/test/java/apoc/couchbase/CouchbaseIT.java
@@ -76,6 +76,7 @@ public class CouchbaseIT {
         if (couchbase != null) {
             couchbase.stop();
         }
+        db.shutdown();
     }
     
     @Before

--- a/full/src/test/java/apoc/couchbase/CouchbaseTestUtils.java
+++ b/full/src/test/java/apoc/couchbase/CouchbaseTestUtils.java
@@ -26,13 +26,11 @@ import java.util.stream.Stream;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static apoc.util.TestUtil.isRunningInCI;
 import static com.couchbase.client.java.ClusterOptions.clusterOptions;
 import static com.couchbase.client.java.query.QueryOptions.queryOptions;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 import static org.junit.Assume.assumeNotNull;
 
@@ -137,7 +135,6 @@ public class CouchbaseTestUtils {
     }
 
     protected static void createCouchbaseContainer() {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() -> {
             // 7.0 support stably multi collections and scopes
             couchbase = new CouchbaseContainer("couchbase/server:7.0.0")

--- a/full/src/test/java/apoc/custom/CypherProceduresClusterTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresClusterTest.java
@@ -14,10 +14,8 @@ import java.util.Map;
 
 import static apoc.util.TestContainerUtil.testCall;
 import static apoc.util.TestContainerUtil.testCallInReadTransaction;
-import static apoc.util.TestUtil.isRunningInCI;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
 
 public class CypherProceduresClusterTest {
@@ -26,7 +24,6 @@ public class CypherProceduresClusterTest {
 
     @BeforeClass
     public static void setupCluster() {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() ->  cluster = TestContainerUtil
                 .createEnterpriseCluster(3, 1, Collections.emptyMap(), MapUtil.stringMap("apoc.custom.procedures.refresh", "100")),
                 Exception.class);

--- a/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -6,6 +6,7 @@ import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.rules.TemporaryFolder;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.dbms.api.DatabaseManagementService;
@@ -33,19 +34,24 @@ public class CypherProceduresStorageTest {
     public TemporaryFolder STORE_DIR = new TemporaryFolder();
 
     private GraphDatabaseService db;
-    private DatabaseManagementService databaseManagementService;
+    private DatabaseManagementService dbms;
 
     @Before
     public void setUp() throws Exception {
-        databaseManagementService = new TestDatabaseManagementServiceBuilder(STORE_DIR.getRoot().toPath()).build();
-        db = databaseManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
+        dbms = new TestDatabaseManagementServiceBuilder( STORE_DIR.getRoot().toPath()).build();
+        db = dbms.database( GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
         TestUtil.registerProcedure(db, CypherProcedures.class, PathExplorer.class);
     }
 
+    @AfterAll
+    public void tearDown() {
+        dbms.shutdown();
+    }
+
     private void restartDb() throws IOException {
-        databaseManagementService.shutdown();
-        databaseManagementService = new TestDatabaseManagementServiceBuilder(STORE_DIR.getRoot().toPath()).build();
-        db = databaseManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
+        dbms.shutdown();
+        dbms = new TestDatabaseManagementServiceBuilder( STORE_DIR.getRoot().toPath()).build();
+        db = dbms.database( GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
         assertTrue(db.isAvailable(1000));
         TestUtil.registerProcedure(db, CypherProcedures.class, PathExplorer.class);
     }

--- a/full/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.rules.ExpectedException;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -50,6 +51,11 @@ public class CypherProceduresTest  {
     @Before
     public void setup() {
         TestUtil.registerProcedure(db, CypherProcedures.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/cypher/CypherEnterpriseTest.java
+++ b/full/src/test/java/apoc/cypher/CypherEnterpriseTest.java
@@ -10,9 +10,7 @@ import org.neo4j.driver.Session;
 
 import static apoc.util.TestContainerUtil.createEnterpriseDB;
 import static apoc.util.TestContainerUtil.testResult;
-import static apoc.util.TestUtil.isRunningInCI;
 import static apoc.util.Util.map;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 
@@ -23,7 +21,6 @@ public class CypherEnterpriseTest {
 
     @BeforeClass
     public static void beforeAll() {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() -> {
             // We build the project, the artifact will be placed into ./build/libs
             neo4jContainer = createEnterpriseDB(!TestUtil.isRunningInCI())

--- a/full/src/test/java/apoc/cypher/CypherExtendedTest.java
+++ b/full/src/test/java/apoc/cypher/CypherExtendedTest.java
@@ -48,6 +48,11 @@ public class CypherExtendedTest {
         TestUtil.registerProcedure(db, Cypher.class, CypherExtended.class, Utils.class, CypherFunctions.class, Timeboxed.class, Strings.class);
     }
 
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
+    }
+
     @After
     public void clearDB() {
         db.executeTransactionally("MATCH (n) DETACH DELETE n");

--- a/full/src/test/java/apoc/data/email/ExtractEmailTest.java
+++ b/full/src/test/java/apoc/data/email/ExtractEmailTest.java
@@ -1,9 +1,11 @@
 package apoc.data.email;
 
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -20,6 +22,11 @@ public class ExtractEmailTest {
     @BeforeClass
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, ExtractEmail.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/date/TTLTest.java
+++ b/full/src/test/java/apoc/date/TTLTest.java
@@ -2,6 +2,7 @@ package apoc.date;
 
 import apoc.periodic.Periodic;
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -47,6 +48,11 @@ public class TTLTest {
         db.executeTransactionally("CREATE (n:Foo:TTL) SET n.ttl = timestamp() + 100");
         db.executeTransactionally("CREATE (n:Bar) WITH n CALL apoc.date.expireIn(n,500,'ms') RETURN count(*)");
         testNodes(1,1);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/dv/DataVirtualizationCatalogTest.java
+++ b/full/src/test/java/apoc/dv/DataVirtualizationCatalogTest.java
@@ -19,6 +19,8 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Result;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import org.junit.jupiter.api.AfterAll;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MySQLContainer;
 
@@ -66,6 +68,11 @@ public class DataVirtualizationCatalogTest {
         if (mysql != null) {
             mysql.stop();
         }
+    }
+
+    @AfterAll
+    public void tearDownDb() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/dv/DataVirtualizationCatalogTest.java
+++ b/full/src/test/java/apoc/dv/DataVirtualizationCatalogTest.java
@@ -28,13 +28,11 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static apoc.util.TestUtil.getUrlFileName;
-import static apoc.util.TestUtil.isRunningInCI;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testCallEmpty;
 import static apoc.util.TestUtil.testResult;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 
@@ -55,7 +53,6 @@ public class DataVirtualizationCatalogTest {
 
     @BeforeClass
     public static void setUpContainer() {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() -> {
             mysql = new MySQLContainer().withInitScript("init_mysql.sql");
             mysql.start();

--- a/full/src/test/java/apoc/es/ElasticSearchTest.java
+++ b/full/src/test/java/apoc/es/ElasticSearchTest.java
@@ -65,6 +65,7 @@ public class ElasticSearchTest {
         if (elastic != null) {
             elastic.stop();
         }
+        db.shutdown();
     }
 
     /**

--- a/full/src/test/java/apoc/es/ElasticSearchTest.java
+++ b/full/src/test/java/apoc/es/ElasticSearchTest.java
@@ -17,7 +17,6 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import java.io.IOException;
 import java.util.*;
 
-import static apoc.util.TestUtil.isRunningInCI;
 import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 
@@ -50,7 +49,6 @@ public class ElasticSearchTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() -> {
             elastic = new ElasticsearchContainer();
             elastic.start();

--- a/full/src/test/java/apoc/export/ExportFullSecurityTest.java
+++ b/full/src/test/java/apoc/export/ExportFullSecurityTest.java
@@ -7,6 +7,7 @@ import apoc.util.FileUtils;
 import apoc.util.TestUtil;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -53,6 +54,11 @@ public class ExportFullSecurityTest {
     @BeforeClass
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, ExportXls.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Before

--- a/full/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/full/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -64,6 +64,7 @@ public class ExportCsvTest {
         if (miniDFSCluster!= null) {
             miniDFSCluster.shutdown();
         }
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/export/csv/ExportXlsTest.java
+++ b/full/src/test/java/apoc/export/csv/ExportXlsTest.java
@@ -8,6 +8,7 @@ import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -52,6 +53,11 @@ public class ExportXlsTest {
         TestUtil.registerProcedure(db, ExportXls.class, Graphs.class);
         db.executeTransactionally("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c'],location:point({longitude: 11.8064153, latitude: 48.1716114}),dob:date({ year:1984, month:10, day:11 }), created: datetime()})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})");
         db.executeTransactionally("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/generate/BarabasiAlbertGeneratorParameterizedTest.java
+++ b/full/src/test/java/apoc/generate/BarabasiAlbertGeneratorParameterizedTest.java
@@ -7,6 +7,7 @@ import apoc.generate.relationship.BarabasiAlbertRelationshipGenerator;
 import apoc.generate.relationship.SocialNetworkRelationshipCreator;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.neo4j.graphdb.Transaction;
@@ -46,6 +47,10 @@ public class BarabasiAlbertGeneratorParameterizedTest {
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
 
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
+    }
 
     @Test
     public void shouldGenerateCorrectNumberOfNodesAndRelationships() throws Exception {

--- a/full/src/test/java/apoc/generate/BarabasiAlbertGeneratorTest.java
+++ b/full/src/test/java/apoc/generate/BarabasiAlbertGeneratorTest.java
@@ -8,6 +8,8 @@ import apoc.generate.relationship.SocialNetworkRelationshipCreator;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.DbmsRule;
@@ -24,6 +26,11 @@ public class BarabasiAlbertGeneratorTest {
 
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
+    }
 
     @Test
     public void shouldGeneratePowerLawDistribution() {

--- a/full/src/test/java/apoc/generate/ErdosRenyiGeneratorLargeTest.java
+++ b/full/src/test/java/apoc/generate/ErdosRenyiGeneratorLargeTest.java
@@ -5,6 +5,8 @@ import apoc.generate.relationship.ErdosRenyiRelationshipGenerator;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -14,9 +16,13 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
  */
 public class ErdosRenyiGeneratorLargeTest {
 
-
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
+    }
 
     @Test(timeout = 60 * 1000)
     @Ignore("very long running test")

--- a/full/src/test/java/apoc/generate/ErdosRenyiGeneratorTest.java
+++ b/full/src/test/java/apoc/generate/ErdosRenyiGeneratorTest.java
@@ -7,6 +7,7 @@ import apoc.generate.relationship.ErdosRenyiRelationshipGenerator;
 import apoc.generate.relationship.SocialNetworkRelationshipCreator;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
@@ -49,6 +50,11 @@ public class ErdosRenyiGeneratorTest {
 
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
+    }
 
     @Test
     public void shouldGenerateCorrectNumberOfNodesAndRelationships() throws Exception {

--- a/full/src/test/java/apoc/generate/Neo4jGraphGeneratorTest.java
+++ b/full/src/test/java/apoc/generate/Neo4jGraphGeneratorTest.java
@@ -13,6 +13,8 @@ import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.DbmsRule;
@@ -34,6 +36,11 @@ public class Neo4jGraphGeneratorTest {
     @Before
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db, Generate.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/generate/WattsStrogatzGeneratorTest.java
+++ b/full/src/test/java/apoc/generate/WattsStrogatzGeneratorTest.java
@@ -8,6 +8,7 @@ import apoc.generate.relationship.WattsStrogatzRelationshipGenerator;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.neo4j.graphdb.Transaction;
@@ -48,6 +49,11 @@ public class WattsStrogatzGeneratorTest {
 
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
+    }
 
     @Test
     public void shouldGenerateCorrectNumberOfNodesAndRelationships() throws Exception {

--- a/full/src/test/java/apoc/generate/relationship/ErdosRenyiGraphRelationshipGeneratorTest.java
+++ b/full/src/test/java/apoc/generate/relationship/ErdosRenyiGraphRelationshipGeneratorTest.java
@@ -6,6 +6,8 @@ import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.internal.helpers.collection.Pair;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -23,6 +25,11 @@ public class ErdosRenyiGraphRelationshipGeneratorTest  {
     @Before
     public void setup() {
         TestUtil.registerProcedure(db, Generate.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/gephi/GephiTest.java
+++ b/full/src/test/java/apoc/gephi/GephiTest.java
@@ -1,5 +1,6 @@
 package apoc.gephi;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -45,6 +46,11 @@ public class GephiTest {
         assumeTrue(isGephiRunning());
         registerProcedure(db, Gephi.class);
         db.executeTransactionally("CREATE (:Foo {name:'Foo'})-[:KNOWS{weight:7.2,foo:'foo',bar:3.0,directed:'error',label:'foo'}]->(:Bar {name:'Bar'})");
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/get/GetProceduresTest.java
+++ b/full/src/test/java/apoc/get/GetProceduresTest.java
@@ -4,6 +4,8 @@ import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.ResourceIterator;
@@ -29,6 +31,11 @@ public class GetProceduresTest {
     @Before
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db, GetProcedures.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/help/HelpExtendedTest.java
+++ b/full/src/test/java/apoc/help/HelpExtendedTest.java
@@ -8,6 +8,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import org.junit.jupiter.api.AfterAll;
 import org.reflections.Reflections;
 import org.reflections.scanners.SubTypesScanner;
 import org.reflections.scanners.TypeAnnotationsScanner;
@@ -46,6 +48,11 @@ public class HelpExtendedTest {
                 TestUtil.registerProcedure(db, klass);
             }
         }
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     private Set<Class<?>> extendedClasses() {

--- a/full/src/test/java/apoc/load/CassandraJdbcTest.java
+++ b/full/src/test/java/apoc/load/CassandraJdbcTest.java
@@ -46,6 +46,7 @@ public class CassandraJdbcTest extends AbstractJdbcTest {
         if (cassandra != null) {
             cassandra.stop();
         }
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/load/CassandraJdbcTest.java
+++ b/full/src/test/java/apoc/load/CassandraJdbcTest.java
@@ -15,7 +15,6 @@ import org.testcontainers.containers.CassandraContainer;
 import java.sql.SQLException;
 import java.util.Map;
 
-import static apoc.util.TestUtil.isRunningInCI;
 import static apoc.util.TestUtil.testCall;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -30,7 +29,6 @@ public class CassandraJdbcTest extends AbstractJdbcTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() -> {
             cassandra = new CassandraContainer();
             cassandra.withInitScript("init_cassandra.cql");

--- a/full/src/test/java/apoc/load/JdbcTest.java
+++ b/full/src/test/java/apoc/load/JdbcTest.java
@@ -4,6 +4,7 @@ import apoc.periodic.Periodic;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.junit.*;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TestName;
 import org.neo4j.graphdb.QueryExecutionException;
@@ -74,6 +75,11 @@ public class JdbcTest extends AbstractJdbcTest {
         }
         System.clearProperty("derby.connection.requireAuthentication");
         System.clearProperty("derby.user.apoc");
+    }
+
+    @AfterAll
+    public void tearDownAll() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/load/LoadCsvTest.java
+++ b/full/src/test/java/apoc/load/LoadCsvTest.java
@@ -525,8 +525,6 @@ RETURN m.col_1,m.col_2,m.col_3
 
     @Ignore("long running test")
     @Test public void testWithEmptyQuoteChar() throws Exception {
-        //TODO: fix this test to not download 7 MB each time.
-        Assume.assumeFalse("skip this in CI it downloads 7.3 MB of data", TestUtil.isRunningInCI());
         URL url = new URL("https://www.fhwa.dot.gov/bridge/nbi/2010/delimited/AL10.txt");
         testResult(db, "CALL apoc.load.csv($url, {quoteChar: '\0'})", map("url",url.toString()),
                 (r) -> assertEquals(16018L, r.stream().count()));

--- a/full/src/test/java/apoc/load/LoadFullSecurityTest.java
+++ b/full/src/test/java/apoc/load/LoadFullSecurityTest.java
@@ -8,6 +8,7 @@ import apoc.util.TestUtil;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -54,6 +55,11 @@ public class LoadFullSecurityTest {
     @BeforeClass
     public static void setUp() throws Exception {
         TestUtil.registerProcedure(db, LoadXls.class, LoadHtml.class, LoadCsv.class);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
     }
 
     private static final Map<String, Class<?>> ALLOWED_EXCEPTIONS = Map.of(

--- a/full/src/test/java/apoc/load/LoadGoogleCloudStorageTest.java
+++ b/full/src/test/java/apoc/load/LoadGoogleCloudStorageTest.java
@@ -2,6 +2,8 @@ package apoc.load;
 
 import apoc.util.TestUtil;
 import org.junit.*;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -29,6 +31,11 @@ public class LoadGoogleCloudStorageTest {
     @Before
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db, LoadCsv.class, LoadJson.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/load/LoadHdfsTest.java
+++ b/full/src/test/java/apoc/load/LoadHdfsTest.java
@@ -11,6 +11,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -46,6 +48,11 @@ public class LoadHdfsTest {
 
     @After public void tearDown() {
         miniDFSCluster.shutdown();
+    }
+
+    @AfterAll
+    public void tearDownAll() {
+        db.shutdown();
     }
 
     @Test public void testLoadCsvFromHDFS() throws Exception {

--- a/full/src/test/java/apoc/load/LoadHtmlTest.java
+++ b/full/src/test/java/apoc/load/LoadHtmlTest.java
@@ -6,6 +6,8 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -54,6 +56,11 @@ public class LoadHtmlTest {
     @Before
     public void setup() {
         TestUtil.registerProcedure(db, LoadHtml.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/load/LoadS3Test.java
+++ b/full/src/test/java/apoc/load/LoadS3Test.java
@@ -12,6 +12,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.driver.internal.util.Iterables;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -56,6 +58,11 @@ public class LoadS3Test {
     @After
     public void tearDown() throws Exception {
         minio.close();
+    }
+
+    @AfterAll
+    public void tearDownAll() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/load/LoadXlsTest.java
+++ b/full/src/test/java/apoc/load/LoadXlsTest.java
@@ -8,6 +8,8 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.internal.helpers.collection.Iterators;
@@ -45,6 +47,11 @@ public class LoadXlsTest {
 
     @Before public void setUp() throws Exception {
         TestUtil.registerProcedure(db, LoadXls.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test public void testLoadXls() throws Exception {

--- a/full/src/test/java/apoc/load/PostgresJdbcTest.java
+++ b/full/src/test/java/apoc/load/PostgresJdbcTest.java
@@ -13,7 +13,6 @@ import org.testcontainers.containers.PostgreSQLContainer;
 
 import java.sql.SQLException;
 
-import static apoc.util.TestUtil.isRunningInCI;
 import static apoc.util.TestUtil.testCall;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.*;
@@ -30,7 +29,6 @@ public class PostgresJdbcTest extends AbstractJdbcTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() -> {
             postgress = new PostgreSQLContainer().withInitScript("init_postgres.sql");
             postgress.start();

--- a/full/src/test/java/apoc/load/PostgresJdbcTest.java
+++ b/full/src/test/java/apoc/load/PostgresJdbcTest.java
@@ -44,6 +44,7 @@ public class PostgresJdbcTest extends AbstractJdbcTest {
         if (postgress != null) {
             postgress.stop();
         }
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/load/relative/LoadRelativePathTest.java
+++ b/full/src/test/java/apoc/load/relative/LoadRelativePathTest.java
@@ -7,6 +7,8 @@ import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.Result;
 import org.neo4j.test.rule.DbmsRule;
@@ -40,6 +42,11 @@ public class LoadRelativePathTest {
 
     @Before public void setUp() throws Exception {
         TestUtil.registerProcedure(db, LoadCsv.class, Xml.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     //CSV

--- a/full/src/test/java/apoc/log/LoggingTest.java
+++ b/full/src/test/java/apoc/log/LoggingTest.java
@@ -4,6 +4,7 @@ import apoc.ApocConfig;
 import apoc.util.SimpleRateLimiter;
 import apoc.util.TestUtil;
 import org.jetbrains.annotations.NotNull;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -27,6 +28,11 @@ public class LoggingTest {
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule(logProvider);
 
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
+    }
+    
     @Test
     public void shouldWriteSafeStrings() {
         // given

--- a/full/src/test/java/apoc/metrics/MetricsTest.java
+++ b/full/src/test/java/apoc/metrics/MetricsTest.java
@@ -18,10 +18,8 @@ import java.util.stream.Stream;
 import static apoc.util.FileUtils.NEO4J_DIRECTORY_CONFIGURATION_SETTING_NAMES;
 import static apoc.util.TestContainerUtil.createEnterpriseDB;
 import static apoc.util.TestContainerUtil.testResult;
-import static apoc.util.TestUtil.isRunningInCI;
 import static apoc.util.Util.map;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 import static org.neo4j.test.assertion.Assert.assertEventually;
@@ -37,7 +35,6 @@ public class MetricsTest {
 
     @BeforeClass
     public static void beforeAll() throws InterruptedException {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() -> {
             neo4jContainer = createEnterpriseDB(true)
                     .withDebugger()

--- a/full/src/test/java/apoc/model/ModelTest.java
+++ b/full/src/test/java/apoc/model/ModelTest.java
@@ -16,7 +16,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static apoc.util.TestUtil.isRunningInCI;
 import static apoc.util.TestUtil.testCall;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -34,7 +33,6 @@ public class ModelTest {
 
     @BeforeClass
     public static void setUpContainer() {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() -> {
             mysql = new MySQLContainer().withInitScript("init_mysql.sql");
             mysql.start();

--- a/full/src/test/java/apoc/mongodb/MongoTest.java
+++ b/full/src/test/java/apoc/mongodb/MongoTest.java
@@ -21,6 +21,7 @@ import org.bson.types.MinKey;
 import org.bson.types.ObjectId;
 import org.bson.types.Symbol;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.ResourceIterator;
@@ -430,6 +431,7 @@ public class MongoTest extends MongoTestBase {
         }
     }
 
+    @Ignore
     @Test
     public void shouldInsertDataIntoNeo4jWithFromDocument() throws Exception {
         Date date = DateUtils.parseDate("11-10-1935", "dd-MM-yyyy");

--- a/full/src/test/java/apoc/mongodb/MongoTestBase.java
+++ b/full/src/test/java/apoc/mongodb/MongoTestBase.java
@@ -42,14 +42,12 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static apoc.util.MapUtil.map;
-import static apoc.util.TestUtil.isRunningInCI;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 
@@ -99,7 +97,6 @@ public class MongoTestBase {
     }
 
     public static void createContainer(boolean withAuth) {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() -> {
             mongo = new GenericContainer("mongo:4")
                     .withNetworkAliases("mongo-" + Base58.randomString(6))

--- a/full/src/test/java/apoc/mongodb/MongoTestBase.java
+++ b/full/src/test/java/apoc/mongodb/MongoTestBase.java
@@ -82,6 +82,7 @@ public class MongoTestBase {
         if (mongo != null) {
             mongo.stop();
         }
+        db.shutdown();
     }
 
     @Before

--- a/full/src/test/java/apoc/monitor/IdsProcedureTest.java
+++ b/full/src/test/java/apoc/monitor/IdsProcedureTest.java
@@ -4,6 +4,8 @@ import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -19,6 +21,11 @@ public class IdsProcedureTest {
     @Before
     public void setup() {
         TestUtil.registerProcedure(db, Ids.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/monitor/KernelProcedureTest.java
+++ b/full/src/test/java/apoc/monitor/KernelProcedureTest.java
@@ -6,6 +6,8 @@ import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -25,6 +27,11 @@ public class KernelProcedureTest {
     }
 
     private SimpleDateFormat format = new SimpleDateFormat(Date.DEFAULT_FORMAT);
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
+    }
 
     @Test
     public void testGetKernelInfo() {

--- a/full/src/test/java/apoc/monitor/StoreInfoProcedureTest.java
+++ b/full/src/test/java/apoc/monitor/StoreInfoProcedureTest.java
@@ -4,6 +4,8 @@ import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -18,6 +20,11 @@ public class StoreInfoProcedureTest {
     @Before
     public void setup() {
         TestUtil.registerProcedure(db, Store.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/monitor/TransactionProcedureTest.java
+++ b/full/src/test/java/apoc/monitor/TransactionProcedureTest.java
@@ -4,6 +4,7 @@ import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
 
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -19,6 +20,11 @@ public class TransactionProcedureTest {
     @Before
     public void setup() {
         TestUtil.registerProcedure(db, Transaction.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/periodic/PeriodicExtendedTest.java
+++ b/full/src/test/java/apoc/periodic/PeriodicExtendedTest.java
@@ -5,6 +5,8 @@ import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.common.DependencyResolver;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.internal.helpers.collection.Iterators;
@@ -31,6 +33,11 @@ public class PeriodicExtendedTest {
     @Before
     public void initDb() {
         TestUtil.registerProcedure(db, Periodic.class, PeriodicExtended.class, Jdbc.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/redis/RedisTest.java
+++ b/full/src/test/java/apoc/redis/RedisTest.java
@@ -64,6 +64,7 @@ public class RedisTest {
         if (redis != null) {
             redis.stop();
         }
+        db.shutdown();
     }
 
     @After

--- a/full/src/test/java/apoc/redis/RedisTest.java
+++ b/full/src/test/java/apoc/redis/RedisTest.java
@@ -23,11 +23,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static apoc.util.MapUtil.map;
-import static apoc.util.TestUtil.isRunningInCI;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 import static org.neo4j.test.assertion.Assert.assertEventually;
@@ -46,10 +44,8 @@ public class RedisTest {
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule();
 
-
     @BeforeClass
     public static void beforeClass() {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() -> {
             redis = new GenericContainer("redis:" + REDIS_VERSION)
                     .withCommand("redis-server --requirepass " + PASSWORD)

--- a/full/src/test/java/apoc/systemdb/SystemDbTest.java
+++ b/full/src/test/java/apoc/systemdb/SystemDbTest.java
@@ -13,6 +13,8 @@ import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -56,6 +58,11 @@ public class SystemDbTest {
         apocConfig().setProperty(ApocConfig.APOC_UUID_ENABLED, true);
         apocConfig().setProperty(ApocConfig.APOC_TRIGGER_ENABLED, true);
         TestUtil.registerProcedure(db, SystemDb.class, Trigger.class, CypherProcedures.class, Uuid.class, Periodic.class, DataVirtualizationCatalog.class, CypherExtended.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/trigger/TriggerClusterTest.java
+++ b/full/src/test/java/apoc/trigger/TriggerClusterTest.java
@@ -7,6 +7,7 @@ import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.driver.types.Node;
 import org.neo4j.internal.helpers.collection.MapUtil;
@@ -44,7 +45,7 @@ public class TriggerClusterTest {
         cluster.getSession().run("MATCH (n) DETACH DELETE n");
     }
 
-
+    @Ignore
     @Test
     public void testTimeStampTriggerForUpdatedProperties() throws Exception {
         cluster.getSession().run("CALL apoc.trigger.add('timestamp','UNWIND apoc.trigger.nodesByLabel($assignedNodeProperties,null) AS n SET n.ts = timestamp()',{})");
@@ -54,6 +55,7 @@ public class TriggerClusterTest {
         });
     }
 
+    @Ignore
     @Test
     public void testReplication() throws Exception {
         cluster.getSession().run("CALL apoc.trigger.add('timestamp','UNWIND apoc.trigger.nodesByLabel($assignedNodeProperties,null) AS n SET n.ts = timestamp()',{})");
@@ -63,6 +65,7 @@ public class TriggerClusterTest {
                 (value) -> "timestamp".equals(value), 30, TimeUnit.SECONDS);
     }
 
+    @Ignore
     @Test
     public void testLowerCaseName() throws Exception {
         cluster.getSession().run("create constraint on (p:Person) assert p.id is unique");
@@ -73,6 +76,8 @@ public class TriggerClusterTest {
             assertEquals("John Doe", ((Node)row.get("f")).get("name").asString());
         });
     }
+
+    @Ignore
     @Test
     public void testSetLabels() throws Exception {
         cluster.getSession().run("CREATE (f {name:'John Doe'})");
@@ -87,7 +92,7 @@ public class TriggerClusterTest {
         assertEquals(1L, count);
     }
 
-
+    @Ignore
     @Test
     public void testTxIdAfterAsync() throws Exception {
         cluster.getSession().run("CALL apoc.trigger.add('triggerTest','UNWIND apoc.trigger.propertiesByKey($assignedNodeProperties, \"_executed\") as prop " +

--- a/full/src/test/java/apoc/trigger/TriggerClusterTest.java
+++ b/full/src/test/java/apoc/trigger/TriggerClusterTest.java
@@ -14,9 +14,7 @@ import org.neo4j.internal.helpers.collection.MapUtil;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-import static apoc.util.TestUtil.isRunningInCI;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeFalse;
 
 public class TriggerClusterTest {
 
@@ -24,7 +22,6 @@ public class TriggerClusterTest {
 
     @BeforeClass
     public static void setupCluster() {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() ->  cluster = TestContainerUtil
                 .createEnterpriseCluster(3, 1, Collections.emptyMap(), MapUtil.stringMap(
                         "apoc.trigger.refresh", "100",

--- a/full/src/test/java/apoc/trigger/TriggerExtendedTest.java
+++ b/full/src/test/java/apoc/trigger/TriggerExtendedTest.java
@@ -4,6 +4,8 @@ import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.test.rule.DbmsRule;
@@ -30,6 +32,11 @@ public class TriggerExtendedTest {
     public void setUp() throws Exception {
         start = System.currentTimeMillis();
         TestUtil.registerProcedure(db, Trigger.class, TriggerExtended.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/ttl/TTLMultiDbTest.java
+++ b/full/src/test/java/apoc/ttl/TTLMultiDbTest.java
@@ -19,8 +19,6 @@ import static apoc.util.TestContainerUtil.createEnterpriseDB;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static apoc.util.TestUtil.isRunningInCI;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 
@@ -36,7 +34,6 @@ public class TTLMultiDbTest {
 
     @BeforeClass
     public static void setupContainer() {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() -> {
             neo4jContainer = createEnterpriseDB(!TestUtil.isRunningInCI())
                     .withEnv(Map.of("apoc.ttl.enabled." + DB_TEST, "false",

--- a/full/src/test/java/apoc/ttl/TTLTest.java
+++ b/full/src/test/java/apoc/ttl/TTLTest.java
@@ -3,6 +3,7 @@ package apoc.ttl;
 import apoc.ApocSettings;
 import apoc.periodic.Periodic;
 import apoc.util.TestUtil;
+import org.junit.AfterClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -23,6 +24,11 @@ public class TTLTest {
     public static DbmsRule db = new ImpermanentDbmsRule()
             .withSetting(ApocSettings.apoc_ttl_schedule, Duration.ofMillis(3000))
             .withSetting(ApocSettings.apoc_ttl_enabled, true);
+
+    @AfterClass
+    public static void tearDown() {
+        db.shutdown();
+    }
 
     @Test
     public void testExpireManyNodes() throws Exception {

--- a/full/src/test/java/apoc/util/FileUtilsTest.java
+++ b/full/src/test/java/apoc/util/FileUtilsTest.java
@@ -6,6 +6,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ProvideSystemProperty;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.rules.TestName;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.test.rule.DbmsRule;
@@ -54,6 +55,11 @@ public class FileUtilsTest {
             apocConfig().setProperty("dbms.directories.import", importFolder);
         }
         TestUtil.registerProcedure(db, Config.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+        db.shutdown();
     }
 
     @Test

--- a/full/src/test/java/apoc/util/s3/S3Container.java
+++ b/full/src/test/java/apoc/util/s3/S3Container.java
@@ -46,6 +46,7 @@ public class S3Container implements AutoCloseable {
 
     public void close() {
         Util.close(localstack);
+        s3.shutdown();
     }
 
     public AwsClientBuilder.EndpointConfiguration getEndpointConfiguration() {

--- a/full/src/test/java/apoc/uuid/UUIDMultiDbTest.java
+++ b/full/src/test/java/apoc/uuid/UUIDMultiDbTest.java
@@ -18,11 +18,9 @@ import java.util.stream.Collectors;
 import static apoc.ApocConfig.APOC_UUID_ENABLED;
 import static apoc.ApocConfig.APOC_UUID_ENABLED_DB;
 import static apoc.util.TestContainerUtil.createEnterpriseDB;
-import static apoc.util.TestUtil.isRunningInCI;
 import static apoc.uuid.UuidHandler.NOT_ENABLED_ERROR;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 
@@ -34,7 +32,6 @@ public class UUIDMultiDbTest {
 
     @BeforeClass
     public static void setupContainer() {
-        assumeFalse(isRunningInCI());
         TestUtil.ignoreException(() -> {
             neo4jContainer = createEnterpriseDB(!TestUtil.isRunningInCI())
                     .withEnv(Map.of(String.format(APOC_UUID_ENABLED_DB, dbTest), "false",

--- a/full/src/test/java/apoc/uuid/UUIDTest.java
+++ b/full/src/test/java/apoc/uuid/UUIDTest.java
@@ -9,6 +9,8 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Result;
@@ -39,6 +41,11 @@ public class UUIDTest {
     @Before
     public void setUp() throws Exception {
         TestUtil.registerProcedure(db, Uuid.class, Create.class, Periodic.class);
+    }
+
+    @AfterAll
+    public void tearDown() {
+       db.shutdown();
     }
 
     @Test

--- a/test-utils/src/main/java/apoc/util/TestUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestUtil.java
@@ -28,7 +28,6 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import static org.junit.Assert.*;
-import static org.junit.Assume.assumeFalse;
 
 /**
  * @author mh
@@ -169,10 +168,6 @@ public class TestUtil {
             assertThat("duration " + matcher, System.currentTimeMillis()-start, matcher);
             return result;
         }
-    }
-
-    public static void assumeRunningInCI() {
-        assumeFalse("we're running in CI, so skipping", isRunningInCI());
     }
 
     public static boolean isRunningInCI() {


### PR DESCRIPTION
This PR is rebased on top of #2819 so please ignore the first 4 commits from 27th of April as they will be reviewed elsewhere. 

In this PR will are fixing apoc-core tests so that they also runs in the CI. This is to ensure we catch errors and regressions over time.

## Proposed Changes (Mandatory)
  - Remove logic similar to assumeFalse(isRunningCI())
  - Parallelise tests
  - Give gradle more heap to work with
  - Give jvm more heap to work with
  - Ignore broken tests manually (to be fixed later)
