### PR TITLE
Fixes #2930: The apoc.import.json constraint check should works only when an unique constraint exists

### DIFF
--- a/core/src/test/java/apoc/export/json/ImportJsonEnterpriseTest.java
+++ b/core/src/test/java/apoc/export/json/ImportJsonEnterpriseTest.java
@@ -1,0 +1,102 @@
+package apoc.export.json;
+
+import apoc.util.CompressionAlgo;
+import apoc.util.Neo4jContainerExtension;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.driver.Session;
+
+import java.io.File;
+
+import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
+import static apoc.export.json.JsonImporter.MISSING_CONSTRAINT_ERROR_MSG;
+import static apoc.util.BinaryTestUtil.fileToBinary;
+import static apoc.util.CompressionConfig.COMPRESSION;
+import static apoc.util.TestContainerUtil.createEnterpriseDB;
+import static apoc.util.TestContainerUtil.testCall;
+import static apoc.util.Util.map;
+import static java.lang.String.format;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ImportJsonEnterpriseTest {
+
+    private static final String MISSING_USER_CONSTRAINT = format(MISSING_CONSTRAINT_ERROR_MSG, "User", "neo4jImportId");
+    private static Neo4jContainerExtension neo4jContainer;
+    private static Session session;
+
+    @BeforeClass
+    public static void beforeAll() {
+        neo4jContainer = createEnterpriseDB(true)
+                .withEnv(APOC_IMPORT_FILE_ENABLED, "true");
+        neo4jContainer.start();
+        session = neo4jContainer.getSession();
+    }
+
+    @AfterClass
+    public static void afterAll() {
+        session.close();
+        neo4jContainer.close();
+    }
+
+    @Before
+    public void before() {
+        session.run("MATCH (n) DETACH DELETE n");
+    }
+
+    @Test
+    public void shouldFailsWithExistenceConstraintDueToMissingUniqueConstraint() {
+        final byte[] file = fileToBinary(new File(ImportJsonTest.directory, "all.json"), CompressionAlgo.GZIP.name());
+
+        session.run("CREATE CONSTRAINT userExistence ON (n:User) assert n.neo4jImportId IS NOT NULL");
+
+        // when
+        try {
+            testCall(session, "CALL apoc.import.json($file, $config)",
+                    map("file", file, "config", map(COMPRESSION, CompressionAlgo.GZIP.name())),
+                    r -> fail("Should fail due to missing constraint"));
+        } catch (RuntimeException e) {
+            assertTrue(e.getMessage().contains(MISSING_USER_CONSTRAINT));
+        } finally {
+            session.run("DROP CONSTRAINT userExistence");
+        }
+        
+    }
+
+    @Test
+    public void shouldFailsWithMultipleNodeKeyDueToMissingUniqueConstraint() {
+        final byte[] file = fileToBinary(new File(ImportJsonTest.directory, "all.json"), CompressionAlgo.GZIP.name());
+
+        session.run("CREATE CONSTRAINT userMultipleKeys ON (n:User) assert (n.neo4jImportId, n.anotherProp) IS NODE KEY");
+
+        // when
+        try {
+            testCall(session, "CALL apoc.import.json($file, $config)",
+                    map("file", file, "config", map(COMPRESSION, CompressionAlgo.GZIP.name())),
+                    r -> fail("Should fail due to missing constraint"));
+        } catch (RuntimeException e) {
+            assertTrue(e.getMessage().contains(MISSING_USER_CONSTRAINT));
+        } finally {
+            session.run("DROP CONSTRAINT userMultipleKeys");
+        }
+        
+    }
+    
+    @Test
+    public void shouldImportWithNodeKeyConstraint() {
+        final byte[] file = fileToBinary(new File(ImportJsonTest.directory, "all.json"), CompressionAlgo.GZIP.name());
+
+        session.run("CREATE CONSTRAINT userNodeKey ON (n:User) assert (n.neo4jImportId) IS NODE KEY");
+
+        try {
+            // when
+            testCall(session, "CALL apoc.import.json($file, $config)",
+                    map("file", file, "config", map(COMPRESSION, CompressionAlgo.GZIP.name())),
+                    r -> ImportJsonTest.assertionsAllJsonProgressInfo(r, true));
+        } finally {
+            session.run("DROP CONSTRAINT userNodeKey");
+        }
+    }
+}

--- a/core/src/test/java/apoc/export/json/ImportJsonEnterpriseTest.java
+++ b/core/src/test/java/apoc/export/json/ImportJsonEnterpriseTest.java
@@ -47,7 +47,7 @@ public class ImportJsonEnterpriseTest {
     }
 
     @Test
-    public void shouldFailsWithExistenceConstraintDueToMissingUniqueConstraint() {
+    public void shouldFailWithExistenceConstraintDueToMissingUniqueConstraint() {
         final byte[] file = fileToBinary(new File(ImportJsonTest.directory, "all.json"), CompressionAlgo.GZIP.name());
 
         session.run("CREATE CONSTRAINT userExistence ON (n:User) assert n.neo4jImportId IS NOT NULL");
@@ -66,7 +66,7 @@ public class ImportJsonEnterpriseTest {
     }
 
     @Test
-    public void shouldFailsWithMultipleNodeKeyDueToMissingUniqueConstraint() {
+    public void shouldFailWithMultipleNodeKeyDueToMissingUniqueConstraint() {
         final byte[] file = fileToBinary(new File(ImportJsonTest.directory, "all.json"), CompressionAlgo.GZIP.name());
 
         session.run("CREATE CONSTRAINT userMultipleKeys ON (n:User) assert (n.neo4jImportId, n.anotherProp) IS NODE KEY");

--- a/core/src/test/java/apoc/export/json/ImportJsonTest.java
+++ b/core/src/test/java/apoc/export/json/ImportJsonTest.java
@@ -56,7 +56,7 @@ public class ImportJsonTest {
 
     private static final long NODES_BIG_JSON = 16L;
     private static final long RELS_BIG_JSON = 4L;
-    private static File directory = new File("../docs/asciidoc/modules/ROOT/examples/data/exportJSON");
+    public static File directory = new File("../docs/asciidoc/modules/ROOT/examples/data/exportJSON");
 
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule()
@@ -358,7 +358,7 @@ public class ImportJsonTest {
         assertionsAllJsonDbResult();
     }
 
-    private void assertionsAllJsonProgressInfo(Map<String, Object> r, boolean isBinary) {
+    public static void assertionsAllJsonProgressInfo(Map<String, Object> r, boolean isBinary) {
         // then
         Assert.assertEquals(isBinary ? null : "all.json", r.get("file"));
         Assert.assertEquals(isBinary ? "binary" : "file", r.get("source"));


### PR DESCRIPTION
Fixes #2930

Excluded node key and unique constraints