### PR TITLE
Fixes #2824: Extend the error message for export procedures to also point out stream:true

### DIFF
--- a/core/src/main/java/apoc/ApocConfig.java
+++ b/core/src/main/java/apoc/ApocConfig.java
@@ -93,7 +93,9 @@ public class ApocConfig extends LifecycleAdapter {
     ));
     private static final String DEFAULT_PATH = ".";
     private static final String CONFIG_DIR = "config-dir=";
-    public static final String EXPORT_TO_FILE_ERROR = "Export to files not enabled, please set apoc.export.file.enabled=true in your apoc.conf";
+    public static final String EXPORT_TO_FILE_ERROR = "Export to files not enabled, please set apoc.export.file.enabled=true in your apoc.conf.\n" +
+            "Otherwise, if you are running in a cloud environment without filesystem access, use the `{stream:true}` config and null as a 'file' parameter to stream the export back to your client.\n" +
+            "Note that the stream mode cannot be used with the apoc.export.xls.* procedures.";
 
     private final Config neo4jConfig;
     private final Log log;

--- a/core/src/test/java/apoc/export/ExportStreamsStatementsTest.java
+++ b/core/src/test/java/apoc/export/ExportStreamsStatementsTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
+import static apoc.ApocConfig.EXPORT_TO_FILE_ERROR;
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.configuration.SettingImpl.newBuilder;
 import static org.neo4j.configuration.SettingValueParsers.BOOL;
@@ -52,8 +53,7 @@ public class ExportStreamsStatementsTest {
             TestUtil.testCall(db, statement, (res) -> {});
         } catch (RuntimeException e) {
             String expectedMessage = "Failed to invoke procedure `apoc.export.csv.all`: " +
-                    "Caused by: java.lang.RuntimeException: Export to files not enabled, " +
-                    "please set apoc.export.file.enabled=true in your apoc.conf";
+                    "Caused by: java.lang.RuntimeException: " + EXPORT_TO_FILE_ERROR;
             assertEquals(expectedMessage, e.getMessage());
             throw e;
         }
@@ -94,8 +94,7 @@ public class ExportStreamsStatementsTest {
             TestUtil.testCall(db, statement, (res) -> {});
         } catch (RuntimeException e) {
             String expectedMessage = "Failed to invoke procedure `apoc.export.cypher.all`: " +
-                    "Caused by: java.lang.RuntimeException: Export to files not enabled, " +
-                    "please set apoc.export.file.enabled=true in your apoc.conf";
+                    "Caused by: java.lang.RuntimeException: " + EXPORT_TO_FILE_ERROR;
             assertEquals(expectedMessage, e.getMessage());
             throw e;
         }

--- a/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
+++ b/core/src/test/java/apoc/export/graphml/ExportGraphMLTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 
 import static apoc.ApocConfig.APOC_EXPORT_FILE_ENABLED;
 import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
+import static apoc.ApocConfig.EXPORT_TO_FILE_ERROR;
 import static apoc.ApocConfig.apocConfig;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.isRunningInCI;
@@ -452,7 +453,7 @@ public class ExportGraphMLTest {
         } catch (QueryExecutionException e) {
             Throwable except = ExceptionUtils.getRootCause(e);
             TestCase.assertTrue(except instanceof RuntimeException);
-            assertEquals("Export to files not enabled, please set apoc.export.file.enabled=true in your apoc.conf", except.getMessage());
+            assertEquals(EXPORT_TO_FILE_ERROR, except.getMessage());
             throw e;
         }
     }

--- a/docs/asciidoc/modules/ROOT/partials/enableFileExport.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/enableFileExport.adoc
@@ -10,7 +10,9 @@ apoc.export.file.enabled=true
 If we try to use any of the export procedures without having first set this property, we'll get the following error message:
 
 |===
-| Failed to invoke procedure: Caused by: java.lang.RuntimeException: Export to files not enabled, please set apoc.export.file.enabled=true in your neo4j.conf
+| Failed to invoke procedure: Caused by: java.lang.RuntimeException: Export to files not enabled, please set apoc.export.file.enabled=true in your apoc.conf.
+Otherwise, if you are running in a cloud environment without filesystem access, use the `{stream:true}` config and null as a 'file' parameter to stream the export back to your client.
+Note that the stream mode cannot be used with the apoc.export.xls.* procedures.
 |===
 
 Export files are written to the `import` directory, which is defined by the `dbms.directories.import` property.

--- a/docs/asciidoc/modules/ROOT/partials/enableS3Export.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/enableS3Export.adoc
@@ -10,7 +10,9 @@ apoc.export.file.enabled=true
 If we try to use any of the export procedures without having first set this property, we'll get the following error message:
 
 |===
-| Failed to invoke procedure: Caused by: java.lang.RuntimeException: Export to files not enabled, please set apoc.export.file.enabled=true in your neo4j.conf
+| Failed to invoke procedure: Caused by: java.lang.RuntimeException: Export to files not enabled, please set apoc.export.file.enabled=true in your apoc.conf. 
+Otherwise, if you are running in a cloud environment without filesystem access, you can use the `{stream:true}` config and null as a 'file' parameter to stream the export back to your client.
+Note that the stream mode cannot be used with the apoc.export.xls.* procedures.
 |===
 
 == Using S3 protocol


### PR DESCRIPTION
Fixes #2824

Changed `apoc.export.file.enabled=true in your neo4j.conf` with `apoc.export.file.enabled=true in your apoc.conf` in `.adoc`

Added note about export.xls: `Note that the stream mode cannot be used with the apoc.export.xls.* procedures.`