### PR TITLE
Fix flaky TransactionProcedureTest

### DIFF
--- a/full/src/test/java/apoc/monitor/TransactionProcedureTest.java
+++ b/full/src/test/java/apoc/monitor/TransactionProcedureTest.java
@@ -1,5 +1,6 @@
 package apoc.monitor;
 
+import apoc.cypher.CypherInitializer;
 import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
@@ -8,8 +9,13 @@ import org.junit.Test;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
+import java.util.concurrent.atomic.AtomicLong;
+
+import static apoc.util.CypherInitializerUtil.getInitializer;
 import static apoc.util.TestUtil.testCall;
+import static org.hamcrest.Matchers.isOneOf;
 import static org.junit.Assert.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class TransactionProcedureTest {
 
@@ -19,27 +25,47 @@ public class TransactionProcedureTest {
     @Before
     public void setup() {
         TestUtil.registerProcedure(db, Transaction.class);
+        // we need to wait until every CypherInitializer transaction is finished to make sure tests are not flaky
+        waitForInitializerBeingFinished(db);
     }
 
     @Test
     public void testGetStoreInfo() {
+        AtomicLong peakTx = new AtomicLong();
+        AtomicLong lastTxId = new AtomicLong();
+        AtomicLong totalOpenedTx = new AtomicLong();
+        AtomicLong totalTx = new AtomicLong();
         testCall(db, "CALL apoc.monitor.tx()", (row) -> {
             assertEquals(0l, row.get("rolledBackTx"));
-            assertEquals(1l, row.get("peakTx"));
-            assertEquals(3l, row.get("lastTxId"));
+            peakTx.set((long) row.get("peakTx"));
+            assertThat(peakTx.get(), isOneOf(1l, 2l));
+            assertEquals(3l, lastTxId.addAndGet((long) row.get("lastTxId")));
             assertEquals(1l, row.get("currentOpenedTx"));
-            assertEquals(4l, row.get("totalOpenedTx"));
-            assertEquals(3l, row.get("totalTx"));
+            assertEquals(5l, totalOpenedTx.addAndGet((long) row.get("totalOpenedTx")));
+            assertEquals(4l, totalTx.addAndGet((long )row.get("totalTx")));
         });
 
         db.executeTransactionally("create ()");
         testCall(db, "CALL apoc.monitor.tx()", (row) -> {
             assertEquals(0l, row.get("rolledBackTx"));
-            assertEquals(1l, row.get("peakTx"));
-            assertEquals(4l, row.get("lastTxId"));
+            assertEquals(peakTx.get(), row.get("peakTx"));
+            assertEquals(lastTxId.incrementAndGet(), row.get("lastTxId"));
             assertEquals(1l, row.get("currentOpenedTx"));
-            assertEquals(6l, row.get("totalOpenedTx"));
-            assertEquals(5l, row.get("totalTx"));
+            assertEquals(totalOpenedTx.addAndGet(2L), row.get("totalOpenedTx"));
+            assertEquals(totalTx.addAndGet(2L), row.get("totalTx"));
         });
+    }
+
+    // equivalent to CypherInitializerTest.waitForInitializerBeingFinished
+    private static void waitForInitializerBeingFinished(DbmsRule dbmsRule) {
+        CypherInitializer initializer = getInitializer(dbmsRule.databaseName(), dbmsRule, CypherInitializer.class);
+        while (!initializer.isFinished()) {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
     }
 }

--- a/test-utils/src/main/java/apoc/util/CypherInitializerUtil.java
+++ b/test-utils/src/main/java/apoc/util/CypherInitializerUtil.java
@@ -1,0 +1,33 @@
+package apoc.util;
+
+import org.neo4j.internal.helpers.Listeners;
+import org.neo4j.kernel.availability.AvailabilityGuard;
+import org.neo4j.kernel.availability.AvailabilityListener;
+import org.neo4j.kernel.availability.DatabaseAvailabilityGuard;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.test.ReflectionUtil;
+import org.neo4j.test.rule.DbmsRule;
+
+public class CypherInitializerUtil {
+
+    /**
+     * get a reference to CypherInitializer for diagnosis. This needs to use reflection.
+     * @return
+     */
+    public static <T> T getInitializer(String dbName, DbmsRule dbmsRule, Class<T> clazz) {
+        GraphDatabaseAPI api = ((GraphDatabaseAPI) (dbmsRule.getManagementService().database(dbName)));
+        DatabaseAvailabilityGuard availabilityGuard = (DatabaseAvailabilityGuard) api.getDependencyResolver().resolveDependency(AvailabilityGuard.class);;
+        try {
+            Listeners<AvailabilityListener> listeners = ReflectionUtil.getPrivateField(availabilityGuard, "listeners", Listeners.class);
+            for (AvailabilityListener listener: listeners) {
+                if (listener.getClass().isAssignableFrom(clazz)) {
+                    return (T) listener;
+                }
+            }
+            throw new IllegalStateException("found no cypher initializer");
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+}


### PR DESCRIPTION
Fix flaky `TransactionProcedureTest.testGetStoreInfo` test after https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/2700.
The `db.executeTransactionally` executed in the pr changed the `apoc.monitor.tx` procedure results.

- Moved `CypherInitializerTest.getInitializer()` to `test-utils`.
- Handled `peakTx`, `lastTxId`, `totalOpenedTx`, `totalTx` differenced before and after `db.executeTransactionally("create ()");` via atomicLong to manage any future changes easier 