### PR TITLE
Forces encoding to UTF8

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,3 +3,4 @@ distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+org.gradle.jvmargs='-Dfile.encoding=UTF-8'


### PR DESCRIPTION
## What
Forces encoding to UTF8

## Why
Because in TeamCity when using a different docker image we are getting some tests failures due to string encodings:

```
error: unmappable character (0x94) for encoding US-ASCII
```