### PR TITLE
Ignore git submodule from commits

### DIFF
--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -45,7 +45,8 @@ shadowJar {
 
 // to init the submodule in case of new submodule or refresh it if exists, every time we compile 
 task gitSubmoduleLoad {
-    def execute = ["bash", "-c", "git submodule status apoc-core | grep -q \"^-\" && rm -r apoc-core && git submodule update --init apoc-core || git submodule update --remote apoc-core"]
+    def execute = ["bash", "-c", "git submodule status apoc-core | grep -q \"^-\" && rm -r apoc-core && git submodule update --init apoc-core || git submodule update --remote apoc-core; " +
+            "git update-index --assume-unchanged apoc-core"]
             .execute()
     execute.waitForProcessOutput(System.out, System.err)
 }

--- a/init.gradle
+++ b/init.gradle
@@ -1,5 +1,6 @@
 initscript {
-    def execute = ["bash", "-c", "rm -r apoc-core && git submodule update --init apoc-core"]
+    def execute = ["bash", "-c", "rm -r apoc-core && git submodule update --init apoc-core; " +
+            "git update-index --assume-unchanged apoc-core"]
             .execute()
     execute.waitForProcessOutput(System.out, System.err)
 }


### PR DESCRIPTION
Ignore git submodule via `git update-index --assume-unchanged apoc-core`,
in `build.core` and init script, so that after building the project or executing an `./gradlew --init-script init.gradle <cmd>` will be hidden from a later `git add .`.

Note that if I directly `git add .` before either of these 2 steps above, 
the sumbodule will appear in the staging area

---

Alternative:
Document somewhere ([maybe here](https://github.com/neo4j-contrib/neo4j-apoc-procedures#build--install-the-current-development-branch-from-source))  that e.g. `git add .` also adds the submodule, 
so we possibly need to remove it with `git restore --staged apoc-core`.

---

Other attempts:
`ignore=all` or `ignore = dirty` in `.gitmodules` hide the submodule with `git status` but not with `git add .`.

`.gitignore` seeems not to work properly

