### PR TITLE
Fix for #2909.

### DIFF
--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -584,7 +584,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                     return VirtualValues.list(objects);
                 } else if (toConvert instanceof Map) {
                     Map<String, Object> map = (Map) toConvert;
-                    MapValueBuilder builder = new MapValueBuilder(map.size());
+                    MapValueBuilder builder = new MapValueBuilder();
                     map.entrySet().stream().forEach(e -> {
                         builder.add(e.getKey(), convertToValueRecursive(e.getValue()));
                     });


### PR DESCRIPTION
Fixes #2909

Instead of passing the actual size of the map (which could be 0) to the constructor for MapValueBuilder, the constructor is called without parameters. This functionality is provided by Neo4j and for some reason the constructor with the parameter throws an exception for value 0.