### PR TITLE
Fixes neo4j/apoc#25: Incorrect behaviours for format durations (neo4j/docs-apoc#29) (neo4j/apoc#179)

### DIFF
--- a/core/src/main/java/apoc/temporal/TemporalProcedures.java
+++ b/core/src/main/java/apoc/temporal/TemporalProcedures.java
@@ -10,6 +10,8 @@ import java.time.format.DateTimeFormatter;
 
 import static apoc.date.Date.*;
 import static apoc.util.DateFormatUtil.*;
+import static apoc.util.DurationFormatUtil.getDurationFormat;
+import static apoc.util.DurationFormatUtil.getOrCreateDurationPattern;
 
 public class TemporalProcedures
 {
@@ -65,15 +67,13 @@ public class TemporalProcedures
             @Name("input") Object input,
             @Name("format") String format
     ) {
+        DurationValue duration = ((DurationValue) input);
+        
         try {
-            LocalDateTime midnight = LocalDateTime.of(0, 1, 1, 0, 0, 0, 0);
-            LocalDateTime newDuration = midnight.plus( (DurationValue) input );
-
-            DateTimeFormatter formatter = getOrCreate(format);
-
-            return newDuration.format(formatter);
+            String pattern = getOrCreateDurationPattern(format);
+            return getDurationFormat(duration, pattern);
         } catch (Exception e){
-        throw new RuntimeException("Available formats are:\n" +
+            throw new RuntimeException("Available formats are:\n" +
                 String.join("\n", getTypes()) +
                 "\nSee also: https://www.elastic.co/guide/en/elasticsearch/reference/5.5/mapping-date-format.html#built-in-date-formats " +
                 "and https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html");

--- a/core/src/main/java/apoc/util/DateFormatUtil.java
+++ b/core/src/main/java/apoc/util/DateFormatUtil.java
@@ -27,54 +27,80 @@ public class DateFormatUtil {
         map.put("iso_time", DateTimeFormatter.ISO_TIME);
         map.put("iso_week_date", DateTimeFormatter.ISO_WEEK_DATE);
         map.put("iso_zoned_date_time", DateTimeFormatter.ISO_ZONED_DATE_TIME);
-        map.put("basic_date", DateTimeFormatter.ofPattern("yyyyMMdd"));
-        map.put("basic_date_time", DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss.SSSZ"));
-        map.put("basic_date_time_no_millis", DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssZ"));
-        map.put("basic_ordinal_date", DateTimeFormatter.ofPattern("yyyyDDD"));
-        map.put("basic_ordinal_date_time", DateTimeFormatter.ofPattern("yyyyDDD'T'HHmmss.SSSZ"));
-        map.put("basic_ordinal_date_time_no_millis", DateTimeFormatter.ofPattern("yyyyDDD'T'HHmmssZ"));
-        map.put("basic_time", DateTimeFormatter.ofPattern("HHmmss.SSSZ"));
-        map.put("basic_time_no_millis", DateTimeFormatter.ofPattern("HHmmssZ"));
-        map.put("basic_t_time", DateTimeFormatter.ofPattern("'T'HHmmss.SSSZ"));
-        map.put("basic_t_time_no_millis", DateTimeFormatter.ofPattern("'T'HHmmssZ"));
-        map.put("basic_week_date", DateTimeFormatter.ofPattern("xxxx'W'wwe"));
-        map.put("basic_week_date_time", DateTimeFormatter.ofPattern("xxxx'W'wwe'T'HHmmss.SSSZ"));
-        map.put("basic_week_date_time_no_millis", DateTimeFormatter.ofPattern("xxxx'W'wwe'T'HHmmssZ"));
-        map.put("date", DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-        map.put("date_hour", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH"));
-        map.put("date_hour_minute", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm"));
-        map.put("date_hour_minute_second", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
-        map.put("date_hour_minute_second_fraction", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"));
-        map.put("date_hour_minute_second_millis", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS"));
-        map.put("date_time", DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ"));
-        map.put("date_time_no_millis", DateTimeFormatter.ofPattern("yyy-MM-dd'T'HH:mm:ssZZ"));
-        map.put("hour", DateTimeFormatter.ofPattern("HH"));
-        map.put("hour_minute", DateTimeFormatter.ofPattern("HH:mm"));
-        map.put("hour_minute_second", DateTimeFormatter.ofPattern("HH:mm:ss"));
-        map.put("hour_minute_second_fraction", DateTimeFormatter.ofPattern("HH:mm:ss.SSS"));
-        map.put("hour_minute_second_millis", DateTimeFormatter.ofPattern("HH:mm:ss.SSS"));
-        map.put("ordinal_date", DateTimeFormatter.ofPattern("yyyy-DDD"));
-        map.put("ordinal_date_time", DateTimeFormatter.ofPattern("yyyy-DDD'T'HH:mm:ss.SSSZZ"));
-        map.put("ordinal_date_time_no_millis", DateTimeFormatter.ofPattern("yyyy-DDD'T'HH:mm:ssZZ"));
-        map.put("time", DateTimeFormatter.ofPattern("HH:mm:ss.SSSZZ"));
-        map.put("time_no_millis", DateTimeFormatter.ofPattern("HH:mm:ssZZ"));
-        map.put("t_time", DateTimeFormatter.ofPattern("'T'HH:mm:ss.SSSZZ"));
-        map.put("t_time_no_millis", DateTimeFormatter.ofPattern("'T'HH:mm:ssZZ"));
-        map.put("week_date", DateTimeFormatter.ofPattern("xxxx-'W'ww-e"));
-        map.put("week_date_time", DateTimeFormatter.ofPattern("xxxx-'W'ww-e'T'HH:mm:ss.SSSZZ"));
-        map.put("week_date_time_no_millis", DateTimeFormatter.ofPattern("xxxx-'W'ww-e'T'HH:mm:ssZZ"));
-        map.put("weekyear", DateTimeFormatter.ofPattern("xxxx"));
-        map.put("weekyear_week", DateTimeFormatter.ofPattern("xxxx-'W'ww"));
-        map.put("weekyear_week_day", DateTimeFormatter.ofPattern("xxxx-'W'ww-e"));
-        map.put("year", DateTimeFormatter.ofPattern("yyyy"));
-        map.put("year_month", DateTimeFormatter.ofPattern("yyyy-MM"));
-        map.put("year_month_day", DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         map.put( "rfc_1123_date_time", DateTimeFormatter.RFC_1123_DATE_TIME );
         ISO_DATE_FORMAT = Collections.unmodifiableMap(map);
     }
 
+    public static Map<String, String> ISO_DURATION_PATTERNS = new HashMap<>() {{
+        //Static default formatters from Java ISO, excluding those with timezone 
+        put("basic_iso_date", "yyyyMMdd");
+        // the letter `I` is used to create nanoseconds in iso format, i.e. with trailing zeros. e.g. '123000' become '123'
+        final String isoDateTime = "yyyy-MM-dd'T'HH:mm:ssI";
+        put("iso_date_time", isoDateTime);
+        put("iso_local_date_time", isoDateTime);
+        final String isoDate = "yyyy-MM-dd";
+        put("iso_date", isoDate);
+        put("iso_local_date", isoDate);
+        final String isoTime = "HH:mm:ssI";
+        put("iso_time", isoTime);
+        put("iso_local_time", isoTime);
+        put("iso_ordinal_date", "yyyy-DDD"); 
+        put("iso_week_date", "YYYY-'W'ww-e");
+    }};
+
+    public static Map<String, String> ELASTIC_PATTERNS = new HashMap<>() {{
+        //Static default formatters from Elasticsearch patterns
+        put("basic_date", "yyyyMMdd");
+        put("basic_date_time", "yyyyMMdd'T'HHmmss.SSSZ");
+        put("basic_date_time_no_millis", "yyyyMMdd'T'HHmmssZ");
+        put("basic_ordinal_date", "yyyyDDD");
+        put("basic_ordinal_date_time", "yyyyDDD'T'HHmmss.SSSZ");
+        put("basic_ordinal_date_time_no_millis", "yyyyDDD'T'HHmmssZ");
+        put("basic_time", "HHmmss.SSSZ");
+        put("basic_time_no_millis", "HHmmssZ");
+        put("basic_t_time", "'T'HHmmss.SSSZ");
+        put("basic_t_time_no_millis", "'T'HHmmssZ");
+        put("basic_week_date", "xxxx'W'wwe");
+        put("basic_week_date_time", "xxxx'W'wwe'T'HHmmss.SSSZ");
+        put("basic_week_date_time_no_millis", "xxxx'W'wwe'T'HHmmssZ");
+        put("date", "yyyy-MM-dd");
+        put("date_hour", "yyyy-MM-dd'T'HH");
+        put("date_hour_minute", "yyyy-MM-dd'T'HH:mm");
+        put("date_hour_minute_second", "yyyy-MM-dd'T'HH:mm:ss");
+        put("date_hour_minute_second_fraction", "yyyy-MM-dd'T'HH:mm:ss.SSS");
+        put("date_hour_minute_second_millis", "yyyy-MM-dd'T'HH:mm:ss.SSS");
+        put("date_time", "yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
+        put("date_time_no_millis", "yyy-MM-dd'T'HH:mm:ssZZ");
+        put("hour", "HH");
+        put("hour_minute", "HH:mm");
+        put("hour_minute_second", "HH:mm:ss");
+        put("hour_minute_second_fraction", "HH:mm:ss.SSS");
+        put("hour_minute_second_millis", "HH:mm:ss.SSS");
+        put("ordinal_date", "yyyy-DDD");
+        put("ordinal_date_time", "yyyy-DDD'T'HH:mm:ss.SSSZZ");
+        put("ordinal_date_time_no_millis", "yyyy-DDD'T'HH:mm:ssZZ");
+        put("time", "HH:mm:ss.SSSZZ");
+        put("time_no_millis", "HH:mm:ssZZ");
+        put("t_time", "'T'HH:mm:ss.SSSZZ");
+        put("t_time_no_millis", "'T'HH:mm:ssZZ");
+        put("week_date", "xxxx-'W'ww-e");
+        put("week_date_time", "xxxx-'W'ww-e'T'HH:mm:ss.SSSZZ");
+        put("week_date_time_no_millis", "xxxx-'W'ww-e'T'HH:mm:ssZZ");
+        put("weekyear", "xxxx");
+        put("weekyear_week", "xxxx-'W'ww");
+        put("weekyear_week_day", "xxxx-'W'ww-e");
+        put("year", "yyyy");
+        put("year_month", "yyyy-MM");
+        put("year_month_day", "yyyy-MM-dd");
+    }};
+
     public static DateTimeFormatter getOrCreate(String format) {
-        return ISO_DATE_FORMAT.containsKey(format.toLowerCase()) ? ISO_DATE_FORMAT.get(format.toLowerCase()) : DateTimeFormatter.ofPattern(format);
+        final String formatLower = format.toLowerCase();
+        
+        if (ISO_DATE_FORMAT.containsKey(formatLower)) {
+            return ISO_DATE_FORMAT.get(formatLower);
+        }
+        return DateTimeFormatter.ofPattern(ELASTIC_PATTERNS.getOrDefault(formatLower, format));
     }
 
     public static Set<String> getTypes() {

--- a/core/src/main/java/apoc/util/DurationFormatUtil.java
+++ b/core/src/main/java/apoc/util/DurationFormatUtil.java
@@ -1,0 +1,113 @@
+package apoc.util;
+
+import org.neo4j.values.storable.DurationFields;
+import org.neo4j.values.storable.DurationValue;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static apoc.util.DateFormatUtil.ELASTIC_PATTERNS;
+import static apoc.util.DateFormatUtil.ISO_DURATION_PATTERNS;
+import static org.neo4j.values.storable.DurationFields.DAYS;
+import static org.neo4j.values.storable.DurationFields.HOURS;
+import static org.neo4j.values.storable.DurationFields.MILLISECONDS;
+import static org.neo4j.values.storable.DurationFields.MINUTES_OF_HOUR;
+import static org.neo4j.values.storable.DurationFields.MONTHS_OF_YEAR;
+import static org.neo4j.values.storable.DurationFields.NANOSECONDS;
+import static org.neo4j.values.storable.DurationFields.NANOSECONDS_OF_SECOND;
+import static org.neo4j.values.storable.DurationFields.QUARTERS_OF_YEAR;
+import static org.neo4j.values.storable.DurationFields.SECONDS_OF_MINUTE;
+import static org.neo4j.values.storable.DurationFields.WEEKS;
+import static org.neo4j.values.storable.DurationFields.YEARS;
+
+public class DurationFormatUtil {
+    public static String getOrCreateDurationPattern(String format) {
+        final String formatLower = format.toLowerCase();
+        return ISO_DURATION_PATTERNS.getOrDefault(formatLower,
+                ELASTIC_PATTERNS.getOrDefault(formatLower, format)
+        );
+    }
+
+    public static String getDurationFormat(DurationValue duration, String formatPattern) {
+        AtomicInteger idx = new AtomicInteger();
+        // we split the pattern via the escape char `'` and format only odd part, 
+        // to manage patterns like  "yy 'years' dd 'days'"
+        return Arrays.stream(formatPattern.split("'"))
+                .map(item -> {
+                    if ((idx.getAndIncrement() % 2) == 0) {
+                        return getInnerDurationFormat(duration, item);
+                    }
+                    return item;
+                })
+                .collect(Collectors.joining());
+    }
+
+    private static String getInnerDurationFormat(DurationValue duration, String formatter) {
+        return Pattern.compile(
+                        "(?<year>[yYu])\\1*|(?<day>[dD])\\2*|(?<monthYear>[ML])\\3*|(?<quarterYear>[qQ])\\4*|(?<week>[wW])\\5*|" +
+                                "(?<hour>[hHkK])\\6*|(?<minHour>m)\\7*|(?<secMin>s)\\8*|(?<nsSeconds>[nS])\\9*|" +
+                                "(?<ms>A)\\10*|(?<ns>N)\\11|(?<iso>I)\\12*"
+                ).matcher(formatter)
+                .replaceAll(res -> {
+                    final Matcher m = (Matcher) res;
+                    if (m.group("year") != null) {
+                        return getFieldDigit(m, duration, YEARS);
+                    }
+                    if (m.group("day") != null) {
+                        return getFieldDigit(m, duration, DAYS);
+                    }
+                    if (m.group("monthYear") != null) {
+                        return getFieldDigit(m, duration, MONTHS_OF_YEAR);
+                    }
+                    if (m.group("quarterYear") != null) {
+                        return getFieldDigit(m, duration, QUARTERS_OF_YEAR);
+                    }
+                    if (m.group("week") != null) {
+                        return getFieldDigit(m, duration, WEEKS);
+                    }
+                    if (m.group("hour") != null) {
+                        return getFieldDigit(m, duration, HOURS);
+                    }
+                    if (m.group("minHour") != null) {
+                        return getFieldDigit(m, duration, MINUTES_OF_HOUR);
+                    }
+                    if (m.group("secMin") != null) {
+                        return getFieldDigit(m, duration, SECONDS_OF_MINUTE);
+                    }
+                    if (m.group("nsSeconds") != null) {
+                        return getFieldDigit(m, duration, NANOSECONDS_OF_SECOND, true);
+                    }
+                    if (m.group("ms") != null) {
+                        return getFieldDigit(m, duration, MILLISECONDS);
+                    }
+                    if (m.group("ns") != null) {
+                        return getFieldDigit(m, duration, NANOSECONDS);
+                    }
+                    // the letter `I` is used to create nanoseconds in iso format, i.e. with trailing zeros. e.g. '123000' become '123'
+                    if (m.group("iso") != null) {
+                        final String isoNanos = getFieldDigit(m, duration, NANOSECONDS_OF_SECOND)
+                                .replaceAll("(?!$)0+$", "");
+                        return isoNanos.isEmpty() ? "" : ("." + isoNanos);
+                    }
+                    // fallback
+                    return formatter;
+                });
+    }
+
+    private static String getFieldDigit(Matcher m, DurationValue duration, DurationFields field) {
+        return getFieldDigit(m, duration, field, false);
+    }
+
+    private static String getFieldDigit(Matcher m, DurationValue duration, DurationFields field, boolean toTruncate) {
+        long replacement = duration.get(field.propertyKey).value();
+        // to add padding zeros, e.g. a duration of 15 years with a pattern 'yyyy' will have m.group().length() = 4
+        // so the string will be String.format("%04d", years>) --> 0015
+        final String formatted = String.format("%0" + m.group().length() + "d", replacement);
+        return toTruncate
+                ? formatted.substring(0, m.group().length())
+                : formatted;
+    }
+}

--- a/docs/asciidoc/modules/ROOT/partials/usage/apoc.temporal.formatDuration.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/apoc.temporal.formatDuration.adoc
@@ -1,4 +1,26 @@
-This function formats durations using a https://www.elastic.co/guide/en/elasticsearch/reference/5.5/mapping-date-format.html#built-in-date-formats[list of built-in formats^].
+This function handles a pattern string similar to the one used in https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#ofPattern-java.lang.String-[DateTimeFormatter.ofPattern(<pattern>)], but with some differences.
+Below is the conversion table between letters and https://neo4j.com/docs/cypher-manual/current/functions/temporal/duration/#functions-duration[Duration Fields]:
+
+[opts="header"]
+|===
+| letter | field
+| `y` or `Y` or `u`  | year
+| `d` or `D` | days
+| `M` or `L` | months of year
+| `q` or `Q` | quarters of year
+| `w` or `W` | weeks
+| `h` or `H` or `k`or `K` | hours
+| `m` | minutes of hour
+| `s` | seconds of minutes
+| `n` or `S` | nanoseconds of seconds 
+| `A` | milliseconds
+| `N` | nanoseconds
+| `I` | ISO nanoseconds, i.e. with trimmed right zero. e.g. `"12300"` becomes `"123"`
+|===
+
+
+It is also possible to use one of a https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html[Predefined Java formats^] or as https://www.elastic.co/guide/en/elasticsearch/reference/5.5/mapping-date-format.html#built-in-date-formats[elastic formats^],
+except ones which require timezone or weekyear, such as `basic_date_time` or `week_date_time`.
 
 [source,cypher]
 ----
@@ -22,4 +44,18 @@ RETURN apoc.temporal.formatDuration( duration({seconds: 10000}), "hour_minute") 
 |===
 | output
 | "02:46"
+|===
+
+
+[source,cypher]
+----
+WITH duration.between(datetime('2017-06-02T18:40:32.1234560'), datetime('2019-07-13T19:41:33')) AS duration
+RETURN apoc.temporal.formatDuration(duration, "yy 'years' MM 'months' www 'weeks' dd 'days' - HH:mm:ss SSSS") AS output
+----
+
+.Results
+[opts="header"]
+|===
+| output
+| "02 years 01 months 001 weeks 11 days - 01:01:00 8765"
 |===


### PR DESCRIPTION
Fixes neo4j/apoc#25

Cherry-pick of https://github.com/neo4j/apoc/commit/6b7436530410c996c310e99357cb0c7b920799db and https://github.com/neo4j/docs-apoc/commit/ff8605b1f639e3e15d039df52ea8ea666243de79