### PR TITLE
Fixes #2932: The apoc.import.csv skipLines config doesn't work correctly

### DIFF
--- a/core/src/main/java/apoc/export/csv/CsvLoaderConfig.java
+++ b/core/src/main/java/apoc/export/csv/CsvLoaderConfig.java
@@ -2,6 +2,7 @@ package apoc.export.csv;
 
 import apoc.util.CompressionAlgo;
 import apoc.util.CompressionConfig;
+import apoc.util.Util;
 
 import java.util.Map;
 
@@ -121,7 +122,7 @@ public class CsvLoaderConfig extends CompressionConfig {
         if (config.get(ARRAY_DELIMITER) != null) builder.arrayDelimiter(getCharacterOrString(config, ARRAY_DELIMITER));
         if (config.get(QUOTATION_CHARACTER) != null) builder.quotationCharacter(getCharacterOrString(config, QUOTATION_CHARACTER));
         if (config.get(STRING_IDS) != null) builder.stringIds((boolean) config.get(STRING_IDS));
-        if (config.get(SKIP_LINES) != null) builder.skipLines((int) config.get(SKIP_LINES));
+        if (config.get(SKIP_LINES) != null) builder.skipLines(Util.toInteger(config.get(SKIP_LINES)));
         if (config.get(BATCH_SIZE) != null) builder.batchSize((int) config.get(BATCH_SIZE));
         if (config.get(IGNORE_DUPLICATE_NODES) != null) builder.ignoreDuplicateNodes((boolean) config.get(IGNORE_DUPLICATE_NODES));
         if (config.get(IGNORE_BLANK_STRING) != null) builder.ignoreBlankString((boolean) config.get(IGNORE_BLANK_STRING));

--- a/core/src/test/java/apoc/export/csv/ImportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ImportCsvTest.java
@@ -192,10 +192,10 @@ public class ImportCsvTest {
     
     @Test
     public void testImportCsvWithSkipLines() {
-        // skip header and another one
+        // skip only-header (default config)
         testSkipLine(1L, 2);
 
-        // skip only-header (default config)
+        // skip header and another one
         testSkipLine(2L, 1);
 
         // skip header and another two (no result because the file has 3 lines)


### PR DESCRIPTION
Fixes #2932

- Leverage on `CsvReader` to skipLines, 
because `CountingReader.skip(n)` calls `java.io.FilterReader.skip(n)`, which skip characters instead of lines.
removing the `CountingReader.skip` is not a breaking-change because by default is `skip(0)`, so the `CountingReader` skip nothing actually. 

- changed deprecated API `CSVReader` to `CSVReaderBuilder`
