### PR TITLE
Fixes #2395: The apoc.cypher.runSchemaFile doesn't support full text indexes (#3084)

### DIFF
--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -1014,10 +1014,7 @@ public class Util {
 
     public static void validateQuery(GraphDatabaseService db, String statement, Set<Mode> supportedModes , QueryExecutionType.QueryType... supportedQueryTypes) {
         db.executeTransactionally("EXPLAIN " + statement, Collections.emptyMap(), result -> {
-            final boolean isQueryTypeValid = supportedQueryTypes == null || supportedQueryTypes.length == 0 || Stream.of(supportedQueryTypes)
-                    .anyMatch(sqt -> sqt.equals(result.getQueryExecutionType().queryType()));
-            
-            if (!isQueryTypeValid) {
+            if (!isQueryTypeValid(result, supportedQueryTypes)) {
                 throw new RuntimeException("Supported query types for the operation are " + Arrays.toString(supportedQueryTypes));
             }
             
@@ -1027,6 +1024,16 @@ public class Util {
             
             return null;
         });
+    }
+
+    public static boolean isQueryValid(GraphDatabaseService db, String statement, QueryExecutionType.QueryType... supportedQueryTypes) {
+        return db.executeTransactionally("EXPLAIN " + statement, Collections.emptyMap(),
+                res -> isQueryTypeValid(res, supportedQueryTypes));
+    }
+
+    private static boolean isQueryTypeValid(Result result, QueryExecutionType.QueryType[] supportedQueryTypes) {
+        return supportedQueryTypes == null || supportedQueryTypes.length == 0 || Stream.of(supportedQueryTypes)
+                .anyMatch(sqt -> sqt.equals(result.getQueryExecutionType().queryType()));
     }
 
     private static boolean procsAreValid(GraphDatabaseService db, Set<Mode> supportedModes, Result result) {

--- a/full/src/main/java/apoc/cypher/CypherExtended.java
+++ b/full/src/main/java/apoc/cypher/CypherExtended.java
@@ -7,6 +7,7 @@ import apoc.util.FileUtils;
 import apoc.util.QueueBasedSpliterator;
 import apoc.util.Util;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.QueryExecutionType;
 import org.neo4j.graphdb.QueryStatistics;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
@@ -222,7 +223,7 @@ public class CypherExtended {
     }
 
     private boolean isSchemaOperation(String stmt) {
-        return stmt.matches("(?is).*(create|drop)\\s+(index|constraint).*");
+        return Util.isQueryValid(db, stmt, QueryExecutionType.QueryType.SCHEMA_WRITE);
     }
     private boolean isPeriodicOperation(String stmt) {
         return stmt.matches("(?is)(.*using\\s+periodic.*)|(.*call\\s+\\{.*\\}\\s+in\\s+transactions.*)");

--- a/full/src/test/resources/constraints.cypher
+++ b/full/src/test/resources/constraints.cypher
@@ -1,1 +1,2 @@
 CREATE CONSTRAINT ON (n:Person) ASSERT n.name IS UNIQUE;
+CREATE CONSTRAINT another_cons ON (n:AnotherLabel) ASSERT n.name IS UNIQUE;

--- a/full/src/test/resources/schema.cypher
+++ b/full/src/test/resources/schema.cypher
@@ -1,1 +1,4 @@
-CREATE INDEX ON :Node(id);
+CREATE FULLTEXT INDEX CustomerIndex1 FOR (n:Customer1) ON EACH [n.name1];
+CREATE FULLTEXT INDEX CustomerIndex21 FOR (n:Customer21) ON EACH [n.name12];
+CREATE FULLTEXT INDEX CustomerIndex231 FOR (n:Customer213) ON EACH [n.name123];
+CREATE INDEX node_index_name FOR (n:Person) ON (n.surname);


### PR DESCRIPTION
Cherry pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/3cb7b7d062adfd86b96596618594731fd5c70f9d