### PR TITLE
Remove usages of db.indexes and db.constraints

### DIFF
--- a/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherTest.java
@@ -1052,9 +1052,9 @@ public class ExportCypherTest {
                 "COMMIT%n");
         
         static final String EXPECTED_SCHEMA_WITH_RELS_OPTIMIZED = String.format("BEGIN%n" +
+                "CREATE RANGE INDEX FOR ()-[rel:KNOWS]-() ON (rel.since, rel.foo);%n" +
                 "CREATE RANGE INDEX FOR (n:Bar) ON (n.first_name, n.last_name);%n" +
                 "CREATE RANGE INDEX FOR (n:Foo) ON (n.name);%n" +
-                "CREATE RANGE INDEX FOR ()-[rel:KNOWS]-() ON (rel.since, rel.foo);%n" +
                 "CREATE CONSTRAINT uniqueConstraint FOR (node:Bar) REQUIRE (node.name) IS UNIQUE;%n" +
                 "CREATE CONSTRAINT UNIQUE_IMPORT_NAME FOR (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
                 "COMMIT%n" +
@@ -1070,9 +1070,9 @@ public class ExportCypherTest {
                 "SCHEMA AWAIT%n");
         
         static final String EXPECTED_SCHEMA_WITH_RELS_AND_IF_NOT_EXISTS = String.format("BEGIN%n" +
+                "CREATE RANGE INDEX IF NOT EXISTS FOR ()-[rel:KNOWS]-() ON (rel.since, rel.foo);%n" +
                 "CREATE RANGE INDEX IF NOT EXISTS FOR (n:Bar) ON (n.first_name, n.last_name);%n" +
                 "CREATE RANGE INDEX IF NOT EXISTS FOR (n:Foo) ON (n.name);%n" +
-                "CREATE RANGE INDEX IF NOT EXISTS FOR ()-[rel:KNOWS]-() ON (rel.since, rel.foo);%n" +
                 "CREATE CONSTRAINT uniqueConstraint IF NOT EXISTS FOR (node:Bar) REQUIRE (node.name) IS UNIQUE;%n" +
                 "CREATE CONSTRAINT UNIQUE_IMPORT_NAME IF NOT EXISTS FOR (node:`UNIQUE IMPORT LABEL`) REQUIRE (node.`UNIQUE IMPORT ID`) IS UNIQUE;%n" +
                 "COMMIT%n" +

--- a/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
+++ b/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
@@ -49,10 +49,10 @@ public class SchemasEnterpriseFeaturesTest {
     @Before
     public void removeAllConstraints() {
         session.writeTransaction(tx -> {
-            final List<String> constraints = tx.run("CALL db.constraints() YIELD name").list(i -> i.get("name").asString());
+            final List<String> constraints = tx.run("SHOW CONSTRAINTS YIELD name").list(i -> i.get("name").asString());
             constraints.forEach(name -> tx.run(String.format("DROP CONSTRAINT %s", name)));
 
-            final List<String> indexes = tx.run("CALL db.indexes() YIELD name").list(i -> i.get("name").asString());
+            final List<String> indexes = tx.run("SHOW INDEXES YIELD name").list(i -> i.get("name").asString());
             indexes.forEach(name -> tx.run(String.format("DROP INDEX %s", name)));
             tx.commit();
             return null;

--- a/core/src/test/java/apoc/schema/SchemasTest.java
+++ b/core/src/test/java/apoc/schema/SchemasTest.java
@@ -727,7 +727,7 @@ public class SchemasTest {
             assertEquals("NO FAILURE", r.get("failure"));
             assertEquals(100d, r.get("populationProgress"));
             assertEquals(1d, r.get("valuesSelectivity"));
-            final long indexId = db.executeTransactionally("CALL db.indexes() YIELD id, name WHERE name = $indexName RETURN id",
+            final long indexId = db.executeTransactionally("SHOW INDEXES YIELD id, name WHERE name = $indexName RETURN id",
                     Map.of("indexName", idxName), res -> res.<Long>columnAs("id").next());
             String expectedIndexDescription = String.format("Index( id=%s, name='%s', type='FULLTEXT', " +
                     "schema=(:Blah:Moon {weightProp, anotherProp}), indexProvider='fulltext-1.0' )", indexId, idxName);


### PR DESCRIPTION
The db.indexes() and db.constraints() procedures will be removed from Neo4j. The replacement is SHOW INDEXES and SHOW CONSTRAINTS, although these are not possible to use from procedures with READ mode.
