### PR TITLE
[NOID] Bump snakeyaml to latest release

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -70,7 +70,7 @@ dependencies {
         exclude module: "commons-lang3"
         exclude module: "commons-text"
     }
-    compile group: 'org.yaml', name: 'snakeyaml', version: '1.26'
+    compile group: 'org.yaml', name: 'snakeyaml', version: '1.32'
     compile group: 'com.github.seancfoley', name: 'ipaddress', version: '5.3.3'
     testCompile group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
     compile(group: 'org.apache.commons', name: 'commons-lang3')

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -86,7 +86,7 @@ dependencies {
         exclude module: "commons-lang3"
         exclude module: "commons-text"
     }
-    compile group: 'org.yaml', name: 'snakeyaml', version: '1.26'
+    compile group: 'org.yaml', name: 'snakeyaml', version: '1.32'
     testCompile group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
 
     testCompile 'net.sourceforge.jexcelapi:jxl:2.6.12'


### PR DESCRIPTION
changelog: [4.3, security] Bumped snakeyaml to 1.32 to mitigate CVE-2022-25857, CVE-2022-38749, CVE-2022-38750, CVE-2022-38751, CVE-2022-38752