### PR TITLE
NO AUTO Brings back jackson databind

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -180,7 +180,7 @@ dependencies {
     // schemacrawler
     compile group: 'us.fatehi', name: 'schemacrawler', version: '15.04.01'
     testCompile group: 'us.fatehi', name: 'schemacrawler-mysql', version: '15.04.01'
-
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.7'
 
     testCompile group: 'org.apache.hive', name: 'hive-jdbc', version: '1.2.2', withoutServers
 


### PR DESCRIPTION
## Why
Jackson-databind was removed in https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/2668 (probably by mistake), so ever since 3.5 produces a runtime error when using this apoc version:


```
Caused by: org.neo4j.kernel.lifecycle.LifecycleException: Component 'apoc.ApocKernelExtensionFactory$ApocLifecycle@6e495b48' was successfully initialized, but failed to start. Please see the attached cause exception "com.fasterxml.jackson.core.type.TypeReference".
        at org.neo4j.kernel.lifecycle.LifeSupport$LifecycleInstance.start(LifeSupport.java:473)
        at org.neo4j.kernel.lifecycle.LifeSupport.start(LifeSupport.java:111)
        at org.neo4j.kernel.extension.AbstractKernelExtensions.start(AbstractKernelExtensions.java:82)
        at org.neo4j.kernel.lifecycle.LifeSupport$LifecycleInstance.start(LifeSupport.java:452)
        at org.neo4j.kernel.lifecycle.LifeSupport.start(LifeSupport.java:111)
        at org.neo4j.kernel.lifecycle.LifeSupport$LifecycleInstance.start(LifeSupport.java:452)
        at org.neo4j.kernel.lifecycle.LifeSupport.start(LifeSupport.java:111)
        at org.neo4j.kernel.NeoStoreDataSource.start(NeoStoreDataSource.java:444)
        ... 15 more
Caused by: java.lang.NoClassDefFoundError: com/fasterxml/jackson/core/type/TypeReference
        at apoc.uuid.Uuid$UuidLifeCycle.start(Uuid.java:137)
        at apoc.ApocKernelExtensionFactory$ApocLifecycle.start(ApocKernelExtensionFactory.java:89)
        at org.neo4j.kernel.lifecycle.LifeSupport$LifecycleInstance.start(LifeSupport.java:452)
        ... 22 more
Caused by: java.lang.ClassNotFoundException: com.fasterxml.jackson.core.type.TypeReference
        at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
        ... 25 more
```

To reproduce a 3.5 version is needed with the following in the config:

```
dbms.security.procedures.whitelist=apoc.*
apoc.uuid.enabled=true
```
