### PR TITLE
Adapt to breaking changes to SHOW DATABASES

### DIFF
--- a/common/src/main/java/apoc/util/Util.java
+++ b/common/src/main/java/apoc/util/Util.java
@@ -687,9 +687,9 @@ public class Util {
     {
         var socketAddress = db.getDependencyResolver().resolveDependency( Config.class ).get( BoltConnector.advertised_address ).toString();
         GraphDatabaseService systemDb = db.getDependencyResolver().resolveDependency( DatabaseManagementService.class ).database( SYSTEM_DATABASE_NAME );
-        String role = systemDb.executeTransactionally( "SHOW DATABASE $databaseName WHERE address = $socketAddress",
-                Map.of( "databaseName", db.databaseName(), "socketAddress", socketAddress ), result -> Iterators.single( result.columnAs( "role" ) ) );
-        return role.equalsIgnoreCase( "LEADER" )  || role.equalsIgnoreCase( "standalone" );
+        Boolean writer = systemDb.executeTransactionally( "SHOW DATABASE $databaseName WHERE address = $socketAddress",
+                Map.of( "databaseName", db.databaseName(), "socketAddress", socketAddress ), result -> Iterators.single( result.columnAs( "writer" ) ) );
+        return writer;
     }
 
     /**

--- a/extended/src/test/java/apoc/systemdb/SystemDbTest.java
+++ b/extended/src/test/java/apoc/systemdb/SystemDbTest.java
@@ -25,7 +25,6 @@ import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.io.File;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -84,12 +83,12 @@ public class SystemDbTest {
 
     @Test
     public void testExecute() {
-        TestUtil.testResult(db, "CALL apoc.systemdb.execute('SHOW DATABASES YIELD name, default, currentStatus, role, requestedStatus, error, address, aliases, access, home') YIELD row RETURN row", result -> {
+        TestUtil.testResult(db, "CALL apoc.systemdb.execute('SHOW DATABASES YIELD name, default, currentStatus, home') YIELD row RETURN row", result -> {
             List<Map<String, Object>> rows = Iterators.asList(result.columnAs("row"));
             // removed key "systemDefault"
             org.hamcrest.MatcherAssert.assertThat(rows, Matchers.containsInAnyOrder(
-                    MapUtil.map( "name", "system", "default", false, "currentStatus", "online", "role", "standalone", "requestedStatus", "online", "error", "", "address", "localhost:7687", "aliases", Collections.EMPTY_LIST, "access", "read-write", "home", false),
-                    MapUtil.map("name", "neo4j", "default", true, "currentStatus", "online", "role", "standalone", "requestedStatus", "online", "error", "", "address", "localhost:7687", "aliases", Collections.EMPTY_LIST, "access", "read-write", "home", true)
+                    MapUtil.map( "name", "system", "default", false, "currentStatus", "online", "home", false),
+                    MapUtil.map("name", "neo4j", "default", true, "currentStatus", "online", "home", true)
             ));
         });
     }


### PR DESCRIPTION
## Proposed Changes (Mandatory)
SHOW DATABASES has a couple of breaking changes in 5.x

* role is now simply 'primary' or 'secondary'
* writer is used to determine the leader
* error is now statusMessage

I made the SystemDBTest even simpler than before, which I think is fine because it's just really testing the ability to execute _something_ there.