### PR TITLE
NO AUTO Forces cache refresh in the CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,8 +22,6 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle


### PR DESCRIPTION
## What
Removes the fallback of the cache in the CI.

## Why
The cache works by getting a combined hash of the `.gradle` and `.gradle-wrapper.properties` files.

If you modify .gradle files, and the hash is xyz, then if the cache does not find that key linux-gradle-xyz, this line was making it default to the latest hash available for linux-gradle, which would still have old dependencies.
