### PR TITLE
[qZZ3O2uX] Updates jackson-databind to fix CVE-2020-36518, CVE-2022-42004, CVE-2022-42003  

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -118,8 +118,8 @@ dependencies {
     testCompile 'org.mock-server:mockserver-netty:5.13.0'
     testCompile 'org.mock-server:mockserver-client-java:5.13.0'
 
-    compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.214' , withoutJacksons
-    testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.214' , withoutJacksons
+    compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.353' , withoutJacksons
+    testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.353' , withoutJacksons
 
     compile group: 'com.opencsv', name: 'opencsv', version: '5.7.1'
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'

--- a/extra-dependencies/nlp/build.gradle
+++ b/extra-dependencies/nlp/build.gradle
@@ -23,8 +23,8 @@ def withoutJacksons = {
 }
 
 dependencies {
-    compile group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.214' , withoutJacksons
-    compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.1', withoutJacksons
+    compile group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.353' , withoutJacksons
+    compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.14.0', withoutJacksons
     compile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0'
 }
 

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -128,17 +128,17 @@ dependencies {
 
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
 
-    compileOnly group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.2', withoutJacksons
+    compileOnly group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.14.0', withoutJacksons
     compileOnly 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0'
 
-    testCompile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.13.2', withoutJacksons
+    testCompile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.14.0', withoutJacksons
     testCompile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0'
 
     testCompile 'org.mock-server:mockserver-netty:5.13.0'
     testCompile 'org.mock-server:mockserver-client-java:5.13.0'
 
-    compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.214' , withoutJacksons
-    testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.214' , withoutJacksons
+    compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.353' , withoutJacksons
+    testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.353' , withoutJacksons
 
     compile group: 'com.opencsv', name: 'opencsv', version: '5.7.1'
     compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'


### PR DESCRIPTION
vuln-fix: Update dependencies which import jackson-databind that had the following vulnerabilities: CVE-2020-36518, CVE-2022-42004, CVE-2022-42003.

