### PR TITLE
Fixes #2223: Add config option for schema exports to retain the index and/or constraint names (#2652)

### DIFF
--- a/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -84,10 +84,10 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists, String idxName) {
+	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists, String name) {
 		String keysString = getPropertiesQuoted(keys, "node.");
 
-		return String.format(STATEMENT_CONSTRAINTS, idxName, getIfNotExists(ifNotExists), Util.quote(label), keysString, Iterables.count(keys) > 1 ? "IS NODE KEY" : "IS UNIQUE");
+		return String.format(STATEMENT_CONSTRAINTS, name, getIfNotExists(ifNotExists), Util.quote(label), keysString, Iterables.count(keys) > 1 ? "IS NODE KEY" : "IS UNIQUE");
 	}
 
 	private String getIfNotExists(boolean ifNotExists) {

--- a/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -31,7 +31,7 @@ import static apoc.export.cypher.formatter.CypherFormatterUtils.quote;
  */
 abstract class AbstractCypherFormatter implements CypherFormatter {
 
-	private static final String STATEMENT_CONSTRAINTS = "CREATE CONSTRAINT%s ON (node:%s) ASSERT (%s) %s;";
+	private static final String STATEMENT_CONSTRAINTS = "CREATE CONSTRAINT%s%s ON (node:%s) ASSERT (%s) %s;";
 
 	private static final String STATEMENT_NODE_FULLTEXT_IDX = "CREATE FULLTEXT INDEX %s FOR (n:%s) ON EACH [%s];";
 	private static final String STATEMENT_REL_FULLTEXT_IDX = "CREATE FULLTEXT INDEX %s FOR ()-[rel:%s]-() ON EACH [%s];";
@@ -44,16 +44,18 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 	}
 
 	@Override
-	public String statementForNodeIndex(String label, Iterable<String> keys, boolean ifNotExists) {
-		return String.format("CREATE INDEX%s FOR (node:%s) ON (%s);", 
+	public String statementForNodeIndex(String label, Iterable<String> keys, boolean ifNotExists, String idxName) {
+		return String.format("CREATE INDEX%s%s FOR (node:%s) ON (%s);",
+				idxName,
 				getIfNotExists(ifNotExists),
 				Util.quote(label),
 				getPropertiesQuoted(keys, "node."));
 	}
 	
 	@Override
-	public String statementForIndexRelationship(String type, Iterable<String> keys, boolean ifNotExists) {
-		return String.format("CREATE INDEX%s FOR ()-[rel:%s]-() ON (%s);", 
+	public String statementForIndexRelationship(String type, Iterable<String> keys, boolean ifNotExists, String idxName) {
+		return String.format("CREATE INDEX%s%s FOR ()-[rel:%s]-() ON (%s);",
+				idxName,
 				getIfNotExists(ifNotExists), 
 				Util.quote(type), 
 				getPropertiesQuoted(keys, "rel."));
@@ -82,10 +84,10 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists) {
+	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists, String name) {
 		String keysString = getPropertiesQuoted(keys, "node.");
 
-		return String.format(STATEMENT_CONSTRAINTS, getIfNotExists(ifNotExists), Util.quote(label), keysString, Iterables.count(keys) > 1 ? "IS NODE KEY" : "IS UNIQUE");
+		return String.format(STATEMENT_CONSTRAINTS, name, getIfNotExists(ifNotExists), Util.quote(label), keysString, Iterables.count(keys) > 1 ? "IS NODE KEY" : "IS UNIQUE");
 	}
 
 	private String getIfNotExists(boolean ifNotExists) {

--- a/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -84,10 +84,10 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists, String name) {
+	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists, String idxName) {
 		String keysString = getPropertiesQuoted(keys, "node.");
 
-		return String.format(STATEMENT_CONSTRAINTS, name, getIfNotExists(ifNotExists), Util.quote(label), keysString, Iterables.count(keys) > 1 ? "IS NODE KEY" : "IS UNIQUE");
+		return String.format(STATEMENT_CONSTRAINTS, idxName, getIfNotExists(ifNotExists), Util.quote(label), keysString, Iterables.count(keys) > 1 ? "IS NODE KEY" : "IS UNIQUE");
 	}
 
 	private String getIfNotExists(boolean ifNotExists) {

--- a/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -43,7 +43,7 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists, String name) {
+	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists, String idxName) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -43,7 +43,7 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists, String idxName) {
+	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists, String name) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -33,17 +33,17 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
-	public String statementForNodeIndex(String label, Iterable<String> key, boolean ifNotExist) {
+	public String statementForNodeIndex(String label, Iterable<String> key, boolean ifNotExist, String idxName) {
 		return "";
 	}
 	
 	@Override
-	public String statementForIndexRelationship(String type, Iterable<String> key, boolean ifNotExists) {
+	public String statementForIndexRelationship(String type, Iterable<String> key, boolean ifNotExists, String idxName) {
 		return "";
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists) {
+	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists, String name) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -19,15 +19,15 @@ public interface CypherFormatter {
 
 	String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties);
 
-	String statementForNodeIndex(String label, Iterable<String> keys, boolean ifNotExist);
+	String statementForNodeIndex(String label, Iterable<String> keys, boolean ifNotExist, String idxName);
 
-	String statementForIndexRelationship(String type, Iterable<String> keys, boolean ifNotExist);
+	String statementForIndexRelationship(String type, Iterable<String> keys, boolean ifNotExist, String idxName);
 
 	String statementForNodeFullTextIndex(String name, Iterable<Label> labels, Iterable<String> keys);
 
 	String statementForRelationshipFullTextIndex(String name, Iterable<RelationshipType> types, Iterable<String> keys);
 
-	String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExist);
+	String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExist, String name);
 
 	String statementForCleanUp(int batchSize);
 

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -27,7 +27,7 @@ public interface CypherFormatter {
 
 	String statementForRelationshipFullTextIndex(String name, Iterable<RelationshipType> types, Iterable<String> keys);
 
-	String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExist, String name);
+	String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExist, String idxName);
 
 	String statementForCleanUp(int batchSize);
 

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -27,7 +27,7 @@ public interface CypherFormatter {
 
 	String statementForRelationshipFullTextIndex(String name, Iterable<RelationshipType> types, Iterable<String> keys);
 
-	String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExist, String idxName);
+	String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExist, String name);
 
 	String statementForCleanUp(int batchSize);
 

--- a/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -43,7 +43,7 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> key, boolean ifNotExists, String idxName) {
+	public String statementForConstraint(String label, Iterable<String> key, boolean ifNotExists, String name) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -33,17 +33,17 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	}
 
 	@Override
-	public String statementForNodeIndex(String label, Iterable<String> key, boolean ifNotExist) {
+	public String statementForNodeIndex(String label, Iterable<String> key, boolean ifNotExist, String idxName) {
 		return "";
 	}
 
 	@Override
-	public String statementForIndexRelationship(String type, Iterable<String> key, boolean ifNotExists) {
+	public String statementForIndexRelationship(String type, Iterable<String> key, boolean ifNotExists, String idxName) {
 		return "";
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> key, boolean ifNotExists) {
+	public String statementForConstraint(String label, Iterable<String> key, boolean ifNotExists, String name) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -43,7 +43,7 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> key, boolean ifNotExists, String name) {
+	public String statementForConstraint(String label, Iterable<String> key, boolean ifNotExists, String idxName) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -29,6 +29,8 @@ public class ExportConfig extends CompressionConfig {
 
     private int batchSize;
     private boolean silent;
+    private boolean saveIndexNames;
+    private boolean saveConstraintNames;
     private boolean bulkImport = false;
     private boolean sampling;
     private String delim;
@@ -88,6 +90,8 @@ public class ExportConfig extends CompressionConfig {
         super(config);
         config = config != null ? config : Collections.emptyMap();
         this.silent = toBoolean(config.getOrDefault("silent",false));
+        this.saveIndexNames = toBoolean(config.getOrDefault("saveIndexNames",false));
+        this.saveConstraintNames = toBoolean(config.getOrDefault("saveConstraintNames",false));
         this.delim = delim(config.getOrDefault("delim", DEFAULT_DELIM).toString());
         this.arrayDelim = delim(config.getOrDefault("arrayDelim", DEFAULT_ARRAY_DELIM).toString());
         this.useTypes = toBoolean(config.get("useTypes"));
@@ -213,5 +217,13 @@ public class ExportConfig extends CompressionConfig {
     
     public boolean ifNotExists() {
         return ifNotExists;
+    }
+
+    public boolean shouldSaveIndexNames() {
+        return saveIndexNames;
+    }
+
+    public boolean shouldSaveConstraintNames() {
+        return saveConstraintNames;
     }
 }

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -2,6 +2,7 @@ package apoc.export.cypher;
 
 import apoc.graph.Graphs;
 import apoc.util.TestUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -25,7 +26,6 @@ import static apoc.export.cypher.ExportCypherTest.ExportCypherResults.*;
 import static apoc.export.util.ExportFormat.*;
 import static apoc.util.Util.map;
 import static org.junit.Assert.*;
-import static org.testcontainers.shaded.org.apache.commons.lang.StringUtils.EMPTY;
 import static org.neo4j.configuration.SettingImpl.newBuilder;
 import static org.neo4j.configuration.SettingValueParsers.BOOL;
 
@@ -192,7 +192,7 @@ public class ExportCypherTest {
         TestUtil.testCall(db, "CALL apoc.export.cypher.all($file,$config)", 
                 map("file", fileName, "config", config),
                 (r) -> assertResults(fileName, r, "database"));
-        final String expectedFile = String.format(EXPECTED_SCHEMA_WITH_NAMES, " barIndex", " fooIndex", EMPTY);
+        final String expectedFile = String.format(EXPECTED_SCHEMA_WITH_NAMES, " barIndex", " fooIndex", StringUtils.EMPTY);
         assertEquals(expectedFile, readFile("all.schema.cypher"));
     }
 
@@ -204,7 +204,7 @@ public class ExportCypherTest {
         TestUtil.testCall(db, "CALL apoc.export.cypher.all($file,$config)", 
                 map("file", fileName, "config", config),
                 (r) -> assertResults(fileName, r, "database"));
-        final String expectedFile = String.format(EXPECTED_SCHEMA_WITH_NAMES, EMPTY, EMPTY, " consBar");
+        final String expectedFile = String.format(EXPECTED_SCHEMA_WITH_NAMES, StringUtils.EMPTY, StringUtils.EMPTY, " consBar");
         assertEquals(expectedFile, readFile("all.schema.cypher"));
     }
 

--- a/docs/asciidoc/modules/ROOT/pages/export/cypher.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/export/cypher.adoc
@@ -63,6 +63,8 @@ The procedures support the following config parameters:
 * `UNWIND_BATCH` - exports the file by batching the entities with the `UNWIND` method as explained in Michael Hunger's article on https://medium.com/neo4j/5-tips-tricks-for-fast-batched-updates-of-graph-structures-with-neo4j-and-cypher-73c7f693c8cc[fast batched writes^].
 * `UNWIND_BATCH_PARAMS` - similar to `UNWIND_BATCH`, but also uses parameters where appropriate
 | awaitForIndexes | Long | 300 | Timeout to use for `db.awaitIndexes` when using `format: "cypher-shell"`
+| saveIndexNames | boolean | false | Save name indexes on export
+| saveConstraintNames | boolean | false | Save name constraints on export
 |===
 
 [[export-cypher-file-export]]


### PR DESCRIPTION
Fixes #2223

Same as https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/2652 for 4.3.

Since starting from 4.3 there are indexes on relations, I added the possibility to save the names of the indexes on them as well.

In this case `saveIndexName` saves both nodes and rels indexes.

Maybe it's worth inserting a `saveRelIndexName` (and / or renaming `saveIndexName` to `saveNodeIndexName`), 
to differentiate between saving node indexes and relations?
