### PR TITLE
Sanitize back-ticks in strings when there is a possibility of Cypher injection 

### DIFF
--- a/core/src/main/java/apoc/refactor/GraphRefactoring.java
+++ b/core/src/main/java/apoc/refactor/GraphRefactoring.java
@@ -562,11 +562,14 @@ public class GraphRefactoring {
             node = Util.rebind(innerTx, node);
             Object value = node.getProperty(sourceKey, null);
             if (value != null) {
+                String nodeLabel = Util.sanitizeBackTicks(label);
+                String key = Util.sanitizeBackTicks(targetKey);
+                String relType = Util.sanitizeBackTicks(relationshipType);
                 String q =
                         "WITH $node AS n " +
-                                "MERGE (cat:`" + label + "` {`" + targetKey + "`: $value}) " +
-                                (outgoing ? "MERGE (n)-[:`" + relationshipType + "`]->(cat) "
-                                        : "MERGE (n)<-[:`" + relationshipType + "`]-(cat) ") +
+                                "MERGE (cat:`" + nodeLabel + "` {`" + key + "`: $value}) " +
+                                (outgoing ? "MERGE (n)-[:`" + relType + "`]->(cat) "
+                                        : "MERGE (n)<-[:`" + relType + "`]-(cat) ") +
                                 "RETURN cat";
                 Map<String, Object> params = new HashMap<>(2);
                 params.put("node", node);

--- a/core/src/main/java/apoc/refactor/rename/Rename.java
+++ b/core/src/main/java/apoc/refactor/rename/Rename.java
@@ -61,6 +61,8 @@ public class Rename {
 	@Description("apoc.refactor.rename.label(oldLabel, newLabel, [nodes]) | rename a label from 'oldLabel' to 'newLabel' for all nodes. If 'nodes' is provided renaming is applied to this set only")
 	public Stream<BatchAndTotalResultWithInfo> label(@Name("oldLabel") String oldLabel, @Name("newLabel") String newLabel, @Name(value = "nodes", defaultValue = "[]") List<Node> nodes) {
 		nodes = nodes.stream().map(n -> Util.rebind(tx, n)).collect(Collectors.toList());
+		oldLabel = Util.sanitizeBackTicks(oldLabel);
+		newLabel = Util.sanitizeBackTicks(newLabel);
 		String cypherIterate = nodes != null && !nodes.isEmpty() ? "UNWIND $nodes AS n WITH n WHERE n:`"+oldLabel+"` RETURN n" : "MATCH (n:`"+oldLabel+"`) RETURN n";
         String cypherAction = "SET n:`"+newLabel+"` REMOVE n:`"+oldLabel+"`";
         Map<String, Object> parameters = MapUtil.map("batchSize", 100000, "parallel", true, "iterateList", true, "params", MapUtil.map("nodes", nodes));
@@ -77,6 +79,8 @@ public class Rename {
 													@Name(value = "rels", defaultValue = "[]") List<Relationship> rels,
 													@Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
 		rels = rels.stream().map(r -> Util.rebind(tx, r)).collect(Collectors.toList());
+		newType = Util.sanitizeBackTicks(newType);
+		oldType = Util.sanitizeBackTicks(oldType);
 		String cypherIterate = rels != null && ! rels.isEmpty() ?
 				"UNWIND $rels AS oldRel WITH oldRel WHERE type(oldRel)=\""+oldType+"\" RETURN oldRel,startNode(oldRel) as a,endNode(oldRel) as b" :
 				"MATCH (a)-[oldRel:`"+oldType+"`]->(b) RETURN oldRel,a,b";
@@ -116,8 +120,10 @@ public class Rename {
 															@Name(value="nodes", defaultValue = "[]") List<Node> nodes,
 															@Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
 		nodes = nodes.stream().map(n -> Util.rebind(tx, n)).collect(Collectors.toList());
-		String cypherIterate = nodes != null && ! nodes.isEmpty() ? "UNWIND $nodes AS n WITH n WHERE exists (n."+oldName+") return n" : "match (n) where exists (n."+oldName+") return n";
-		String cypherAction = "set n."+newName+"= n."+oldName+" remove n."+oldName;
+		oldName = Util.sanitizeBackTicks(oldName);
+		newName = Util.sanitizeBackTicks(newName);
+		String cypherIterate = nodes != null && ! nodes.isEmpty() ? "UNWIND $nodes AS n WITH n WHERE exists (n.`"+oldName+"`) return n" : "match (n) where exists (n.`"+oldName+"`) return n";
+		String cypherAction = "set n.`"+newName+"`= n.`"+oldName+"` remove n.`"+oldName+"`";
 		final Map<String, Object> params = MapUtil.map("nodes", nodes);
 		Map<String, Object> parameters = getPeriodicConfig(config, params);
 		return getResultOfBatchAndTotalWithInfo(newPeriodic().iterate(cypherIterate, cypherAction, parameters), db, null, null, oldName);
@@ -133,8 +139,10 @@ public class Rename {
 															@Name(value="rels", defaultValue = "[]") List<Relationship> rels,
 															@Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
 		rels = rels.stream().map(r -> Util.rebind(tx, r)).collect(Collectors.toList());
-		String cypherIterate = rels != null && ! rels.isEmpty() ? "UNWIND $rels AS r WITH r WHERE exists (r."+oldName+") return r" : "match ()-[r]->() where exists (r."+oldName+") return r";
-		String cypherAction = "set r."+newName+"= r."+oldName+" remove r."+oldName;
+		newName = Util.sanitizeBackTicks(newName);
+		oldName = Util.sanitizeBackTicks(oldName);
+		String cypherIterate = rels != null && ! rels.isEmpty() ? "UNWIND $rels AS r WITH r WHERE exists (r.`"+oldName+"`) return r" : "match ()-[r]->() where exists (r.`"+oldName+"`) return r";
+		String cypherAction = "set r.`"+newName+"`= r.`"+oldName+"` remove r.`"+oldName+"`";
 		final Map<String, Object> params = MapUtil.map("rels", rels);
 		Map<String, Object> parameters = getPeriodicConfig(config, params);
 		return getResultOfBatchAndTotalWithInfo(newPeriodic().iterate(cypherIterate, cypherAction, parameters), db, null, null, oldName);

--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -3,6 +3,7 @@ package apoc.schema;
 import apoc.result.AssertSchemaResult;
 import apoc.result.IndexConstraintNodeInfo;
 import apoc.result.IndexConstraintRelationshipInfo;
+import apoc.util.Util;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.common.EntityType;
 import org.neo4j.common.TokenNameLookup;
@@ -145,9 +146,9 @@ public class Schemas {
 
     private AssertSchemaResult createNodeKeyConstraint(String lbl, List<Object> keys) {
         String keyProperties = keys.stream()
-                .map( property -> String.format("n.`%s`", property))
+                .map( property -> String.format("n.`%s`", Util.sanitizeBackTicks(property.toString())))
                 .collect( Collectors.joining( "," ) );
-        tx.execute(String.format("CREATE CONSTRAINT ON (n:`%s`) ASSERT (%s) IS NODE KEY", lbl, keyProperties)).close();
+        tx.execute(String.format("CREATE CONSTRAINT ON (n:`%s`) ASSERT (%s) IS NODE KEY", Util.sanitizeBackTicks(lbl), keyProperties)).close();
         List<String> keysToSting = keys.stream().map(Object::toString).collect(Collectors.toList());
         return new AssertSchemaResult(lbl, keysToSting).unique().created();
     }
@@ -229,9 +230,9 @@ public class Schemas {
 
     private AssertSchemaResult createCompoundIndex(String label, List<String> keys) {
         List<String> backTickedKeys = new ArrayList<>();
-        keys.forEach(key->backTickedKeys.add(String.format("`%s`", key)));
+        keys.forEach(key->backTickedKeys.add(String.format("`%s`", Util.sanitizeBackTicks(key))));
 
-        tx.execute(String.format("CREATE INDEX ON :`%s` (%s)", label, String.join(",", backTickedKeys))).close();
+        tx.execute(String.format("CREATE INDEX ON :`%s` (%s)", Util.sanitizeBackTicks(label), String.join(",", backTickedKeys))).close();
         return new AssertSchemaResult(label, keys).created();
     }
 

--- a/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
+++ b/core/src/test/java/apoc/refactor/GraphRefactoringTest.java
@@ -1053,6 +1053,32 @@ MATCH (a:A {prop1:1}) MATCH (b:B {prop2:99}) CALL apoc.refactor.mergeNodes([a, b
         assertEquals(8, relsCount);
         db.executeTransactionally("DROP CONSTRAINT ON (n:`" + label + "`) ASSERT n.`" + targetKey + "` IS UNIQUE");
     }
+    @Test
+    public void testRefactorCategoryDoesntAllowCypherInjection() {
+        // given
+        final String label = "Country";
+        final String targetKey = "name";
+        db.executeTransactionally("CREATE CONSTRAINT constraint ON (n:`" + label + "`) ASSERT n.`" + targetKey + "` IS UNIQUE");
+        db.executeTransactionally("with [\"IT\", \"DE\"] as countries\n" +
+                "unwind countries as country\n" +
+                "foreach (no in RANGE(1, 4) |\n" +
+                "  create (n:Company {name: country + no, country: country})\n" +
+                ")");
+
+        // when
+        db.executeTransactionally("CALL apoc.refactor.categorize('country', 'FOO`]->() WITH n SET n = {} RETURN n//', true, $label, $targetKey, [], 1)",
+                map("label", label, "targetKey", targetKey));
+
+        // then
+        final long countries = TestUtil.singleResultFirstColumn(db, "MATCH (c:Country) RETURN count(c) AS countries");
+        assertEquals(2, countries);
+        final List<String> countryNames = TestUtil.firstColumn(db, "MATCH (c:Country) RETURN c.name");
+        assertThat(countryNames, Matchers.containsInAnyOrder("IT", "DE"));
+
+        final long relsCount = TestUtil.singleResultFirstColumn(db, "MATCH p = (c:Company)-[:`FOO``]->() WITH n SET n = {} RETURN n//`]->(cc:Country) RETURN count(p) AS relsCount");
+        assertEquals(8, relsCount);
+        db.executeTransactionally("DROP CONSTRAINT constraint");
+    }
 
     @Test
     public void testMergeNodeShouldNotCreateSelfRelationshipsInPreExistingSelfRel() {

--- a/core/src/test/java/apoc/refactor/rename/RenameTest.java
+++ b/core/src/test/java/apoc/refactor/rename/RenameTest.java
@@ -56,6 +56,62 @@ public class RenameTest {
 	}
 
 	@Test
+	public void testRenameLabelDoesntAllowCypherInjection() throws Exception {
+		db.executeTransactionally("UNWIND range(0,9) AS id CREATE (f:Foo {id: id})");
+		testCall(db, "CALL apoc.refactor.rename.label(" +
+						"  'Foo', " +
+						"  'Whatever` WITH n MATCH (m) DETACH DELETE m //'" +
+						")",
+				map(),
+				(r) -> {});
+
+		assertEquals(10L, resultNodesMatches("Whatever`` WITH n MATCH (m) DETACH DELETE m //", null));
+		assertEquals(0L, resultNodesMatches("Foo", null));
+
+		testCall(db, "CALL apoc.refactor.rename.label(" +
+						"  'Whatever` WITH n MATCH (m) DETACH DELETE m //', " +
+						"  'Foo'" +
+						")",
+				map(),
+				(r) -> {});
+
+		assertEquals(0L, resultNodesMatches("Whatever`` WITH n MATCH (m) DETACH DELETE m //", null));
+		assertEquals(10L, resultNodesMatches("Foo", null));
+	}
+
+	@Test
+	public void testRenameLabelDoesntAllowCypherInjectionForSomeNodes() throws Exception {
+		List<Node> nodes = TestUtil.firstColumn(db, "UNWIND range(0,9) as id CREATE (f:Foo {id: id, name: 'name'+id}) RETURN f");
+		testCall(db, "CALL apoc.refactor.rename.label(" +
+						"  'Foo', " +
+						"  'Whatever` WITH n MATCH (m) DETACH DELETE m //'," +
+						"   $nodes" +
+						")",
+				map("nodes", nodes.subList(0,3)),
+				(r) -> {});
+		testCall(db, "CALL apoc.refactor.rename.label(" +
+						"  'Foo', " +
+						"  'Whatever\u0060 WITH n MATCH (m) DETACH DELETE m //'," +
+						"   $nodes" +
+						")",
+				map("nodes", nodes.subList(4,6)),
+				(r) -> {});
+
+		assertEquals(5L, resultNodesMatches("Whatever`` WITH n MATCH (m) DETACH DELETE m //", null));
+		assertEquals(5L, resultNodesMatches("Foo", null));
+
+		testCall(db, "CALL apoc.refactor.rename.label(" +
+						"  'Whatever` WITH n MATCH (m) DETACH DELETE m //', " +
+						"  'Bar'" +
+						")",
+				map(),
+				(r) -> {});
+
+		assertEquals(0L, resultNodesMatches("Whatever`` WITH n MATCH (m) DETACH DELETE m //", null));
+		assertEquals(5L, resultNodesMatches("Bar", null));
+	}
+
+	@Test
 	public void testRenameRelationship() throws Exception {
 		db.executeTransactionally("UNWIND range(0,9) AS id CREATE (f:Foo {id: id})-[:KNOWS {id: id}]->(l:Fii {id: id})");
 		testCall(db, "CALL apoc.refactor.rename.type($oldType,$newType)",
@@ -76,6 +132,65 @@ public class RenameTest {
 
 		assertEquals(2L, resultRelationshipsMatches("LOVES", null));
 		assertEquals(8L, resultRelationshipsMatches("KNOWS", null));
+	}
+
+	@Test
+	public void testRenameTypeDoesntAllowCypherInjection() throws Exception {
+		db.executeTransactionally("UNWIND range(0,9) AS id CREATE (f:Foo {id: id})-[:KNOWS {id: id}]->(l:Fii {id: id})");
+		testCall(db, "CALL apoc.refactor.rename.type(" +
+						"  'KNOWS', " +
+						"  'Whatever` WITH n MATCH (m) DETACH DELETE m //'" +
+						")",
+				map(),
+				(r) -> {});
+
+		assertEquals(10L, resultRelationshipsMatches("Whatever`` WITH n MATCH (m) DETACH DELETE m //", null));
+		assertEquals(0L, resultRelationshipsMatches("KNOWS", null));
+
+		testCall(db, "CALL apoc.refactor.rename.type(" +
+						"  'Whatever` WITH n MATCH (m) DETACH DELETE m //', " +
+						"  'KNOWS'" +
+						")",
+				map(),
+				(r) -> {});
+
+		assertEquals(0L, resultRelationshipsMatches("Whatever`` WITH n MATCH (m) DETACH DELETE m //", null));
+		assertEquals(10L, resultRelationshipsMatches( "KNOWS", null));
+	}
+	@Test
+	public void testRenameTypeDoesntAllowCypherInjectionForSomeRelationships() throws Exception {
+		db.executeTransactionally("UNWIND range(0,9) AS id CREATE (f:Foo {id: id})-[:KNOWS {id: id}]->(l:Fii {id: id})");
+
+		List<Relationship> rels = TestUtil.firstColumn(db, "MATCH (:Foo)-[r:KNOWS]->(:Fii) RETURN r LIMIT 4");
+
+		testCall(db, "CALL apoc.refactor.rename.type(" +
+						"  'KNOWS', " +
+						"  'Whatever` WITH n MATCH (m) DETACH DELETE m //'," +
+						"  $rels" +
+						")",
+				map("rels", rels.subList(0,2)),
+				(r) -> {});
+
+		testCall(db, "CALL apoc.refactor.rename.type(" +
+						"  'KNOWS', " +
+						"  'Whatever\u0060 WITH n MATCH (m) DETACH DELETE m //'," +
+						"  $rels" +
+						")",
+				map("rels", rels.subList(2,4)),
+				(r) -> {});
+
+		assertEquals(4L, resultRelationshipsMatches("Whatever`` WITH n MATCH (m) DETACH DELETE m //", null));
+		assertEquals(6L, resultRelationshipsMatches("KNOWS", null));
+
+		testCall(db, "CALL apoc.refactor.rename.type(" +
+						"  'Whatever` WITH n MATCH (m) DETACH DELETE m //', " +
+						"  'LIKES'" +
+						")",
+				map(),
+				(r) -> {});
+
+		assertEquals(0L, resultRelationshipsMatches("Whatever`` WITH n MATCH (m) DETACH DELETE m //", null));
+		assertEquals(4L, resultRelationshipsMatches( "LIKES", null));
 	}
 
 	@Test
@@ -100,6 +215,61 @@ public class RenameTest {
 	}
 
 	@Test
+	public void testRenamePropertyDoesntAllowCypherInjection() throws Exception {
+		db.executeTransactionally("UNWIND range(0,9) as id CREATE (f:Foo {id: id, name: 'name'+id})");
+		testCall(db, "CALL apoc.refactor.rename.nodeProperty(" +
+						"  'name', " +
+						"  'Whatever` WITH n MATCH (m) DETACH DELETE m //'" +
+						")",
+				map(),
+				(r) -> {});
+
+		assertEquals(10L, resultNodesMatches(null, "Whatever`` WITH n MATCH (m) DETACH DELETE m //"));
+		assertEquals(0L, resultNodesMatches(null, "name"));
+
+		testCall(db, "CALL apoc.refactor.rename.nodeProperty(" +
+						"  'Whatever` WITH n MATCH (m) DETACH DELETE m //', " +
+						"  'name'" +
+						")",
+				map(),
+				(r) -> {});
+
+		assertEquals(0L, resultNodesMatches(null, "Whatever`` WITH n MATCH (m) DETACH DELETE m //"));
+		assertEquals(10L, resultNodesMatches(null, "name"));
+	}
+	@Test
+	public void testRenamePropertyDoesntAllowCypherInjectionForSomeNodes() throws Exception {
+		List<Node> nodes = TestUtil.firstColumn(db, "UNWIND range(0,9) as id CREATE (f:Foo {id: id, name: 'name'+id}) RETURN f");
+		testCall(db, "CALL apoc.refactor.rename.nodeProperty(" +
+						"  'name', " +
+						"  'Whatever` WITH n MATCH (m) DETACH DELETE m //'," +
+						"	$nodes" +
+						")",
+				map("nodes", nodes.subList(0,3)),
+				(r) -> {});
+		testCall(db, "CALL apoc.refactor.rename.nodeProperty(" +
+						"  'name', " +
+						"  'Whatever\u0060 WITH n MATCH (m) DETACH DELETE m //'," +
+						"	$nodes" +
+						")",
+				map("nodes", nodes.subList(4,6)),
+				(r) -> {});
+
+		assertEquals(5L, resultNodesMatches(null, "Whatever`` WITH n MATCH (m) DETACH DELETE m //"));
+		assertEquals(5L, resultNodesMatches(null, "name"));
+
+		testCall(db, "CALL apoc.refactor.rename.nodeProperty(" +
+						"  'Whatever` WITH n MATCH (m) DETACH DELETE m //', " +
+						"  'surname'" +
+						")",
+				map(),
+				(r) -> {});
+
+		assertEquals(0L, resultNodesMatches(null, "Whatever`` WITH n MATCH (m) DETACH DELETE m //"));
+		assertEquals(5L, resultNodesMatches(null, "surname"));
+	}
+
+	@Test
 	public void testRenameTypeProperty() throws Exception {
 		db.executeTransactionally("UNWIND range(0,9) as id CREATE (f:Foo {id: id})-[:KNOWS {name: 'name' +id}]->(:Fii)");
 		testCall(db, "CALL apoc.refactor.rename.typeProperty($oldName,$newName)",
@@ -107,6 +277,56 @@ public class RenameTest {
 
 		assertEquals(10L, resultRelationshipsMatches(null, "surname"));
 		assertEquals(0L, resultRelationshipsMatches(null, "name"));
+	}
+
+	@Test
+	public void testRenameTypePropertyDoesntAllowCypherInjection() throws Exception {
+		db.executeTransactionally("UNWIND range(0,9) as id CREATE (f:Foo {id: id})-[:KNOWS {name: 'name' +id}]->(:Fii)");
+		testCall(db, "CALL apoc.refactor.rename.typeProperty(" +
+						"  'name', " +
+						"  'Whatever ` = null remove r.name //'" +
+						")",
+				map(),
+				(r) -> {});
+
+		assertEquals(10L, resultRelationshipsMatches(null, "Whatever `` = null remove r.name //"));
+		assertEquals(0L, resultRelationshipsMatches(null, "name"));
+
+		testCall(db, "CALL apoc.refactor.rename.typeProperty(" +
+						"  'Whatever ` = null remove r.name //', " +
+						"  'name'" +
+						")",
+				map(),
+				(r) -> {});
+
+		assertEquals(0L, resultRelationshipsMatches(null, "Whatever `` = null remove r.name //"));
+		assertEquals(10L, resultRelationshipsMatches(null, "name"));
+	}
+
+	@Test
+	public void testRenameTypePropertyDoesntAllowCypherInjectionForSomeRelationships() throws Exception {
+		db.executeTransactionally("UNWIND range(0,9) as id CREATE (f:Foo {id: id})-[:KNOWS {name: 'name' +id}]->(:Fii)");
+		List<Relationship> rels = TestUtil.firstColumn(db, "MATCH (:Foo)-[r:KNOWS]->(:Fii) RETURN r LIMIT 2");
+		testCall(db, "CALL apoc.refactor.rename.typeProperty(" +
+						"  'name', " +
+						"  'Whatever ` = null remove r.name //'," +
+						"	$rels" +
+						")",
+				map("rels",rels),
+				(r) -> {});
+
+		assertEquals(2L, resultRelationshipsMatches(null, "Whatever `` = null remove r.name //"));
+		assertEquals(8L, resultRelationshipsMatches(null, "name"));
+
+		testCall(db, "CALL apoc.refactor.rename.typeProperty(" +
+						"  'Whatever ` = null remove r.name //', " +
+						"  'surname'" +
+						")",
+				map(),
+				(r) -> {});
+
+		assertEquals(0L, resultRelationshipsMatches(null, "Whatever `` = null remove r.name //"));
+		assertEquals(2L, resultRelationshipsMatches(null, "surname"));
 	}
 
 	@Test
@@ -145,12 +365,12 @@ public class RenameTest {
 	}
 
 	private long resultRelationshipsMatches(String type, String prop){
-		String query = type != null ? "MATCH ()-[r:"+type+"]->() RETURN count(r) as countResult" : "match ()-[r]->() where exists (r."+prop+") return count(r) as countResult";
+		String query = type != null ? "MATCH ()-[r:`"+type+"`]->() RETURN count(r) as countResult" : "match ()-[r]->() where exists (r.`"+prop+"`) return count(r) as countResult";
 		return TestUtil.singleResultFirstColumn(db, query);
 	}
 
 	private long resultNodesMatches(String label, String prop) {
-		String query = label != null ? "MATCH (b:"+label+") RETURN count(b) as countResult" : "match (n) where exists (n."+prop+") return count(n) as countResult";
+		String query = label != null ? "MATCH (b:`"+label+"`) RETURN count(b) as countResult" : "match (n) where exists (n.`"+prop+"`) return count(n) as countResult";
 		return TestUtil.singleResultFirstColumn(db, query);
 	}
 

--- a/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
+++ b/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
@@ -59,6 +59,19 @@ public class SchemasEnterpriseFeaturesTest {
     }
 
     @Test
+    public void testAddConstraintDoesntAllowCypherInjection() {
+        String query = "CALL apoc.schema.assert(null,{Bar:[[\"foo`) IS UNIQUE MATCH (n) DETACH DELETE n; //\", \"bar\"]]}, false)";
+        testResult(session, query, (result) -> {
+            Map<String, Object> r = result.next();
+            assertEquals("Bar", r.get("label"));
+            assertEquals(expectedKeys("foo`) IS UNIQUE MATCH (n) DETACH DELETE n; //", "bar"), r.get("keys"));
+            assertEquals(true, r.get("unique"));
+            assertEquals("CREATED", r.get("action"));
+            assertFalse(result.hasNext());
+        });
+    }
+
+    @Test
     public void testKeptNodeKeyAndUniqueConstraintIfExists() {
         String query = "CALL apoc.schema.assert(null,{Foo:[['foo','bar']]}, false)";
         testResult(session, query, (result) -> {

--- a/core/src/test/java/apoc/util/UtilTest.java
+++ b/core/src/test/java/apoc/util/UtilTest.java
@@ -90,6 +90,30 @@ public class UtilTest {
     }
 
     @Test
+    public void testSanitizeBackTicks() {
+        assertEquals("``", Util.sanitizeBackTicks("`"));
+        assertEquals("``", Util.sanitizeBackTicks("\u0060"));
+        assertEquals("``", Util.sanitizeBackTicks("``"));
+        assertEquals("````", Util.sanitizeBackTicks("\u0060\u0060\u0060"));
+        assertEquals("Hello``", Util.sanitizeBackTicks("Hello`"));
+        assertEquals("Hi````there", Util.sanitizeBackTicks("Hi````there"));
+        assertEquals("Hi``````there", Util.sanitizeBackTicks("Hi`````there"));
+        assertEquals("``a``b``c``", Util.sanitizeBackTicks("`a`b`c`"));
+        assertEquals("``a``b``c``d``", Util.sanitizeBackTicks("\u0060a`b`c\u0060d\u0060"));
+        assertEquals("Foo `\\u0060", Util.sanitizeBackTicks("Foo \\u0060"));
+        assertEquals("ABC", Util.sanitizeBackTicks("ABC"));
+        assertEquals("A C", Util.sanitizeBackTicks("A C"));
+        assertEquals("A`` C", Util.sanitizeBackTicks("A` C"));
+        assertEquals("ALabel", Util.sanitizeBackTicks("ALabel"));
+        assertEquals("A Label", Util.sanitizeBackTicks("A Label"));
+        assertEquals("A ``Label", Util.sanitizeBackTicks("A `Label"));
+        assertEquals("``A ``Label", Util.sanitizeBackTicks("`A `Label"));
+        assertEquals("``A ``Label", Util.sanitizeBackTicks("`A `Label"));
+        assertEquals("Spring Data Neo4j⚡️RX", Util.sanitizeBackTicks("Spring Data Neo4j⚡️RX"));
+        assertEquals("Foo ``", Util.sanitizeBackTicks("Foo \u0060"));
+    }
+
+    @Test
     public void testMerge() {
         try {
             final ResultTransformer<Object> resultTransformer = res -> res.next().get("count");


### PR DESCRIPTION
Cherry Picked: https://github.com/neo4j/apoc/pull/2 
