### PR TITLE
Avoid reusing the AmbientCursor in node.getLabels()

### DIFF
--- a/core/src/main/java/apoc/path/LabelMatcher.java
+++ b/core/src/main/java/apoc/path/LabelMatcher.java
@@ -1,7 +1,5 @@
 package apoc.path;
 
-import org.neo4j.graphdb.Node;
-
 import java.util.*;
 
 /**
@@ -24,7 +22,7 @@ public class LabelMatcher {
 
     private static LabelMatcher ACCEPTS_ALL_LABEL_MATCHER = new LabelMatcher() {
         @Override
-        public boolean matchesLabels(Node node) {
+        public boolean matchesLabels(Set<String> nodeLabels) {
             return true;
         }
 
@@ -66,10 +64,7 @@ public class LabelMatcher {
         return this;
     }
 
-    public boolean matchesLabels(Node node) {
-        Set<String> nodeLabels = new HashSet<>();
-        node.getLabels().forEach(label -> nodeLabels.add(label.name()));
-
+    public boolean matchesLabels(Set<String> nodeLabels) {
         for ( String label : labels ) {
             if (nodeLabels.contains(label)) {
                 return true;

--- a/core/src/main/java/apoc/path/LabelMatcherGroup.java
+++ b/core/src/main/java/apoc/path/LabelMatcherGroup.java
@@ -3,6 +3,9 @@ package apoc.path;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.traversal.Evaluation;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.neo4j.graphdb.traversal.Evaluation.*;
 
 /**
@@ -68,19 +71,22 @@ public class LabelMatcherGroup {
     }
 
     public Evaluation evaluate(Node node, boolean belowMinLevel) {
-        if (blacklistMatcher.matchesLabels(node)) {
+        Set<String> nodeLabels = new HashSet<>();
+        node.getLabels().forEach(label -> nodeLabels.add(label.name()));
+
+        if (blacklistMatcher.matchesLabels(nodeLabels)) {
             return EXCLUDE_AND_PRUNE;
         }
 
-        if (terminatorNodeMatcher.matchesLabels(node)) {
+        if (terminatorNodeMatcher.matchesLabels(nodeLabels)) {
             return belowMinLevel ? EXCLUDE_AND_CONTINUE : INCLUDE_AND_PRUNE;
         }
 
-        if (endNodeMatcher.matchesLabels(node)) {
+        if (endNodeMatcher.matchesLabels(nodeLabels)) {
             return belowMinLevel ? EXCLUDE_AND_CONTINUE : INCLUDE_AND_CONTINUE;
         }
 
-        if (whitelistMatcher.isEmpty() || whitelistMatcher.matchesLabels(node)) {
+        if (whitelistMatcher.isEmpty() || whitelistMatcher.matchesLabels(nodeLabels)) {
             return endNodesOnly || belowMinLevel ? EXCLUDE_AND_CONTINUE : INCLUDE_AND_CONTINUE;
         }
 

--- a/core/src/main/java/apoc/path/PathExplorer.java
+++ b/core/src/main/java/apoc/path/PathExplorer.java
@@ -219,7 +219,7 @@ public class PathExplorer {
 		return optionalStream;
 	}
 
-	public static Traverser traverse(TraversalDescription traversalDescription,
+	public static Traverser traverse(TraversalDescription td,
 									 Iterable<Node> startNodes,
 									 String pathFilter,
 									 String labelFilter,
@@ -231,7 +231,6 @@ public class PathExplorer {
 									 EnumMap<NodeFilter, List<Node>> nodeFilter,
 									 String sequence,
 									 boolean beginSequenceAtStart) {
-		TraversalDescription td = traversalDescription;
 		// based on the pathFilter definition now the possible relationships and directions must be shown
 
 		td = bfs ? td.breadthFirst() : td.depthFirst();


### PR DESCRIPTION
We were calling node.getLabels() severals which is unecessary work, and is also might have correctness implications because it is an AmbientCursor. During the bug, https://trello.com/c/zLF4jj16/194-s4sony-europe-network-map-attack-surface-underlyingstorageexception-access-to-record-node-went-out-of-bounds-of-the-page, we had a conversation with Sergey were he mentions that AmbientCursor reuse should be avoided.

(cherry picked from commit c8a96f3e298d34951882fa2375ce77926258d662)

Fixes #<Replace with the number of the issue, Mandatory>

One sentence summary of the change.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  -
  -
  -
