### PR TITLE
Fix failing extra-dependencies in dev

### DIFF
--- a/extra-dependencies/bolt/build.gradle
+++ b/extra-dependencies/bolt/build.gradle
@@ -17,7 +17,7 @@ jar {
 }
 
 dependencies {
-    implementation group: 'org.neo4j.driver', name: 'neo4j-java-driver-slim', version: '4.4.3'
+    implementation group: 'org.neo4j.driver', name: 'neo4j-java-driver-slim', version: '4.4.5'
 }
 
 

--- a/extra-dependencies/bolt/build.gradle
+++ b/extra-dependencies/bolt/build.gradle
@@ -17,7 +17,7 @@ jar {
 }
 
 dependencies {
-    compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.0.0'
+    implementation group: 'org.neo4j.driver', name: 'neo4j-java-driver-slim', version: '4.4.3'
 }
 
 

--- a/extra-dependencies/hadoop/build.gradle
+++ b/extra-dependencies/hadoop/build.gradle
@@ -33,8 +33,8 @@ def commonExclusions = {
 }
 
 dependencies {
-    compile group: 'org.apache.hadoop', name: 'hadoop-hdfs-client', version: '3.3.1', commonExclusions
-    compile group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.1', commonExclusions
+    implementation group: 'org.apache.hadoop', name: 'hadoop-hdfs-client', version: '3.3.1', commonExclusions
+    implementation group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.1', commonExclusions
 }
 
 

--- a/extra-dependencies/selenium/build.gradle
+++ b/extra-dependencies/selenium/build.gradle
@@ -18,8 +18,8 @@ jar {
 
 dependencies {
     // currently we cannot update to the latest version due to guava minimum version required (31.0.1-jre)
-    compile group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59', {
+    implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59', {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    compile group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '4.4.3'
+    implementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '4.4.3'
 }

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -47,7 +47,7 @@ dependencies {
 //    implementation group: 'commons-codec', name: 'commons-codec', version: '1.14'
     implementation group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
     implementation group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
-    compileOnly group: 'org.neo4j.driver', name: 'neo4j-java-driver-slim', version: '4.4.3'
+    compileOnly group: 'org.neo4j.driver', name: 'neo4j-java-driver-slim', version: '4.4.5'
     implementation group: 'com.novell.ldap', name: 'jldap', version: '2009-10-07'
 
     antlr "org.antlr:antlr4:4.7.2", {


### PR DESCRIPTION
Fix failing extra-dependencies in dev

- Changed `compile` to `implementation`
- Changed `bolt` dependency consistently with `full/build.gradle` dep.
- Updated `neo4j-java-driver-slim` to `4.4.5` in `extra-dependencies` and `full` gradle