### PR TITLE
fixes #3349: Can not create custom procedure with void return type using apoc.custom.declareProcedure

### DIFF
--- a/full/src/main/java/apoc/custom/CypherProcedures.java
+++ b/full/src/main/java/apoc/custom/CypherProcedures.java
@@ -203,14 +203,16 @@ public class CypherProcedures {
     private void checkMode(QueryExecutionType.QueryType queryType, Mode mode) {
         Map<QueryExecutionType.QueryType, Mode> map = Map.of(QueryExecutionType.QueryType.WRITE, Mode.WRITE,
                 QueryExecutionType.QueryType.READ_ONLY, Mode.READ,
-                QueryExecutionType.QueryType.READ_WRITE, Mode.WRITE);
+                QueryExecutionType.QueryType.READ_WRITE, Mode.WRITE,
+                QueryExecutionType.QueryType.DBMS, Mode.DBMS,
+                QueryExecutionType.QueryType.SCHEMA_WRITE, Mode.SCHEMA);
         
         if (!map.get(queryType).equals(mode)) {
             throw new RuntimeException(String.format("The query execution type is %s, but you provided mode %s.\n" +
                             "Supported modes are %s",
                     queryType.name(), 
                     mode.name(), 
-                    map.values().stream().sorted().collect(Collectors.toList()).toString()));
+                    map.values().stream().sorted().collect(Collectors.toList())));
         }
     }
 

--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -287,6 +287,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
     public static List<FieldSignature> deserializeSignatures(String s) {
         List<Map<String, Object>> mapped = Util.fromJson(s, List.class);
+        if (mapped.isEmpty()) return ProcedureSignature.VOID;
         return mapped.stream().map(map -> {
             String typeString = (String) map.get("type");
             if (typeString.endsWith("?")) {


### PR DESCRIPTION
Fixes #3349

Extended Cypher Procedures in order to support `DBMS` and `SCHEMA` procedures.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Added the new modes
  - Added Test
