### PR TITLE
Fixes #2878: apoc 4.4.0.4 is reported as incompatible with neo4j-community-4.4.6 in neo4j.log

### DIFF
--- a/core/src/test/java/apoc/cypher/CypherIsVersionDifferentTest.java
+++ b/core/src/test/java/apoc/cypher/CypherIsVersionDifferentTest.java
@@ -12,27 +12,28 @@ public class CypherIsVersionDifferentTest {
 
     @Test
     public void shouldReturnFalseOnlyWithCompatibleVersion() {
-        assertTrue(isVersionDifferent(List.of("3.5"), "4.4.0.2", "."));
-        assertTrue(isVersionDifferent(List.of("5_0"), "4.4.0.2", "."));
-        assertFalse(isVersionDifferent(List.of("3.5.12"), "3.5.0.9", "."));
-        assertFalse(isVersionDifferent(List.of("3.5.12"), "3.5.1.9", "."));
-        assertFalse(isVersionDifferent(List.of("4.4.5"), "4.4.0.4", "."));
+        assertTrue(isVersionDifferent(List.of("3.5"), "4.4.0.2"));
+        assertTrue(isVersionDifferent(List.of("5_0"), "4.4.0.2"));
+        assertFalse(isVersionDifferent(List.of("3.5.12"), "3.5.0.9"));
+        assertFalse(isVersionDifferent(List.of("3.5.12"), "3.5.1.9"));
+        assertFalse(isVersionDifferent(List.of("4.4.5"), "4.4.0.4"));
 
         // we expect that APOC versioning is always consistent to Neo4j versioning
-        assertTrue(isVersionDifferent(List.of(""), "5_2_0_1", "_"));
-        assertTrue(isVersionDifferent(List.of("5_1_0"), "5_0_0_1", "_"));
-        assertTrue(isVersionDifferent(List.of("5_1_0"), "5-1,0,1", "_"));
-        assertTrue(isVersionDifferent(List.of("5_1_0"), "5_2_0_1", "_"));
-        assertTrue(isVersionDifferent(List.of("5_22_1"), "5_2_0_1", "_"));
-        assertTrue(isVersionDifferent(List.of("5_2_1"), "5_22_0_1", "_"));
-        assertTrue(isVersionDifferent(List.of("55_2_1"), "5_2_1", "_"));
-        assertTrue(isVersionDifferent(List.of("55_2_1"), "5_2_1_0_1", "_"));
-        assertTrue(isVersionDifferent(List.of("5-1,9,9"), "5-1,0,1", "_"));
+        assertTrue(isVersionDifferent(List.of(""), "5_2_0_1"));
+        assertTrue(isVersionDifferent(List.of("5_1_0"), "5_0_0_1"));
+        assertTrue(isVersionDifferent(List.of("5_1_0"), "5_2_0_1"));
+        assertTrue(isVersionDifferent(List.of("5_22_1"), "5_2_0_1"));
+        assertTrue(isVersionDifferent(List.of("5_2_1"), "5_22_0_1"));
+        assertTrue(isVersionDifferent(List.of("55_2_1"), "5_2_1"));
+        assertTrue(isVersionDifferent(List.of("55_2_1"), "5_2_1_0_1"));
+        assertTrue(isVersionDifferent(List.of("51-1-9-9"), "5-1-1-9"));
+
+        assertFalse(isVersionDifferent(List.of("4_4_5"), "4.4.0.4"));
+        assertFalse(isVersionDifferent(List.of("5_1_0"), "5-1-0-1"));
+        assertFalse(isVersionDifferent(List.of("5_22_1"), "5_22_0_1"));
+        assertFalse(isVersionDifferent(List.of("5_0"), "5_0_0_1"));
+        assertFalse(isVersionDifferent(List.of("5_0_1"), "5_0_0_1"));
         
-        assertFalse(isVersionDifferent(List.of("5_22_1"), "5_22_0_1", "_"));
-        assertFalse(isVersionDifferent(List.of("5_0"), "5_0_0_1", "_"));
-        assertFalse(isVersionDifferent(List.of("5_0_1"), "5_0_0_1", "_"));
-        
-        assertFalse(isVersionDifferent(List.of("5-1-9-9"), "5-1-0-1", "-"));
+        assertFalse(isVersionDifferent(List.of("5-1-9-9"), "5-1-0-1"));
     }
 }

--- a/core/src/test/java/apoc/cypher/CypherIsVersionDifferentTest.java
+++ b/core/src/test/java/apoc/cypher/CypherIsVersionDifferentTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import java.util.List;
 
+import static apoc.cypher.CypherInitializer.isVersionDifferent;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -11,10 +12,27 @@ public class CypherIsVersionDifferentTest {
 
     @Test
     public void shouldReturnFalseOnlyWithCompatibleVersion() {
-        assertTrue(CypherInitializer.isVersionDifferent(List.of("3.5"), "4.4.0.2"));
-        assertTrue(CypherInitializer.isVersionDifferent(List.of("5_0"), "4.4.0.2"));
+        assertTrue(isVersionDifferent(List.of("3.5"), "4.4.0.2", "."));
+        assertTrue(isVersionDifferent(List.of("5_0"), "4.4.0.2", "."));
+        assertFalse(isVersionDifferent(List.of("3.5.12"), "3.5.0.9", "."));
+        assertFalse(isVersionDifferent(List.of("3.5.12"), "3.5.1.9", "."));
+        assertFalse(isVersionDifferent(List.of("4.4.5"), "4.4.0.4", "."));
 
         // we expect that APOC versioning is always consistent to Neo4j versioning
-        assertFalse(CypherInitializer.isVersionDifferent(List.of("5_0"), "5_0_0_1"));
+        assertTrue(isVersionDifferent(List.of(""), "5_2_0_1", "_"));
+        assertTrue(isVersionDifferent(List.of("5_1_0"), "5_0_0_1", "_"));
+        assertTrue(isVersionDifferent(List.of("5_1_0"), "5-1,0,1", "_"));
+        assertTrue(isVersionDifferent(List.of("5_1_0"), "5_2_0_1", "_"));
+        assertTrue(isVersionDifferent(List.of("5_22_1"), "5_2_0_1", "_"));
+        assertTrue(isVersionDifferent(List.of("5_2_1"), "5_22_0_1", "_"));
+        assertTrue(isVersionDifferent(List.of("55_2_1"), "5_2_1", "_"));
+        assertTrue(isVersionDifferent(List.of("55_2_1"), "5_2_1_0_1", "_"));
+        assertTrue(isVersionDifferent(List.of("5-1,9,9"), "5-1,0,1", "_"));
+        
+        assertFalse(isVersionDifferent(List.of("5_22_1"), "5_22_0_1", "_"));
+        assertFalse(isVersionDifferent(List.of("5_0"), "5_0_0_1", "_"));
+        assertFalse(isVersionDifferent(List.of("5_0_1"), "5_0_0_1", "_"));
+        
+        assertFalse(isVersionDifferent(List.of("5-1-9-9"), "5-1-0-1", "-"));
     }
 }


### PR DESCRIPTION
Fixes #2878