### PR TITLE
Fixes #2468: APOC uses Jackson version prior to 2.11 not compatible with latest spring-boot (#2521)

### DIFF
--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -115,7 +115,6 @@ dependencies {
     testImplementation group: 'org.mock-server', name: 'mockserver-netty', version: '5.6.0'
     testImplementation group: 'org.mock-server', name: 'mockserver-client-java', version: '5.6.0'
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.214' , withoutJacksons
-    testImplementation group: 'org.codehaus.jackson', name: 'jackson-mapper-asl', version: '1.9.7'
     testImplementation group: 'us.fatehi', name: 'schemacrawler-mysql', version: '15.04.01'
     testImplementation group: 'org.xmlunit', name: 'xmlunit-core', version: '2.2.1'
     testImplementation group: 'com.github.adejanovski', name: 'cassandra-jdbc-wrapper', version: '3.1.0'


### PR DESCRIPTION
Cherry pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/e5abd54f2ef325d3e9eef6c9e90e3089503cfa77

Removed `jackson-mapper-asl`, not used (old jackson-databind package)