### PR TITLE
Fixes #2826: The apoc.import.csv/graphml procedures create empty wrong empty nodes with UNIQUE constraint violation

### DIFF
--- a/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
+++ b/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
@@ -79,7 +79,8 @@ public class CsvEntityLoader {
 
             final String[] loadCsvCompatibleHeader = fields.stream().map(f -> f.getName()).toArray(String[]::new);
             AtomicInteger lineNo = new AtomicInteger();
-            try (BatchTransaction btx = new BatchTransaction(db, clc.getBatchSize(), reporter)) {
+            BatchTransaction btx = new BatchTransaction(db, clc.getBatchSize(), reporter);
+            try {
                 csv.forEach(line -> {
                     lineNo.getAndIncrement();
 
@@ -140,6 +141,12 @@ public class CsvEntityLoader {
                     btx.increment();
                     reporter.update(1, 0, props++);
                 });
+                btx.commit();
+            } catch (RuntimeException e) {
+                btx.rollback();
+                throw e;
+            } finally {
+                btx.close();
             }
         }
     }
@@ -185,7 +192,8 @@ public class CsvEntityLoader {
             final String[] loadCsvCompatibleHeader = fields.stream().map(f -> f.getName()).toArray(String[]::new);
 
             AtomicInteger lineNo = new AtomicInteger();
-            try (BatchTransaction btx = new BatchTransaction(db, clc.getBatchSize(), reporter)) {
+            BatchTransaction btx = new BatchTransaction(db, clc.getBatchSize(), reporter);
+            try {
                 csv.forEach(line -> {
                     lineNo.getAndIncrement();
 
@@ -228,6 +236,12 @@ public class CsvEntityLoader {
                     btx.increment();
                     reporter.update(0, 1, props);
                 });
+                btx.commit();
+            } catch (RuntimeException e) {
+                btx.rollback();
+                throw e;
+            } finally {
+                btx.close();
             }
         }
     }

--- a/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
+++ b/core/src/main/java/apoc/export/graphml/XmlGraphMLReader.java
@@ -210,7 +210,8 @@ public class XmlGraphMLReader {
         Map<String, Key> nodeKeys = new HashMap<>();
         Map<String, Key> relKeys = new HashMap<>();
         int count = 0;
-        try (BatchTransaction tx = new BatchTransaction(db, batchSize * 10, reporter)) {
+        BatchTransaction tx = new BatchTransaction(db, batchSize * 10, reporter);
+        try {
 
             while (reader.hasNext()) {
                 XMLEvent event = (XMLEvent) reader.next();
@@ -288,6 +289,12 @@ public class XmlGraphMLReader {
                     }
                 }
             }
+            tx.commit();
+        } catch (Exception e) {
+            tx.rollback();
+            throw e;
+        } finally { 
+            tx.close();
         }
         return count;
     }

--- a/core/src/main/java/apoc/export/util/BatchTransaction.java
+++ b/core/src/main/java/apoc/export/util/BatchTransaction.java
@@ -41,6 +41,10 @@ public class BatchTransaction implements AutoCloseable {
         doCommit(log);
     }
 
+    public void rollback() {
+        tx.rollback();
+    }
+    
     private void doCommit(boolean log) {
         tx.commit();
         tx.close();
@@ -56,7 +60,6 @@ public class BatchTransaction implements AutoCloseable {
     @Override
     public void close() {
         if (tx!=null) {
-            tx.commit();
             tx.close();
             if (reporter!=null) reporter.progress("finish after " + count + " row(s) ");
         }


### PR DESCRIPTION
Fixes #2826