### PR TITLE
fix 3.5.x apoc.bolt.*

### DIFF
--- a/src/main/java/apoc/bolt/Bolt.java
+++ b/src/main/java/apoc/bolt/Bolt.java
@@ -168,7 +168,7 @@ public class Bolt {
                 end = nodesCache.computeIfAbsent(relationship.endNodeId(), retrieveNode);
             } else {
                 start = nodesCache.getOrDefault(relationship.startNodeId(), new VirtualNode(relationship.startNodeId(), db));
-                end = nodesCache.getOrDefault(relationship.startNodeId(), new VirtualNode(relationship.endNodeId(), db));
+                end = nodesCache.getOrDefault(relationship.endNodeId(), new VirtualNode(relationship.endNodeId(), db));
             }
             return new VirtualRelationship(relationship.id(), start, end, RelationshipType.withName(relationship.type()), relationship.asMap());
         } else {


### PR DESCRIPTION
Fixes #<fix 3.5.x apoc.bolt.*>

Fixed relationship end node ID.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

- Modify the ID of the end node to avoid the error of the relationship binding ID.
