### PR TITLE
Unparallelise tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ subprojects {
 
         maxHeapSize = "8G"
         forkEvery = 50
-        maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+        maxParallelForks = 1
         minHeapSize = "128m"
         maxHeapSize = "512m"
 


### PR DESCRIPTION
Attempt to fix the TeamCity build by reverting the parallelisation of the tests.

## Proposed Changes (Mandatory)

  - Unparallelise tests
