### PR TITLE
[d7Ivq7cM] Bump snakeyaml in extended APOC

### DIFF
--- a/full/build.gradle
+++ b/full/build.gradle
@@ -85,7 +85,7 @@ dependencies {
         exclude module: "snakeyaml"
         exclude module: "commons-lang3"
     }
-    compile group: 'org.yaml', name: 'snakeyaml', version: '1.26'
+    compile group: 'org.yaml', name: 'snakeyaml', version: '1.32'
     testCompile group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
 
     testCompile 'net.sourceforge.jexcelapi:jxl:2.6.12'


### PR DESCRIPTION
Fixes CVE-2022-25857
Fixes CVE-2022-38749
Fixes CVE-2022-38750
Fixes CVE-2022-38751
Fixes CVE-2022-38752