### PR TITLE
Fixes #2223: Add config option for schema exports to retain the index constraint names (#2892)

### DIFF
--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -259,12 +259,15 @@ public class MultiStatementCypherSubGraphExporter {
                         }
                     }
                     // "normal" schema index
+                    String idxName = exportConfig.shouldSaveIndexNames()
+                            ? " " + name
+                            : StringUtils.EMPTY;
                     String tokenName = tokenNames.get(0);
                     final boolean ifNotExist = exportConfig.ifNotExists();
                     if (isNode) {
-                        return this.cypherFormat.statementForNodeIndex(indexType, tokenName, props, ifNotExist);
+                        return this.cypherFormat.statementForNodeIndex(indexType, tokenName, props, ifNotExist, idxName);
                     } else {
-                        return this.cypherFormat.statementForIndexRelationship(indexType, tokenName, props, ifNotExist);
+                        return this.cypherFormat.statementForIndexRelationship(indexType, tokenName, props, ifNotExist, idxName);
                     }
 
                 })

--- a/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -46,15 +46,15 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 	}
 
 	@Override
-	public String statementForNodeIndex(String indexType, String label, Iterable<String> keys, boolean ifNotExists) {
-		return String.format("CREATE %s INDEX%s FOR (n:%s) ON (%s);", 
-				indexType, getIfNotExists(ifNotExists), Util.quote(label), getPropertiesQuoted(keys, "n."));
+	public String statementForNodeIndex(String indexType, String label, Iterable<String> keys, boolean ifNotExists, String idxName) {
+		return String.format("CREATE %s INDEX%s%s FOR (n:%s) ON (%s);", 
+				indexType, idxName, getIfNotExists(ifNotExists), Util.quote(label), getPropertiesQuoted(keys, "n."));
 	}
 	
 	@Override
-	public String statementForIndexRelationship(String indexType, String type, Iterable<String> keys, boolean ifNotExists) {
-		return String.format("CREATE %s INDEX%s FOR ()-[rel:%s]-() ON (%s);", 
-				indexType, getIfNotExists(ifNotExists), Util.quote(type), getPropertiesQuoted(keys, "rel."));
+	public String statementForIndexRelationship(String indexType, String type, Iterable<String> keys, boolean ifNotExists, String idxName) {
+		return String.format("CREATE %s INDEX%s%s FOR ()-[rel:%s]-() ON (%s);", 
+				indexType, idxName, getIfNotExists(ifNotExists), Util.quote(type), getPropertiesQuoted(keys, "rel."));
 	}
 
 	@Override

--- a/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -33,12 +33,12 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
-	public String statementForNodeIndex(String indexType, String label, Iterable<String> key, boolean ifNotExist) {
+	public String statementForNodeIndex(String indexType, String label, Iterable<String> key, boolean ifNotExist, String idxName) {
 		return "";
 	}
 	
 	@Override
-	public String statementForIndexRelationship(String indexType, String type, Iterable<String> key, boolean ifNotExists) {
+	public String statementForIndexRelationship(String indexType, String type, Iterable<String> key, boolean ifNotExists, String idxName) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -19,9 +19,9 @@ public interface CypherFormatter {
 
 	String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties);
 
-	String statementForNodeIndex(String indexType, String label, Iterable<String> keys, boolean ifNotExist);
+	String statementForNodeIndex(String indexType, String label, Iterable<String> keys, boolean ifNotExist, String idxName);
 
-	String statementForIndexRelationship(String indexType, String type, Iterable<String> keys, boolean ifNotExist);
+	String statementForIndexRelationship(String indexType, String type, Iterable<String> keys, boolean ifNotExist, String idxName);
 
 	String statementForNodeFullTextIndex(String name, Iterable<Label> labels, Iterable<String> keys);
 

--- a/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -33,12 +33,12 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	}
 
 	@Override
-	public String statementForNodeIndex(String indexType, String label, Iterable<String> key, boolean ifNotExist) {
+	public String statementForNodeIndex(String indexType, String label, Iterable<String> key, boolean ifNotExist, String idxName) {
 		return "";
 	}
 
 	@Override
-	public String statementForIndexRelationship(String indexType, String type, Iterable<String> key, boolean ifNotExist) {
+	public String statementForIndexRelationship(String indexType, String type, Iterable<String> key, boolean ifNotExist, String idxName) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -29,6 +29,7 @@ public class ExportConfig extends CompressionConfig {
 
     private int batchSize;
     private boolean silent;
+    private boolean saveIndexNames;
     private boolean bulkImport = false;
     private boolean sampling;
     private String delim;
@@ -88,6 +89,7 @@ public class ExportConfig extends CompressionConfig {
         super(config);
         config = config != null ? config : Collections.emptyMap();
         this.silent = toBoolean(config.getOrDefault("silent",false));
+        this.saveIndexNames = toBoolean(config.getOrDefault("saveIndexNames",false));
         this.delim = delim(config.getOrDefault("delim", DEFAULT_DELIM).toString());
         this.arrayDelim = delim(config.getOrDefault("arrayDelim", DEFAULT_ARRAY_DELIM).toString());
         this.useTypes = toBoolean(config.get("useTypes"));
@@ -213,5 +215,9 @@ public class ExportConfig extends CompressionConfig {
     
     public boolean ifNotExists() {
         return ifNotExists;
+    }
+
+    public boolean shouldSaveIndexNames() {
+        return saveIndexNames;
     }
 }

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -192,8 +192,7 @@ public class ExportCypherTest {
         TestUtil.testCall(db, "CALL apoc.export.cypher.all($file,$config)", 
                 map("file", fileName, "config", config),
                 (r) -> assertResults(fileName, r, "database"));
-        final String expectedFile = String.format(EXPECTED_SCHEMA_WITH_NAMES, " barIndex", " fooIndex", StringUtils.EMPTY);
-        assertEquals(expectedFile, readFile("all.schema.cypher"));
+        assertEquals(EXPECTED_SCHEMA_WITH_NAMES, readFile("all.schema.cypher"));
     }
 
     @Test
@@ -844,21 +843,20 @@ public class ExportCypherTest {
         static final String EXPECTED_NODES_EMPTY = String.format("BEGIN%n" +
                 "COMMIT%n");
 
+        private static final String EXPECTED_CONSTRAINTS_AND_AWAIT = "CREATE CONSTRAINT uniqueConstraint FOR (node:Bar) REQUIRE (node.name) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT UNIQUE_IMPORT_NAME FOR (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n" +
+                "SCHEMA AWAIT%n";
+        
         static final String EXPECTED_SCHEMA = String.format("BEGIN%n" +
                 "CREATE RANGE INDEX FOR (n:Bar) ON (n.first_name, n.last_name);%n" +
                 "CREATE RANGE INDEX FOR (n:Foo) ON (n.name);%n" +
-                "CREATE CONSTRAINT uniqueConstraint FOR (node:Bar) REQUIRE (node.name) IS UNIQUE;%n" +
-                "CREATE CONSTRAINT UNIQUE_IMPORT_NAME FOR (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
-                "COMMIT%n" +
-                "SCHEMA AWAIT%n");
+                EXPECTED_CONSTRAINTS_AND_AWAIT);
 
-        static final String EXPECTED_SCHEMA_WITH_NAMES = "BEGIN%n" +
-                "CREATE RANGE INDEX%s FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
-                "CREATE RANGE INDEX%s FOR (node:Foo) ON (node.name);%n" +
-                "CREATE CONSTRAINT%s ON (node:Bar) REQUIRE (node.name) IS UNIQUE;%n" +
-                "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
-                "COMMIT%n" +
-                "SCHEMA AWAIT%n";
+        static final String EXPECTED_SCHEMA_WITH_NAMES = String.format("BEGIN%n" +
+                "CREATE RANGE INDEX barIndex FOR (n:Bar) ON (n.first_name, n.last_name);%n" +
+                "CREATE RANGE INDEX fooIndex FOR (n:Foo) ON (n.name);%n" +
+                EXPECTED_CONSTRAINTS_AND_AWAIT);
 
         static final String EXPECTED_SCHEMA_EMPTY = String.format("BEGIN%n" +
                 "COMMIT%n" +
@@ -899,8 +897,8 @@ public class ExportCypherTest {
                 "SCHEMA AWAIT%n");
 
         static final String EXPECTED_ONLY_SCHEMA_NEO4J_SHELL_WITH_NAMES = "BEGIN\n" +
-                "CREATE INDEX barIndex FOR (node:Bar) ON (node.first_name, node.last_name);\n" +
-                "CREATE INDEX fooIndex FOR (node:Foo) ON (node.name);\n" +
+                "CREATE RANGE INDEX barIndex FOR (n:Bar) ON (n.first_name, n.last_name);\n" +
+                "CREATE RANGE INDEX fooIndex FOR (n:Foo) ON (n.name);\n" +
                 "CREATE CONSTRAINT uniqueConstraint FOR (node:Bar) REQUIRE (node.name) IS UNIQUE;\n" +
                 "COMMIT\n" +
                 "SCHEMA AWAIT\n";
@@ -1009,8 +1007,8 @@ public class ExportCypherTest {
                 "SCHEMA AWAIT%n");
         
         static final String EXPECTED_SCHEMA_WITH_RELS_AND_NAME_OPTIMIZED = String.format("BEGIN%n" +
-                "CREATE RANGE INDEX barIndex FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
-                "CREATE RANGE INDEX fooIndex FOR (node:Foo) ON (node.name);%n" +
+                "CREATE RANGE INDEX barIndex FOR (n:Bar) ON (n.first_name, n.last_name);%n" +
+                "CREATE RANGE INDEX fooIndex FOR (n:Foo) ON (n.name);%n" +
                 "CREATE RANGE INDEX rel_index_name FOR ()-[rel:KNOWS]-() ON (rel.since, rel.foo);%n" +
                 "CREATE CONSTRAINT uniqueConstraint FOR (node:Bar) REQUIRE (node.name) IS UNIQUE;%n" +
                 "CREATE CONSTRAINT UNIQUE_IMPORT_NAME FOR (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
@@ -1043,11 +1041,11 @@ public class ExportCypherTest {
                 "SCHEMA AWAIT%n");
 
         static final String EXPECTED_SCHEMA_OPTIMIZED_WITH_RELS_IF_NOT_EXISTS_AND_NAME = String.format("BEGIN%n" +
-                "CREATE RANGE INDEX barIndex IF NOT EXISTS FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
-                "CREATE RANGE INDEX fooIndex IF NOT EXISTS FOR (node:Foo) ON (node.name);%n" +
+                "CREATE RANGE INDEX barIndex IF NOT EXISTS FOR (n:Bar) ON (n.first_name, n.last_name);%n" +
+                "CREATE RANGE INDEX fooIndex IF NOT EXISTS FOR (n:Foo) ON (n.name);%n" +
                 "CREATE RANGE INDEX rel_index_name IF NOT EXISTS FOR ()-[rel:KNOWS]-() ON (rel.since, rel.foo);%n" +
-                "CREATE CONSTRAINT uniqueConstraint IF NOT EXISTS ON (node:Bar) REQUIRE (node.name) IS UNIQUE;%n" +
-                "CREATE CONSTRAINT IF NOT EXISTS ON (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT uniqueConstraint IF NOT EXISTS FOR (node:Bar) REQUIRE (node.name) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT UNIQUE_IMPORT_NAME IF NOT EXISTS FOR (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
                 "COMMIT%n" +
                 "SCHEMA AWAIT%n");
 

--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -2,6 +2,7 @@ package apoc.export.cypher;
 
 import apoc.graph.Graphs;
 import apoc.util.TestUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -15,6 +16,7 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 
@@ -57,8 +59,8 @@ public class ExportCypherTest {
     public void setUp() throws Exception {
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
         TestUtil.registerProcedure(db, ExportCypher.class, Graphs.class);
-        db.executeTransactionally("CREATE RANGE INDEX FOR (n:Bar) ON (n.first_name, n.last_name)");
-        db.executeTransactionally("CREATE RANGE INDEX FOR (n:Foo) ON (n.name)");
+        db.executeTransactionally("CREATE RANGE INDEX barIndex FOR (n:Bar) ON (n.first_name, n.last_name)");
+        db.executeTransactionally("CREATE RANGE INDEX fooIndex FOR (n:Foo) ON (n.name)");
         db.executeTransactionally("CREATE CONSTRAINT uniqueConstraint FOR (b:Bar) REQUIRE b.name IS UNIQUE");
         if (testName.getMethodName().endsWith(OPTIMIZED)) {
             db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})-[:KNOWS {since:2016}]->(b:Bar {name:'bar',age:42}),(c:Bar:Person {age:12}),(d:Bar {age:12})," +
@@ -183,6 +185,18 @@ public class ExportCypherTest {
     }
 
     @Test
+    public void testExportAllCypherSchemaWithSaveIdxNames() throws Exception {
+        final Map<String, Object> config = new HashMap<>(ExportCypherTest.exportConfig);
+        config.put("saveIndexNames", true);
+        String fileName = "all.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.all($file,$config)", 
+                map("file", fileName, "config", config),
+                (r) -> assertResults(fileName, r, "database"));
+        final String expectedFile = String.format(EXPECTED_SCHEMA_WITH_NAMES, " barIndex", " fooIndex", StringUtils.EMPTY);
+        assertEquals(expectedFile, readFile("all.schema.cypher"));
+    }
+
+    @Test
     public void testExportAllCypherCleanUp() throws Exception {
         String fileName = "all.cypher";
         TestUtil.testCall(db, "CALL apoc.export.cypher.all($file,$exportConfig)", map("file", fileName, "exportConfig", exportConfig),
@@ -289,6 +303,16 @@ public class ExportCypherTest {
         TestUtil.testCall(db, "CALL apoc.export.cypher.schema($file,$exportConfig)", map("file", fileName, "exportConfig", exportConfig), (r) -> {
         });
         assertEquals(EXPECTED_ONLY_SCHEMA_NEO4J_SHELL, readFile(fileName));
+    }
+
+    @Test
+    public void testExportSchemaCypherWithIdxNames() throws Exception {
+        final Map<String, Object> config = new HashMap<>(ExportCypherTest.exportConfig);
+        config.putAll(map("saveIndexNames", true));
+        String fileName = "onlySchema.cypher";
+        TestUtil.testCall(db, "CALL apoc.export.cypher.schema($file,$config)", 
+                map("file", fileName, "config", config), (r) -> {});
+        assertEquals(EXPECTED_ONLY_SCHEMA_NEO4J_SHELL_WITH_NAMES, readFile(fileName));
     }
 
     @Test
@@ -747,18 +771,32 @@ public class ExportCypherTest {
         String fileName = "relIndex.cypher";
         db.executeTransactionally("CREATE RANGE INDEX rel_index_name FOR ()-[r:KNOWS]-() ON (r.since, r.foo)");
 
-        relIndexTestCommon(fileName, EXPECTED_SCHEMA_WITH_RELS_OPTIMIZED, false);
+        relIndexTestCommon(fileName, EXPECTED_SCHEMA_WITH_RELS_OPTIMIZED, map("ifNotExists", false));
 
         // with ifNotExists: true
-        relIndexTestCommon(fileName, EXPECTED_SCHEMA_WITH_RELS_AND_IF_NOT_EXISTS, true);
+        relIndexTestCommon(fileName, EXPECTED_SCHEMA_WITH_RELS_AND_IF_NOT_EXISTS, map("ifNotExists", true));
+
+        db.executeTransactionally("DROP INDEX rel_index_name");
+    }
+    
+    @Test
+    public void shouldSaveCorrectlyRelIndexesWithNameOptimized() throws FileNotFoundException {
+        String fileName = "relIndex.cypher";
+        db.executeTransactionally("CREATE RANGE INDEX rel_index_name FOR ()-[r:KNOWS]-() ON (r.since, r.foo)");
+
+        relIndexTestCommon(fileName, EXPECTED_SCHEMA_WITH_RELS_AND_NAME_OPTIMIZED, map("ifNotExists", false, "saveIndexNames", true));
+
+        // with ifNotExists: true
+        relIndexTestCommon(fileName, EXPECTED_SCHEMA_OPTIMIZED_WITH_RELS_IF_NOT_EXISTS_AND_NAME, map("ifNotExists", true, "saveIndexNames", true));
 
         db.executeTransactionally("DROP INDEX rel_index_name");
     }
 
-    private void relIndexTestCommon(String fileName, String expectedSchema, boolean ifNotExists) throws FileNotFoundException {
+    private void relIndexTestCommon(String fileName, String expectedSchema, Map<String, Object> config) throws FileNotFoundException {
+        Map<String, Object> exportConfig = map("separateFiles", true, "format", "neo4j-shell");
+        exportConfig.putAll(config);
         TestUtil.testCall(db, "CALL apoc.export.cypher.all($file, $exportConfig)",
-                map("file", fileName, "exportConfig", 
-                        map("ifNotExists", ifNotExists, "separateFiles", true, "format", "neo4j-shell")),
+                map("file", fileName, "exportConfig", exportConfig),
                 (r) -> assertResultsOptimized(fileName, r));
         assertEquals(EXPECTED_NODES_OPTIMIZED, readFile("relIndex.nodes.cypher"));
         assertEquals(EXPECTED_RELATIONSHIPS_OPTIMIZED, readFile("relIndex.relationships.cypher"));
@@ -814,6 +852,14 @@ public class ExportCypherTest {
                 "COMMIT%n" +
                 "SCHEMA AWAIT%n");
 
+        static final String EXPECTED_SCHEMA_WITH_NAMES = "BEGIN%n" +
+                "CREATE RANGE INDEX%s FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
+                "CREATE RANGE INDEX%s FOR (node:Foo) ON (node.name);%n" +
+                "CREATE CONSTRAINT%s ON (node:Bar) REQUIRE (node.name) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT ON (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n" +
+                "SCHEMA AWAIT%n";
+
         static final String EXPECTED_SCHEMA_EMPTY = String.format("BEGIN%n" +
                 "COMMIT%n" +
                 "SCHEMA AWAIT%n");
@@ -851,6 +897,13 @@ public class ExportCypherTest {
                 "CREATE CONSTRAINT uniqueConstraint FOR (node:Bar) REQUIRE (node.name) IS UNIQUE;%n" +
                 "COMMIT%n" +
                 "SCHEMA AWAIT%n");
+
+        static final String EXPECTED_ONLY_SCHEMA_NEO4J_SHELL_WITH_NAMES = "BEGIN\n" +
+                "CREATE INDEX barIndex FOR (node:Bar) ON (node.first_name, node.last_name);\n" +
+                "CREATE INDEX fooIndex FOR (node:Foo) ON (node.name);\n" +
+                "CREATE CONSTRAINT uniqueConstraint FOR (node:Bar) REQUIRE (node.name) IS UNIQUE;\n" +
+                "COMMIT\n" +
+                "SCHEMA AWAIT\n";
 
         static final String EXPECTED_CYPHER_POINT = String.format("BEGIN%n" +
                 "CREATE (:Test:`UNIQUE IMPORT LABEL` {name:\"foo\", place2d:point({x: 2.3, y: 4.5, crs: 'cartesian'}), place3d1:point({x: 2.3, y: 4.5, z: 1.2, crs: 'cartesian-3d'}), `UNIQUE IMPORT ID`:3});%n" +
@@ -955,6 +1008,15 @@ public class ExportCypherTest {
                 "COMMIT%n" +
                 "SCHEMA AWAIT%n");
         
+        static final String EXPECTED_SCHEMA_WITH_RELS_AND_NAME_OPTIMIZED = String.format("BEGIN%n" +
+                "CREATE RANGE INDEX barIndex FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
+                "CREATE RANGE INDEX fooIndex FOR (node:Foo) ON (node.name);%n" +
+                "CREATE RANGE INDEX rel_index_name FOR ()-[rel:KNOWS]-() ON (rel.since, rel.foo);%n" +
+                "CREATE CONSTRAINT uniqueConstraint FOR (node:Bar) REQUIRE (node.name) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT UNIQUE_IMPORT_NAME FOR (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n" +
+                "SCHEMA AWAIT%n");
+        
         static final String EXPECTED_SCHEMA_WITH_RELS_AND_IF_NOT_EXISTS = String.format("BEGIN%n" +
                 "CREATE RANGE INDEX IF NOT EXISTS FOR (n:Bar) ON (n.first_name, n.last_name);%n" +
                 "CREATE RANGE INDEX IF NOT EXISTS FOR (n:Foo) ON (n.name);%n" +
@@ -977,6 +1039,15 @@ public class ExportCypherTest {
                 "CREATE RANGE INDEX IF NOT EXISTS FOR (n:Foo) ON (n.name);%n" +
                 "CREATE CONSTRAINT uniqueConstraint IF NOT EXISTS FOR (node:Bar) REQUIRE (node.name) IS UNIQUE;%n" +
                 "CREATE CONSTRAINT UNIQUE_IMPORT_NAME IF NOT EXISTS FOR (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
+                "COMMIT%n" +
+                "SCHEMA AWAIT%n");
+
+        static final String EXPECTED_SCHEMA_OPTIMIZED_WITH_RELS_IF_NOT_EXISTS_AND_NAME = String.format("BEGIN%n" +
+                "CREATE RANGE INDEX barIndex IF NOT EXISTS FOR (node:Bar) ON (node.first_name, node.last_name);%n" +
+                "CREATE RANGE INDEX fooIndex IF NOT EXISTS FOR (node:Foo) ON (node.name);%n" +
+                "CREATE RANGE INDEX rel_index_name IF NOT EXISTS FOR ()-[rel:KNOWS]-() ON (rel.since, rel.foo);%n" +
+                "CREATE CONSTRAINT uniqueConstraint IF NOT EXISTS ON (node:Bar) REQUIRE (node.name) IS UNIQUE;%n" +
+                "CREATE CONSTRAINT IF NOT EXISTS ON (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
                 "COMMIT%n" +
                 "SCHEMA AWAIT%n");
 

--- a/docs/asciidoc/modules/ROOT/pages/export/cypher.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/export/cypher.adoc
@@ -63,6 +63,7 @@ The procedures support the following config parameters:
 * `UNWIND_BATCH` - exports the file by batching the entities with the `UNWIND` method as explained in Michael Hunger's article on https://medium.com/neo4j/5-tips-tricks-for-fast-batched-updates-of-graph-structures-with-neo4j-and-cypher-73c7f693c8cc[fast batched writes^].
 * `UNWIND_BATCH_PARAMS` - similar to `UNWIND_BATCH`, but also uses parameters where appropriate
 | awaitForIndexes | Long | 300 | Timeout to use for `db.awaitIndexes` when using `format: "cypher-shell"`
+| saveIndexNames | boolean | false | Save name indexes on export
 |===
 
 [[export-cypher-file-export]]


### PR DESCRIPTION
Cherry pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/b28604a7f23b473931590a1fb9fc21a3b9127274