### PR TITLE
NO AUTO Bump neo4j and driver version, force cache refresh in CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,8 +22,6 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -120,7 +120,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "4.4.5"
+    neo4jVersion = "4.4.8"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.15.1'

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     apt group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective   // mandatory to run @ServiceProvider based META-INF code generation
 //    compile group: 'commons-codec', name: 'commons-codec', version: '1.14'
     compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
-    compileOnly group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.4.5'
+    compileOnly group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.4.9'
     compile group: 'com.novell.ldap', name: 'jldap', version: '2009-10-07'
 
     antlr "org.antlr:antlr4:4.7.2", {

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     compile group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.2', withoutServers
     compile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.3.2', withoutServers
 
-    compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.4.5'
+    compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.4.9'
     compile group: 'org.jetbrains', name: 'annotations', version: "17.0.0"
 
     // Test Containers


### PR DESCRIPTION
## What
* Bumps neo4j and driver version.
* Forces cache refresh in CI, because the current key would not pick up changes in .gradle files for example.
