### PR TITLE
Export cypher overwrite in case of merge with multi-relationships - 3.5

### DIFF
--- a/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -5,6 +5,7 @@ import apoc.export.util.Reporter;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
 
 import java.io.PrintWriter;
 import java.util.Map;
@@ -23,12 +24,17 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
-	public String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties) {
-		return new CreateCypherFormatter().statementForRelationship(relationship, uniqueConstraints, indexedProperties);
+	public String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, ExportConfig exportConfig) {
+		return new CreateCypherFormatter().statementForRelationship(relationship, uniqueConstraints, indexedProperties, exportConfig);
 	}
 
 	@Override
 	public String statementForCleanUp(int batchSize) {
+		return "";
+	}
+
+	@Override
+	public String statementForCleanUpRel(RelationshipType type, int batchSize) {
 		return "";
 	}
 
@@ -48,7 +54,7 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
-	public void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
-		buildStatementForRelationships("CREATE ", " SET ", relationship, uniqueConstraints, exportConfig, out, reporter, db);
+	public void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db, Map<RelationshipType, Long> relsCount) {
+		buildStatementForRelationships("CREATE ", " SET ", relationship, uniqueConstraints, exportConfig, out, reporter, db, relsCount);
 	}
 }

--- a/src/main/java/apoc/export/cypher/formatter/CreateCypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/CreateCypherFormatter.java
@@ -5,6 +5,7 @@ import apoc.export.util.Reporter;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
 
 import java.io.PrintWriter;
 import java.util.Map;
@@ -36,7 +37,7 @@ public class CreateCypherFormatter extends AbstractCypherFormatter implements Cy
     }
 
     @Override
-    public String statementForRelationship(Relationship relationship,  Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties) {
+    public String statementForRelationship(Relationship relationship,  Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, ExportConfig exportConfig) {
         StringBuilder result = new StringBuilder(100);
         result.append("MATCH ");
         result.append(CypherFormatterUtils.formatNodeLookup("n1", relationship.getStartNode(), uniqueConstraints, indexedProperties));
@@ -58,8 +59,8 @@ public class CreateCypherFormatter extends AbstractCypherFormatter implements Cy
     }
 
     @Override
-    public void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
-        buildStatementForRelationships("CREATE ", "SET ", relationship, uniqueConstraints, exportConfig, out, reporter, db);
+    public void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db, Map<RelationshipType, Long> relsCount) {
+        buildStatementForRelationships("CREATE ", "SET ", relationship, uniqueConstraints, exportConfig, out, reporter, db, relsCount);
     }
 
 }

--- a/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -17,7 +17,7 @@ public interface CypherFormatter {
 
 	String statementForNode(Node node, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, Set<String> indexNames);
 
-	String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties);
+	String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, ExportConfig exportConfig);
 
 	String statementForIndex(String label, Iterable<String> keys);
 
@@ -28,9 +28,11 @@ public interface CypherFormatter {
 	String statementForConstraint(String label, Iterable<String> keys);
 
 	String statementForCleanUp(int batchSize);
+	
+	String statementForCleanUpRel(RelationshipType type, int batchSize);
 
 	void statementForNodes(Iterable<Node> node, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db);
 
-	void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db);
+	void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db, Map<RelationshipType, Long> relsCount);
 
 }

--- a/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
+++ b/src/main/java/apoc/export/cypher/formatter/CypherFormatterUtils.java
@@ -26,6 +26,8 @@ public class CypherFormatterUtils {
     public final static String UNIQUE_ID_LABEL = "UNIQUE IMPORT LABEL";
     public final static String UNIQUE_ID_PROP = "UNIQUE IMPORT ID";
     public final static String Q_UNIQUE_ID_LABEL = quote(UNIQUE_ID_LABEL);
+    public final static String UNIQUE_ID_REL = "UNIQUE IMPORT ID REL";
+    public final static String Q_UNIQUE_ID_REL = quote(UNIQUE_ID_REL);
 
     public final static String FUNCTION_TEMPLATE = "%s('%s')";
 

--- a/src/main/java/apoc/export/cypher/formatter/UpdateAllCypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/UpdateAllCypherFormatter.java
@@ -5,6 +5,7 @@ import apoc.export.util.Reporter;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
 
 import java.io.PrintWriter;
 import java.util.Map;
@@ -23,8 +24,8 @@ public class UpdateAllCypherFormatter extends AbstractCypherFormatter implements
 	}
 
 	@Override
-	public String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties) {
-        return super.mergeStatementForRelationship(CypherFormat.UPDATE_ALL, relationship, uniqueConstraints, indexedProperties);
+	public String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, ExportConfig exportConfig) {
+        return super.mergeStatementForRelationship(CypherFormat.UPDATE_ALL, relationship, uniqueConstraints, indexedProperties, exportConfig);
 	}
 
 	@Override
@@ -33,7 +34,7 @@ public class UpdateAllCypherFormatter extends AbstractCypherFormatter implements
 	}
 
 	@Override
-	public void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
-		buildStatementForRelationships("MERGE ", "SET ", relationship, uniqueConstraints, exportConfig, out, reporter, db);
+	public void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db, Map<RelationshipType, Long> relsCount) {
+		buildStatementForRelationships("MERGE ", "SET ", relationship, uniqueConstraints, exportConfig, out, reporter, db, relsCount);
 	}
 }

--- a/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -5,6 +5,7 @@ import apoc.export.util.Reporter;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
 
 import java.io.PrintWriter;
 import java.util.Map;
@@ -23,12 +24,17 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	}
 
 	@Override
-	public String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties) {
-        return super.mergeStatementForRelationship(CypherFormat.UPDATE_STRUCTURE, relationship, uniqueConstraints, indexedProperties);
+	public String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, ExportConfig exportConfig) {
+        return super.mergeStatementForRelationship(CypherFormat.UPDATE_STRUCTURE, relationship, uniqueConstraints, indexedProperties, exportConfig);
 	}
 
 	@Override
 	public String statementForCleanUp(int batchSize) {
+		return "";
+	}
+
+	@Override
+	public String statementForCleanUpRel(RelationshipType type, int batchSize) {
 		return "";
 	}
 
@@ -47,7 +53,7 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	}
 
 	@Override
-	public void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db) {
-		buildStatementForRelationships("MERGE ", "SET ", relationship, uniqueConstraints, exportConfig, out, reporter, db);
+	public void statementForRelationships(Iterable<Relationship> relationship, Map<String, Set<String>> uniqueConstraints, ExportConfig exportConfig, PrintWriter out, Reporter reporter, GraphDatabaseService db, Map<RelationshipType, Long> relsCount) {
+		buildStatementForRelationships("MERGE ", "SET ", relationship, uniqueConstraints, exportConfig, out, reporter, db, relsCount);
 	}
 }

--- a/src/main/java/apoc/export/util/ExportConfig.java
+++ b/src/main/java/apoc/export/util/ExportConfig.java
@@ -27,6 +27,8 @@ public class ExportConfig {
 
     private int batchSize;
     private boolean silent;
+    private boolean uniqueIdRels; 
+    private boolean cleanupUniqueRels;
     private boolean bulkImport = false;
     private String delim;
     private String quotes;
@@ -80,6 +82,14 @@ public class ExportConfig {
 
     public CypherFormat getCypherFormat() { return cypherFormat; }
 
+    public boolean isUniqueIdRels() {
+        return uniqueIdRels;
+    }
+
+    public boolean isCleanupUniqueIdRels() {
+        return cleanupUniqueRels;
+    }
+
     public ExportConfig(Map<String,Object> config) {
         config = config != null ? config : Collections.emptyMap();
         this.silent = toBoolean(config.getOrDefault("silent",false));
@@ -101,6 +111,8 @@ public class ExportConfig {
         this.batchSize = ((Number)config.getOrDefault("batchSize", DEFAULT_BATCH_SIZE)).intValue();
         this.unwindBatchSize = ((Number)getOptimizations().getOrDefault("unwindBatchSize", DEFAULT_UNWIND_BATCH_SIZE)).intValue();
         this.awaitForIndexes = ((Number)config.getOrDefault("awaitForIndexes", 300)).longValue();
+        this.uniqueIdRels = toBoolean(config.get("uniqueIdRels"));
+        this.cleanupUniqueRels = toBoolean(config.getOrDefault("cleanupUniqueRels", uniqueIdRels));
         validate();
     }
 

--- a/src/test/java/apoc/export/cypher/ExportCypherTestUtils.java
+++ b/src/test/java/apoc/export/cypher/ExportCypherTestUtils.java
@@ -1,0 +1,195 @@
+package apoc.export.cypher;
+
+public class ExportCypherTestUtils {
+    protected final static String NODES_MULTI_RELS = ":begin\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}) SET n.name=\"MyName\", n:Person;\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) SET n.a=1, n:Project;\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) SET n.name=\"one\", n:Team;\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}) SET n.name=\"two\", n:Team;\n" +
+            ":commit\n";
+
+    protected final static String NODES_MULTI_RELS_ADD_STRUCTURE = ":begin\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}) ON CREATE SET n.name=\"MyName\", n:Person;\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) ON CREATE SET n.a=1, n:Project;\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) ON CREATE SET n.name=\"one\", n:Team;\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}) ON CREATE SET n.name=\"two\", n:Team;\n" +
+            ":commit\n";
+
+    protected final static String NODES_UNWIND = ":begin\n" +
+            "UNWIND [{_id:1, properties:{a:1}}] AS row\n" +
+            "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Project;\n" +
+            "UNWIND [{_id:2, properties:{name:\"one\"}}, {_id:3, properties:{name:\"two\"}}] AS row\n" +
+            "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Team;\n" +
+            "UNWIND [{_id:0, properties:{name:\"MyName\"}}] AS row\n" +
+            "CREATE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Person;\n" +
+            ":commit\n";
+
+    protected final static String NODES_UNWIND_ADD_STRUCTURE = ":begin\n" +
+            "UNWIND [{_id:1, properties:{a:1}}] AS row\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) ON CREATE SET n += row.properties SET n:Project;\n" +
+            "UNWIND [{_id:2, properties:{name:\"one\"}}, {_id:3, properties:{name:\"two\"}}] AS row\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) ON CREATE SET n += row.properties SET n:Team;\n" +
+            "UNWIND [{_id:0, properties:{name:\"MyName\"}}] AS row\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) ON CREATE SET n += row.properties SET n:Person;\n" +
+            ":commit\n";
+
+    protected final static String NODES_UNWIND_UPDATE_STRUCTURE = ":begin\n" +
+            "UNWIND [{_id:1, properties:{a:1}}] AS row\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Project;\n" +
+            "UNWIND [{_id:2, properties:{name:\"one\"}}, {_id:3, properties:{name:\"two\"}}] AS row\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Team;\n" +
+            "UNWIND [{_id:0, properties:{name:\"MyName\"}}] AS row\n" +
+            "MERGE (n:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row._id}) SET n += row.properties SET n:Person;\n" +
+            ":commit\n";
+
+    protected final static String NODES_MULTI_REL_CREATE = ":begin\n" +
+            "CREATE (:Person:`UNIQUE IMPORT LABEL` {name:\"MyName\", `UNIQUE IMPORT ID`:0});\n" +
+            "CREATE (:Project:`UNIQUE IMPORT LABEL` {a:1, `UNIQUE IMPORT ID`:1});\n" +
+            "CREATE (:Team:`UNIQUE IMPORT LABEL` {name:\"one\", `UNIQUE IMPORT ID`:2});\n" +
+            "CREATE (:Team:`UNIQUE IMPORT LABEL` {name:\"two\", `UNIQUE IMPORT ID`:3});\n" +
+            ":commit\n";
+
+    protected final static String SCHEMA_MULTI_REL = ":begin\n" +
+            "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;\n" +
+            ":commit\n";
+
+    protected final static String SCHEMA_UPDATE_STRUCTURE_MULTI_REL = ":begin\n" +
+            ":commit\n";
+
+    protected final static String RELS_MULTI_RELS = ":begin\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:0}]->(n2) SET r.id=1;\n" +
+            "\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:1}]->(n2) SET r.id=2;\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:2}]->(n2) SET r.id=2;\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:3}]->(n2) SET r.id=3;\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:4}]->(n2) SET r.id=4;\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:5}]->(n2) SET r.id=5;\n" +
+            "\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) MERGE (n1)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:6}]->(n2) SET r.name=\"aaa\";\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}) MERGE (n1)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:7}]->(n2) SET r.name=\"eee\";\n" +
+            ":commit\n";
+
+    protected final static String RELS_UNWIND_MULTI_RELS = ":begin\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:5}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:5}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:1}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:0}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:3}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:3}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:3}, properties:{name:\"eee\"}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "CREATE (start)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:7}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:4}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:4}]->(end) SET r += row.properties;\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:2}, properties:{name:\"aaa\"}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "CREATE (start)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:6}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:2}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:1}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:2}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "CREATE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:2}]->(end) SET r += row.properties;\n" +
+            ":commit\n" +
+            "\n";
+
+    protected final static String RELS_UNWIND_UPDATE_ALL_MULTI_RELS = ":begin\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:5}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:5}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:1}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:0}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:3}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:3}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:3}, properties:{name:\"eee\"}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "MERGE (start)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:7}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:4}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:4}]->(end) SET r += row.properties;\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:2}, properties:{name:\"aaa\"}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "MERGE (start)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:6}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:2}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:1}]->(end) SET r += row.properties;\n" +
+            "UNWIND [{start: {_id:0}, end: {_id:1}, properties:{id:2}}] AS row\n" +
+            "MATCH (start:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.start._id})\n" +
+            "MATCH (end:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`: row.end._id})\n" +
+            "MERGE (start)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:2}]->(end) SET r += row.properties;\n" +
+            ":commit\n\n";
+
+    protected final static String RELS_ADD_STRUCTURE_MULTI_RELS = ":begin\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) CREATE (n1)-[r:WORKS_FOR {id:1}]->(n2);\n" +
+            "\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) CREATE (n1)-[r:WORKS_FOR {id:2}]->(n2);\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) CREATE (n1)-[r:WORKS_FOR {id:2}]->(n2);\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) CREATE (n1)-[r:WORKS_FOR {id:3}]->(n2);\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) CREATE (n1)-[r:WORKS_FOR {id:4}]->(n2);\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) CREATE (n1)-[r:WORKS_FOR {id:5}]->(n2);\n" +
+            "\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) CREATE (n1)-[r:IS_TEAM_MEMBER_OF {name:\"aaa\"}]->(n2);\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}) CREATE (n1)-[r:IS_TEAM_MEMBER_OF {name:\"eee\"}]->(n2);\n" +
+            ":commit\n";
+
+    protected final static String RELSUPDATE_STRUCTURE_2 = ":begin\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:0}]->(n2) ON CREATE SET r.id=1;\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:1}]->(n2) ON CREATE SET r.id=2;\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:2}]->(n2) ON CREATE SET r.id=2;\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:3}]->(n2) ON CREATE SET r.id=3;\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:4}]->(n2) ON CREATE SET r.id=4;\n" +
+            "\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:1}) MERGE (n1)-[r:WORKS_FOR{`UNIQUE IMPORT ID REL`:5}]->(n2) ON CREATE SET r.id=5;\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:2}) MERGE (n1)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:6}]->(n2) ON CREATE SET r.name=\"aaa\";\n" +
+            "MATCH (n1:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:0}), (n2:`UNIQUE IMPORT LABEL`{`UNIQUE IMPORT ID`:3}) MERGE (n1)-[r:IS_TEAM_MEMBER_OF{`UNIQUE IMPORT ID REL`:7}]->(n2) ON CREATE SET r.name=\"eee\";\n" +
+            ":commit\n";
+
+    protected final static String CLEANUP = ":begin\n" +
+            "MATCH (n:`UNIQUE IMPORT LABEL`) WITH n LIMIT 5 REMOVE n:`UNIQUE IMPORT LABEL` REMOVE n.`UNIQUE IMPORT ID`;\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "DROP CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) ASSERT (node.`UNIQUE IMPORT ID`) IS UNIQUE;\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "MATCH ()-[rel:IS_TEAM_MEMBER_OF]->() WHERE rel.`UNIQUE IMPORT ID REL` IS NOT NULL WITH rel LIMIT 5 REMOVE rel.`UNIQUE IMPORT ID REL`;\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "MATCH ()-[rel:WORKS_FOR]->() WHERE rel.`UNIQUE IMPORT ID REL` IS NOT NULL WITH rel LIMIT 5 REMOVE rel.`UNIQUE IMPORT ID REL`;\n" +
+            ":commit\n" +
+            ":begin\n" +
+            "MATCH ()-[rel:WORKS_FOR]->() WHERE rel.`UNIQUE IMPORT ID REL` IS NOT NULL WITH rel LIMIT 5 REMOVE rel.`UNIQUE IMPORT ID REL`;\n" +
+            ":commit\n";
+
+    protected final static String CLEANUP_EMPTY = ":begin\n:commit\n:begin\n:commit\n";
+}


### PR DESCRIPTION
Export cypher overwrite in case of merge with multi-relationships

Until 4.2

For 4.3+ leverage rel-indexes --> see https://github.com/vga91/neo4j-apoc-procedures/pull/264/files