### PR TITLE
Var docs fixes: path.expand, ttl, import.csv and group.nodes (for 4.2)

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/graph-querying/config-params.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/graph-querying/config-params.adoc
@@ -19,8 +19,8 @@ See xref::graph-querying/expand-subgraph.adoc#expand-subgraph-label-filters[].
 If set to `true`, a `null` value is yielded whenever the expansion would normally eliminate rows due to no results.
 | endNodes | List<Node> | null | only these nodes can end returned paths, and expansion will continue past these nodes, if possible.
 | terminatorNodes | List<Node> | null | Only these nodes can end returned paths, and expansion won't continue past these nodes.
-| whiteListNodes | List<Node> | null | Only these nodes are allowed in the expansion (though endNodes and terminatorNodes will also be allowed, if present).
-| blackListNodes | List<Node> | null | None of the paths returned will include these nodes.
+| whitelistNodes | List<Node> | null | Only these nodes are allowed in the expansion (though endNodes and terminatorNodes will also be allowed, if present).
+| blacklistNodes | List<Node> | null | None of the paths returned will include these nodes.
 |===
 
 It also has the following fixed parameter:

--- a/docs/asciidoc/modules/ROOT/pages/graph-querying/expand-spanning-tree.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/graph-querying/expand-spanning-tree.adoc
@@ -44,8 +44,8 @@ See <<expand-spanning-tree-label-filters>>.
 If set to `true`, a `null` value is yielded whenever the expansion would normally eliminate rows due to no results.
 | endNodes | List<Node> | null | only these nodes can end returned paths, and expansion will continue past these nodes, if possible.
 | terminatorNodes | List<Node> | null | Only these nodes can end returned paths, and expansion won't continue past these nodes.
-| whiteListNodes | List<Node> | null | Only these nodes are allowed in the expansion (though endNodes and terminatorNodes will also be allowed, if present).
-| blackListNodes | List<Node> | null | None of the paths returned will include these nodes.
+| whitelistNodes | List<Node> | null | Only these nodes are allowed in the expansion (though endNodes and terminatorNodes will also be allowed, if present).
+| blacklistNodes | List<Node> | null | None of the paths returned will include these nodes.
 |===
 
 It also has the following fixed parameter:

--- a/docs/asciidoc/modules/ROOT/pages/graph-querying/expand-subgraph-nodes.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/graph-querying/expand-subgraph-nodes.adoc
@@ -43,8 +43,8 @@ See <<expand-subgraph-nodes-label-filters>>.
 If set to `true`, a `null` value is yielded whenever the expansion would normally eliminate rows due to no results.
 | endNodes | List<Node> | null | only these nodes can end returned paths, and expansion will continue past these nodes, if possible.
 | terminatorNodes | List<Node> | null | Only these nodes can end returned paths, and expansion won't continue past these nodes.
-| whiteListNodes | List<Node> | null | Only these nodes are allowed in the expansion (though endNodes and terminatorNodes will also be allowed, if present).
-| blackListNodes | List<Node> | null | None of the paths returned will include these nodes.
+| whitelistNodes | List<Node> | null | Only these nodes are allowed in the expansion (though endNodes and terminatorNodes will also be allowed, if present).
+| blacklistNodes | List<Node> | null | None of the paths returned will include these nodes.
 |===
 
 It also has the following fixed parameter:

--- a/docs/asciidoc/modules/ROOT/pages/import/import-csv.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/import-csv.adoc
@@ -30,18 +30,10 @@ The `<relationships>` parameter is also a list, where each element is a map defi
 | type | relationship type | 'WORKS_AT'
 |===
 
-The `<config>` parameter is a map
+The `<config>` parameter is a map containing optional configurations.
 
-[opts=header,cols="m,a,m,m"]
-|===
-| name | description | default | https://neo4j.com/docs/operations-manual/current/tools/neo4j-admin-import/[import tool counterpart]
-| delimiter | delimiter character between columns | , | --delimiter=,
-| arrayDelimiter | delimiter character in arrays | ; | --array-delimiter=;
-| ignoreDuplicateNodes | for duplicate nodes, only load the first one and skip the rest (true) or fail the import (false) | false | --ignore-duplicate-nodes=false
-| quotationCharacter | quotation character | " | --quote='"'
-| stringIds | treat ids as strings | true | --id-type=STRING
-| skipLines | lines to skip (incl. header) | 1 | N/A
-|===
+include::partial$usage/config/apoc.import.csv.adoc[]
+
 
 == Examples for apoc.import.csv
 

--- a/docs/asciidoc/modules/ROOT/pages/overview/apoc.nodes/apoc.nodes.group.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/overview/apoc.nodes/apoc.nodes.group.adoc
@@ -20,7 +20,7 @@ apoc.nodes.group(labels :: LIST? OF STRING?, groupByProperties :: LIST? OF STRIN
 | Name | Type | Default 
 |labels|LIST? OF STRING?|null
 |groupByProperties|LIST? OF STRING?|null
-|aggregations|LIST? OF MAP?|[{*=count}, {*=count}]
+|aggregations|LIST? OF MAP?|`[{&#96;&#42;&#96;:"count"},{&#96;&#42;&#96;:"count"}]`
 |config|MAP?|{}
 |===
 
@@ -38,5 +38,5 @@ apoc.nodes.group(labels :: LIST? OF STRING?, groupByProperties :: LIST? OF STRIN
 == Usage Examples
 include::partial$usage/apoc.nodes.group.adoc[]
 
-xref::graph-querying/node-querying.adoc[More documentation of apoc.nodes.group,role=more information]
+xref::virtual/graph-grouping.adoc[More documentation of apoc.nodes.group,role=more information]
 

--- a/docs/asciidoc/modules/ROOT/pages/virtual/graph-grouping.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/virtual/graph-grouping.adoc
@@ -71,7 +71,7 @@ Possible operators:
 * `avg`
 * `collect`
 
-The default is: `+[{*:count},{*:count}]+` which just counts nodes and relationships.
+The default is: `[{&#96;&#42;&#96;:"count"},{&#96;&#42;&#96;:"count"}]` which just counts nodes and relationships.
 
 == Configuration
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.nodes.group.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.nodes.group.adoc
@@ -33,9 +33,9 @@ RETURN apoc.rel.startNode(rel) AS start, rel, apoc.rel.endNode(rel) AS end;
 [opts="header"]
 |===
 | start                                                   | rel                         | end
-| (:Person {gender: "female", min_age: 28, `count_*`: 2}) | [:MEMBER_OF {`count_*`: 3}] | (:Forum {gender: NULL, `count_*`: 2})
-| (:Person {gender: "female", min_age: 28, `count_*`: 2}) | [:KNOWS {`count_*`: 2}]     | (:Person {gender: "male", min_age: 42, `count_*`: 1})
-| (:Person {gender: "female", min_age: 28, `count_*`: 2}) | [:KNOWS {`count_*`: 2}]     | (:Person {gender: "male", min_age: 42, `count_*`: 1})
-| (:Person {gender: "male", min_age: 42, `count_*`: 1})   | [:MEMBER_OF {`count_*`: 1}] | (:Forum {gender: NULL, `count_*`: 2})
+| (:Person {gender: "female", min_age: 28, &#96;count_*&#96;: 2}) | [:MEMBER_OF {&#96;count_*&#96;: 3}] | (:Forum {gender: NULL, &#96;count_*&#96;: 2})
+| (:Person {gender: "female", min_age: 28, &#96;count_*&#96;: 2}) | [:KNOWS {&#96;count_*&#96;: 2}]     | (:Person {gender: "male", min_age: 42, &#96;count_*&#96;: 1})
+| (:Person {gender: "female", min_age: 28, &#96;count_*&#96;: 2}) | [:KNOWS {&#96;count_*&#96;: 2}]     | (:Person {gender: "male", min_age: 42, &#96;count_*&#96;: 1})
+| (:Person {gender: "male", min_age: 42, &#96;count_*&#96;: 1})   | [:MEMBER_OF {&#96;count_*&#96;: 1}] | (:Forum {gender: NULL, &#96;count_*&#96;: 2})
 
 |===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.nodes.link.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.nodes.link.adoc
@@ -5,3 +5,4 @@ This procedure supports the following config parameters:
 |===
 | name | type | default | description
 | avoidDuplicates | boolean | false | If true, the relationship will not be created, if it already exists
+|===

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.path.spanningTree.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.path.spanningTree.adoc
@@ -19,8 +19,8 @@ See <<expand-spanning-tree-label-filters>>.
 If set to `true`, a `null` value is yielded whenever the expansion would normally eliminate rows due to no results.
 | endNodes | List<Node> | null | only these nodes can end returned paths, and expansion will continue past these nodes, if possible.
 | terminatorNodes | List<Node> | null | Only these nodes can end returned paths, and expansion won't continue past these nodes.
-| whiteListNodes | List<Node> | null | Only these nodes are allowed in the expansion (though endNodes and terminatorNodes will also be allowed, if present).
-| blackListNodes | List<Node> | null | None of the paths returned will include these nodes.
+| whitelistNodes | List<Node> | null | Only these nodes are allowed in the expansion (though endNodes and terminatorNodes will also be allowed, if present).
+| blacklistNodes | List<Node> | null | None of the paths returned will include these nodes.
 |===
 
 It also has the following fixed parameter:

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.path.subgraphNodes.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.path.subgraphNodes.adoc
@@ -19,8 +19,8 @@ See <<expand-subgraph-nodes-label-filters>>.
 If set to `true`, a `null` value is yielded whenever the expansion would normally eliminate rows due to no results.
 | endNodes | List<Node> | null | only these nodes can end returned paths, and expansion will continue past these nodes, if possible.
 | terminatorNodes | List<Node> | null | Only these nodes can end returned paths, and expansion won't continue past these nodes.
-| whiteListNodes | List<Node> | null | Only these nodes are allowed in the expansion (though endNodes and terminatorNodes will also be allowed, if present).
-| blackListNodes | List<Node> | null | None of the paths returned will include these nodes.
+| whitelistNodes | List<Node> | null | Only these nodes are allowed in the expansion (though endNodes and terminatorNodes will also be allowed, if present).
+| blacklistNodes | List<Node> | null | None of the paths returned will include these nodes.
 |===
 
 It also has the following fixed parameter:


### PR DESCRIPTION
Cherry pick `d12ef6d12e5bd48bb56f3de96a255887dd91a4b2`