### PR TITLE
Fixes #2797 and #2780: Graph Refactoring procedures internally handle errors instead of throwing them, leaving half-created results

### DIFF
--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -31,6 +31,7 @@ import org.neo4j.internal.kernel.api.procs.ProcedureCallContext;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLog;
 import org.neo4j.procedure.TerminationGuard;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.storable.PointValue;
@@ -990,5 +991,10 @@ public class Util {
     public static String toCypherMap(Map<String, Object> map) {
         final StringBuilder builder = formatProperties(map);
         return "{" + formatToString(builder) + "}";
+    }
+
+    public static <T extends Entity> T withTransactionAndRebind(GraphDatabaseService db, Transaction transaction, Function<Transaction, T> action) {
+        T result = retryInTx(NullLog.getInstance(), db, action, 0, 0, r -> {});
+        return rebind(transaction, result);
     }
 }

--- a/core/src/test/java/apoc/refactor/GraphRefactoringEnterpriseTest.java
+++ b/core/src/test/java/apoc/refactor/GraphRefactoringEnterpriseTest.java
@@ -1,0 +1,114 @@
+package apoc.refactor;
+
+import apoc.util.Neo4jContainerExtension;
+import apoc.util.TestUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.internal.value.NullValue;
+
+import java.util.Map;
+
+import static apoc.refactor.GraphRefactoringTest.CLONE_NODES_QUERY;
+import static apoc.refactor.GraphRefactoringTest.CLONE_SUBGRAPH_QUERY;
+import static apoc.refactor.GraphRefactoringTest.EXTRACT_QUERY;
+import static apoc.util.TestContainerUtil.createEnterpriseDB;
+import static apoc.util.TestContainerUtil.testCall;
+import static apoc.util.TestUtil.isRunningInCI;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeNotNull;
+import static org.junit.Assume.assumeTrue;
+
+public class GraphRefactoringEnterpriseTest {
+    private static final String CREATE_REL_FOR_EXTRACT_NODE = "CREATE (:Start)-[r:TO_MOVE {name: 'foobar', surname: 'baz'}]->(:End)";
+    private static final String DELETE_REL_FOR_EXTRACT_NODE = "MATCH p=(:Start)-[r:TO_MOVE]->(:End) DELETE p";
+    private static Neo4jContainerExtension neo4jContainer;
+    private static Session session;
+
+    @BeforeClass
+    public static void beforeAll() {
+        assumeFalse(isRunningInCI());
+        TestUtil.ignoreException(() -> {
+            neo4jContainer = createEnterpriseDB(true);
+            neo4jContainer.start();
+        }, Exception.class);
+        assumeNotNull(neo4jContainer);
+        assumeTrue("Neo4j Instance should be up-and-running", neo4jContainer.isRunning());
+        session = neo4jContainer.getSession();
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        if (neo4jContainer != null && neo4jContainer.isRunning()) {
+            session.close();
+            neo4jContainer.close();
+        }
+    }
+    
+    @Test
+    public void testCloneNodesWithNodeKeyConstraint() {
+        nodeKeyCommons(CLONE_NODES_QUERY);
+    }
+
+    @Test
+    public void testCloneNodesWithBothExistenceAndUniqueConstraint() {
+        uniqueNotNullCommons(CLONE_NODES_QUERY);
+    }
+    
+    @Test
+    public void testCloneSubgraphWithNodeKeyConstraint() {
+        nodeKeyCommons(CLONE_SUBGRAPH_QUERY);
+    }
+
+    @Test
+    public void testCloneSubgraphWithBothExistenceAndUniqueConstraint() {
+        uniqueNotNullCommons(CLONE_SUBGRAPH_QUERY);
+    }
+    
+    @Test
+    public void testExtractNodesWithNodeKeyConstraint() {
+        session.writeTransaction(tx -> tx.run(CREATE_REL_FOR_EXTRACT_NODE));
+        nodeKeyCommons(EXTRACT_QUERY);
+        session.writeTransaction(tx -> tx.run(DELETE_REL_FOR_EXTRACT_NODE));
+    }
+
+    @Test
+    public void testExtractNodesWithBothExistenceAndUniqueConstraint() {
+        session.writeTransaction(tx -> tx.run(CREATE_REL_FOR_EXTRACT_NODE));
+        uniqueNotNullCommons(EXTRACT_QUERY);
+        session.writeTransaction(tx -> tx.run(DELETE_REL_FOR_EXTRACT_NODE));
+    }
+
+    private void nodeKeyCommons(String query) {
+        session.writeTransaction(tx -> tx.run("CREATE CONSTRAINT nodeKey ON (p:MyBook) ASSERT (p.name, p.surname) IS NODE KEY"));
+        cloneNodesAssertions(query, "already exists with label `MyBook` and properties `name` = 'foobar', `surname` = 'baz'");
+        session.writeTransaction(tx -> tx.run("DROP CONSTRAINT nodeKey"));
+        
+    }
+
+    private void uniqueNotNullCommons(String query) {
+        session.writeTransaction(tx -> tx.run("CREATE CONSTRAINT unique ON (p:MyBook) ASSERT (p.name) IS UNIQUE"));
+        session.writeTransaction(tx -> tx.run("CREATE CONSTRAINT notNull ON (p:MyBook) ASSERT (p.name) IS NOT NULL"));
+
+        cloneNodesAssertions(query, "already exists with label `MyBook` and property `name` = 'foobar'");
+        session.writeTransaction(tx -> tx.run("DROP CONSTRAINT unique"));
+        session.writeTransaction(tx -> tx.run("DROP CONSTRAINT notNull"));
+    }
+
+    private void cloneNodesAssertions(String query, String message) {
+        session.writeTransaction(tx -> tx.run("CREATE (n:MyBook {name: 'foobar', surname: 'baz'})"));
+        testCall(session, query,
+                r -> {
+                    final String error = (String) r.get("error");
+                    assertTrue(error.contains(message));
+                    assertNull(r.get("output"));
+                    
+                });
+        session.writeTransaction(tx -> tx.run("MATCH (n:MyBook) DELETE n"));
+    }
+}

--- a/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -16,7 +16,6 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
-import org.neo4j.graphdb.config.Setting;
 import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -47,6 +46,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.neo4j.configuration.SettingImpl.newBuilder;
 import static org.neo4j.configuration.SettingValueParsers.BOOL;
@@ -57,6 +57,11 @@ import static org.neo4j.graphdb.Label.label;
  * @since 25.03.16
  */
 public class GraphRefactoringTest {
+    protected static final String CLONE_NODES_QUERY = "match (n:MyBook) with n call apoc.refactor.cloneNodes([n], true) " +
+            "YIELD output, error RETURN output, error";
+    protected static final String CLONE_SUBGRAPH_QUERY = "MATCH (n:MyBook) with n call apoc.refactor.cloneSubgraph([n], [], {}) YIELD output, error RETURN output, error";
+    protected static final String EXTRACT_QUERY = "MATCH p=(:Start)-[r:TO_MOVE]->(:End) with r call apoc.refactor.extractNode([r], ['MyBook'], 'OUT', 'IN') " +
+            "YIELD output, error RETURN output, error";
 
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule()
@@ -1243,6 +1248,43 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
                     assertSelfRel(relIterator.next(), "Q");
                     assertFalse(relIterator.hasNext());
                 });
+    }
+
+    @Test
+    public void issue2797WithCloneNodes() {
+        issue2797Common(CLONE_NODES_QUERY);
+    }
+
+    @Test
+    public void issue2797WithExtractNode() {
+        db.executeTransactionally("CREATE (:Start)-[r:TO_MOVE {name: 1}]->(:End)");
+        issue2797Common(EXTRACT_QUERY);
+    }
+
+    @Test
+    public void issue2797WithCloneSubgraph() {
+        issue2797Common(CLONE_SUBGRAPH_QUERY);
+    }
+    
+    private void issue2797Common(String extractQuery) {
+        db.executeTransactionally(("CREATE CONSTRAINT unique_book ON (book:MyBook) ASSERT book.name IS UNIQUE"));
+
+        db.executeTransactionally(("CREATE (n:MyBook {name: 1})"));
+        
+        testCall(db, extractQuery, r -> {
+            final String actualError = (String) r.get("error");
+            assertTrue(actualError.contains("already exists with label `MyBook` and property `name` = 1"));
+            assertNull(r.get("output"));
+        });
+
+        testCall(db, "MATCH (n:MyBook) RETURN properties(n) AS props", 
+                r -> {
+                    final Map<String, Long> expected = Map.of("name", 1L);
+                    assertEquals(expected, r.get("props"));
+                });
+
+        db.executeTransactionally("DROP CONSTRAINT unique_book");
+        db.executeTransactionally("MATCH (n:MyBook) DELETE n");
     }
 
     private void assertSelfRel(Relationship next) {


### PR DESCRIPTION
Fixes #2797
Fixes #2780

Tested in the procedures with `tx.createNode()` and `tx.createNode(label)`, 
excluding those concerning the system db and virtual entities.
The error is not present in `apoc.create. *`,, `apoc.generate. *`
`apoc.nodes.link`,` apoc.refactor. * `. `apoc.generate.`
The error is instead present, as well as in the `apoc.refactor. *` also in `apoc.import.graphml / csv` (created separated issue for export procs).

Regarding the refactor procs the error is caused by the catch that silently fails the procedure:
```
        try {
            final Node node = tx.createNode(Util.labels(labelNames));
.....
            return Stream.of(new NodeResult(setProperties(node, props)));
        } catch (Exception e) {
            return result.withError(e);
        }
```

Note that regarding the issue `2797` case, even with this pr `cloneNodes` cannot work due to `ConstraintException`. 
However, currently But it gives "wrong error", that is `must have the property XX` instead of` ConstraintException`, so it make sense to include it on this pr.
