### PR TITLE
Use non-deprecated UserFunctionSignature constructor

### DIFF
--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -198,9 +198,10 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                 inputs,
                 typeof((String) node.getProperty(SystemPropertyKeys.output.name())),
                 null,
-                new String[0],
                 description,
                 "apoc.custom",
+                false,
+                false,
                 false
         ), statement, forceSingle);
     }
@@ -327,7 +328,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
     public UserFunctionSignature functionSignature(String name, String output, List<List<String>> inputs, String description) {
         AnyType outType = typeof(output.isEmpty() ? "LIST OF MAP" : output);
-        return new UserFunctionSignature(qualifiedName(name), inputSignatures(inputs), outType, null, new String[0], description, "apoc.custom",false);
+        return new UserFunctionSignature(qualifiedName(name), inputSignatures(inputs), outType, null, description, "apoc.custom", false, false, false);
     }
 
     /**

--- a/full/src/main/java/apoc/custom/Signatures.java
+++ b/full/src/main/java/apoc/custom/Signatures.java
@@ -112,9 +112,10 @@ public class Signatures {
         List<FieldSignature> inputSignatures = signature.parameter().stream().map(p -> getInputField(name(p.name()), type(p.type()), defaultValue(p.defaultValue(), type(p.type())))).collect(Collectors.toList());
 
         String deprecated = "";
-        String[] allowed = new String[0];
         boolean caseInsensitive = true;
-        return new UserFunctionSignature(name, inputSignatures, type, deprecated, allowed, description, "apoc.custom",caseInsensitive);
+        boolean isBuiltIn = false;
+        boolean internal = false;
+        return new UserFunctionSignature(name, inputSignatures, type, deprecated, description, "apoc.custom", caseInsensitive, isBuiltIn, internal);
     }
 
     private DefaultParameterValue defaultValue(SignatureParser.DefaultValueContext defaultValue, Neo4jTypes.AnyType type) {


### PR DESCRIPTION
The UserFunctionSignature constructor which APOC used was deprecated in Neo4j and will be removed. The allowed field is not used in 5.0 and there is two new fields for Neo4j builtIn and internal functions, which should be false for everything in APOC.

This PR should only go into dev, and not be backported.