### PR TITLE
NO AUTO Tries to deflake CREATE DATABASE tests

### DIFF
--- a/full/src/test/java/apoc/ttl/TTLMultiDbTest.java
+++ b/full/src/test/java/apoc/ttl/TTLMultiDbTest.java
@@ -49,7 +49,7 @@ public class TTLMultiDbTest {
 
         driver = GraphDatabase.driver(neo4jContainer.getBoltUrl(), AuthTokens.basic("neo4j", "apoc"));
 
-        try (Session session = driver.session()) {
+        try (Session session = driver.session(SessionConfig.forDatabase("system"))) {
             session.writeTransaction(tx -> tx.run("CREATE DATABASE " + DB_TEST + " WAIT;"));
             session.writeTransaction(tx -> tx.run("CREATE DATABASE " + DB_FOO + " WAIT;"));
             session.writeTransaction(tx -> tx.run("CREATE DATABASE " + DB_BAR + " WAIT;"));

--- a/full/src/test/java/apoc/uuid/UUIDMultiDbTest.java
+++ b/full/src/test/java/apoc/uuid/UUIDMultiDbTest.java
@@ -43,7 +43,7 @@ public class UUIDMultiDbTest {
 
         driver = GraphDatabase.driver(neo4jContainer.getBoltUrl(), AuthTokens.basic("neo4j", "apoc"));
 
-        try (Session session = driver.session()) {
+        try (Session session = driver.session(SessionConfig.forDatabase("system"))) {
             session.writeTransaction(tx -> tx.run(String.format("CREATE DATABASE %s WAIT;", dbTest)));
         }
     }


### PR DESCRIPTION
## What
Opens a session against `system` database directly before the `CREATE DATABASE` statements.

## Why
Reconcilarion and instance startup are async in Neo4j 5.x. In 5.x when the DBMS is started and bolt port is opened the only guarantee is that system is available.