### PR TITLE
Fixes #2659: Apoc.import.graphml doesn't work for edges

### DIFF
--- a/core/src/main/java/apoc/export/graphml/ExportGraphML.java
+++ b/core/src/main/java/apoc/export/graphml/ExportGraphML.java
@@ -69,6 +69,8 @@ public class ExportGraphML {
             XmlGraphMLReader graphMLReader = new XmlGraphMLReader(db, tx).reporter(reporter)
                     .batchSize(exportConfig.getBatchSize())
                     .relType(exportConfig.defaultRelationshipType())
+                    .source(exportConfig.getSource())
+                    .target(exportConfig.getTarget())
                     .nodeLabels(exportConfig.readLabels());
 
             if (exportConfig.storeNodeIds()) graphMLReader.storeNodeIds();

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLWriter.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLWriter.java
@@ -1,9 +1,12 @@
 package apoc.export.graphml;
 
 import apoc.export.util.*;
+import org.apache.commons.lang3.StringUtils;
 import org.neo4j.cypher.export.SubGraph;
 import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Relationship;
 
 import javax.xml.stream.XMLOutputFactory;
@@ -131,8 +134,8 @@ public class XmlGraphMLWriter {
     private int writeRelationship(XMLStreamWriter writer, Relationship rel, ExportConfig config) throws XMLStreamException {
         writer.writeStartElement("edge");
         writer.writeAttribute("id", id(rel));
-        writer.writeAttribute("source", id(rel.getStartNode()));
-        writer.writeAttribute("target", id(rel.getEndNode()));
+        getNodeAttribute(writer, XmlNodeExport.NodeType.SOURCE, config, rel);
+        getNodeAttribute(writer, XmlNodeExport.NodeType.TARGET, config, rel);
         if (config.getFormat() == ExportFormat.TINKERPOP) {
             writeData(writer, "labelE", rel.getType().name());
         } else {
@@ -145,6 +148,29 @@ public class XmlGraphMLWriter {
         int props = writeProps(writer, rel);
         endElement(writer);
         return props;
+    }
+
+    private void getNodeAttribute(XMLStreamWriter writer, XmlNodeExport.NodeType nodeType, ExportConfig config, Relationship rel) throws XMLStreamException {
+
+        final XmlNodeExport.ExportNode xmlNodeInterface = nodeType.get();
+        final Node node = xmlNodeInterface.getNode(rel);
+        final String name = nodeType.getName();
+        final ExportConfig.NodeConfig nodeConfig = xmlNodeInterface.getNodeConfig(config);
+        // without config the source/target configs, we leverage the internal node id
+        if (StringUtils.isBlank(nodeConfig.id)) {
+            writer.writeAttribute(name, id(node));
+            return;
+        }
+        // with source/target with an id configured 
+        // we put a source with the property value and a sourceType with the prop type of node
+        try {
+            final Object nodeProperty = node.getProperty(nodeConfig.id);
+            writer.writeAttribute(name, nodeProperty.toString());
+            writer.writeAttribute(nodeType.getNameType(), MetaInformation.typeFor(nodeProperty.getClass(), MetaInformation.GRAPHML_ALLOWED));
+        } catch (NotFoundException e) {
+            throw new RuntimeException(
+                    "The config source and/or target cannot be used because the node with id " + node.getId() + " doesn't have property " + nodeConfig.id);
+        }
     }
 
     private String id(Relationship rel) {

--- a/core/src/main/java/apoc/export/graphml/XmlNodeExport.java
+++ b/core/src/main/java/apoc/export/graphml/XmlNodeExport.java
@@ -1,0 +1,72 @@
+package apoc.export.graphml;
+
+import apoc.export.util.ExportConfig;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+
+import static apoc.export.util.ExportConfig.NodeConfig;
+
+public class XmlNodeExport {
+    
+    public interface ExportNode {
+        NodeConfig getNodeConfig(ExportConfig config);
+        NodeConfig getNodeConfigReader(XmlGraphMLReader reader);
+        Node getNode(Relationship rel);
+    }
+
+    enum NodeType {
+        SOURCE("source", new ExportNode() {
+            @Override
+            public ExportConfig.NodeConfig getNodeConfig(ExportConfig config) {
+                return config.getSource();
+            }
+
+            @Override
+            public Node getNode(Relationship rel) {
+                return rel.getStartNode();
+            }
+
+            @Override
+            public NodeConfig getNodeConfigReader(XmlGraphMLReader reader) {
+                return reader.getSource();
+            }
+        }),
+        
+        TARGET("target", new ExportNode() {
+            @Override
+            public ExportConfig.NodeConfig getNodeConfig(ExportConfig config) {
+                return config.getTarget();
+            }
+
+            @Override
+            public Node getNode(Relationship rel) {
+                return rel.getEndNode();
+            }
+
+            @Override
+            public NodeConfig getNodeConfigReader(XmlGraphMLReader reader) {
+                return reader.getTarget();
+            }
+        });
+
+        private final String name;
+        private final ExportNode exportNode;
+
+        NodeType(String name, ExportNode exportNode) {
+            this.name = name;
+            this.exportNode = exportNode;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getNameType() {
+            return name + "Type";
+        }
+
+        ExportNode get() {
+            return exportNode;
+        }
+    }
+}

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -14,6 +14,18 @@ import static java.util.Arrays.asList;
  * @since 19.01.14
  */
 public class ExportConfig extends CompressionConfig {
+
+    public static class NodeConfig {
+        public String label;
+        public String id;
+
+        public NodeConfig(Map<String, String> config) {
+            config = config == null ? Collections.emptyMap() : config;
+            this.label = config.get("label");
+            this.id = config.get("id");
+        }
+    }
+    
     public static final char QUOTECHAR = '"';
     public static final String NONE_QUOTES = "none";
     public static final String ALWAYS_QUOTES = "always";
@@ -26,6 +38,8 @@ public class ExportConfig extends CompressionConfig {
     public static final String DEFAULT_QUOTES = ALWAYS_QUOTES;
     private final boolean streamStatements;
     private final boolean ifNotExists;
+    private final NodeConfig source;
+    private final NodeConfig target;
 
     private int batchSize;
     private boolean silent;
@@ -109,6 +123,8 @@ public class ExportConfig extends CompressionConfig {
         this.samplingConfig = (Map<String, Object>) config.getOrDefault("samplingConfig", new HashMap<>());
         this.unwindBatchSize = ((Number)getOptimizations().getOrDefault("unwindBatchSize", DEFAULT_UNWIND_BATCH_SIZE)).intValue();
         this.awaitForIndexes = ((Number)config.getOrDefault("awaitForIndexes", 300)).longValue();
+        this.source = new NodeConfig((Map<String, String>) config.get("source"));
+        this.target = new NodeConfig((Map<String, String>) config.get("target"));
         validate();
     }
 
@@ -148,6 +164,14 @@ public class ExportConfig extends CompressionConfig {
 
     public String defaultRelationshipType() {
         return config.getOrDefault("defaultRelationshipType","RELATED").toString();
+    }
+
+    public NodeConfig getSource() {
+        return source;
+    }
+
+    public NodeConfig getTarget() {
+        return target;
     }
 
     public boolean readLabels() {

--- a/docs/asciidoc/modules/ROOT/pages/export/graphml.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/export/graphml.adoc
@@ -64,6 +64,10 @@ The procedures support the following config parameters:
 | defaultRelationshipType | "RELATED" | set relationship type (import/export graphml)
 | separateFiles | false | export results in separated file by type (nodes, relationships..)
 | stream | false | stream the xml directly to the client into the `data` field
+| useTypes | false | Write the attribute type information to the graphml output
+| source | Map<String,String> | Empty map | To be used together with `target` to import (via `apoc.import.graphml`) a relationships-only file. In this case the source and target attributes of `edge` tag are not based on an internal id of nodes but on a custom property value. + 
+For example, with a path like `(:Foo {name: "aaa"})-[:KNOWS]->(:Bar {age: 666})`, we can export the `KNOWS` rel with a config `<edge id="e2" source="aaa" sourceType="string" target="666" targetType="long" label="KNOWS"><data key="label">KNOWS</data><data key="id">1</data></edge>`. Note the additional `sourceType`/`targetType` to detect the right type during the import.
+| target | Map<String,String> | Empty map | Same as `source`, for end node.
 |===
 
 [[export-graphml-file-export]]
@@ -92,6 +96,9 @@ include::partial$createExportGraph.adoc[]
 The Neo4j Browser visualization below shows the imported graph:
 
 image::play-movies.png[title="Movies Graph Visualization"]
+
+[[roundtip-separated-files]]
+include::partial$roundtripSeparatedGraphml.adoc[]
 
 [[export-graphml-whole-database]]
 === Export whole database to GraphML

--- a/docs/asciidoc/modules/ROOT/partials/roundtripSeparatedGraphml.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/roundtripSeparatedGraphml.adoc
@@ -1,0 +1,138 @@
+== Round trip separated GraphML files
+
+With this dataset:
+
+[source,cypher]
+----
+CREATE (f:Foo:Foo2:Foo0 {name:'foo', born:Date('2018-10-10'), place:point({ longitude: 56.7, latitude: 12.78, height: 100 })})-[:KNOWS]->(b:Bar {name:'bar',age:42, place:point({ longitude: 56.7, latitude: 12.78})});
+CREATE (:Foo {name: 'zzz'})-[:KNOWS]->(:Bar {age: 0});
+CREATE (:Foo {name: 'aaa'})-[:KNOWS {id: 1}]->(:Bar {age: 666});
+----
+
+we can execute these 3 export queries:
+
+[source,cypher]
+----
+// Foo nodes
+call apoc.export.graphml.query('MATCH (start:Foo)-[:KNOWS]->(:Bar) RETURN start', 'queryNodesFoo.graphml', {useTypes: true});
+
+// Bar nodes
+call apoc.export.graphml.query('MATCH (:Foo)-[:KNOWS]->(end:Bar) RETURN end', 'queryNodesBar.graphml', {useTypes: true});
+
+// KNOWS rels
+MATCH (:Foo)-[rel:KNOWS]->(:Bar) 
+WITH collect(rel) as rels
+call apoc.export.graphml.data([], rels, 'queryRelationship.graphml', {useTypes: true})
+YIELD nodes, relationships RETURN nodes, relationships;
+----
+
+
+In this case we will have these 3 files:
+.queryNodesFoo.graphml
+[source,xml]
+----
+<?xml version='1.0' encoding='UTF-8'?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+<key id="born" for="node" attr.name="born" attr.type="string"/>
+<key id="name" for="node" attr.name="name" attr.type="string"/>
+<key id="place" for="node" attr.name="place" attr.type="string"/>
+<key id="labels" for="node" attr.name="labels" attr.type="string"/>
+<graph id="G" edgedefault="directed">
+<node id="n0" labels=":Foo:Foo0:Foo2"><data key="labels">:Foo:Foo0:Foo2</data><data key="born">2018-10-10</data><data key="name">foo</data><data key="place">{"crs":"wgs-84-3d","latitude":12.78,"longitude":56.7,"height":100.0}</data></node>
+<node id="n3" labels=":Foo"><data key="labels">:Foo</data><data key="name">zzz</data></node>
+<node id="n5" labels=":Foo"><data key="labels">:Foo</data><data key="name">aaa</data></node>
+</graph>
+</graphml>
+----
+
+.queryNodesBar.graphml
+[source,xml]
+----
+<?xml version='1.0' encoding='UTF-8'?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+<key id="name" for="node" attr.name="name" attr.type="string"/>
+<key id="place" for="node" attr.name="place" attr.type="string"/>
+<key id="age" for="node" attr.name="age" attr.type="long"/>
+<key id="labels" for="node" attr.name="labels" attr.type="string"/>
+<graph id="G" edgedefault="directed">
+<node id="n1" labels=":Bar"><data key="labels">:Bar</data><data key="name">bar</data><data key="age">42</data><data key="place">{"crs":"wgs-84","latitude":12.78,"longitude":56.7,"height":null}</data></node>
+<node id="n4" labels=":Bar"><data key="labels">:Bar</data><data key="age">0</data></node>
+<node id="n6" labels=":Bar"><data key="labels">:Bar</data><data key="age">666</data></node>
+</graph>
+</graphml>
+----
+
+.queryRelationship.graphml
+[source,xml]
+----
+<?xml version='1.0' encoding='UTF-8'?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+<key id="label" for="edge" attr.name="label" attr.type="string"/>
+<key id="id" for="edge" attr.name="id" attr.type="long"/>
+<graph id="G" edgedefault="directed">
+<edge id="e0" source="n0" target="n1" label="KNOWS"><data key="label">KNOWS</data></edge>
+<edge id="e1" source="n3" target="n4" label="KNOWS"><data key="label">KNOWS</data></edge>
+<edge id="e2" source="n5" target="n6" label="KNOWS"><data key="label">KNOWS</data><data key="id">1</data></edge>
+</graph>
+</graphml>
+----
+
+So we can import, in another db, in this way, to recreate the original dataset, using these queries:
+[source,cypher]
+----
+CALL apoc.import.graphml('queryNodesFoo.graphml', {readLabels: true, storeNodeIds: true});
+CALL apoc.import.graphml('queryNodesBar.graphml', {readLabels: true, storeNodeIds: true});
+CALL apoc.import.graphml('queryRelationship.graphml', {readLabels: true, source: {label: 'Foo'}, target: {label: 'Bar'}});
+----
+
+Note that we have to execute the import of nodes before, 
+and we used the `useTypes: true` to import the attribute `id` of `node` tags as a property and `readLabels` to populate nodes with labels.
+
+
+=== With custom property key 
+
+Otherwise, we can leverage a custom property and avoid importing the `id` attribute (via `useTypes:true`)
+in this way (same dataset and nodes export query as before):
+
+[source,cypher]
+----
+// KNOWS rels
+MATCH (:Foo)-[rel:KNOWS]->(:Bar) 
+WITH collect(rel) as rels
+call apoc.export.graphml.data([], rels, 'queryRelationship.graphml', 
+  {useTypes: true, source: {id: 'name'}, label: {id: 'age'}})
+YIELD nodes, relationships RETURN nodes, relationships;
+----
+
+[Note]
+====
+Is strongly recommended using an unique constraint to ensure uniqueness, 
+so in this case for label `Foo` and property `name` and for label `Bar` and property `age`
+====
+
+
+The above query generate this rel file:
+
+.queryRelationship.graphml
+[source,xml]
+----
+<?xml version='1.0' encoding='UTF-8'?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+<key id="label" for="edge" attr.name="label" attr.type="string"/>
+<key id="id" for="edge" attr.name="id" attr.type="long"/>
+<graph id="G" edgedefault="directed">
+<edge id="e0" source="foo" sourceType="string" target="42" targetType="long" label="KNOWS"><data key="label">KNOWS</data></edge>
+<edge id="e1" source="zzz" sourceType="string" target="0" targetType="long" label="KNOWS"><data key="label">KNOWS</data></edge>
+<edge id="e2" source="aaa" sourceType="string" target="666" targetType="long" label="KNOWS"><data key="label">KNOWS</data><data key="id">1</data></edge>
+</graph>
+</graphml>
+----
+
+Finally, we can import the files using the same id (name and age) as above:
+[source,cypher]
+----
+CALL apoc.import.graphml('queryNodesFoo.graphml', {readLabels: true});
+CALL apoc.import.graphml('queryNodesBar.graphml', {readLabels: true});
+CALL apoc.import.graphml('queryRelationship.graphml', 
+  {readLabels: true, source: {label: 'Foo', id: 'name'}, target: {label: 'Bar', id: 'age'}});
+----

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.import.graphml.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.import.graphml.adoc
@@ -229,3 +229,6 @@ RETURN source, format, nodes, relationships, properties
 | source    | format    | nodes | relationships | properties
 | "binary"  | "graphml" | 2     | 1             | 7
 |===
+
+[[roundtip-separated-files]]
+include::partial$roundtripSeparatedGraphml.adoc[]

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.graphml.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.import.graphml.adoc
@@ -9,5 +9,19 @@ The procedure support the following config parameters:
 | storeNodeIds | Boolean | false | store the `id` property of `node` elements
 | batchSize | Integer | 20000 | The number of elements to process per transaction
 | compression | `Enum[NONE, BYTES, GZIP, BZIP2, DEFLATE, BLOCK_LZ4, FRAMED_SNAPPY]` | `null` | Allow taking binary data, either not compressed (value: `NONE`) or compressed (other values)
+| source | Map<String,String> | Empty map | See below
+| target | Map<String,String> | Empty map | See below
 See the xref::overview/apoc.load/apoc.load.csv.adoc#_binary_file[Binary file example]
 |===
+
+=== source / target config
+
+Allows the import of relations in case the source and / or target nodes are not present in the file, searching for nodes via a custom label and property.
+To do this, we can insert into the config map `source: {label: '<MY_SOURCE_LABEL>', id: `'<MY_SOURCE_ID>'`}` and/or `source: {label: '<MY_TARGET_LABEL>', id: `'<MY_TARGET_ID>'`}`
+In this way, we can search start and end nodes via the source and end attribute of `edge` tag.
+
+For example, with a config map `{source: {id: 'myId', label: 'Foo'}, target: {id: 'other', label: 'Bar'}}`
+with a edge row like `<edge id="e0" source="n0" target="n1" label="KNOWS"><data key="label">KNOWS</data></edge>`
+we search a source node `(:Foo {myId: 'n0'})` and an end node `(:Bar {other: 'n1'})`.
+The id key is optional (the default is `'id'`).
+


### PR DESCRIPTION
Fixes #2659

Added 2 configs `source` and `target` with keys `label` and (optional) `id` to import rel-only files, e.g.:

```
call apoc.import.graphml("rels.graphml", {startLabel: 'Person', endLabel: 'Movie'})
```

Added same config for export graphml procs (currently with only `id` key) to export a custom property instead of current "n<internalId>" as a source / target attribute value
