### PR TITLE
Fixes #2817: When importing a string array field with a blank value, the attribute value is interpreted as [""] instead of NULL as expected

### DIFF
--- a/core/src/main/java/apoc/export/csv/CsvLoaderConfig.java
+++ b/core/src/main/java/apoc/export/csv/CsvLoaderConfig.java
@@ -3,7 +3,6 @@ package apoc.export.csv;
 import apoc.util.CompressionAlgo;
 import apoc.util.CompressionConfig;
 
-import java.nio.charset.Charset;
 import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -22,6 +21,7 @@ public class CsvLoaderConfig extends CompressionConfig {
     private static final String BATCH_SIZE = "batchSize";
     private static final String IGNORE_DUPLICATE_NODES = "ignoreDuplicateNodes";
     private static final String IGNORE_BLANK_STRING = "ignoreBlankString";
+    private static final String IGNORE_EMPTY_CELL_ARRAY = "ignoreEmptyCellArray";
 
     private static char DELIMITER_DEFAULT = ',';
     private static char ARRAY_DELIMITER_DEFAULT = ';';
@@ -31,6 +31,7 @@ public class CsvLoaderConfig extends CompressionConfig {
     private static int BATCH_SIZE_DEFAULT = 2000;
     private static boolean IGNORE_DUPLICATE_NODES_DEFAULT = false;
     private static boolean IGNORE_BLANK_STRING_DEFAULT = false;
+    private static boolean IGNORE_EMPTY_CELL_ARRAY_DEFAULT = false;
 
     private final char delimiter;
     private final char arrayDelimiter;
@@ -40,6 +41,7 @@ public class CsvLoaderConfig extends CompressionConfig {
     private final int batchSize;
     private final boolean ignoreDuplicateNodes;
     private final boolean ignoreBlankString;
+    private final boolean ignoreEmptyCellArray;
 
     private CsvLoaderConfig(Builder builder) {
         super(Map.of(COMPRESSION, builder.compressionAlgo, CHARSET, builder.charset));
@@ -51,6 +53,7 @@ public class CsvLoaderConfig extends CompressionConfig {
         this.batchSize = builder.batchSize;
         this.ignoreDuplicateNodes = builder.ignoreDuplicateNodes;
         this.ignoreBlankString = builder.ignoreBlankString;
+        this.ignoreEmptyCellArray = builder.ignoreEmptyCellArray;
     }
 
     public char getDelimiter() {
@@ -81,6 +84,10 @@ public class CsvLoaderConfig extends CompressionConfig {
 
     public boolean isIgnoreBlankString() {
         return ignoreBlankString;
+    }
+
+    public boolean isIgnoreEmptyCellArray() {
+        return ignoreEmptyCellArray;
     }
 
     /**
@@ -118,6 +125,7 @@ public class CsvLoaderConfig extends CompressionConfig {
         if (config.get(BATCH_SIZE) != null) builder.batchSize((int) config.get(BATCH_SIZE));
         if (config.get(IGNORE_DUPLICATE_NODES) != null) builder.ignoreDuplicateNodes((boolean) config.get(IGNORE_DUPLICATE_NODES));
         if (config.get(IGNORE_BLANK_STRING) != null) builder.ignoreBlankString((boolean) config.get(IGNORE_BLANK_STRING));
+        if (config.get(IGNORE_EMPTY_CELL_ARRAY) != null) builder.ignoreEmptyCellArray((boolean) config.get(IGNORE_EMPTY_CELL_ARRAY));
         builder.binary((String) config.getOrDefault(COMPRESSION, CompressionAlgo.GZIP.name()));
         builder.charset((String) config.getOrDefault(CHARSET, UTF_8.name()));
         
@@ -136,6 +144,7 @@ public class CsvLoaderConfig extends CompressionConfig {
         private int batchSize = BATCH_SIZE_DEFAULT;
         private boolean ignoreDuplicateNodes = IGNORE_DUPLICATE_NODES_DEFAULT;
         private boolean ignoreBlankString = IGNORE_BLANK_STRING_DEFAULT;
+        private boolean ignoreEmptyCellArray = IGNORE_EMPTY_CELL_ARRAY_DEFAULT;
         private String compressionAlgo = null;
         private String charset = UTF_8.name();
 
@@ -189,6 +198,11 @@ public class CsvLoaderConfig extends CompressionConfig {
 
         public Builder ignoreBlankString(boolean ignoreBlankString) {
             this.ignoreBlankString = ignoreBlankString;
+            return this;
+        }
+
+        public Builder ignoreEmptyCellArray(boolean ignoreArrayEmptyCell) {
+            this.ignoreEmptyCellArray = ignoreArrayEmptyCell;
             return this;
         }
 

--- a/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
+++ b/core/src/main/java/apoc/export/csv/CsvPropertyConverter.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetTime;
 import java.time.ZonedDateTime;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -22,7 +23,11 @@ public class CsvPropertyConverter {
         if (field.isArray()) {
             final List list = (List) value;
             final boolean listContainingNull = list.stream().anyMatch(Objects::isNull);
-            if (listContainingNull) {
+            // todo - to maintain compatibility with neo4j-admin import, we skip ONLY empty cells
+            //  while array cell like "...., ,....", will be imported as propKey: [" "]
+            //  might be worth add another config to ignore blank item as well, and/or array elements, e.g "...,a;b;;;c,..."
+            final boolean isEmptyCell = config.isIgnoreEmptyCellArray() && list.equals(Collections.singletonList(""));
+            if (listContainingNull || isEmptyCell) {
                 return false;
             }
             final Object[] prototype = getPrototypeFor(field.getType().toUpperCase());

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -148,7 +148,14 @@ public class ImportCsvTest {
                             ":ID(node_space_1),:LABEL,str_attribute:STRING,int_attribute:INT,int_attribute_array:INT[],double_attribute_array:FLOAT[]\n" +
                             "n1,Thing,once upon a time,1,\"2;3\",\"2.3;3.5\"\n" +
                             "n2,Thing,,2,\"4;5\",\"2.6;3.6\"\n" +
-                            "n3,Thing,,,,\n"
+                            "n3,Thing,,,,\n"),
+                    new AbstractMap.SimpleEntry<>("emptyArray", 
+                            "id:ID,:LABEL,arr:STRING[],description:STRING\n" +
+                            "1,Arrays,a;b;c;d;e,normal,\n" +
+                            "2,Arrays,,withNull\n" +
+                            "3,Arrays,a;;c;;e,withEmptyItem\n" +
+                            "4,Arrays,a; ;c; ;e,withBlankItem\n" +
+                            "5,Arrays, ,withWhiteSpace\n"
                     )
             ).collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
 
@@ -480,6 +487,38 @@ public class ImportCsvTest {
                     assertNull(thirdProps.get("str_attribute"));
                     assertFalse(r.hasNext());
                 });
+    }
+
+    @Test
+    public void testEmptyArray() {
+        TestUtil.testCall(db, "CALL apoc.import.csv([{fileName: 'file:/emptyArray.csv', labels:[]}], [], $conf)",
+                map( "conf", map("ignoreEmptyCellArray", true)),
+                r -> assertEquals(5L, r.get("nodes")));
+
+        TestUtil.testResult(db, "MATCH (node:Arrays) RETURN node ORDER BY node.id", r -> {
+            final Map<String, Object> propsOne = ((Node) r.next().get("node")).getAllProperties();
+            assertEquals("normal", propsOne.get("description"));
+            assertArrayEquals(new String[] { "a", "b", "c", "d", "e" }, (String[]) propsOne.get("arr"));
+            
+            final Map<String, Object> propsTwo = ((Node) r.next().get("node")).getAllProperties();
+            assertEquals("withNull", propsTwo.get("description"));
+            assertFalse(propsTwo.containsKey("arr"));
+            
+            final Map<String, Object> propsThree = ((Node) r.next().get("node")).getAllProperties();
+            assertEquals("withEmptyItem", propsThree.get("description"));
+            assertArrayEquals(new String[] { "a", "", "c", "", "e" }, (String[]) propsThree.get("arr"));
+            
+            final Map<String, Object> propsFour = ((Node) r.next().get("node")).getAllProperties();
+            assertEquals("withBlankItem", propsFour.get("description"));
+            assertArrayEquals(new String[] { "a", " ", "c", " ", "e" }, (String[]) propsFour.get("arr"));
+            
+            final Map<String, Object> propsFive = ((Node) r.next().get("node")).getAllProperties();
+            assertEquals("withWhiteSpace", propsFive.get("description"));
+            assertArrayEquals(new String[] { " " }, (String[]) propsFive.get("arr"));
+            
+            assertFalse(r.hasNext());
+        });
+        
     }
 
     @Test

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.csv.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.csv.adoc
@@ -11,5 +11,6 @@ The procedure support the following config parameters:
 | stringIds | Boolean | true | treat ids as strings  | `--id-type=STRING`
 | skipLines | Integer | 1 | lines to skip (incl. header)  | N/A
 | ignoreBlankString | Boolean | false | if true ignore properties with a blank string | N/A
+| ignoreEmptyCellArray | Boolean | false | if true ignore array properties containing a single empty string, like the import tool | N/A
 | compression | `Enum[NONE, BYTES, GZIP, BZIP2, DEFLATE, BLOCK_LZ4, FRAMED_SNAPPY]` | `null` | Allow taking binary data, either not compressed (value: `NONE`) or compressed (other values) . See the xref::overview/apoc.load/apoc.load.csv.adoc#_binary_file[Binary file example] | N/A
 |===


### PR DESCRIPTION
Fixes #2817

Also, added tests for arrays, to check consistency with `neo4j-admin import` tool. 