### PR TITLE
Bumps json path to 2.7.0

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 
     apt group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
     compile group: 'commons-codec', name: 'commons-codec', version: '1.14'
-    compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
+    compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.7.0'
     compile group: 'net.minidev', name: 'json-smart', version: '2.4.8'
     compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
 


### PR DESCRIPTION
## Why

To avoid confusions that `json-path` 2.4 could be importing `json-smart` 2.3, that included [this](https://nvd.nist.gov/vuln/detail/CVE-2021-27568) security vulnerability and that's why we overrode `json-smart` to 2.4.2 more than one year ago: https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/1860

The dependency tree shows 2.3 is evicted by 2.4.8:

```
./gradlew -q full:dependencies // or ./gradlew -q core:dependencies

+--- com.jayway.jsonpath:json-path:2.4.0
|    +--- net.minidev:json-smart:2.3 -> 2.4.8
|    |    \--- net.minidev:accessors-smart:2.4.8
|    |         \--- org.ow2.asm:asm:9.1 -> 9.2
|    \--- org.slf4j:slf4j-api:1.7.25 -> 1.7.30
```
