### PR TITLE
Fixes #2992: apoc.diff.nodes() returns list-type properties as different when they are the same

### DIFF
--- a/core/src/main/java/apoc/diff/Diff.java
+++ b/core/src/main/java/apoc/diff/Diff.java
@@ -10,6 +10,8 @@ import org.neo4j.procedure.UserFunction;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * @author Benjamin Clauss
@@ -45,9 +47,10 @@ public class Diff {
     }
 
     private Map<String, Object> getPropertiesInCommon(Map<String, Object> left, Map<String, Object> right) {
-        Map<String, Object> inCommon = new HashMap<>(left);
-        inCommon.entrySet().retainAll(right.entrySet());
-        return inCommon;
+        // we use filter(entry -> Objects.deepEquals...) instead of retainAll because retainAll use `.equals()`, so it doesn't compare arrays 
+        return left.entrySet().stream()
+                .filter(entry -> Objects.deepEquals(entry.getValue(), right.get(entry.getKey())))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     private Map<String, Map<String, Object>> getPropertiesDiffering(Map<String, Object> left, Map<String, Object> right) {
@@ -57,7 +60,7 @@ public class Diff {
         keyPairs.keySet().retainAll(right.keySet());
 
         for (Map.Entry<String, Object> entry : keyPairs.entrySet()) {
-            if (!left.get(entry.getKey()).equals(right.get(entry.getKey()))) {
+            if (!Objects.deepEquals(left.get(entry.getKey()), right.get(entry.getKey()))) {
                 Map<String, Object> pairs = new HashMap<>();
                 pairs.put("left", left.get(entry.getKey()));
                 pairs.put("right", right.get(entry.getKey()));

--- a/core/src/test/java/apoc/diff/DiffTest.java
+++ b/core/src/test/java/apoc/diff/DiffTest.java
@@ -12,8 +12,6 @@ import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/core/src/test/java/apoc/diff/DiffTest.java
+++ b/core/src/test/java/apoc/diff/DiffTest.java
@@ -12,7 +12,10 @@ import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.*;
@@ -50,6 +53,24 @@ public class DiffTest {
             node3.setProperty("prop4", "for");
             tx.commit();
         }
+    }
+
+    @Test
+    public void nodesWithList() {
+        final List<String> list = List.of("tomatoes", "bread", "cookies");
+        TestUtil.testCall(db, "CREATE (charlie:Person $propCharlie), (hannah:Person $propHanna)\n" +
+                "RETURN apoc.diff.nodes(charlie, hannah) AS result", 
+                Map.of("propCharlie", Map.of("name", "Charlie", "alpha", "one", "born", 1999, "grocery_list", list),
+                        "propHanna", Map.of("name", "Hannah", "beta", "two", "born", 1999, "grocery_list", list)),
+                r -> {
+            Map<String, Map<String, Object>> res = (Map<String, Map<String, Object>>) r.get("result");
+            Map<String, Object> inCommon = res.get("inCommon");
+            assertArrayEquals(list.toArray(), (String[]) inCommon.get("grocery_list"));
+            assertEquals(1999, inCommon.get("born"));
+            assertEquals(Map.of("alpha", "one"), res.get("leftOnly"));
+            assertEquals(Map.of("beta", "two"), res.get("rightOnly"));
+            assertEquals(Map.of("name", Map.of("left", "Charlie", "right", "Hannah")), res.get("different"));
+        });
     }
 
     @Test


### PR DESCRIPTION
Fixes #2992

- Changed `equals` with `deepEquals`, in order to compare arrays