### PR TITLE
Fixed nodes.next() in `apoc.meta.graph`

### DIFF
--- a/core/src/main/java/apoc/meta/Meta.java
+++ b/core/src/main/java/apoc/meta/Meta.java
@@ -1118,8 +1118,8 @@ public class Meta {
             long sample = getSampleForLabelCount(labelCount, metaConfig.getSample());
             while (nodes.hasNext()) {
                 count++;
+                Node node = nodes.next();
                 if(count % sample == 0) {
-                    Node node = nodes.next();
                     long maxRels = metaConfig.getMaxRels();
                     for (Relationship rel : node.getRelationships(direction, relationshipType)) {
                         Node otherNode = direction == Direction.OUTGOING ? rel.getEndNode() : rel.getStartNode();


### PR DESCRIPTION
Fixed `nodes.next()` in `apoc.meta.graph`.

In 4.4 the `apoc.meta.graph` is sometimes slower because of different retrieve order of `tx.findNodes()` (line 1114).
This causes several more iterations to return the condition ` if (otherNode.hasLabel(labelToLabel)) return true;` (line 1126), because the `next()` method is called after the `if(count % sample == 0)` and then the `while (nodes.hasNext())` cycles empty several times.
This decrease performance significantly, according to the order of `findNodes`.

Most important thing, the `next()` inside the `count % sample == 0` block is a bug because we only extrapolate the first n nodes instead of a node each n.

