### PR TITLE
Adds missing WAIT in CREATE DATABASE

### DIFF
--- a/full/src/test/java/apoc/uuid/UUIDMultiDbTest.java
+++ b/full/src/test/java/apoc/uuid/UUIDMultiDbTest.java
@@ -44,7 +44,7 @@ public class UUIDMultiDbTest {
         driver = GraphDatabase.driver(neo4jContainer.getBoltUrl(), AuthTokens.basic("neo4j", "apoc"));
 
         try (Session session = driver.session()) {
-            session.writeTransaction(tx -> tx.run(String.format("CREATE DATABASE %s;", dbTest)));
+            session.writeTransaction(tx -> tx.run(String.format("CREATE DATABASE %s WAIT;", dbTest)));
         }
     }
 


### PR DESCRIPTION
`CREATE DATABASE` is not synchronous by default anymore in a single instance, so we need to add WAIT