### PR TITLE
[hDJkPkOQ] Add QueryType validation in apoc.trigger.add

### DIFF
--- a/core/src/main/java/apoc/trigger/TriggerNewProcedures.java
+++ b/core/src/main/java/apoc/trigger/TriggerNewProcedures.java
@@ -18,6 +18,9 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.neo4j.configuration.GraphDatabaseSettings.SYSTEM_DATABASE_NAME;
+import static org.neo4j.graphdb.QueryExecutionType.QueryType.READ_ONLY;
+import static org.neo4j.graphdb.QueryExecutionType.QueryType.READ_WRITE;
+import static org.neo4j.graphdb.QueryExecutionType.QueryType.WRITE;
 
 
 public class TriggerNewProcedures {
@@ -54,7 +57,8 @@ public class TriggerNewProcedures {
 
         // TODO - to be deleted in 5.x, because in a cluster, not all DBMS host all the databases on them,
         // so we have to assume that the leader of the system database doesn't have access to this user database
-        Util.validateQuery(ApocConfig.apocConfig().getDatabase(databaseName), statement);
+        Util.validateQuery(ApocConfig.apocConfig().getDatabase(databaseName), statement,
+                READ_ONLY, WRITE, READ_WRITE);
 
         Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());
         TriggerInfo removed = TriggerHandlerNewProcedures.install(databaseName, name, statement, selector, params);

--- a/core/src/main/java/apoc/trigger/TriggerNewProcedures.java
+++ b/core/src/main/java/apoc/trigger/TriggerNewProcedures.java
@@ -15,6 +15,7 @@ import org.neo4j.procedure.Procedure;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.neo4j.configuration.GraphDatabaseSettings.SYSTEM_DATABASE_NAME;
@@ -27,6 +28,8 @@ public class TriggerNewProcedures {
     // public for testing purpose
     public static final String TRIGGER_NOT_ROUTED_ERROR = "The procedure should be routed and executed against the LEADER system database";
     public static final String TRIGGER_BAD_TARGET_ERROR = "Triggers can only be installed on user databases.";
+    public static final String TRIGGER_QUERY_TYPES_ERROR = "The trigger statement must contain READ_ONLY, WRITE, or READ_WRITE query.";
+    public static final String TRIGGER_MODES_ERROR = "The trigger statement cannot contain procedures that are not in WRITE, READ, or DEFAULT mode.";
 
     @Context public GraphDatabaseService db;
     
@@ -58,6 +61,9 @@ public class TriggerNewProcedures {
         // TODO - to be deleted in 5.x, because in a cluster, not all DBMS host all the databases on them,
         // so we have to assume that the leader of the system database doesn't have access to this user database
         Util.validateQuery(ApocConfig.apocConfig().getDatabase(databaseName), statement,
+                TRIGGER_MODES_ERROR,
+                Set.of(Mode.WRITE, Mode.READ, Mode.DEFAULT),
+                TRIGGER_QUERY_TYPES_ERROR,
                 READ_ONLY, WRITE, READ_WRITE);
 
         Map<String,Object> params = (Map)config.getOrDefault("params", Collections.emptyMap());

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -1014,14 +1014,24 @@ public class Util {
         validateQuery(db, statement, Collections.emptySet(), supportedQueryTypes);
     }
 
-    public static void validateQuery(GraphDatabaseService db, String statement, Set<Mode> supportedModes , QueryExecutionType.QueryType... supportedQueryTypes) {
+    public static void validateQuery(GraphDatabaseService db, String statement, Set<Mode> supportedModes, QueryExecutionType.QueryType... supportedQueryTypes) {
+        validateQuery(db, statement,
+                "Supported inner procedure modes for the operation are " + new TreeSet<>(supportedModes),
+                supportedModes,
+                "Supported query types for the operation are " + Arrays.toString(supportedQueryTypes),
+                supportedQueryTypes);
+    }
+
+    public static void validateQuery(GraphDatabaseService db, String statement,
+                                     String supportedModesError, Set<Mode> supportedModes ,
+                                     String supportedQueryTypesError, QueryExecutionType.QueryType... supportedQueryTypes) {
         db.executeTransactionally("EXPLAIN " + statement, Collections.emptyMap(), result -> {
             if (!isQueryTypeValid(result, supportedQueryTypes)) {
-                throw new RuntimeException("Supported query types for the operation are " + Arrays.toString(supportedQueryTypes));
+                throw new RuntimeException(supportedQueryTypesError);
             }
             
             if (!procsAreValid(db, supportedModes, result)) {
-                throw new RuntimeException("Supported inner procedure modes for the operation are " + new TreeSet<>(supportedModes));
+                throw new RuntimeException(supportedModesError);
             }
             
             return null;

--- a/core/src/test/java/apoc/trigger/TriggerNewProceduresTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerNewProceduresTest.java
@@ -583,4 +583,18 @@ public class TriggerNewProceduresTest {
                 map("name", UUID.randomUUID().toString()) );
     }
 
+    @Test
+    public void testTriggerInstallWithSchemaOperation() {
+        String query = "CREATE INDEX periodicIdx FOR (n:Bar) ON (n.first_name, n.last_name)";
+        try {
+            testCall(sysDb, "CALL apoc.trigger.install('neo4j', 'triggerSchema', 'CREATE INDEX periodicIdx FOR (n:Bar) ON (n.first_name, n.last_name)', {phase: 'before'})",
+                    Map.of("query", query),
+                    (row) -> fail("Should fail because of unsupported schema operation"));
+        } catch (RuntimeException e) {
+            final String expected = "Failed to invoke procedure `apoc.trigger.install`: " +
+                    "Caused by: java.lang.RuntimeException: Supported query types for the operation are [READ_ONLY, WRITE, READ_WRITE]";
+            assertEquals(expected, e.getMessage());
+        }
+    }
+
 }

--- a/core/src/test/java/apoc/trigger/TriggerNewProceduresTest.java
+++ b/core/src/test/java/apoc/trigger/TriggerNewProceduresTest.java
@@ -1,6 +1,7 @@
 package apoc.trigger;
 
 import apoc.nodes.Nodes;
+import apoc.schema.Schemas;
 import apoc.util.TestUtil;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -31,7 +32,9 @@ import java.util.concurrent.TimeUnit;
 
 import static apoc.ApocConfig.SUN_JAVA_COMMAND;
 import static apoc.trigger.TriggerNewProcedures.TRIGGER_BAD_TARGET_ERROR;
+import static apoc.trigger.TriggerNewProcedures.TRIGGER_MODES_ERROR;
 import static apoc.trigger.TriggerNewProcedures.TRIGGER_NOT_ROUTED_ERROR;
+import static apoc.trigger.TriggerNewProcedures.TRIGGER_QUERY_TYPES_ERROR;
 import static apoc.trigger.TriggerTestUtil.TIMEOUT;
 import static apoc.trigger.TriggerTestUtil.TRIGGER_DEFAULT_REFRESH;
 import static apoc.trigger.TriggerTestUtil.awaitTriggerDiscovered;
@@ -74,8 +77,8 @@ public class TriggerNewProceduresTest {
         db = databaseManagementService.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
         sysDb = databaseManagementService.database(GraphDatabaseSettings.SYSTEM_DATABASE_NAME);
         waitDbsAvailable(db, sysDb);
-        TestUtil.registerProcedure(sysDb, TriggerNewProcedures.class, Nodes.class);
-        TestUtil.registerProcedure(db, Trigger.class, Nodes.class);
+        TestUtil.registerProcedure(sysDb, TriggerNewProcedures.class, Nodes.class, Schemas.class);
+        TestUtil.registerProcedure(db, Trigger.class, Nodes.class, Schemas.class);
         
     }
 
@@ -584,15 +587,29 @@ public class TriggerNewProceduresTest {
     }
 
     @Test
-    public void testTriggerInstallWithSchemaOperation() {
+    public void testTriggerInstallWithSchemaCommand() {
         String query = "CREATE INDEX periodicIdx FOR (n:Bar) ON (n.first_name, n.last_name)";
         try {
             testCall(sysDb, "CALL apoc.trigger.install('neo4j', 'triggerSchema', 'CREATE INDEX periodicIdx FOR (n:Bar) ON (n.first_name, n.last_name)', {phase: 'before'})",
                     Map.of("query", query),
-                    (row) -> fail("Should fail because of unsupported schema operation"));
+                    (row) -> fail("Should fail because of unsupported schema command"));
         } catch (RuntimeException e) {
             final String expected = "Failed to invoke procedure `apoc.trigger.install`: " +
-                    "Caused by: java.lang.RuntimeException: Supported query types for the operation are [READ_ONLY, WRITE, READ_WRITE]";
+                    "Caused by: java.lang.RuntimeException: " + TRIGGER_QUERY_TYPES_ERROR;
+            assertEquals(expected, e.getMessage());
+        }
+    }
+
+    @Test
+    public void testTriggerInstallWithSchemaProcedure() {
+        String query = "CREATE INDEX periodicIdx FOR (n:Bar) ON (n.first_name, n.last_name)";
+        try {
+            testCall(sysDb, "CALL apoc.trigger.install('neo4j', 'triggerSchemaProc', 'CALL apoc.schema.assert({}, {})', {phase: 'before'})",
+                    Map.of("query", query),
+                    (row) -> fail("Should fail because of unsupported schema procedure"));
+        } catch (RuntimeException e) {
+            final String expected = "Failed to invoke procedure `apoc.trigger.install`: " +
+                    "Caused by: java.lang.RuntimeException: " + TRIGGER_MODES_ERROR;
             assertEquals(expected, e.getMessage());
         }
     }


### PR DESCRIPTION
Added QueryType validations in validateQuery() method,
so as to fail if the procedure tries to execute schema operations.

See point 2 here: https://github.com/neo4j/apoc/pull/208#pullrequestreview-1145222227

Only for 4.4, since the `apoc.trigger.add` is deprecated and in 5.x the `validateQuery()` is not longer present.