### PR TITLE
[NOID] Updates docs for apoc.load.csv new escape + delimiter behaviour

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/import/load-csv.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/load-csv.adoc
@@ -151,5 +151,37 @@ YIELD value
 RETURN value["list"], value["map"]
 ----
 
+=== Escaping delimiters behaviour
+
+From 4.4.0.11 onwards, for 4.4 versions, the behaviour is to escape a delimiter and then split the columns. For this input:
+
+.test.csv
+----
+name,age
+Selma\,9
+----
+
+[source, cypher]
+----
+CALL apoc.load.csv('test.csv', {sep: ',', escapeChar: '\'})
+YIELD lineNo, list, map
+RETURN *;
+----
+
+we would an error containing the following error message:
+
+[source, cypher]
+----
+Please check whether you included a delimiter before a column separator or forgot a column separator.
+----
+
+The previous behaviour was to split the columns and then escape them. The results yielded by the above query were:
+
+.Results
+[opts="header",cols="1,1,1"]
+|===
+| lineNo | list | map
+| 0      | ["Selma", "9"]     | {name: "Selma", age: "9"}
+|===
 
 


### PR DESCRIPTION
Adds a section to LOAD CSV with the new escaping behaviour introduced by https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3258

<img width="1792"  src="https://user-images.githubusercontent.com/5649971/200963826-47c07ef8-87e5-4f78-9ff5-4c70ac5a1f4c.png">

