### PR TITLE
Added apoc.trigger.refresh note in the trigger adoc initial page

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/background-operations/triggers.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/background-operations/triggers.adoc
@@ -7,7 +7,8 @@ In a trigger you register Cypher statements that are called when data in Neo4j i
 You can run them before or after commit.
 
 
-Enable `apoc.trigger.enabled=true` in `$NEO4J_HOME/conf/apoc.conf` first.
+include::partial$triggers.adoc[]
+
 
 [separator=¦,opts=header,cols="5,1m,1m"]
 |===


### PR DESCRIPTION
Currently the config `apoc.trigger.refresh` is not present [in the main page](https://neo4j.com/labs/apoc/4.4/background-operations/triggers/).

Added `apoc.trigger.refresh` note, as for [the add page](https://neo4j.com/labs/apoc/4.4/overview/apoc.trigger/apoc.trigger.add/#_enable_triggers)

