### PR TITLE
restore forced firefoxdriver

### DIFF
--- a/full/src/main/java/apoc/load/LoadHtmlBrowser.java
+++ b/full/src/main/java/apoc/load/LoadHtmlBrowser.java
@@ -26,9 +26,7 @@ public class LoadHtmlBrowser {
     }
     
     public static InputStream getFirefoxInputStream(String url, Map<String, String> query, LoadHtmlConfig config, boolean isHeadless, boolean isAcceptInsecureCerts) {
-        WebDriverManager.firefoxdriver()
-                .driverVersion("0.30.0")
-                .setup();
+        WebDriverManager.firefoxdriver().setup();
         FirefoxOptions firefoxOptions = new FirefoxOptions();
         firefoxOptions.setHeadless(isHeadless);
         firefoxOptions.setAcceptInsecureCerts(isAcceptInsecureCerts);


### PR DESCRIPTION
restore forced firefoxdriver

Now the issue related to https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/2859 no longer seems present
