### PR TITLE
NO AUTO Adds blocklist for load methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,7 @@ dependencies {
 //    apt 'net.biville.florent:neo4j-sproc-compiler:1.2'  // temporarily disabled until byte[] is supported by sproc compiler
     apt group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective	
     compile group: 'commons-codec', name: 'commons-codec', version: '1.14'
+    compile group: 'com.github.seancfoley', name: 'ipaddress', version: '5.3.3'
     compileOnly group: 'com.sun.mail', name: 'javax.mail', version: '1.6.0'
     testCompile group: 'com.sun.mail', name: 'javax.mail', version: '1.6.0'
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.4.0'

--- a/src/main/java/apoc/util/FileUtils.java
+++ b/src/main/java/apoc/util/FileUtils.java
@@ -249,10 +249,14 @@ public class FileUtils {
         return ApocConfiguration.get("dbms.directories.import", "import");
     }
 
-    public static void checkReadAllowed(String url) {
-        if (isFile(url) && !ApocConfiguration.isEnabled("import.file.enabled"))
-            throw new RuntimeException(LOAD_FROM_FILE_ERROR);
+    public static void checkReadAllowed(String url) throws IOException {
+        if (isFile(url) && !ApocConfiguration.isEnabled("import.file.enabled")) {
+            throw new RuntimeException( LOAD_FROM_FILE_ERROR );
+        } else {
+            ApocConfiguration.checkAllowedUrl(url);
+        }
     }
+
     public static void checkWriteAllowed(ExportConfig exportConfig, String fileName) {
         if (!ApocConfiguration.isEnabled("export.file.enabled"))
             if (exportConfig == null || (fileName != null && !fileName.equals("")) || !exportConfig.streamStatements()) {

--- a/src/main/java/apoc/util/Util.java
+++ b/src/main/java/apoc/util/Util.java
@@ -418,6 +418,7 @@ public class Util {
     }
 
     public static StreamConnection readHttpInputStream(String urlAddress, Map<String, Object> headers, String payload) throws IOException {
+        FileUtils.checkReadAllowed(urlAddress);
         URLConnection con = openUrlConnection(urlAddress, headers);
         writePayload(con, payload);
         String newUrl = handleRedirect(con, urlAddress);


### PR DESCRIPTION
Cherry picks #2467

## What

Uses Neo4j internal option `unsupported.dbms.cypher_ip_blocklist`, which consists on a list of ip addresses in CDIR notation, i.e. ip + mask for subnets, e.g. `192.167.2.3/8, 192.234.3.123/16`. When using the `apoc.load.json(url)` command, the url will be looked up in a DNS resolver and we will fail if it is on the list of blocked ip addresses.

## Why

To prevent users trying to load data from any url. To completely block all ipv4 and ipv6 addresses one should use:

```
unsupported.dbms.cypher_ip_blocklist=0.0.0.0/0,::/0
```

