### PR TITLE
Solves some problems with the 5.1 build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "apoc-core"]
 	path = apoc-core
 	url = https://github.com/neo4j/apoc
-	branch = 5.1.0
+	branch = 5.1

--- a/extended/src/test/java/apoc/systemdb/SystemDbTest.java
+++ b/extended/src/test/java/apoc/systemdb/SystemDbTest.java
@@ -103,7 +103,7 @@ public class SystemDbTest {
     @Test
     public void testWriteStatements() {
         // count exhaust the result - this is important here
-        TestUtil.count(db, "CALL apoc.systemdb.execute([\"CREATE USER dummy SET PASSWORD '123'\"])");
+        TestUtil.count(db, "CALL apoc.systemdb.execute([\"CREATE USER dummy SET PASSWORD '12345678'\"])");
 
         assertEquals(2L, TestUtil.count(db, "CALL apoc.systemdb.execute('SHOW USERS')"));
     }

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,7 +1,7 @@
 :readme:
 :branch: 5.1
 :docs: https://neo4j.com/docs/labs/apoc/current
-:apoc-release: 5.1.0.0
+:apoc-release: 5.1.0
 :neo4j-version: 5.1.0
 :img: https://raw.githubusercontent.com/neo4j-contrib/neo4j-apoc-procedures/{branch}/docs/images
 


### PR DESCRIPTION
* Fixes `SystemDbTest` that was failing in TeamCity with:
```
org.neo4j.graphdb.QueryExecutionException: Failed to invoke procedure `apoc.systemdb.execute`: Caused by: org.neo4j.exceptions.InvalidArgumentException: A password must be at least 8 characters.
```
* Changes release number from 5.1.0.0 to 5.1.0 in the docs.
* Points the apoc-core submodule to the 5.1 branch
