### PR TITLE
Deleting nodes when having an apoc.trigger registered returns Neo.DatabaseError.Transaction.TransactionCommitFailed (#2596)

### DIFF
--- a/core/src/main/java/apoc/result/VirtualRelationship.java
+++ b/core/src/main/java/apoc/result/VirtualRelationship.java
@@ -28,6 +28,11 @@ public class VirtualRelationship implements Relationship {
     private final long id;
     private final Map<String, Object> props = new HashMap<>();
 
+    public VirtualRelationship(Node startNode, Node endNode, RelationshipType type, Map<String, Object> props) {
+        this(startNode, endNode, type);
+        this.props.putAll(props);
+    }
+
     public VirtualRelationship(Node startNode, Node endNode, RelationshipType type) {
         validateNodes(startNode, endNode);
         this.id = MIN_ID.getAndDecrement();

--- a/docs/asciidoc/modules/ROOT/pages/background-operations/triggers.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/background-operations/triggers.adoc
@@ -61,6 +61,8 @@ You can use these helper functions to extract nodes or relationships by label/re
 |===
 | apoc.trigger.nodesByLabel($assignedLabels/$assignedNodeProperties,'Label') | function to filter entries by label, to be used within a trigger statement with `$assignedLabels` and `$removedLabels`
 | apoc.trigger.propertiesByKey($assignedNodeProperties,'key') | function to filter propertyEntries by property-key, to be used within a trigger statement with $assignedNode/RelationshipProperties and $removedNode/RelationshipProperties. Returns [{old,[new],key,node,relationship}]
+| apoc.trigger.toNode(node, $removedLabels, $removedNodeProperties) | function to rebuild a node as a virtual, to be used in triggers with a not 'afterAsync' phase
+| apoc.trigger.toRelationship(rel, $removedRelationshipProperties) | function to rebuild a relationship as a virtual, to be used in triggers with a not 'afterAsync' phase
 |===
 
 [WARNING]
@@ -327,6 +329,47 @@ We can pass as a 4th parameter, a `{params: {parameterMaps}}` to insert addition
 CALL apoc.trigger.add('timeParams','UNWIND $createdNodes AS n SET n.time = $time', {}, {params: {time: timestamp()}});
 ----
 
+.Handle deleted entities
+
+If we to create a 'before' or 'after' trigger query, with `$deletedRelationships` or `$deletedNodes`,
+and then we want to retrieve entities information like labels and/or properties,
+we cannot use the 'classic' cypher functions `labels()` and `properties()`,
+but we can leverage on xref::virtual/virtual-nodes-rels.adoc[virtual nodes and relationships],
+via the functions `apoc.trigger.toNode(node, $removedLabels, $removedNodeProperties)` and `apoc.trigger.toRelationship(rel, $removedRelationshipProperties)`.
+
+So that, we can retrieve information about nodes and relations, 
+using the `apoc.any.properties`, and the `apoc.node.labels` functions.
+
+For example, if we want to create a new node with the same properties (plus the id) and with an additional label retrieved for each deleted node, we can execute:
+
+[source,cypher]
+----
+CALL apoc.trigger.add('myTrigger', 
+"UNWIND $deletedNodes as deletedNode 
+WITH apoc.trigger.toNode(deletedNode, $removedLabels, $removedNodeProperties) AS deletedNode 
+CREATE (r:Report {id: id(deletedNode)}) WITH r, deletedNode 
+CALL apoc.create.addLabels(r, apoc.node.labels(deletedNode)) yield node with node, deletedNode 
+set node+=apoc.any.properties(deletedNode)" ,
+{phase:'before'})
+----
+
+Or also, if we want to  create a node `Report` with the same properties (plus the id and rel-type as additional properties) for each deleted relationship, we can execute:
+
+[source,cypher]
+----
+CALL apoc.trigger.add('myTrigger', 
+"UNWIND $deletedRelationships as deletedRel 
+WITH apoc.trigger.toRelationship(deletedRel, $removedRelationshipProperties) AS deletedRel 
+CREATE (r:Report {id: id(deletedRel), type: apoc.rel.type(deletedRel)}) 
+WITH r, deletedRelset r+=apoc.any.properties(deletedRel)" ,
+{phase:'before'})
+----
+
+[NOTE]
+====
+By using phase 'afterAsync', we don't need to execute `apoc.trigger.toNode` and `apoc.trigger.toRelationship`,
+because using this one, the rebuild of entities is executed automatically under the hood.
+====
 
 .Other examples
 [source,cypher]

--- a/full/src/main/java/apoc/trigger/TriggerExtended.java
+++ b/full/src/main/java/apoc/trigger/TriggerExtended.java
@@ -3,12 +3,16 @@ package apoc.trigger;
 import apoc.Description;
 import apoc.Extended;
 import apoc.coll.SetBackedList;
+import apoc.result.VirtualNode;
+import apoc.result.VirtualRelationship;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
 import org.neo4j.procedure.*;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -101,5 +105,42 @@ TriggerExtended {
             }
         }
         return new TriggerInfo(name, null, null, false, false);
+    }
+    
+    @UserFunction
+    @Description("apoc.trigger.toNode(node, $removedLabels, $removedNodeProperties) | function to rebuild a node as a virtual, to be used in triggers with a not 'afterAsync' phase")
+    public Node toNode(@Name("id") Node node, @Name("removedLabels") Map<String, List<Node>> removedLabels, @Name("removedNodeProperties") Map<String, List<Map>> removedNodeProperties) {
+
+        final long id = node.getId();
+        final Label[] labels = removedLabels.entrySet().stream()
+                .filter(i -> i.getValue().stream().anyMatch(l -> l.getId() == id))
+                .map(e -> Label.label(e.getKey()))
+                .toArray(Label[]::new);
+
+        final Map<String, Object> props = removedNodeProperties.entrySet().stream()
+                .map(i -> i.getValue().stream()
+                        .filter(l -> ((Node) l.get("node")).getId() == id)
+                        .findAny()
+                        .map(v -> new AbstractMap.SimpleEntry<>(i.getKey(), v.get("old"))))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
+
+        return new VirtualNode(labels, props);
+    }
+    
+    @UserFunction
+    @Description("apoc.trigger.toRelationship(rel, $removedRelationshipProperties) | function to rebuild a relationship as a virtual, to be used in triggers with a not 'afterAsync' phase")
+    public Relationship toRelationship(@Name("id") Relationship rel, @Name("removedRelationshipProperties") Map<String, List<Map>> removedRelationshipProperties) {
+        final Map<String, Object> props = removedRelationshipProperties.entrySet().stream()
+                .map(i -> i.getValue().stream()
+                        .filter(l -> ((Relationship) l.get("relationship")).getId() == rel.getId())
+                        .findAny()
+                        .map(v -> new AbstractMap.SimpleEntry<>(i.getKey(), v.get("old"))))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
+        
+        return new VirtualRelationship(rel.getStartNode(), rel.getEndNode(), rel.getType(), props);
     }
 }

--- a/full/src/main/resources/extended.txt
+++ b/full/src/main/resources/extended.txt
@@ -163,4 +163,6 @@ apoc.static.get
 apoc.static.getAll
 apoc.trigger.nodesByLabel
 apoc.trigger.propertiesByKey
+apoc.trigger.toNode
+apoc.trigger.toRelationship
 apoc.ttl.config

--- a/full/src/test/java/apoc/trigger/TriggerExtendedTest.java
+++ b/full/src/test/java/apoc/trigger/TriggerExtendedTest.java
@@ -1,21 +1,27 @@
 package apoc.trigger;
 
+import apoc.create.Create;
+import apoc.nodes.Nodes;
 import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.AfterAll;
-
+import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static apoc.ApocSettings.apoc_trigger_enabled;
 import static org.junit.Assert.assertEquals;
+import static org.neo4j.configuration.GraphDatabaseSettings.procedure_unrestricted;
 
 /**
  * @author mh
@@ -24,6 +30,7 @@ import static org.junit.Assert.assertEquals;
 public class TriggerExtendedTest {
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(procedure_unrestricted, List.of("apoc*"))
             .withSetting(apoc_trigger_enabled, true);  // need to use settings here, apocConfig().setProperty in `setUp` is too late
 
     private long start;
@@ -31,7 +38,7 @@ public class TriggerExtendedTest {
     @Before
     public void setUp() throws Exception {
         start = System.currentTimeMillis();
-        TestUtil.registerProcedure(db, Trigger.class, TriggerExtended.class);
+        TestUtil.registerProcedure(db, Trigger.class, TriggerExtended.class, Nodes.class, Create.class);
     }
 
     @AfterAll
@@ -87,4 +94,72 @@ public class TriggerExtendedTest {
                 (value) -> value == 2L, 30, TimeUnit.SECONDS);
     }
 
+    @Test
+    public void testIssue1152() {
+        db.executeTransactionally("CREATE (n:To:Delete {prop1: 'val1', prop2: 'val2'}) RETURN id(n) as id");
+        
+        testIssue1152Common("before");
+        testIssue1152Common("after");
+    }
+
+    private void testIssue1152Common(String phase) {
+        // we check also that we can execute write operation (through virtualNode functions, e.g. apoc.create.addLabels)
+        final String query = "UNWIND $deletedNodes as deletedNode " +
+                "WITH apoc.trigger.toNode(deletedNode, $removedLabels, $removedNodeProperties) AS deletedNode " +
+                "CREATE (r:Report {id: id(deletedNode)}) WITH r, deletedNode " +
+                "CALL apoc.create.addLabels(r, apoc.node.labels(deletedNode)) yield node with node, deletedNode " +
+                "set node+=apoc.any.properties(deletedNode)";
+        
+        db.executeTransactionally("call apoc.trigger.add('issue1152', $query , {phase: $phase})",
+                Map.of("query", query, "phase", phase));
+
+        db.executeTransactionally("MATCH (f:To:Delete) DELETE f");
+
+        TestUtil.testCall(db, "MATCH (n:Report:To:Delete) RETURN n", (row) -> {
+            final Node n = (Node) row.get("n");
+            assertEquals("val1", n.getProperty("prop1"));
+            assertEquals("val2", n.getProperty("prop2"));
+        });
+    }
+
+    @Test
+    public void testRetrievePropsDeletedRelationship() {
+        db.executeTransactionally("CREATE (s:Start)-[r:MY_TYPE {prop1: 'val1', prop2: 'val2'}]->(e:End), (s)-[:REMAINING_REL]->(e)");
+        
+        final String query = "UNWIND $deletedRelationships as deletedRel " +
+                "WITH apoc.trigger.toRelationship(deletedRel, $removedRelationshipProperties) AS deletedRel " +
+                "MATCH (s)-[r:REMAINING_REL]->(e) WITH r, deletedRel " +
+                "set r+=apoc.any.properties(deletedRel), r.type= type(deletedRel)";
+
+        final String assertionQuery = "MATCH (:Start)-[n:REMAINING_REL]->(:End) RETURN n";
+        testRetrievePropsDeletedRelationshipCommon("before", query, assertionQuery);
+        testRetrievePropsDeletedRelationshipCommon("after", query, assertionQuery);
+    }
+
+    @Test
+    public void testRetrievePropsDeletedRelationshipWithQueryCreation() {
+        db.executeTransactionally("CREATE (:Start)-[r:MY_TYPE {prop1: 'val1', prop2: 'val2'}]->(:End)");
+        
+        final String query = "UNWIND $deletedRelationships as deletedRel " +
+                "WITH apoc.trigger.toRelationship(deletedRel, $removedRelationshipProperties) AS deletedRel " +
+                "CREATE (r:Report {type: type(deletedRel)}) WITH r, deletedRel " +
+                "set r+=apoc.any.properties(deletedRel)";
+
+        final String assertionQuery = "MATCH (n:Report) RETURN n";
+        testRetrievePropsDeletedRelationshipCommon("before", query, assertionQuery);
+        testRetrievePropsDeletedRelationshipCommon("after", query, assertionQuery);
+    }
+
+    private void testRetrievePropsDeletedRelationshipCommon(String phase, String triggerQuery, String assertionQuery) {
+        db.executeTransactionally("call apoc.trigger.add('myTrigger', $query , {phase: $phase})",
+                Map.of("name", UUID.randomUUID().toString(), "query", triggerQuery, "phase", phase));
+        db.executeTransactionally("MATCH (:Start)-[r:MY_TYPE]->(:End) DELETE r");
+
+        TestUtil.testCall(db, assertionQuery, (row) -> {
+            final Entity n = (Entity) row.get("n");
+            assertEquals("MY_TYPE", n.getProperty("type"));
+            assertEquals("val1", n.getProperty("prop1"));
+            assertEquals("val2", n.getProperty("prop2"));
+        });
+    }
 }


### PR DESCRIPTION
Cherry pick 36b036afd73f69c75eb7324b2fbf81108c1d7a59, Fixes https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/1152 and https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/2247