### PR TITLE
Forced geckodriver version

### DIFF
--- a/full/src/main/java/apoc/load/LoadHtmlBrowser.java
+++ b/full/src/main/java/apoc/load/LoadHtmlBrowser.java
@@ -26,7 +26,9 @@ public class LoadHtmlBrowser {
     }
     
     public static InputStream getFirefoxInputStream(String url, Map<String, String> query, LoadHtmlConfig config, boolean isHeadless, boolean isAcceptInsecureCerts) {
-        WebDriverManager.firefoxdriver().setup();
+        WebDriverManager.firefoxdriver()
+                .driverVersion("0.30.0")
+                .setup();
         FirefoxOptions firefoxOptions = new FirefoxOptions();
         firefoxOptions.setHeadless(isHeadless);
         firefoxOptions.setAcceptInsecureCerts(isAcceptInsecureCerts);


### PR DESCRIPTION
Forced geckodriver version for selenium,
otherwise a `No proper candidate URL to download geckodriver 0.31.0` will throws.


There seems to be some problem possibly related to this https://github.com/mozilla/geckodriver/issues/2009.

Indeed, on the release page https://github.com/mozilla/geckodriver/releases there is 0.30.0 as latest (instead of 0.31.0), this  appears to be suspicious.