### PR TITLE
Makes gradle go to Maven Central for extra-dependencies project

### DIFF
--- a/extra-dependencies/build.gradle
+++ b/extra-dependencies/build.gradle
@@ -1,8 +1,10 @@
 allprojects {
     repositories {
+        mavenCentral()
         maven {
             url "https://repo.gradle.org/gradle/libs-releases"
         }
+        mavenLocal()
     }
 }
 


### PR DESCRIPTION
Cherry-picks #3287

## Why

Because our TeamCity build are failing when doing `./gradlew buildDependencies` inside `extra-dependencies` folder.

<img width="1919" src="https://user-images.githubusercontent.com/5649971/201942144-10810160-21ac-49f8-b6a3-7ff6851a80e6.png">

It's unclear to me why it started failing now, probably because those dependencies were removed from the gradle-libs repo.
