### PR TITLE
Fixes #3070: The apoc.export.csv.all with bulkImport config doesn't work with a file name without extension

### DIFF
--- a/core/src/main/java/apoc/export/cypher/FileManagerFactory.java
+++ b/core/src/main/java/apoc/export/cypher/FileManagerFactory.java
@@ -2,8 +2,8 @@ package apoc.export.cypher;
 
 import java.io.OutputStream;
 import apoc.export.util.ExportConfig;
-import apoc.util.CompressionAlgo;
 import apoc.util.Util;
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.PrintWriter;
@@ -19,6 +19,8 @@ import static apoc.util.FileUtils.getOutputStream;
  * @since 06.12.17
  */
 public class FileManagerFactory {
+    private final static String DOT = ".";
+    
     public static ExportFileManager createFileManager(String fileName, boolean separatedFiles) {
         return createFileManager(fileName, separatedFiles, ExportConfig.EMPTY);
     }
@@ -29,13 +31,7 @@ public class FileManagerFactory {
         }
         fileName = fileName.trim();
 
-        final CompressionAlgo compressionAlgo = CompressionAlgo.valueOf(config.getCompressionAlgo());
-
-        // In case of export with separated files (with bulkImport: true) in case of compressed file retrieve also the compression extension
-        // e.g. from test.one.two.csv to test.one.two.nodes.LABELNAME.csv.gz, test.one.two.relationships.RELTYPE.csv.gz, etc...
-        // otherwise it becomes test.one.two.nodes.LABELNAME.csv, etc..
-        int indexOfDot = StringUtils.lastOrdinalIndexOf(fileName, ".", compressionAlgo.equals(CompressionAlgo.NONE) ? 1 : 2);
-        String fileType = fileName.substring(indexOfDot + 1);
+        String fileType = FilenameUtils.getExtension(fileName);
         return new PhysicalExportFileManager(fileType, fileName, separatedFiles, config);
     }
 
@@ -48,7 +44,7 @@ public class FileManagerFactory {
         private ExportConfig config;
 
         public PhysicalExportFileManager(String fileType, String fileName, boolean separatedFiles, ExportConfig config) {
-            this.fileType = fileType;
+            this.fileType = StringUtils.isBlank(fileType) ? "" : fileType;
             this.fileName = fileName;
             this.separatedFiles = separatedFiles;
             this.config = config;
@@ -70,8 +66,15 @@ public class FileManagerFactory {
         }
 
         private String normalizeFileName(final String fileName, String suffix) {
+            if (StringUtils.isBlank(suffix)) {
+                return fileName;
+            }
+            // in case of file without dot extension, we just add the suffix 
+            if (StringUtils.isEmpty(fileType)) {
+                return fileName + DOT + suffix;
+            }
             // TODO check if this should be follow the same rules of FileUtils.readerFor
-            return fileName.replace("." + fileType, "." + (suffix != null ? suffix + "." + fileType : fileType));
+            return fileName.replace(fileType, suffix + DOT + fileType);
         }
 
         @Override

--- a/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
@@ -8,8 +8,6 @@ import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
@@ -119,9 +117,8 @@ public class ExportCsvNeo4jAdminTest {
     
     @Test
     public void testCypherExportCsvForAdminNeo4jImportWithConfigWithCompression() {
-        String fileBaseName = "query_nodes_with_csvgz_ext";
-        String fileExpectedExt = ".csv" + GZIP_EXT;
-        assertionTestExportForAdminNeo4jImport(GZIP, fileBaseName, fileExpectedExt);
+        String fileBaseName = "query_nodes_with_csvgz_ext.csv";
+        assertionTestExportForAdminNeo4jImport(GZIP, fileBaseName, GZIP_EXT);
     }
     
     @Test
@@ -138,9 +135,8 @@ public class ExportCsvNeo4jAdminTest {
 
     @Test
     public void testCypherExportCsvForAdminNeo4jImportWithCompressionAndWithoutExtensionAndMultiDotInName() {
-        String fileBaseName = "query_nodes_with_ext.dots";
-        String fileExpectedExt = ".name" + GZIP_EXT;
-        assertionTestExportForAdminNeo4jImport(GZIP, fileBaseName, fileExpectedExt);
+        String fileBaseName = "query_nodes_with_ext.dots.name";
+        assertionTestExportForAdminNeo4jImport(GZIP, fileBaseName, GZIP_EXT);
     }
 
     private void assertionTestExportForAdminNeo4jImport(CompressionAlgo algo, String fileBaseName, String fileExpectedExt) {

--- a/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvNeo4jAdminTest.java
@@ -7,8 +7,10 @@ import apoc.util.CompressionAlgo;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.internal.helpers.collection.Iterators;
@@ -82,13 +84,13 @@ public class ExportCsvNeo4jAdminTest {
         directory.mkdirs();
     }
 
-    @ClassRule
-    public static DbmsRule db = new ImpermanentDbmsRule()
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule()
             .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath())
             .withSetting(ApocSettings.apoc_export_file_enabled, true);
 
-    @BeforeClass
-    public static void setUp() throws Exception {
+    @Before
+    public void before() throws Exception {
         TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class);
         db.executeTransactionally("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})");
         db.executeTransactionally("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})");
@@ -96,18 +98,53 @@ public class ExportCsvNeo4jAdminTest {
     }
 
     @Test
-    public void testCypherExportCsvForAdminNeo4jImportWithConfig() {
-        String fileName = "query_nodes.csv";
-        assertionTestExportForAdminNeo4jImport(CompressionAlgo.NONE, fileName);
+    public void testCypherExportCsvForAdminNeo4jImportWithCompressionNone() {
+        String fileBaseName = "query_nodes_no_compress_and_Ext";
+        String fileExpectedExt = ".csv";
+        assertionTestExportForAdminNeo4jImport(CompressionAlgo.NONE, fileBaseName, fileExpectedExt);
+    }
+
+    @Test
+    public void testCypherExportCsvForAdminNeo4jImportWithCompressionNoneWithoutExtension() {
+        String fileBaseName = "query_nodes_no_compress";
+        assertionTestExportForAdminNeo4jImport(CompressionAlgo.NONE, fileBaseName, "");
+    }
+
+    @Test
+    public void testCypherExportCsvForAdminNeo4jImportWithCompressionNoneAndMultiDotInName() {
+        String fileBaseName = "query_nodes.dots.in";
+        String fileExpectedExt = ".name";
+        assertionTestExportForAdminNeo4jImport(CompressionAlgo.NONE, fileBaseName, fileExpectedExt);
     }
     
     @Test
     public void testCypherExportCsvForAdminNeo4jImportWithConfigWithCompression() {
-        String fileName = "query_nodes.csv" + GZIP_EXT;
-        assertionTestExportForAdminNeo4jImport(GZIP, fileName);
+        String fileBaseName = "query_nodes_with_csvgz_ext";
+        String fileExpectedExt = ".csv" + GZIP_EXT;
+        assertionTestExportForAdminNeo4jImport(GZIP, fileBaseName, fileExpectedExt);
+    }
+    
+    @Test
+    public void testCypherExportCsvForAdminNeo4jImportWithCompressionAndWithoutExtension() {
+        String fileBaseName = "query_nodes_with_ext";
+        assertionTestExportForAdminNeo4jImport(GZIP, fileBaseName, GZIP_EXT);
+    }
+    
+    @Test
+    public void testCypherExportCsvForAdminNeo4jImportWithCompressionAndWithoutAnyExtension() {
+        String fileBaseName = "query_nodes_with_no_ext";
+        assertionTestExportForAdminNeo4jImport(GZIP, fileBaseName, "");
     }
 
-    private void assertionTestExportForAdminNeo4jImport(CompressionAlgo algo, String fileName) {
+    @Test
+    public void testCypherExportCsvForAdminNeo4jImportWithCompressionAndWithoutExtensionAndMultiDotInName() {
+        String fileBaseName = "query_nodes_with_ext.dots";
+        String fileExpectedExt = ".name" + GZIP_EXT;
+        assertionTestExportForAdminNeo4jImport(GZIP, fileBaseName, fileExpectedExt);
+    }
+
+    private void assertionTestExportForAdminNeo4jImport(CompressionAlgo algo, String fileBaseName, String fileExpectedExt) {
+        final String fileName = fileBaseName + fileExpectedExt;
         File dir = new File(directory, fileName);
 
         TestUtil.testCall(db, "CALL apoc.export.csv.all($fileName,{compression: $compression, bulkImport: true, separateHeader: true, delim: ';'})",
@@ -124,25 +161,39 @@ public class ExportCsvNeo4jAdminTest {
         );
 
         String file = dir.getParent() + File.separator;
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS, "query_nodes.header.nodes.Address.csv", algo);
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS1, "query_nodes.header.nodes.Address1.Address.csv", algo);
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER, "query_nodes.header.nodes.User.csv", algo);
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER1, "query_nodes.header.nodes.User1.User.csv", algo);
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_TYPES_NODE, "query_nodes.header.nodes.Types.csv", algo);
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_KNOWS, "query_nodes.header.relationships.KNOWS.csv", algo);
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_NEXT_DELIVERY, "query_nodes.header.relationships.NEXT_DELIVERY.csv", algo);
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS, "query_nodes.nodes.Address.csv", algo);
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS1, "query_nodes.nodes.Address1.Address.csv", algo);
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER, "query_nodes.nodes.User.csv", algo);
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER1, "query_nodes.nodes.User1.User.csv", algo);
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_TYPES_NODE, "query_nodes.nodes.Types.csv", algo);
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_KNOWS, "query_nodes.relationships.KNOWS.csv", algo);
-        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_NEXT_DELIVERY, "query_nodes.relationships.NEXT_DELIVERY.csv", algo);
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS, fileBaseName + ".header.nodes.Address" + fileExpectedExt,  algo);
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS1, fileBaseName + ".header.nodes.Address1.Address" + fileExpectedExt,  algo);
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER, fileBaseName + ".header.nodes.User" + fileExpectedExt,  algo);
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER1, fileBaseName + ".header.nodes.User1.User" + fileExpectedExt,  algo);
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_TYPES_NODE, fileBaseName + ".header.nodes.Types" + fileExpectedExt,  algo);
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_KNOWS, fileBaseName + ".header.relationships.KNOWS" + fileExpectedExt,  algo);
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_NEXT_DELIVERY, fileBaseName + ".header.relationships.NEXT_DELIVERY" + fileExpectedExt,  algo);
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS, fileBaseName + ".nodes.Address" + fileExpectedExt,  algo);
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS1, fileBaseName + ".nodes.Address1.Address" + fileExpectedExt,  algo);
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER, fileBaseName + ".nodes.User" + fileExpectedExt,  algo);
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER1, fileBaseName + ".nodes.User1.User" + fileExpectedExt,  algo);
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_TYPES_NODE, fileBaseName + ".nodes.Types" + fileExpectedExt,  algo);
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_KNOWS, fileBaseName + ".relationships.KNOWS" + fileExpectedExt,  algo);
+        assertFileEquals(file, EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_NEXT_DELIVERY, fileBaseName + ".relationships.NEXT_DELIVERY" + fileExpectedExt,  algo);
     }
 
     @Test
-    public void testExportGraphNeo4jAdminCsv() throws Exception {
-        String fileName = "graph.csv";
+    public void testExportGraphNeo4jAdminCsvWithoutFileExt() {
+        testExportGraphNeo4jAdminCsvCommon("graph_with_no_ext", "");
+    }
+
+    @Test
+    public void testExportGraphNeo4jAdminCsvWithFileExt() {
+        testExportGraphNeo4jAdminCsvCommon("graph", ".csv");
+    }
+
+    @Test
+    public void testExportGraphNeo4jAdminCsvWithFileExtMultiDotInName() {
+        testExportGraphNeo4jAdminCsvCommon("graph.multi.dots.name.file", ".csv");
+    }
+
+    private void testExportGraphNeo4jAdminCsvCommon(String fileBaseName, String fileExpectedExt) {
+        final String fileName = fileBaseName + fileExpectedExt;
         File output = new File(directory, fileName);
         String separator = ";";
         TestUtil.testCall(db, "CALL apoc.graph.fromDB('test',{}) yield graph " +
@@ -152,13 +203,13 @@ public class ExportCsvNeo4jAdminTest {
                 (r) -> assertResults(fileName, r, "graph"));
 
         String file = output.getParent() + File.separator;
-        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS + EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS, "graph.nodes.Address.csv", separator);
-        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS1 + EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS1, "graph.nodes.Address1.Address.csv", separator);
-        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER + EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER, "graph.nodes.User.csv", separator);
-        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER1 + EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER1, "graph.nodes.User1.User.csv", separator);
-        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_TYPES_NODE + EXPECTED_NEO4J_ADMIN_IMPORT_TYPES_NODE, "graph.nodes.Types.csv", separator);
-        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_KNOWS + EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_KNOWS, "graph.relationships.KNOWS.csv", separator);
-        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_NEXT_DELIVERY + EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_NEXT_DELIVERY, "graph.relationships.NEXT_DELIVERY.csv", separator);
+        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS + EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS, fileBaseName + ".nodes.Address" + fileExpectedExt, separator);
+        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_ADDRESS1 + EXPECTED_NEO4J_ADMIN_IMPORT_NODE_ADDRESS1, fileBaseName + ".nodes.Address1.Address" + fileExpectedExt, separator);
+        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER + EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER, fileBaseName + ".nodes.User" + fileExpectedExt, separator);
+        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_NODE_USER1 + EXPECTED_NEO4J_ADMIN_IMPORT_NODE_USER1, fileBaseName + ".nodes.User1.User" + fileExpectedExt, separator);
+        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_TYPES_NODE + EXPECTED_NEO4J_ADMIN_IMPORT_TYPES_NODE, fileBaseName + ".nodes.Types" + fileExpectedExt, separator);
+        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_KNOWS + EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_KNOWS, fileBaseName + ".relationships.KNOWS" + fileExpectedExt, separator);
+        assertFileEquals(file,EXPECTED_NEO4J_ADMIN_IMPORT_HEADER_RELATIONSHIP_NEXT_DELIVERY + EXPECTED_NEO4J_ADMIN_IMPORT_RELATIONSHIP_NEXT_DELIVERY, fileBaseName + ".relationships.NEXT_DELIVERY" + fileExpectedExt, separator);
     }
 
     private void assertFileEquals(String base, String expected, String file) {
@@ -174,15 +225,10 @@ public class ExportCsvNeo4jAdminTest {
     }
 
     private void assertFileEquals(String base, String expected, String file, String separator, CompressionAlgo algo) {
-        String fileExt = algo.equals(GZIP) ? GZIP_EXT : "";
         final List<Map<String, Object>> expectedList = convertCSVString(expected, separator);
-        final String actual = BinaryTestUtil.readFileToString(new File(base + file + fileExt), StandardCharsets.UTF_8, algo);
+        final String actual = BinaryTestUtil.readFileToString(new File(base + file), StandardCharsets.UTF_8, algo);
         final List<Map<String, Object>> actualList = convertCSVString(actual, separator);
         assertEquals(expectedList, actualList);
-    }
-
-    private List<Map<String, Object>> convertCSVString(String csv) {
-        return convertCSVString(csv, ",");
     }
 
     private List<Map<String, Object>> convertCSVString(String csv, String separator) {

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -191,6 +191,22 @@ public class ExportCsvTest {
     @Test
     public void testExportAllCsv() throws Exception {
         String fileName = "all.csv";
+        testExportCsvAllCommon(fileName);
+    }
+
+    @Test
+    public void testExportAllCsvWithDotInName() {
+        String fileName = "all.with.dot.filename.csv";
+        testExportCsvAllCommon(fileName);
+    }
+
+    @Test
+    public void testExportAllCsvWithoutExtension() {
+        String fileName = "all";
+        testExportCsvAllCommon(fileName);
+    }
+
+    private void testExportCsvAllCommon(String fileName) {
         TestUtil.testCall(db, "CALL apoc.export.csv.all($file,null)", map("file", fileName),
                 (r) -> assertResults(fileName, r, "database"));
         assertEquals(EXPECTED, readFile(fileName));


### PR DESCRIPTION
Fixes #3070

If the file has at leas one dots, eg "test.ccc" / "test.foo.bar.ccc", 
via `FilenameUtils.getExtension` we consider the "ccc" part to be appended to `fileName.nodes.LABELNAME`.
If the file has no dots, I simply attach `.nodes.LABELNAME` to it.


- Added tests with multiple points in the filename
- Changed `DbmsRule` from `@ClassRule` to `@Rule` in order to recreate the dataset and avoid conflicts