### PR TITLE
Forces dependency to especific version to avoid binary incompatibilities

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -68,6 +68,13 @@ dependencies {
         exclude group: "org.yaml"
         exclude module: "snakeyaml"
     }
+
+    // This was reported here https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3048
+    compile(group: 'org.apache.commons', name: 'commons-lang3') {
+        version {
+            strictly '3.12.0'
+        }
+    }
     compile group: 'org.yaml', name: 'snakeyaml', version: '1.26'
     compile group: 'com.github.seancfoley', name: 'ipaddress', version: '5.3.3'
     testCompile group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'


### PR DESCRIPTION
Solves https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3048

Also checked that this problem is present in dev, so this will be cherry picked there.