### PR TITLE
Removed neo4jVersionOverride from apoc gradle version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ downloadLicenses {
 
 allprojects {
     group = 'org.neo4j.procedure'
-    version = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : '5.3.1'
+    version = '5.3.1'
     archivesBaseName = 'apoc'
     description = """neo4j-apoc-procedures"""
 }


### PR DESCRIPTION
- Removed neo4jVersionOverride from apoc gradle version

In TC we execute various `./gradlew ... Pneo4jVersionOverride=<neo4jVersion> ... taskName`,

The `neo4jVersionOverride` property should only be present with the neo4j version, not with the apoc version