### PR TITLE
Removes jcenter from the repositories used for dependencies

### DIFF
--- a/extra-dependencies/build.gradle
+++ b/extra-dependencies/build.gradle
@@ -1,6 +1,5 @@
 allprojects {
     repositories {
-        jcenter()
         maven {
             url "https://repo.gradle.org/gradle/libs-releases"
         }


### PR DESCRIPTION
## What
JCenter shouldn't be used as a repository for dependencies anymore

## Why
Cause it was deprecated and shutdown, as described [here](https://blog.gradle.org/jcenter-shutdown). It's causing problems with our internal builds.
