### PR TITLE
Add wait to create databases

### DIFF
--- a/full/src/test/java/apoc/ttl/TTLMultiDbTest.java
+++ b/full/src/test/java/apoc/ttl/TTLMultiDbTest.java
@@ -50,9 +50,9 @@ public class TTLMultiDbTest {
         driver = GraphDatabase.driver(neo4jContainer.getBoltUrl(), AuthTokens.basic("neo4j", "apoc"));
 
         try (Session session = driver.session()) {
-            session.writeTransaction(tx -> tx.run("CREATE DATABASE " + DB_TEST + ";"));
-            session.writeTransaction(tx -> tx.run("CREATE DATABASE " + DB_FOO + ";"));
-            session.writeTransaction(tx -> tx.run("CREATE DATABASE " + DB_BAR + ";"));
+            session.writeTransaction(tx -> tx.run("CREATE DATABASE " + DB_TEST + " WAIT;"));
+            session.writeTransaction(tx -> tx.run("CREATE DATABASE " + DB_FOO + " WAIT;"));
+            session.writeTransaction(tx -> tx.run("CREATE DATABASE " + DB_BAR + " WAIT;"));
         }
 
     }


### PR DESCRIPTION
In 5.0 the ddl to create database in "standalones" became async (so databases are not created after the command)  and this is causing these tests to fail. Using WAIT in create databases should be the default way of creating databases to avoid these issues.

