### PR TITLE
Add wait to create databases

### DIFF
--- a/full/src/test/java/apoc/ttl/TTLMultiDbTest.java
+++ b/full/src/test/java/apoc/ttl/TTLMultiDbTest.java
@@ -50,9 +50,9 @@ public class TTLMultiDbTest {
         driver = GraphDatabase.driver(neo4jContainer.getBoltUrl(), AuthTokens.basic("neo4j", "apoc"));
 
         try (Session session = driver.session()) {
-            session.writeTransaction(tx -> tx.run("CREATE DATABASE " + DB_TEST + ";"));
-            session.writeTransaction(tx -> tx.run("CREATE DATABASE " + DB_FOO + ";"));
-            session.writeTransaction(tx -> tx.run("CREATE DATABASE " + DB_BAR + ";"));
+            session.writeTransaction(tx -> tx.run("CREATE DATABASE " + DB_TEST + " WAIT;"));
+            session.writeTransaction(tx -> tx.run("CREATE DATABASE " + DB_FOO + " WAIT;"));
+            session.writeTransaction(tx -> tx.run("CREATE DATABASE " + DB_BAR + " WAIT;"));
         }
 
     }


### PR DESCRIPTION
In 5.0 the ddl to create database in "standalones" became async, and this is causing
some tests to fail.

