### PR TITLE
[NOID] Removes load json test, the data is not in the external API anymore

### DIFF
--- a/core/src/test/java/apoc/load/LoadJsonTest.java
+++ b/core/src/test/java/apoc/load/LoadJsonTest.java
@@ -179,15 +179,6 @@ public class LoadJsonTest {
                     assertEquals(map("foo",asList(1L,2L,3L)), row.get("value"));
                 });
     }
-    @Test @Ignore public void testLoadJsonGraphCommons() throws Exception {
-		String url = "https://graphcommons.com/graphs/8da5327d-7829-4dfe-b60b-4c0bda956b2a.json";
-		testCall(db, "CALL apoc.load.json($url)",map("url", url), // 'file:map.json' YIELD value RETURN value
-                (row) -> {
-                    Map value = (Map)row.get("value");
-                    assertEquals(true, value.containsKey("users"));
-                    assertEquals(true, value.containsKey("nodes"));
-                });
-    }
 
     @Test public void testLoadJsonStackOverflow() throws Exception {
         String url = "https://api.stackexchange.com/2.2/questions?pagesize=10&order=desc&sort=creation&tagged=neo4j&site=stackoverflow&filter=!5-i6Zw8Y)4W7vpy91PMYsKM-k9yzEsSC1_Uxlf";


### PR DESCRIPTION
Cherry-picks https://github.com/neo4j/apoc/pull/243

## Why
The `json` disappeared from the external service. There's still another test that loads a json from stackexchange, so that should be enough to test the functionality.

These files should be moved to the repo probably and accessed through a github url rather than depending on external services.
