### PR TITLE
Fix docs cve 2021-27568

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -42,6 +42,7 @@ dependencies {
 
     apt group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
     compile group: 'commons-codec', name: 'commons-codec', version: '1.14'
+    // when json-path is changed, it have to be changed in json-path-version version in antora.yml as well.
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.7.0'
     compile group: 'net.minidev', name: 'json-smart', version: '2.4.8'
     compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'

--- a/docs/asciidoc/antora.yml
+++ b/docs/asciidoc/antora.yml
@@ -9,3 +9,4 @@ asciidoc:
     branch: "4.4"
     apoc-release-absolute: "4.4"
     apoc-release: "4.4.0.5"
+    json-path-version: "2.7.0"

--- a/docs/asciidoc/modules/ROOT/pages/import/includes/jsonpath.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/includes/jsonpath.adoc
@@ -34,7 +34,7 @@ All of the operators and options for specifying JSON paths are included in the n
 
 
 Moreover, we can customize the Json path options, adding the config {pathOptions: `LIST OF STRINGS`},
-where the strings are based on https://javadoc.io/doc/com.jayway.jsonpath/json-path/2.4.0/com/jayway/jsonpath/Option.html[Enum<Option>].
+where the strings are based on https://javadoc.io/doc/com.jayway.jsonpath/json-path/{json-path-version}/com/jayway/jsonpath/Option.html[Enum<Option>].
 The default value is `["SUPPRESS_EXCEPTIONS", "DEFAULT_PATH_LEAF_TO_NULL"]`. Note that we can also insert `[]`, that is "without options".
 So with the following json:
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.convert.fromJsonList.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.convert.fromJsonList.adoc
@@ -32,7 +32,7 @@ RETURN apoc.convert.fromJsonList('[
 |===
 
 Moreover, we can customize the Json path options, adding as third parameter (`pathOptions`) a list of strings,
-where the strings are based on https://javadoc.io/doc/com.jayway.jsonpath/json-path/2.4.0/com/jayway/jsonpath/Option.html[Enum<Option>].
+where the strings are based on https://javadoc.io/doc/com.jayway.jsonpath/json-path/{json-path-version}/com/jayway/jsonpath/Option.html[Enum<Option>].
 The default value is `["SUPPRESS_EXCEPTIONS", "DEFAULT_PATH_LEAF_TO_NULL"]`. Note that we can also insert `[]`, that is "without options".
 So we can execute (with default pathOptions):
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.convert.fromJsonMap.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.convert.fromJsonMap.adoc
@@ -45,7 +45,7 @@ In this case we should instead use xref::overview/apoc.convert/apoc.convert.from
 
 
 Moreover, we can customize the Json path options, adding as third parameter (`pathOptions`) a list of strings,
-where the strings are based on https://javadoc.io/doc/com.jayway.jsonpath/json-path/2.4.0/com/jayway/jsonpath/Option.html[Enum<Option>].
+where the strings are based on https://javadoc.io/doc/com.jayway.jsonpath/json-path/{json-path-version}/com/jayway/jsonpath/Option.html[Enum<Option>].
 The default value is `["SUPPRESS_EXCEPTIONS", "DEFAULT_PATH_LEAF_TO_NULL"]`. Note that we can also insert `[]`, that is "without options".
 So we can execute (with default pathOptions):
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.convert.getJsonProperty.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.convert.getJsonProperty.adoc
@@ -34,7 +34,7 @@ RETURN apoc.convert.getJsonProperty(p, "json", "$.a") AS output;
 
 
 Moreover, we can customize the Json path options, adding as third parameter (`pathOptions`) a list of strings,
-where the strings are based on https://javadoc.io/doc/com.jayway.jsonpath/json-path/2.4.0/com/jayway/jsonpath/Option.html[Enum<Option>].
+where the strings are based on https://javadoc.io/doc/com.jayway.jsonpath/json-path/{json-path-version}/com/jayway/jsonpath/Option.html[Enum<Option>].
 The default value is `["SUPPRESS_EXCEPTIONS", "DEFAULT_PATH_LEAF_TO_NULL"]`. Note that we can also insert `[]`, that is "without options".
 So, with a `(n:JsonPathNode {prop: '{"columns":{"col2":{"_id":"772col2"}}}'})` we can execute (with default pathOptions):
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.convert.getJsonPropertyMap.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.convert.getJsonPropertyMap.adoc
@@ -21,7 +21,7 @@ RETURN apoc.convert.getJsonPropertyMap(p, "json") AS output;
 
 
 Moreover, we can customize the Json path options, adding as third parameter (`pathOptions`) a list of strings,
-where the strings are based on https://javadoc.io/doc/com.jayway.jsonpath/json-path/2.4.0/com/jayway/jsonpath/Option.html[Enum<Option>].
+where the strings are based on https://javadoc.io/doc/com.jayway.jsonpath/json-path/{json-path-version}/com/jayway/jsonpath/Option.html[Enum<Option>].
 The default value is `["SUPPRESS_EXCEPTIONS", "DEFAULT_PATH_LEAF_TO_NULL"]`. Note that we can also insert `[]`, that is "without options".
 So, with a `(n:JsonPathNode {prop: '{"columns":{"col2":{"_id":"772col2"}}}'})` we can execute (with default pathOptions):
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.json.path.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.json.path.adoc
@@ -19,7 +19,7 @@ RETURN apoc.json.path(p.json, "$.a") AS output;
 |===
 
 Moreover, we can customize the Json path options, adding as third parameter (`pathOptions`) a list of strings,
-where the strings are based on https://javadoc.io/doc/com.jayway.jsonpath/json-path/2.4.0/com/jayway/jsonpath/Option.html[Enum<Option>].
+where the strings are based on https://javadoc.io/doc/com.jayway.jsonpath/json-path/{json-path-version}/com/jayway/jsonpath/Option.html[Enum<Option>].
 The default value is `["SUPPRESS_EXCEPTIONS", "DEFAULT_PATH_LEAF_TO_NULL"]`. Note that we can also insert `[]`, that is "without options".
 So we can execute (with default pathOptions):
 

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.load.jsonArray.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.load.jsonArray.adoc
@@ -27,7 +27,7 @@ CALL apoc.load.jsonArray("file:///map.json", "$.foo");
 
 
 Moreover, we can customize the Json path options, adding the config {pathOptions: `LIST OF STRINGS`},
-where the strings are based on https://javadoc.io/doc/com.jayway.jsonpath/json-path/2.4.0/com/jayway/jsonpath/Option.html[Enum<Option>].
+where the strings are based on https://javadoc.io/doc/com.jayway.jsonpath/json-path/{json-path-version}/com/jayway/jsonpath/Option.html[Enum<Option>].
 The default value is `["SUPPRESS_EXCEPTIONS", "DEFAULT_PATH_LEAF_TO_NULL"]`. Note that we can also insert `[]`, that is "without options".
 So with the following json:
 

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -46,7 +46,6 @@ dependencies {
     testCompile "org.jetbrains.kotlin:kotlin-stdlib"
     apt group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective   // mandatory to run @ServiceProvider based META-INF code generation
 //    compile group: 'commons-codec', name: 'commons-codec', version: '1.14'
-    compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'
     compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
     compileOnly group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.0.0'
     compile group: 'com.novell.ldap', name: 'jldap', version: '2009-10-07'


### PR DESCRIPTION
Fix docs cve 2021-27568

- Added `json-path-version` attribute in `antora.yml`
- Updated `json-path` in docs via antora attribute
- Added doc note in `build.gradle`
