### PR TITLE
[iREBdGuF] Stop recommending loading/unrestricting all procedures

### DIFF
--- a/docs/asciidoc/modules/ROOT/nav.adoc
+++ b/docs/asciidoc/modules/ROOT/nav.adoc
@@ -4,6 +4,7 @@
 * xref::installation/index.adoc[]
         ** xref::installation/index.adoc#neo4j-server[Neo4j Server]
         ** xref::installation/index.adoc#docker[Docker]
+        ** xref::installation/index.adoc#restricted[Load and unrestrict procedures/functions]
 
 * xref::usage/index.adoc[]
 * xref::overview/index.adoc[]

--- a/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
@@ -63,6 +63,6 @@ and put it into `plugin` folder.
 
 
 [[restricted]]
-== Restricted procedures/functions
+== Load and unrestrict procedures/functions
 
 include::partial$restricted.adoc[tags=warnings,leveloffset=1]

--- a/docs/asciidoc/modules/ROOT/partials/restricted.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/restricted.adoc
@@ -1,12 +1,34 @@
 [WARNING]
 ====
 // tag::warnings[]
-For security reasons, procedures that use internal APIs are disabled by default.
-They can be enabled by specifying config in `$NEO4J_HOME/conf/neo4j.conf` e.g. `+dbms.security.procedures.unrestricted=apoc.*+`
+The Extended APOC library contains over 150 functions and procedures.
 
-If you want to do this when using the Neo4j Docker container, you need to amend `+-e NEO4J_dbms_security_procedures_unrestricted=apoc.\\\*+` to your `docker run ...` command.
+It is *not* recommended to load all of these into the dbms, but instead use the principle of least privilege.
+This principle dictates that you only load the functions and procedures necessary to execute your queries.
+
+The procedures and functions that should be loaded can be specified using the Neo4j configuration setting `+dbms.security.procedures.allowlist+` in `$NEO4J_HOME/conf/neo4j.conf`.
+For example, to load `apoc.load.csv` and all functions in the `apoc.cypher` package, use `+dbms.security.procedures.allowlist=apoc.load.csv,apoc.cypher.*+`.
+
+
+Please note that using e.g. `apoc.cypher.*`, if the https://neo4j.com/docs/apoc/{branch}[APOC Core] plugin is installed, will also load the `the `apoc.cypher.*` Core procedures / functions,
+as well as other plugins that may be using the same package.
+
+
+The default of the setting is `*`.
+This means that if you do not explicitly give it a value (or no value), all APOC procedures and functions, as well as other potential libraries in the plugins directory will be loaded.
+
+For security reasons, procedures and functions that use internal APIs are disabled by default.
+In this case, it is also recommended to use the principle of least privilege and only unrestrict those procedures and functions which you are certain to use.
+Procedures and functions can be unrestricted using the Neo4j configuration setting `+dbms.security.procedures.unrestricted+` in `$NEO4J_HOME/conf/neo4j.conf`.
+For example, if you need to unrestrict `apoc.ttl.expire` and `apoc.ttl.expireIn`, use: `+dbms.security.procedures.unrestricted=apoc.ttl.expire,apoc.ttl.expireIn+`.
+
+To unrestrict a whole package of APOC functions and procedures when using the Neo4j Docker container, you need to amend the Docker environment variables.
+For example, if you need to add the full `apoc.custom` package, add `+-e NEO4J_dbms_security_procedures_unrestricted=apoc.custom.\\\*+` to your `docker run ...` command.
 The three backslashes are necessary to prevent wildcard expansions.
 
-You _can_ also whitelist procedures and functions in general to be loaded using: `+dbms.security.procedures.whitelist=apoc.coll.*,apoc.load.*+`
+Please note that if you have APOC Core installed, 
+the same goes for the `dbms.security.procedures.allowlist` one, 
+so setting `dbms.security.procedures.unrestricted=package.name.*` will unrestrict both Extended and Core procedures / functions.
+
 // end::warnings[]
 ====

--- a/readme.adoc
+++ b/readme.adoc
@@ -160,13 +160,10 @@ Go to https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases[here] for 
 [WARNING]
 ====
 // tag::warnings[]
-For security reasons, procedures that use internal APIs are disabled by default.
-They can be enabled by specifying config in `$NEO4J_HOME/conf/neo4j.conf` e.g. `+dbms.security.procedures.unrestricted=apoc.*+`
+For security reasons, procedures and functions that use internal APIs are disabled by default.
+Loading and enabling APOC procedures and functions can be configured using the Neo4j config file.
 
-If you want to do this when using the Neo4j Docker container, you need to amend `+-e NEO4J_dbms_security_procedures_unrestricted=apoc.\\\*+` to your `docker run ...` command.
-The three backslashes are necessary to prevent wildcard expansions.
-
-You _can_ also allow procedures and functions in general to be loaded using: `+dbms.security.procedures.allowlist=apoc.coll.*,apoc.load.*+`
+For more details, see {docs}/installation#restricted[the APOC installation documentation].
 // end::warnings[]
 ====
 


### PR DESCRIPTION
NB: **Not cherry-picked in 5.4.0 to be consistent with APOC Core docs (which has been updated this docs in 5.5+ version)**

- Cherry-pick https://github.com/neo4j/docs-apoc/commit/08d5a1150d3a4b536ca8e04f666fcaab9b3448b6

- Cherry-pick https://github.com/neo4j/apoc/commit/91176749d317aa64c6650af8fc2c5d8de02f5861

- Added note to specify that unrestricting / loading an `apoc.package.name` will unrestrict / load Apoc Core ones as well.