### PR TITLE
[4HrPR2Rm] Use internal function instead of procedure for compatibility

### DIFF
--- a/core/src/test/java/apoc/cypher/CypherIsVersionDifferentTest.java
+++ b/core/src/test/java/apoc/cypher/CypherIsVersionDifferentTest.java
@@ -15,6 +15,8 @@ public class CypherIsVersionDifferentTest {
         assertFalse(isVersionDifferent("3.5.12", "3.5.0.9"));
         assertFalse(isVersionDifferent("3.5.12", "3.5.1.9"));
         assertFalse(isVersionDifferent("4.4.5", "4.4.0.4"));
+        assertFalse(isVersionDifferent("4.4-aura", "4.4.0.4"));
+        assertTrue(isVersionDifferent("4.4-aura", "4.3.0.4"));
 
         // we expect that APOC versioning is always consistent to Neo4j versioning
         assertTrue(isVersionDifferent("", "5_2_0_1"));

--- a/core/src/test/java/apoc/cypher/CypherIsVersionDifferentTest.java
+++ b/core/src/test/java/apoc/cypher/CypherIsVersionDifferentTest.java
@@ -2,8 +2,6 @@ package apoc.cypher;
 
 import org.junit.Test;
 
-import java.util.List;
-
 import static apoc.cypher.CypherInitializer.isVersionDifferent;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -12,28 +10,28 @@ public class CypherIsVersionDifferentTest {
 
     @Test
     public void shouldReturnFalseOnlyWithCompatibleVersion() {
-        assertTrue(isVersionDifferent(List.of("3.5"), "4.4.0.2"));
-        assertTrue(isVersionDifferent(List.of("5_0"), "4.4.0.2"));
-        assertFalse(isVersionDifferent(List.of("3.5.12"), "3.5.0.9"));
-        assertFalse(isVersionDifferent(List.of("3.5.12"), "3.5.1.9"));
-        assertFalse(isVersionDifferent(List.of("4.4.5"), "4.4.0.4"));
+        assertTrue(isVersionDifferent("3.5", "4.4.0.2"));
+        assertTrue(isVersionDifferent("5_0", "4.4.0.2"));
+        assertFalse(isVersionDifferent("3.5.12", "3.5.0.9"));
+        assertFalse(isVersionDifferent("3.5.12", "3.5.1.9"));
+        assertFalse(isVersionDifferent("4.4.5", "4.4.0.4"));
 
         // we expect that APOC versioning is always consistent to Neo4j versioning
-        assertTrue(isVersionDifferent(List.of(""), "5_2_0_1"));
-        assertTrue(isVersionDifferent(List.of("5_1_0"), "5_0_0_1"));
-        assertTrue(isVersionDifferent(List.of("5_1_0"), "5_2_0_1"));
-        assertTrue(isVersionDifferent(List.of("5_22_1"), "5_2_0_1"));
-        assertTrue(isVersionDifferent(List.of("5_2_1"), "5_22_0_1"));
-        assertTrue(isVersionDifferent(List.of("55_2_1"), "5_2_1"));
-        assertTrue(isVersionDifferent(List.of("55_2_1"), "5_2_1_0_1"));
-        assertTrue(isVersionDifferent(List.of("51-1-9-9"), "5-1-1-9"));
+        assertTrue(isVersionDifferent("", "5_2_0_1"));
+        assertTrue(isVersionDifferent("5_1_0", "5_0_0_1"));
+        assertTrue(isVersionDifferent("5_1_0", "5_2_0_1"));
+        assertTrue(isVersionDifferent("5_22_1", "5_2_0_1"));
+        assertTrue(isVersionDifferent("5_2_1", "5_22_0_1"));
+        assertTrue(isVersionDifferent("55_2_1", "5_2_1"));
+        assertTrue(isVersionDifferent("55_2_1", "5_2_1_0_1"));
+        assertTrue(isVersionDifferent("51-1-9-9", "5-1-1-9"));
 
-        assertFalse(isVersionDifferent(List.of("4_4_5"), "4.4.0.4"));
-        assertFalse(isVersionDifferent(List.of("5_1_0"), "5-1-0-1"));
-        assertFalse(isVersionDifferent(List.of("5_22_1"), "5_22_0_1"));
-        assertFalse(isVersionDifferent(List.of("5_0"), "5_0_0_1"));
-        assertFalse(isVersionDifferent(List.of("5_0_1"), "5_0_0_1"));
+        assertFalse(isVersionDifferent("4_4_5", "4.4.0.4"));
+        assertFalse(isVersionDifferent("5_1_0", "5-1-0-1"));
+        assertFalse(isVersionDifferent("5_22_1", "5_22_0_1"));
+        assertFalse(isVersionDifferent("5_0", "5_0_0_1"));
+        assertFalse(isVersionDifferent("5_0_1", "5_0_0_1"));
         
-        assertFalse(isVersionDifferent(List.of("5-1-9-9"), "5-1-0-1"));
+        assertFalse(isVersionDifferent("5-1-9-9", "5-1-0-1"));
     }
 }

--- a/full/src/test/java/apoc/monitor/TransactionProcedureTest.java
+++ b/full/src/test/java/apoc/monitor/TransactionProcedureTest.java
@@ -41,8 +41,8 @@ public class TransactionProcedureTest {
             assertThat(peakTx.get(), isOneOf(1l, 2l));
             assertEquals(3l, lastTxId.addAndGet((long) row.get("lastTxId")));
             assertEquals(1l, row.get("currentOpenedTx"));
-            assertEquals(5l, totalOpenedTx.addAndGet((long) row.get("totalOpenedTx")));
-            assertEquals(4l, totalTx.addAndGet((long )row.get("totalTx")));
+            assertEquals(4l, totalOpenedTx.addAndGet((long) row.get("totalOpenedTx")));
+            assertEquals(3l, totalTx.addAndGet((long )row.get("totalTx")));
         });
 
         db.executeTransactionally("create ()");


### PR DESCRIPTION
This has been requested by Neo4j Aura, which couldn't see if the procedure call came from APOC or a user

Cherry-pick of https://github.com/neo4j/apoc/pull/219 