### PR TITLE
Makes load csv tests less flaky

### DIFF
--- a/full/src/test/java/apoc/load/LoadCsvTest.java
+++ b/full/src/test/java/apoc/load/LoadCsvTest.java
@@ -492,7 +492,7 @@ RETURN m.col_1,m.col_2,m.col_3
     }
 
     @Test public void testLoadCsvZipByUrl() throws Exception {
-        URL url = new URL("https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/3.4/src/test/resources/testload.zip?raw=true");
+        URL url = new URL("https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/4.4/core/src/test/resources/testload.tar?raw=true");
         testResult(db, "CALL apoc.load.csv($url,{results:['map','list','stringMap','strings']})", map("url",url.toString()+"!csv/test.csv"), // 'file:test.csv'
                 (r) -> {
                     assertRow(r,0L,"name","Selma","age","8");
@@ -503,7 +503,7 @@ RETURN m.col_1,m.col_2,m.col_3
     }
 
     @Test public void testLoadCsvTarByUrl() throws Exception {
-        URL url = new URL("https://github.com/neo4j/apoc/blob/dev/core/src/test/resources/testload.tar?raw=true");
+        URL url = new URL("https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/4.4/core/src/test/resources/testload.tar?raw=true");
         testResult(db, "CALL apoc.load.csv($url,{results:['map','list','stringMap','strings']})", map("url",url.toString()+"!csv/test.csv"), // 'file:test.csv'
                 (r) -> {
                     assertRow(r,0L,"name","Selma","age","8");
@@ -514,7 +514,7 @@ RETURN m.col_1,m.col_2,m.col_3
     }
 
     @Test public void testLoadCsvTarGzByUrl() throws Exception {
-        URL url = new URL("https://github.com/neo4j/apoc/blob/dev/core/src/test/resources/testload.tar.gz?raw=true");
+        URL url = new URL("https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/4.4/core/src/test/resources/testload.tar.gz?raw=true");
         testResult(db, "CALL apoc.load.csv($url,{results:['map','list','stringMap','strings']})", map("url",url.toString()+"!csv/test.csv"), // 'file:test.csv'
                 (r) -> {
                     assertRow(r,0L,"name","Selma","age","8");
@@ -525,7 +525,7 @@ RETURN m.col_1,m.col_2,m.col_3
     }
 
     @Test public void testLoadCsvTgzByUrl() throws Exception {
-        URL url = new URL("https://github.com/neo4j/apoc/blob/dev/core/src/test/resources/testload.tgz?raw=true");
+        URL url = new URL("https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/4.4/core/src/test/resources/testload.tgz?raw=true");
         testResult(db, "CALL apoc.load.csv($url,{results:['map','list','stringMap','strings']})", map("url",url.toString()+"!csv/test.csv"), // 'file:test.csv'
                 (r) -> {
                     assertRow(r,0L,"name","Selma","age","8");


### PR DESCRIPTION
## Why
Because we have tests failing intermitently in GitHub Actions. Possibly because they are using links in the apoc-core (lives in another organization) and GitHub API rates limit you for different organizations.
<img width="2245" src="https://user-images.githubusercontent.com/5649971/201950912-08074662-115c-4aef-8354-bd01788dcef8.png">

## What
Changes links for load csv tests.
