### PR TITLE
Various changes for 5.x releases

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -12,7 +12,7 @@ jobs:
     env:
       DOCKER_ENTERPRISE_URL: ${{ secrets.DOCKER_ENTERPRISE_DEV_URL }}
       DOCKER_COMMUNITY_URL: ${{ secrets.DOCKER_COMMUNITY_DEV_URL }}
-      TEAMCITY_URL: ${{ secrets.TEAMCITY_DEV_URL }}
+      TEAMCITY_DEV_URL: ${{ secrets.TEAMCITY_DEV_URL }}
       TEAMCITY_USER: ${{ secrets.TEAMCITY_USER }}
       TEAMCITY_PASSWORD: ${{ secrets.TEAMCITY_PASSWORD }}
       ENTERPRISE_TAR: enterprise-docker.tar

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ downloadLicenses {
 
 allprojects {
     group = 'org.neo4j.procedure'
-    version = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : '5.3.0'
+    version = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : '5.4.0'
     archivesBaseName = 'apoc'
     description = """neo4j-apoc-procedures"""
 }
@@ -71,8 +71,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.3.0-enterprise',
-                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:5.3.0',
+                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.4.0-enterprise',
+                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:5.4.0',
                 'coreDir': 'apoc-core/core'
 
         maxHeapSize = "8G"
@@ -130,7 +130,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.3.0"
+    neo4jVersion = "5.4.0"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.16.2'

--- a/docs/asciidoc/antora.yml
+++ b/docs/asciidoc/antora.yml
@@ -8,4 +8,4 @@ asciidoc:
     docs-version: "5.0"
     branch: "5.0"
     apoc-release-absolute: "5.0"
-    apoc-release: "5.0.0-rc01"
+    apoc-release: "5.4.0"

--- a/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
@@ -22,6 +22,7 @@ The version compatibility matrix explains the mapping between Neo4j and APOC ver
 [opts=header]
 |===
 |apoc version | neo4j version
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.2.0[5.2.0^] | 5.2.0 (5.2.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.1.0[5.1.0^]| 5.1.0 (5.1.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.1[4.4.0.1^] | 4.4.0 (4.3.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.3.0.4[4.3.0.4^] | 4.3.7 (4.3.x)
@@ -40,6 +41,26 @@ See the compatibility matrix in https://neo4j.com/labs/apoc/4.4/installation/ to
 == Docker
 
 include::partial$docker.adoc[tags=docker,leveloffset=1]
+
+
+[[mvnrepository]]
+== Maven Repository
+
+In a `pom.xml` of a maven project, you can add these two dependencies from https://mvnrepository.com/artifact/org.neo4j.procedure[Maven Repository]:
+
+[source,subs=attributes]
+----
+&lt;dependency&gt;
+    &lt;groupId&gt;org.neo4j.procedure&lt;/groupId&gt;
+    &lt;artifactId&gt;apoc-extended&lt;/artifactId&gt;
+    &lt;version&gt;{apoc-release}&lt;/version&gt;
+    &lt;classifier&gt;extended&lt;/classifier&gt;
+&lt;/dependency&gt;
+----
+
+Alternatively, you can download the jar https://repo1.maven.org/maven2/org/neo4j/procedure/apoc-extended/{apoc-release}/apoc-extended-{apoc-release}-extended.jar[from here] (if it is not already present via `apoc-core`)
+and put them into `plugin` folder.
+
 
 [[restricted]]
 == Restricted procedures/functions

--- a/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
@@ -58,8 +58,8 @@ In a `pom.xml` of a maven project, you can add these two dependencies from https
 &lt;/dependency&gt;
 ----
 
-Alternatively, you can download the jar https://repo1.maven.org/maven2/org/neo4j/procedure/apoc-extended/{apoc-release}/apoc-extended-{apoc-release}-extended.jar[from here] (if it is not already present via `apoc-core`)
-and put them into `plugin` folder.
+Alternatively, you can download the jar https://repo1.maven.org/maven2/org/neo4j/procedure/apoc-extended/{apoc-release}/apoc-extended-{apoc-release}-extended.jar[from here]
+and put it into `plugin` folder.
 
 
 [[restricted]]

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -29,7 +29,7 @@ plugins {
     id 'org.neo4j.doc.build.docbook' version '1.0-alpha12'
 }
 
-if (!project.hasProperty('apocVersion')) { ext.apocVersion = '5.0.0.0-rc01' }
+if (!project.hasProperty('apocVersion')) { ext.apocVersion = '5.4.0' }
 
 ext {
     versionParts = apocVersion.split('-')

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     implementation project(':common')
     implementation group: 'com.novell.ldap', name: 'jldap', version: '2009-10-07'
     implementation group: 'org.jsoup', name: 'jsoup', version: '1.14.3'
-    implementation group: 'com.opencsv', name: 'opencsv', version: '4.6'
+    implementation group: 'com.opencsv', name: 'opencsv', version: '5.7.1'
     implementation group: 'com.github.javafaker', name: 'javafaker', version: '1.0.2'
     implementation group: 'us.fatehi', name: 'schemacrawler', version: '15.04.01'
 

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -148,7 +148,7 @@ publishing {
     }
     publications {
         shadow(MavenPublication) { publication ->
-            artifactId("apoc")
+            artifactId("apoc-extended")
             project.shadow.component(publication)
             artifact(mySourcesJar)
             artifact(myJavadocJar)
@@ -156,8 +156,8 @@ publishing {
 
             pom.withXml {
                 def root = asNode()
-                root.appendNode("name", "neo4j-apoc-procedure")
-                root.appendNode("description", "A collection of useful Neo4j Procedures")
+                root.appendNode("name", "neo4j-apoc-extended")
+                root.appendNode("description", "Extended package for Neo4j Procedures")
                 root.appendNode("url", "http://github.com/neo4j-contrib/neo4j-apoc-procedures")
 
                 def scmNode = root.appendNode("scm")

--- a/extended/src/test/java/apoc/bolt/BoltTest.java
+++ b/extended/src/test/java/apoc/bolt/BoltTest.java
@@ -3,6 +3,7 @@ package apoc.bolt;
 import apoc.cypher.Cypher;
 import apoc.export.cypher.ExportCypher;
 import apoc.util.Neo4jContainerExtension;
+import apoc.util.TestContainerUtil;
 import apoc.util.TestContainerUtil.ApocPackage;
 import apoc.util.TestUtil;
 import apoc.util.Util;
@@ -430,6 +431,9 @@ public class BoltTest {
     }
 
     private String getBoltUrl() {
-        return "'" + "bolt://neo4j:apoc@" + neo4jContainer.getContainerIpAddress() + ":" + neo4jContainer.getMappedPort(7687) + "'";
+        return String.format("'bolt://neo4j:%s@%s:%s'",
+                TestContainerUtil.password,
+                neo4jContainer.getContainerIpAddress(),
+                neo4jContainer.getMappedPort(7687));
     }
 }

--- a/extended/src/test/java/apoc/couchbase/CouchbaseTestUtils.java
+++ b/extended/src/test/java/apoc/couchbase/CouchbaseTestUtils.java
@@ -134,6 +134,7 @@ public class CouchbaseTestUtils {
     protected static void createCouchbaseContainer() {
         // 7.0 support stably multi collections and scopes
         couchbase = new CouchbaseContainer("couchbase/server:7.0.0")
+                .withStartupAttempts(3)
                 .withCredentials(USERNAME, PASSWORD)
                 .withBucket(new BucketDefinition(BUCKET_NAME));
         couchbase.start();

--- a/extended/src/test/java/apoc/load/LoadCsvTest.java
+++ b/extended/src/test/java/apoc/load/LoadCsvTest.java
@@ -183,7 +183,7 @@ RETURN m.col_1,m.col_2,m.col_3
     public void testLoadCsvEscape() { 
         URL url = getUrlFileName("test-escape.csv");
         final List<String> results = List.of("map", "list", "stringMap", "strings");
-        testResult(db, "CALL apoc.load.csv($url, $config)", 
+        testResult(db, "CALL apoc.load.csv($url, $config)",
                 map("url", url.toString(), "config", map("results", results)),
                 (r) -> {
                     assertRow(r, 0L,"name", "Naruto", "surname","Uzumaki");
@@ -193,10 +193,45 @@ RETURN m.col_1,m.col_2,m.col_3
         testResult(db, "CALL apoc.load.csv($url,$config)",
                 map("url", url.toString(), "config", map("results", results, "escapeChar", "NONE")),
                 (r) -> {
-                    assertRow(r, 0L,"name", "Narut\\o\\", "surname","Uzu\\maki");
+                    assertRow(r, 0L,"name", "Narut\\o", "surname","Uzu\\maki");
                     assertRow(r, 1L,"name", "Minat\\o", "surname","Nami\\kaze");
                     assertFalse(r.hasNext());
                 });
+    }
+
+    @Test
+    public void testLoadCsvWithEscapedDelimiters() {
+        String url = "test-escaped-delimiters.csv";
+        final List<String> results = List.of("map", "list", "stringMap", "strings");
+
+        /* In OpenCSV library 5.1 -> 5.2 they corrected a bug: https://sourceforge.net/p/opencsv/bugs/212/
+           Now when we have an escaping character before a delimiter,
+           the delimiter is ignored
+
+           This means before a line:
+                one\,two
+
+           with the escaping character '\' and ',' as separator would parse
+           as two columns. As in first it splits, then escapes.
+           Now it looks like the new version of the library first escapes
+           (so the ',' is escaped)
+           and then splits, so it parses as one column.
+        */
+        var e = assertThrows(RuntimeException.class, () -> testResult(db, "CALL apoc.load.csv($url, $config)",
+                       map("url", url, "config", map("results", results)),
+                       (r) -> {
+                           // Consume the stream so it throws the exception
+                           r.stream().toArray();
+                       })
+            );
+        assertTrue(e.getMessage().contains("Please check whether you included a delimiter before a column separator or forgot a column separator."));
+
+        testResult(db, "CALL apoc.load.csv($url,$config)",
+                   map("url", url, "config", map("results", results, "escapeChar", "NONE")),
+                   (r) -> {
+                       assertRow(r, 0L,"name", "Narut\\o\\", "surname","Uzu\\maki");
+                       assertFalse(r.hasNext());
+                   });
     }
 
     @Test public void testLoadCsvNoHeader() throws Exception {

--- a/extended/src/test/java/apoc/load/LoadHtmlTest.java
+++ b/extended/src/test/java/apoc/load/LoadHtmlTest.java
@@ -110,22 +110,24 @@ public class LoadHtmlTest {
 
     @Test
     public void testWithWaitUntilAndOneElementNotFound() {
-        testCall(db, "CALL apoc.load.html($url,$query,$config)",
-                map("url", URL_HTML_JS,
-                        "query", map("elementExistent", "strong", "elementNotExistent", ".asdfgh"),
-                        "config", map("browser", "CHROME", "wait", 5)),
-                result -> {
-                    Map<String, Object> value = (Map<String, Object>) result.get("value");
-                    List<Map<String, Object>> notExistent = (List<Map<String, Object>>) value.get("elementNotExistent");
-                    List<Map<String, Object>> existent = (List<Map<String, Object>>) value.get("elementExistent");
-                    assertTrue(notExistent.isEmpty());
-                    assertEquals(1, existent.size());
-                    final Map<String, Object> tag = existent.get(0);
-                    assertEquals("This is a new text node", tag.get("text"));
-                    assertEquals("strong", tag.get("tagName"));
-                });
+        skipIfBrowserNotPresentOrCompatible(() -> {
+            testCall(db, "CALL apoc.load.html($url,$query,$config)",
+                    map("url", URL_HTML_JS,
+                            "query", map("elementExistent", "strong", "elementNotExistent", ".asdfgh"),
+                            "config", map("browser", "CHROME", "wait", 5)),
+                    result -> {
+                        Map<String, Object> value = (Map<String, Object>) result.get("value");
+                        List<Map<String, Object>> notExistent = (List<Map<String, Object>>) value.get("elementNotExistent");
+                        List<Map<String, Object>> existent = (List<Map<String, Object>>) value.get("elementExistent");
+                        assertTrue(notExistent.isEmpty());
+                        assertEquals(1, existent.size());
+                        final Map<String, Object> tag = existent.get(0);
+                        assertEquals("This is a new text node", tag.get("text"));
+                        assertEquals("strong", tag.get("tagName"));
+                    });
+        });
     }
-
+    
     @Test
     public void testWithBaseUriConfig() {
         Map<String, Object> query = map("urlTest", ".urlTest");
@@ -181,7 +183,7 @@ public class LoadHtmlTest {
                     assertEquals(expected, actual);
                 });
     }
-    
+
     @Test
     public void shouldEmulateJsoupFunctions() {
         // getElementsByTag
@@ -482,25 +484,39 @@ public class LoadHtmlTest {
     }
 
     private void testCallGeneratedJsWithBrowser(String browser) {
-        testCall(db, "CALL apoc.load.html($url,$query,$config)",
-                map("url", URL_HTML_JS,
-                        "query", map("td", "td", "strong", "strong"),
-                        "config", map("browser", browser, "driverVersion", "0.30.0")),
-                result -> {
-                    Map<String, Object> value = (Map<String, Object>) result.get("value");
-                    List<Map<String, Object>> tdList = (List<Map<String, Object>>) value.get("td");
-                    List<Map<String, Object>> strongList = (List<Map<String, Object>>) value.get("strong");
-                    assertEquals(4, tdList.size());
-                    final String templateString = "foo bar - baz";
-                    AtomicInteger integer = new AtomicInteger();
-                    tdList.forEach(tag -> {
-                        assertEquals("td", tag.get("tagName"));
-                        assertEquals(integer.getAndIncrement() + templateString, tag.get("text"));
+        skipIfBrowserNotPresentOrCompatible(() -> {
+            testCall(db, "CALL apoc.load.html($url,$query,$config)",
+                    map("url", URL_HTML_JS,
+                            "query", map("td", "td", "strong", "strong"),
+                            "config", map("browser", browser, "driverVersion", "0.30.0")),
+                    result -> {
+                        Map<String, Object> value = (Map<String, Object>) result.get("value");
+                        List<Map<String, Object>> tdList = (List<Map<String, Object>>) value.get("td");
+                        List<Map<String, Object>> strongList = (List<Map<String, Object>>) value.get("strong");
+                        assertEquals(4, tdList.size());
+                        final String templateString = "foo bar - baz";
+                        AtomicInteger integer = new AtomicInteger();
+                        tdList.forEach(tag -> {
+                            assertEquals("td", tag.get("tagName"));
+                            assertEquals(integer.getAndIncrement() + templateString, tag.get("text"));
+                        });
+                        assertEquals(1, strongList.size());
+                        final Map<String, Object> tagStrong = strongList.get(0);
+                        assertEquals("This is a new text node", tagStrong.get("text"));
+                        assertEquals("strong", tagStrong.get("tagName"));
                     });
-                    assertEquals(1, strongList.size());
-                    final Map<String, Object> tagStrong = strongList.get(0);
-                    assertEquals("This is a new text node", tagStrong.get("text"));
-                    assertEquals("strong", tagStrong.get("tagName"));
-                });
+        });
+    }
+    
+    public static void skipIfBrowserNotPresentOrCompatible(Runnable runnable) {
+        try {
+            runnable.run();
+        } catch (RuntimeException e) {
+            // The test don't fail if the current chrome/firefox version is incompatible or if the browser is not installed
+            final String msg = e.getMessage();
+            if (!msg.contains("cannot find Chrome binary") && !msg.contains("Cannot find firefox binary")) {
+                throw e;
+            }
+        }
     }
 }

--- a/extended/src/test/java/apoc/load/LoadHtmlTestParameterized.java
+++ b/extended/src/test/java/apoc/load/LoadHtmlTestParameterized.java
@@ -20,6 +20,7 @@ import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
 import static apoc.load.LoadHtmlTest.RESULT_QUERY_H2;
 import static apoc.load.LoadHtmlTest.RESULT_QUERY_METADATA;
+import static apoc.load.LoadHtmlTest.skipIfBrowserNotPresentOrCompatible;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testResult;
 import static com.google.common.collect.Lists.newArrayList;
@@ -57,18 +58,21 @@ public class LoadHtmlTestParameterized {
         Map<String, Object> query = map("metadata", "meta", "h2", "h2");
 
         Map<String, Object> config = browserSet() ? Map.of("browser", browser) : emptyMap();
-        testResult(db, "CALL apoc.load.html($url,$query, $config)",
-                map("url",new File("src/test/resources/wikipedia.html").toURI().toString(), "query", query, "config", config),
-                result -> {
-                    Map<String, Object> row = result.next();
-                    Map<String, Object> value = (Map<String, Object>) row.get("value");
 
-                    List<Map<String, Object>> metadata = (List<Map<String, Object>>) value.get("metadata");
-                    List<Map<String, Object>> h2 = (List<Map<String, Object>>) value.get("h2");
-
-                    assertEquals(asList(RESULT_QUERY_METADATA).toString().trim(), metadata.toString().trim());
-                    assertEquals(asList(RESULT_QUERY_H2).toString().trim(), h2.toString().trim());
-                });
+        skipIfBrowserNotPresentOrCompatible(() -> {
+            testResult(db, "CALL apoc.load.html($url,$query, $config)",
+                    map("url",new File("src/test/resources/wikipedia.html").toURI().toString(), "query", query, "config", config),
+                    result -> {
+                        Map<String, Object> row = result.next();
+                        Map<String, Object> value = (Map<String, Object>) row.get("value");
+    
+                        List<Map<String, Object>> metadata = (List<Map<String, Object>>) value.get("metadata");
+                        List<Map<String, Object>> h2 = (List<Map<String, Object>>) value.get("h2");
+    
+                        assertEquals(asList(RESULT_QUERY_METADATA).toString().trim(), metadata.toString().trim());
+                        assertEquals(asList(RESULT_QUERY_H2).toString().trim(), h2.toString().trim());
+                    });
+        });
     }
 
     @Test
@@ -78,13 +82,15 @@ public class LoadHtmlTestParameterized {
         addBrowserIfSet(confList);
         Map<String, Object> config = map(confList.toArray());
 
-        testResult(db, "CALL apoc.load.html($url, $query, $config)",
-                map("url",new File("src/test/resources/wikipedia.html").toURI().toString(), "query", query, "config", config),
-                result -> {
-                    Map<String, Object> row = result.next();
-                    assertEquals(map("h2",asList(RESULT_QUERY_H2)).toString().trim(), row.get("value").toString().trim());
-                    assertFalse(result.hasNext());
-                });
+        skipIfBrowserNotPresentOrCompatible(() -> {
+            testResult(db, "CALL apoc.load.html($url, $query, $config)",
+                    map("url",new File("src/test/resources/wikipedia.html").toURI().toString(), "query", query, "config", config),
+                    result -> {
+                        Map<String, Object> row = result.next();
+                        assertEquals(map("h2",asList(RESULT_QUERY_H2)).toString().trim(), row.get("value").toString().trim());
+                        assertFalse(result.hasNext());
+                    });
+        });
     }
 
     @Test
@@ -94,26 +100,28 @@ public class LoadHtmlTestParameterized {
         addBrowserIfSet(confList);
         Map<String, Object> config = map(confList.toArray());
 
-        testResult(db, "CALL apoc.load.html($url, $query, $config)",
-                map("url",new File("src/test/resources/wikipedia.html").toURI().toString(), "query", query, "config", config),
-                result -> {
-                    Map<String, Object> row = result.next();
-                    Map<String, Object> value = (Map<String, Object>) row.get("value");
+        skipIfBrowserNotPresentOrCompatible(() -> {
+            testResult(db, "CALL apoc.load.html($url, $query, $config)",
+                    map("url",new File("src/test/resources/wikipedia.html").toURI().toString(), "query", query, "config", config),
+                    result -> {
+                        Map<String, Object> row = result.next();
+                        Map<String, Object> value = (Map<String, Object>) row.get("value");
 
-                    List<Map<String, Object>> toc = (List) value.get("toc");
-                    Map<String, Object> first = toc.get(0);
+                        List<Map<String, Object>> toc = (List) value.get("toc");
+                        Map<String, Object> first = toc.get(0);
 
-                    // Should be <ul>
-                    assertEquals("ul", first.get("tagName"));
+                        // Should be <ul>
+                        assertEquals("ul", first.get("tagName"));
 
-                    // Should have four children
-                    assertEquals(4, ((List) first.get("children")).size());
+                        // Should have four children
+                        assertEquals(4, ((List) first.get("children")).size());
 
-                    Map<String, Object> firstChild = (Map)((List) first.get("children")).get(0);
+                        Map<String, Object> firstChild = (Map)((List) first.get("children")).get(0);
 
-                    assertEquals("li", firstChild.get("tagName"));
-                    assertEquals(1, ((List) firstChild.get("children")).size());
-                });
+                        assertEquals("li", firstChild.get("tagName"));
+                        assertEquals(1, ((List) firstChild.get("children")).size());
+                    });
+        });
     }
 
     private void addBrowserIfSet(List<Object> confList) {

--- a/extended/src/test/java/apoc/systemdb/SystemDbTest.java
+++ b/extended/src/test/java/apoc/systemdb/SystemDbTest.java
@@ -103,7 +103,7 @@ public class SystemDbTest {
     @Test
     public void testWriteStatements() {
         // count exhaust the result - this is important here
-        TestUtil.count(db, "CALL apoc.systemdb.execute([\"CREATE USER dummy SET PASSWORD '123'\"])");
+        TestUtil.count(db, "CALL apoc.systemdb.execute([\"CREATE USER dummy SET PASSWORD '12345678'\"])");
 
         assertEquals(2L, TestUtil.count(db, "CALL apoc.systemdb.execute('SHOW USERS')"));
     }

--- a/extended/src/test/java/apoc/util/s3/S3Container.java
+++ b/extended/src/test/java/apoc/util/s3/S3Container.java
@@ -26,7 +26,9 @@ public class S3Container implements AutoCloseable {
 
 
     public S3Container() {
-        localstack = new LocalStackContainer("0.8.10").withServices(S3);
+        localstack = new LocalStackContainer("0.8.10")
+                .withStartupAttempts(3)
+                .withServices(S3);
         localstack.start();
         s3 = AmazonS3ClientBuilder
                 .standard()

--- a/extended/src/test/resources/test-escape.csv
+++ b/extended/src/test/resources/test-escape.csv
@@ -1,3 +1,3 @@
 name,surname
-Narut\o\,Uzu\maki
+Narut\o,Uzu\maki
 Minat\o,Nami\kaze

--- a/extended/src/test/resources/test-escaped-delimiters.csv
+++ b/extended/src/test/resources/test-escaped-delimiters.csv
@@ -1,0 +1,2 @@
+name,surname
+Narut\o\,Uzu\maki

--- a/extra-dependencies/build.gradle
+++ b/extra-dependencies/build.gradle
@@ -14,7 +14,7 @@ configure(subprojects) {
 
 
 subprojects {
-    version = '5.0.0.0-rc01'
+    version = '5.4.0'
     group = 'org.neo4j.contrib'
 }
 

--- a/extra-dependencies/xls/build.gradle
+++ b/extra-dependencies/xls/build.gradle
@@ -18,12 +18,19 @@ jar {
 }
 
 dependencies {
-    implementation group: 'org.apache.poi', name: 'poi', version: '5.1.0'
-    implementation group: 'org.apache.poi', name: 'poi-ooxml-lite', version: '5.1.0'
-    implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.1.0' , {
-        exclude group: 'org.apache.commons', module: 'commons-compress' 
+    implementation group: 'org.apache.poi', name: 'poi', version: '5.1.0', {
+        exclude group: 'org.apache.logging.log4j'
     }
-    implementation group: 'org.apache.xmlbeans', name: 'xmlbeans', version: '5.0.2'
+    implementation group: 'org.apache.poi', name: 'poi-ooxml-lite', version: '5.1.0', {
+        exclude group: 'org.apache.logging.log4j'
+    }
+    implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.1.0' , {
+        exclude group: 'org.apache.commons', module: 'commons-compress'
+        exclude group: 'org.apache.logging.log4j'
+    }
+    implementation group: 'org.apache.xmlbeans', name: 'xmlbeans', version: '5.0.2', {
+        exclude group: 'org.apache.logging.log4j'
+    }
     implementation group: 'com.github.virtuald', name: 'curvesapi', version: '1.06'
     implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
 }

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,15 +1,15 @@
 :readme:
-:branch: 5.0
+:branch: 5.4
 :docs: https://neo4j.com/labs/apoc/5
-:apoc-release: 5.0.0.0-rc01
-:neo4j-version: 5.0.0
+:apoc-release: 5.4.0
+:neo4j-version: 5.4.0
 :img: https://raw.githubusercontent.com/neo4j-contrib/neo4j-apoc-procedures/{branch}/docs/images
 
 https://community.neo4j.com[image:https://img.shields.io/discourse/users?logo=discourse&server=https%3A%2F%2Fcommunity.neo4j.com[Discourse users]]
 https://discord.gg/neo4j[image:https://img.shields.io/discord/787399249741479977?logo=discord&logoColor=white[Discord]]
 
 
-= Awesome Procedures for Neo4j {branch}.x (Extended)
+= Awesome Procedures for Neo4j {neo4j-version}.x (Extended)
 
 // tag::readme[]
 
@@ -183,6 +183,7 @@ The trailing `<apoc>` part of the version number will be incremented with every 
 [opts=header]
 |===
 |apoc version | neo4j version
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.3.0[5.3.0^] | 5.3.0 (5.3.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.2.0[5.2.0^] | 5.2.0 (5.2.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.1.0[5.1.0^] | 5.1.0 (5.1.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.1[4.4.0.1^] | 4.4.0 (4.3.x)

--- a/readme.adoc
+++ b/readme.adoc
@@ -183,6 +183,8 @@ The trailing `<apoc>` part of the version number will be incremented with every 
 [opts=header]
 |===
 |apoc version | neo4j version
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.2.0[5.2.0^] | 5.2.0 (5.2.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.1.0[5.1.0^] | 5.1.0 (5.1.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.1[4.4.0.1^] | 4.4.0 (4.3.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.3.0.4[4.3.0.4^] | 4.3.7 (4.3.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.2.0.9[4.2.0.9^] | 4.2.11 (4.2.x)

--- a/teamcity-repository.gradle
+++ b/teamcity-repository.gradle
@@ -3,7 +3,7 @@ allprojects {
         repositories {
             maven {
                 name = 'teamcity-neo4j-dev'
-                url =  System.getenv('TEAMCITY_URL')
+                url =  System.getenv('TEAMCITY_DEV_URL')
                 credentials {
                     username System.getenv('TEAMCITY_USER')
                     password System.getenv('TEAMCITY_PASSWORD')


### PR DESCRIPTION
- Various changes for 5.x releases (Cherry pick of https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3284)
- Bumps neo4j version
- Updated branch numbers in readme
- Fix failing testWriteStatements in TeamCity (See #3289)
- Fix various tests in 5.x (Cherry pick of #3286)
- Fixes CVE-2022-42889 in transitive dependencies [5.x, extended] (Cherry pick of #3258)
- Fixed BoltTest after neo4j/apoc#242 pwd change
- Fixed `CoreExtendedTest` by making teamcity-repository.gradle consistent with the core one
- Fixed assertions LoadHtmlTest