### PR TITLE
Fixes #3000: apoc.refactor.cloneNodes withRelationships = true - hangs and does not complete call

### DIFF
--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -55,11 +55,11 @@ public class GraphRefactoring {
 
                     newNode = copyProperties(properties, newNode);
                     copyLabels(node, newNode);
-                    if (withRelationships) {
-                        copyRelationships(node, newNode, false, true);
-                    }
                     return newNode;
                 });
+                if (withRelationships) {
+                    copyRelationships(node, copy, false, true);
+                }
                 return result.withOther(copy);
             } catch (Exception e) {
                 return result.withError(e);


### PR DESCRIPTION
Fixes #3000

The bug appeared with [this pr](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/2845/files), in which i've added explicit transaction where needed.
In the issue case, the nodes included in the `apoc.refactor.cloneNodes` are connected to each other,
so we have to close the node creation's transaction first, 
and after we can create "mixed" relationships between the original and cloned nodes.