### PR TITLE
Changing store version type in apoc.monitor.kernel()

### DIFF
--- a/core/src/main/java/apoc/result/KernelInfoResult.java
+++ b/core/src/main/java/apoc/result/KernelInfoResult.java
@@ -15,7 +15,7 @@ public class KernelInfoResult {
 
     public String databaseName;
 
-    public long storeLogVersion;
+    public String storeLogVersion;
 
     public String storeCreationDate;
 
@@ -25,7 +25,7 @@ public class KernelInfoResult {
             String storeId,
             Date kernelStartTime,
             String databaseName,
-            long storeLogVersion,
+            String storeLogVersion,
             Date storeCreationDate) {
 
         SimpleDateFormat format = new SimpleDateFormat(apoc.date.Date.DEFAULT_FORMAT);

--- a/full/src/main/java/apoc/monitor/Kernel.java
+++ b/full/src/main/java/apoc/monitor/Kernel.java
@@ -51,7 +51,7 @@ public class Kernel {
                 database.getStoreId().toString(),
                 startDate,
                 graphDatabaseService.databaseName(),
-                database.getLegacyStoreId().getStoreVersion(),
+                database.getStoreId().getStoreVersionUserString(),
                 new Date(database.getStoreId().getCreationTime())
         ));
     }

--- a/full/src/test/java/apoc/monitor/KernelProcedureTest.java
+++ b/full/src/test/java/apoc/monitor/KernelProcedureTest.java
@@ -1,7 +1,6 @@
 package apoc.monitor;
 
 import apoc.date.Date;
-import apoc.date.DateExpiry;
 import apoc.util.TestUtil;
 import org.junit.Before;
 import org.junit.Rule;


### PR DESCRIPTION
Database format (usually referred to as store version)
used to be identified by 8 byte integer. This is no longer
true from 5.0, so the procedure apoc.monitor.kernel()
that unfortunately exposes this kernel detail has to be
modified accordingly.
