### PR TITLE
Fixes #2699: The apoc.refactor.mergeNodes remove entities if a list with 2 equal nodes is passed

### DIFF
--- a/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -32,6 +32,7 @@ import java.util.stream.StreamSupport;
 
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testCallCount;
 import static apoc.util.TestUtil.testCallEmpty;
 import static apoc.util.TestUtil.testResult;
 import static apoc.util.Util.isSelfRel;
@@ -523,7 +524,23 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                     assertEquals(1L, rel.getProperty("a"));
                 });
     }
+    
+    @Test
+    public void testRefactorWithSameEntities() {
+        Node node = db.executeTransactionally("CREATE (n:SingleNode) RETURN n", emptyMap(), 
+                r -> Iterators.single(r.columnAs("n")));
+        testCall(db, "MATCH (n:SingleNode) CALL apoc.refactor.mergeNodes([n,n]) yield node return node",
+                r -> assertEquals(node, r.get("node")));
+        testCallCount(db, "MATCH (n:SingleNode) RETURN n", 1);
 
+        Relationship rel = db.executeTransactionally("CREATE (n:Start)-[r:REL_TO_MERGE]->(:End) RETURN r", emptyMap(), 
+                r -> Iterators.single(r.columnAs("r")));
+        testCall(db, "MATCH (n:Start)-[r:REL_TO_MERGE]->(:End) CALL apoc.refactor.mergeRelationships([r,r]) yield rel return rel", r -> {
+            assertEquals(rel, r.get("rel"));
+        });
+        testCallCount(db, "MATCH (n:Start)-[r:REL_TO_MERGE]->(:End) RETURN r", 1);
+    }
+    
     @Test
     public void testCollapseNode() throws Exception {
         Long id = db.executeTransactionally("CREATE (f:Foo)-[:FOO {a:1}]->(b:Bar {c:3})-[:BAR {b:2}]->(f) RETURN id(b) as id", emptyMap(), result -> Iterators.single(result.columnAs("id")));


### PR DESCRIPTION
Fixes #2699