### PR TITLE
[JB2or4Qk] apoc.cypher.runFile does not return paths

### DIFF
--- a/core/src/main/java/apoc/cypher/Cypher.java
+++ b/core/src/main/java/apoc/cypher/Cypher.java
@@ -157,7 +157,9 @@ public class Cypher {
         int queueCapacity = Util.toInteger(config.getOrDefault("queueCapacity",100));
 
         StringReader stringReader = new StringReader(cypher);
-        return runManyStatements(stringReader ,params, false, addStatistics, timeout, queueCapacity);
+        return runManyStatements(stringReader ,params, false, addStatistics, timeout, queueCapacity)
+                .collect(toList()).stream()
+                .map(rowResult -> new RowResult(rowResult.row, Util.anyRebind(tx, rowResult.result)));
     }
 
     @Procedure(mode = READ)

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -10,12 +10,14 @@ import apoc.result.VirtualRelationship;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.collections.api.iterator.LongIterator;
+import org.neo4j.graphalgo.impl.util.PathImpl;
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.NotInTransactionException;
+import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.QueryExecutionType;
 import org.neo4j.graphdb.Relationship;
@@ -23,6 +25,7 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionTerminatedException;
+import org.neo4j.internal.helpers.collection.Iterables;
 import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.internal.helpers.collection.Pair;
 import org.neo4j.internal.kernel.api.procs.ProcedureCallContext;
@@ -1059,5 +1062,28 @@ public class Util {
     public static <T extends Entity> T withTransactionAndRebind(GraphDatabaseService db, Transaction transaction, Function<Transaction, T> action) {
         T result = retryInTx(NullLog.getInstance(), db, action, 0, 0, r -> {});
         return rebind(transaction, result);
+    }
+
+    public static <T> T anyRebind(Transaction tx, T any) {
+        if (any instanceof Map) {
+            return (T) ((Map<String, Object>) any).entrySet().stream()
+                    .collect(Collectors.toMap(e -> e.getKey(), e -> anyRebind(tx, e.getValue())));
+        }
+        if (any instanceof Path) {
+            final Path path = (Path) any;
+            PathImpl.Builder builder = new PathImpl.Builder(Util.rebind(tx, path.startNode()));
+            for (Relationship rel: path.relationships()) {
+                builder = builder.push(Util.rebind(tx, rel));
+            }
+            return (T) builder.build();
+        }
+        if (any instanceof Iterable) {
+            return (T) Iterables.stream((Iterable) any)
+                    .map(i -> anyRebind(tx, i)).collect(Collectors.toList());
+        }
+        if (any instanceof Entity) {
+            return (T) Util.rebind(tx, (Entity) any);
+        }
+        return any;
     }
 }

--- a/full/src/main/java/apoc/cypher/CypherExtended.java
+++ b/full/src/main/java/apoc/cypher/CypherExtended.java
@@ -101,7 +101,8 @@ public class CypherExtended {
                     .onClose(() -> Util.close(scanner, (e) -> log.info("Cannot close the scanner for file " + fileName + " because the following exception", e)));
         });
 
-        return result;
+        return result.collect(toList()).stream()
+                .map(rowResult -> new RowResult(rowResult.row, Util.anyRebind(tx, rowResult.result)));
     }
 
     @Procedure(mode=Mode.SCHEMA)

--- a/full/src/test/java/apoc/cypher/CypherExtendedTest.java
+++ b/full/src/test/java/apoc/cypher/CypherExtendedTest.java
@@ -25,6 +25,8 @@ import java.util.stream.IntStream;
 
 import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
+import static apoc.util.CypherTestUtil.datasetRunProcsWithReturn;
+import static apoc.util.CypherTestUtil.cypherRunWithReturnCommon;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testCallCount;
 import static apoc.util.TestUtil.testResult;
@@ -139,6 +141,32 @@ public class CypherExtendedTest {
                     assertEquals(1L, toLong(result.get("nodesDeleted")));
                     assertEquals(false, r.hasNext());
                 });
+    }
+
+    @Test
+    public void testRunFileWithCreateAndReturnFile() {
+        testResult(db, "CALL apoc.cypher.runFile('create_return.cypher')",
+                r -> cypherRunWithReturnCommon(r, false));
+    }
+
+    @Test
+    public void testRunFileWithOnlyReturnFile() {
+        datasetRunProcsWithReturn(db);
+        testResult(db, "CALL apoc.cypher.runFile('only_return.cypher')",
+                r -> cypherRunWithReturnCommon(r, true));
+    }
+
+    @Test
+    public void testRunFileWithCreateAndReturnFiles() {
+        testResult(db, "CALL apoc.cypher.runFiles(['create_return.cypher'])",
+                r -> cypherRunWithReturnCommon(r, false));
+    }
+
+    @Test
+    public void testRunFileWithOnlyReturnFiles() {
+        datasetRunProcsWithReturn(db);
+        testResult(db, "CALL apoc.cypher.runFiles(['only_return.cypher'])",
+                r -> cypherRunWithReturnCommon(r, true));
     }
 
     @Test

--- a/full/src/test/resources/create_return.cypher
+++ b/full/src/test/resources/create_return.cypher
@@ -1,0 +1,4 @@
+CREATE (n:Node {id:1}) RETURN n;
+CREATE (start:Start {id:1})-[rel:REL {id: 2}]->(end:End {id: 3}) RETURN start, rel, end;
+UNWIND range(1,2) as idx WITH idx CREATE path=(:StartPath {id:idx})-[:REL_PATH {id: idx}]->(:EndPath {id: idx}) RETURN path;
+UNWIND range(1,2) as idx WITH idx CREATE path=(:StartPath {id:idx})-[:REL_PATH {id: idx}]->(:EndPath {id: idx}) RETURN collect(path) as paths;

--- a/full/src/test/resources/only_return.cypher
+++ b/full/src/test/resources/only_return.cypher
@@ -1,0 +1,4 @@
+MATCH (n:Node {id:1}) RETURN n;
+MATCH (start:Start {id:1})-[rel:REL {id: 2}]->(end:End {id: 3}) RETURN start, rel, end;
+MATCH path=(start:StartPath)-[:REL_PATH]->(:EndPath) RETURN path ORDER BY start.id;
+MATCH path=(start:StartPath)-[:REL_PATH]->(:EndPath) WITH path ORDER BY start.id RETURN collect(path) as paths;

--- a/test-utils/src/main/java/apoc/util/CypherTestUtil.java
+++ b/test-utils/src/main/java/apoc/util/CypherTestUtil.java
@@ -1,0 +1,98 @@
+package apoc.util;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Result;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class CypherTestUtil {
+
+    public static void cypherRunWithReturnCommon(Result r, boolean onlyReturn) {
+        Map<String, Object> row = r.next();
+        assertEquals(0L, row.get("row"));
+        Map result = (Map) row.get("result");
+        final Node n = (Node) result.get("n");
+        assertEquals(List.of(Label.label("Node")), n.getLabels());
+        assertEquals(Map.of("id", 1L), n.getAllProperties());
+        row = r.next();
+        assertEquals(-1L, row.get("row"));
+        result = (Map) row.get("result");
+        cypherRunWithReturnCommon(result, 1L, 0L, 1L, onlyReturn);
+        row = r.next();
+        assertEquals(0L, row.get("row"));
+        result = (Map) row.get("result");
+        final Node start = (Node) result.get("start");
+        assertEquals(List.of(Label.label("Start")), start.getLabels());
+        assertEquals(Map.of("id", 1L), start.getAllProperties());
+        final Node end = (Node) result.get("end");
+        assertEquals(List.of(Label.label("End")), end.getLabels());
+        assertEquals(Map.of("id", 3L), end.getAllProperties());
+        final Relationship rel = (Relationship) result.get("rel");
+        assertEquals(RelationshipType.withName("REL"), rel.getType());
+        assertEquals(Map.of("id", 2L), rel.getAllProperties());
+        row = r.next();
+        assertEquals(-1L, row.get("row"));
+        result = (Map) row.get("result");
+        cypherRunWithReturnCommon(result, 2L, 1L, 1L, onlyReturn);
+        row = r.next();
+        assertEquals(0L, row.get("row"));
+        result = (Map) row.get("result");
+        Path path = (Path) result.get("path");
+        cypherRunWithReturnCommon(path, 1L);
+        row = r.next();
+        assertEquals(1L, row.get("row"));
+        result = (Map) row.get("result");
+        path = (Path) result.get("path");
+        cypherRunWithReturnCommon(path, 2L);
+        row = r.next();
+        assertEquals(-1L, row.get("row"));
+        result = (Map) row.get("result");
+        cypherRunWithReturnCommon(result, 4L, 2L, 2L, onlyReturn);
+        row = r.next();
+        assertEquals(0L, row.get("row"));
+        result = (Map) row.get("result");
+        final List<Path> paths = (List<Path>) result.get("paths");
+        assertEquals(2, paths.size());
+        cypherRunWithReturnCommon(paths.get(0), 1L);
+        cypherRunWithReturnCommon(paths.get(1), 2L);
+        row = r.next();
+        result = (Map) row.get("result");
+        assertEquals(-1L, row.get("row"));
+        cypherRunWithReturnCommon(result, 4L, 2L, 1L, onlyReturn);
+        assertFalse(r.hasNext());
+    }
+
+    public static void cypherRunWithReturnCommon(Map result, long expectedNodesCreated, long expectedRelsCreated, long expectedRows, boolean onlyReturn) {
+        assertEquals(onlyReturn ? 0 : (int) expectedNodesCreated, result.get("nodesCreated"));
+        assertEquals(onlyReturn ? 0 : (int) expectedRelsCreated, result.get("relationshipsCreated"));
+        assertEquals(expectedRows, (long) result.get("rows"));
+    }
+
+    public static void cypherRunWithReturnCommon(Path path, long idProp) {
+        assertEquals(1, path.length());
+        Node startNode = path.startNode();
+        assertEquals(List.of(Label.label("StartPath")), startNode.getLabels());
+        assertEquals(Map.of("id", idProp), startNode.getAllProperties());
+        Node endNode = path.endNode();
+        assertEquals(List.of(Label.label("EndPath")), endNode.getLabels());
+        assertEquals(Map.of("id", idProp), endNode.getAllProperties());
+        Relationship rel = path.relationships().iterator().next();
+        assertEquals(RelationshipType.withName("REL_PATH"), rel.getType());
+        assertEquals(Map.of("id", idProp), rel.getAllProperties());
+    }
+
+    public static void datasetRunProcsWithReturn(GraphDatabaseService db) {
+        db.executeTransactionally("CREATE (n:Node {id:1})");
+        db.executeTransactionally("CREATE (:Start {id:1})-[:REL {id: 2}]->(:End {id: 3})");
+        db.executeTransactionally("UNWIND range(1,2) as idx WITH idx CREATE path=(:StartPath {id:idx})-[:REL_PATH {id: idx}]->(:EndPath {id: idx})");
+    }
+}


### PR DESCRIPTION
Regards both APOC `core` and `extended` .

----

Due to asynchronous implementation, the `testRunFileWithCreateAndReturnFile` fails in a flaky way.
The `collect(toList())` seems to solve it, but of course impact performance.
I think besides this solution, we have other 2 ways:
- remove the `collect` and document that both CREATE and RETURN are not allowed 
- make the `collect(toList()` configurable, but in this case it would be an additional feature in `core` (because of `runMany`)

----

Moreover, the `Util.anyRebind(..)` created is equivalent to this https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3098/files#diff-f88abb534773494608522b01357e40fd270d873f32d7286d83bf3ac0c120925cR15,
which I placed to full because the other pr doesn't regards core.
In case, could we change the other pr after this one is merged?