### PR TITLE
Ignores broken tests in TeamCity

### DIFF
--- a/src/test/java/apoc/util/TestUtil.java
+++ b/src/test/java/apoc/util/TestUtil.java
@@ -160,7 +160,7 @@ public class TestUtil {
     }
 
     public static boolean isCI() {
-        return "true".equals(System.getenv("CI"));
+        return "true".equals(System.getenv("CI")) || System.getenv("TEAMCITY_VERSION") != null;
     }
 
     public static GraphDatabaseBuilder apocGraphDatabaseBuilder() {


### PR DESCRIPTION
Similar to what was done for other versions, ignore container tests also in TeamCity for a final release of 3.5
