### PR TITLE
Fixes #2890: The apoc.export.graphml.query export additional unwanted nodes

### DIFF
--- a/core/src/main/java/apoc/export/cypher/ExportCypher.java
+++ b/core/src/main/java/apoc/export/cypher/ExportCypher.java
@@ -96,7 +96,7 @@ public class ExportCypher {
         Result result = tx.execute(query);
         SubGraph graph;
         try {
-            graph = CypherResultSubGraph.from(tx, result, c.getRelsInBetween());
+            graph = CypherResultSubGraph.from(tx, result, c.getRelsInBetween(), c.isAddRelNodes());
         } catch (IllegalStateException e) {
             throw new RuntimeException("Full-text indexes on relationships are not supported, please delete them in order to complete the process");
         }

--- a/core/src/main/java/apoc/export/graphml/ExportGraphML.java
+++ b/core/src/main/java/apoc/export/graphml/ExportGraphML.java
@@ -110,7 +110,7 @@ public class ExportGraphML {
     public Stream<ProgressInfo> query(@Name("query") String query, @Name("file") String fileName, @Name("config") Map<String, Object> config) throws Exception {
         ExportConfig c = new ExportConfig(config);
         Result result = tx.execute(query);
-        SubGraph graph = CypherResultSubGraph.from(tx, result, c.getRelsInBetween());
+        SubGraph graph = CypherResultSubGraph.from(tx, result, c.getRelsInBetween(), c.isAddRelNodes());
         String source = String.format("statement: nodes(%d), rels(%d)",
                 Iterables.count(graph.getNodes()), Iterables.count(graph.getRelationships()));
         return exportGraphML(fileName, source, graph, c);

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -55,6 +55,7 @@ public class ExportConfig extends CompressionConfig {
     private Set<String> caption;
     private boolean writeNodeProperties;
     private boolean nodesOfRelationships;
+    private boolean addRelNodes;
     private ExportFormat format;
     private CypherFormat cypherFormat;
     private final Map<String, Object> config;
@@ -133,6 +134,7 @@ public class ExportConfig extends CompressionConfig {
         this.samplingConfig = (Map<String, Object>) config.getOrDefault("samplingConfig", new HashMap<>());
         this.unwindBatchSize = ((Number)getOptimizations().getOrDefault("unwindBatchSize", DEFAULT_UNWIND_BATCH_SIZE)).intValue();
         this.awaitForIndexes = ((Number)config.getOrDefault("awaitForIndexes", 300)).longValue();
+        this.addRelNodes = toBoolean(config.getOrDefault("addRelNodes", true));
         this.multipleRelationshipsWithType = toBoolean(config.get(RELS_WITH_TYPE_KEY));
         this.source = new NodeConfig((Map<String, String>) config.get("source"));
         this.target = new NodeConfig((Map<String, String>) config.get("target"));
@@ -161,7 +163,6 @@ public class ExportConfig extends CompressionConfig {
             this.quotes = toBoolean(config.get("quotes")) ? ALWAYS_QUOTES : NONE_QUOTES;
         }
     }
-
     public boolean getRelsInBetween() {
         return nodesOfRelationships;
     }
@@ -248,6 +249,10 @@ public class ExportConfig extends CompressionConfig {
     
     public boolean ifNotExists() {
         return ifNotExists;
+    }
+
+    public boolean isAddRelNodes() {
+        return addRelNodes;
     }
 
     public boolean shouldSaveIndexNames() {

--- a/core/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/CypherResultSubGraph.java
@@ -37,18 +37,24 @@ public class CypherResultSubGraph implements SubGraph
         labels.addAll( Iterables.asCollection( data.getLabels() ) );
     }
 
-    public void add( Relationship rel )
+    public void add( Relationship rel, boolean addNodes )
     {
         final long id = rel.getId();
         if ( !relationships.containsKey( id ) )
         {
             addRel( id, rel );
-            add( rel.getStartNode() );
-            add( rel.getEndNode() );
+            if (addNodes) {
+                add( rel.getStartNode() );
+                add( rel.getEndNode() );
+            }
         }
     }
 
-    public static SubGraph from(Transaction tx, Result result, boolean addBetween)
+    public static SubGraph from(Transaction tx, Result result, boolean addBetween) {
+        return from(tx, result, addBetween, true);
+    }
+        
+    public static SubGraph from(Transaction tx, Result result, boolean addBetween, boolean addRelNodes)
     {
         final CypherResultSubGraph graph = new CypherResultSubGraph();
         final List<String> columns = result.columns();
@@ -57,7 +63,7 @@ public class CypherResultSubGraph implements SubGraph
             for ( String column : columns )
             {
                 final Object value = row.get( column );
-                graph.addToGraph( value );
+                graph.addToGraph( value, addRelNodes );
             }
         }
         for ( IndexDefinition def : tx.schema().getIndexes() )
@@ -124,7 +130,7 @@ public class CypherResultSubGraph implements SubGraph
         }
     }
 
-    private void addToGraph( Object value )
+    private void addToGraph( Object value, boolean addNodes )
     {
         if ( value instanceof Node )
         {
@@ -132,13 +138,13 @@ public class CypherResultSubGraph implements SubGraph
         }
         if ( value instanceof Relationship )
         {
-            add( (Relationship) value );
+            add( (Relationship) value, addNodes );
         }
         if ( value instanceof Iterable )
         {
             for ( Object inner : (Iterable) value )
             {
-                addToGraph( inner );
+                addToGraph( inner, addNodes );
             }
         }
     }

--- a/docs/asciidoc/modules/ROOT/pages/export/graphml.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/export/graphml.adoc
@@ -64,6 +64,9 @@ The procedures support the following config parameters:
 | defaultRelationshipType | "RELATED" | set relationship type (import/export graphml)
 | separateFiles | false | export results in separated file by type (nodes, relationships..)
 | stream | false | stream the xml directly to the client into the `data` field
+| addRelNodes | true | if enabled export start and end nodes, in case of query returning relationships
+| nodesOfRelationships | false | if enabled export other terminal nodes, in case of query returning relationships and start or end nodes..
+    Note that both `addRelNodes` and `nodesOfRelationships` have to be false not to return other node, because with `addRelNodes=true` the start and end nodes are always returned.
 | useTypes | false | Write the attribute type information to the graphml output
 | source | Map<String,String> | Empty map | To be used together with `target` to import (via `apoc.import.graphml`) a relationships-only file. In this case the source and target attributes of `edge` tag are not based on an internal id of nodes but on a custom property value. + 
 For example, with a path like `(:Foo {name: "aaa"})-[:KNOWS]->(:Bar {age: 666})`, we can export the `KNOWS` rel with a config `<edge id="e2" source="aaa" sourceType="string" target="666" targetType="long" label="KNOWS"><data key="label">KNOWS</data><data key="id">1</data></edge>`. Note the additional `sourceType`/`targetType` to detect the right type during the import.

--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.cypher.query.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.export.cypher.query.adoc
@@ -26,4 +26,7 @@ The procedure support the following config parameters:
 * `UNWIND_BATCH_PARAMS` - similar to `UNWIND_BATCH`, but also uses parameters where appropriate
 | awaitForIndexes | Long | 300 | Timeout to use for `db.awaitIndexes` when using `format: "cypher-shell"`
 | ifNotExists | boolean | false | If true adds the keyword `IF NOT EXISTS` to constraints and indexes
+| addRelNodes | true | if enabled export start and end nodes, in case of query returning relationships
+| nodesOfRelationships | false | if enabled export other terminal nodes, in case of query returning relationships and start or end nodes.
+    Note that both `addRelNodes` and `nodesOfRelationships` have to be false not to return other node, because with `addRelNodes=true` the start and end nodes are always returned.
 |===


### PR DESCRIPTION
Fixes #2890

The bug regards the export cypher as well, because the same method it's called.

Added config in order to export or not start/end nodes, with default `true`.

----

Other fixes: documented and unit-tested `nodesOfRelationships` config
