### PR TITLE
Excludes selenium tests in TeamCity (#3001)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,10 @@ subprojects {
         // We need to ignore the failures because we may have tests muted
         if (System.env.TEAMCITY_VERSION != null) {
             ignoreFailures(true)
+            if (project.hasProperty('excludeSeleniumTests')) {
+                exclude '**/LoadHtmlTest*'
+                exclude '**/LoadHtmlTestParameterized*'
+            }
         }
 
         filter {


### PR DESCRIPTION
Cherry-picks #3001

## What
Excludes selenium tests from TeamCity if flag passed. The idea is to have two steps in the build:

```
1. gradlew test -PexcludeSeleniumTests
2. gradlew test --tests LoadHtmlTest --tests LoadHtmlTestParameterized
```

## Why
So that we are able to have a different docker image for 1. and 2. The reason for that is some tests in 1. need to span a new docker container (dependencies, neo4j itself, etc), which requires root containers, and 2. explicitly requires non root access for emulating Chrome browsers (for safety reasons)
