### PR TITLE
[qwJFy8pp] Add @Admin to trigger procedures

### DIFF
--- a/core/src/main/java/apoc/trigger/Trigger.java
+++ b/core/src/main/java/apoc/trigger/Trigger.java
@@ -103,6 +103,7 @@ public class Trigger {
         return new TriggerInfo(name, null, null, false, false);
     }
 
+    @Admin
     @Procedure(mode = Mode.READ)
     @Description("list all installed triggers")
     public Stream<TriggerInfo> list() {

--- a/core/src/main/java/apoc/trigger/Trigger.java
+++ b/core/src/main/java/apoc/trigger/Trigger.java
@@ -4,6 +4,7 @@ import apoc.util.Util;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.logging.Log;
+import org.neo4j.procedure.Admin;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Mode;
@@ -43,6 +44,7 @@ public class Trigger {
         }
     }
 
+    @Admin
     @Deprecated
     @Procedure(mode = Mode.WRITE, deprecatedBy = "apoc.trigger.install")
     @Description("add a trigger kernelTransaction under a name, in the kernelTransaction you can use {createdNodes}, {deletedNodes} etc., the selector is {phase:'before/after/rollback/afterAsync'} returns previous and new trigger information. Takes in an optional configuration.")
@@ -60,6 +62,7 @@ public class Trigger {
         return Stream.of(new TriggerInfo(name,statement,selector, params,true, false));
     }
 
+    @Admin
     @Deprecated
     @Procedure(mode = Mode.WRITE, deprecatedBy = "apoc.trigger.drop")
     @Description("remove previously added trigger, returns trigger information")
@@ -73,6 +76,7 @@ public class Trigger {
         return Stream.of(new TriggerInfo(name,(String)removed.get("statement"), (Map<String, Object>) removed.get("selector"), (Map<String, Object>) removed.get("params"),false, false));
     }
 
+    @Admin
     @Deprecated
     @Procedure(mode = Mode.WRITE, deprecatedBy = "apoc.trigger.dropAll")
     @Description("removes all previously added trigger, returns trigger information")
@@ -112,6 +116,7 @@ public class Trigger {
                 );
     }
 
+    @Admin
     @Deprecated
     @Procedure(mode = Mode.WRITE, deprecatedBy = "apoc.trigger.stop")
     @Description("CALL apoc.trigger.pause(name) | it pauses the trigger")
@@ -126,6 +131,7 @@ public class Trigger {
                 (Map<String,Object>) paused.get("params"),true, true));
     }
 
+    @Admin
     @Deprecated
     @Procedure(mode = Mode.WRITE, deprecatedBy = "apoc.trigger.start")
     @Description("CALL apoc.trigger.resume(name) | it resumes the paused trigger")

--- a/core/src/main/java/apoc/trigger/TriggerNewProcedures.java
+++ b/core/src/main/java/apoc/trigger/TriggerNewProcedures.java
@@ -5,6 +5,7 @@ import apoc.util.Util;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.kernel.api.procedure.SystemProcedure;
 import org.neo4j.logging.Log;
+import org.neo4j.procedure.Admin;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Mode;
@@ -75,6 +76,7 @@ public class TriggerNewProcedures {
 
     // TODO - change with @SystemOnlyProcedure
     @SystemProcedure
+    @Admin
     @Procedure(mode = Mode.WRITE)
     @Description("CALL apoc.trigger.install(databaseName, name, statement, selector, config) | eventually adds a trigger for a given database which is invoked when a successful transaction occurs.")
     public Stream<TriggerInfo> install(@Name("databaseName") String databaseName, @Name("name") String name, @Name("statement") String statement, @Name(value = "selector")  Map<String,Object> selector, @Name(value = "config", defaultValue = "{}") Map<String,Object> config) {
@@ -96,6 +98,7 @@ public class TriggerNewProcedures {
 
     // TODO - change with @SystemOnlyProcedure
     @SystemProcedure
+    @Admin
     @Procedure(mode = Mode.WRITE)
     @Description("CALL apoc.trigger.drop(databaseName, name) | eventually removes an existing trigger, returns the trigger's information")
     public Stream<TriggerInfo> drop(@Name("databaseName") String databaseName, @Name("name")String name) {
@@ -110,6 +113,7 @@ public class TriggerNewProcedures {
     
     // TODO - change with @SystemOnlyProcedure
     @SystemProcedure
+    @Admin
     @Procedure(mode = Mode.WRITE)
     @Description("CALL apoc.trigger.dropAll(databaseName) | eventually removes all previously added trigger, returns triggers' information")
     public Stream<TriggerInfo> dropAll(@Name("databaseName") String databaseName) {
@@ -120,6 +124,7 @@ public class TriggerNewProcedures {
 
     // TODO - change with @SystemOnlyProcedure
     @SystemProcedure
+    @Admin
     @Procedure(mode = Mode.WRITE)
     @Description("CALL apoc.trigger.stop(databaseName, name) | eventually pauses the trigger")
     public Stream<TriggerInfo> stop(@Name("databaseName") String databaseName, @Name("name")String name) {
@@ -134,6 +139,7 @@ public class TriggerNewProcedures {
 
     // TODO - change with @SystemOnlyProcedure
     @SystemProcedure
+    @Admin
     @Procedure(mode = Mode.WRITE)
     @Description("CALL apoc.trigger.start(databaseName, name) | eventually unpauses the paused trigger")
     public Stream<TriggerInfo> start(@Name("databaseName") String databaseName, @Name("name")String name) {

--- a/core/src/test/java/apoc/trigger/TriggerClusterRoutingTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerClusterRoutingTest.java
@@ -132,6 +132,7 @@ public class TriggerClusterRoutingTest {
                     failsWithNonAdminUser(neo4jUserSession, "apoc.trigger.removeAll", "call apoc.trigger.removeAll");
                     failsWithNonAdminUser(neo4jUserSession, "apoc.trigger.pause", "call apoc.trigger.pause('abc')");
                     failsWithNonAdminUser(neo4jUserSession, "apoc.trigger.resume", "call apoc.trigger.resume('abc')");
+                    failsWithNonAdminUser(neo4jUserSession, "apoc.trigger.list", "call apoc.trigger.list");
                 }
             }
             

--- a/docs/asciidoc/modules/ROOT/pages/background-operations/triggers.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/background-operations/triggers.adoc
@@ -18,6 +18,11 @@ Moreover, they accept as first parameter the name of the database towards which 
 
 Through this implementation, we can use these procedures in a cluster environment,
 by leveraging the cluster routing mechanism.
+
+Moreover, to use these procedures the user must have the `admin` role, 
+otherwise the procedure throws with an error `permission has not been granted for user 'xxx'`,
+to prevent anyone from adding a trigger that could escalate privileges. 
+For example, a user who doesn't have permissions to delete entities, may create a trigger that does.
 ====
 
 [WARNING]

--- a/docs/asciidoc/modules/ROOT/pages/background-operations/triggers.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/background-operations/triggers.adoc
@@ -19,10 +19,8 @@ Moreover, they accept as first parameter the name of the database towards which 
 Through this implementation, we can use these procedures in a cluster environment,
 by leveraging the cluster routing mechanism.
 
-Moreover, to use these procedures the user must have the `admin` role, 
-otherwise the procedure throws with an error `permission has not been granted for user 'xxx'`,
-to prevent anyone from adding a trigger that could escalate privileges. 
-For example, a user who doesn't have permissions to delete entities, may create a trigger that does.
+These procedures are only executable by a user with admin permissions.
+If this is not the case, the procedure throws an exception with the message `permission has not been granted for user 'xxx'`.
 ====
 
 [WARNING]


### PR DESCRIPTION
- Added `@Admin` annotation to trigger procedures
- Added `testTriggersAllowedOnlyWithAdmin`

---

Please note that this is a breaking change
that we've introduced in order to improve procedures security.


---

Better to use `@Admin` check instead of `Util.checkAdmin`, like [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/8a9d0ca3758817ad92dc61b39cc7e54451cfcc44) :
- it will most likely be compatible with future versions
- it doesn't require additional contexts:
- we don't have to specify the procedure name, e.g. `Util.checkAdmin(securityContext, callContext,"apoc.trigger.install");`


```
    @Context
    public SecurityContext securityContext;
    @Context
    public ProcedureCallContext callContext;
```
- similar error, but with more details

```
// with Admin annotation
Executing admin procedure 'apoc.trigger.remove' permission has not been granted for user 'name' with roles [PUBLIC, editor, publisher] restricted to TOKEN_WRITE.
```

```
// with Util.checkAdmin
Failed to invoke procedure `apoc.trigger.add`: Caused by: java.lang.RuntimeException: This procedure apoc.trigger.install is only available to admin users
```

