### PR TITLE
[xc2oVWgi] document warnings for dependencies excluded from APOC Core jar

### DIFF
--- a/docs/asciidoc/modules/ROOT/nav.adoc
+++ b/docs/asciidoc/modules/ROOT/nav.adoc
@@ -7,6 +7,7 @@
         ** xref::installation/index.adoc#neo4j-server[Neo4j Server]
         ** xref::installation/index.adoc#docker[Docker]
         ** xref::installation/index.adoc#restricted[Load and unrestrict procedures/functions]
+        ** xref::installation/index.adoc#dependencies[Additional dependencies excluded from the APOC Core jar]
 
 * xref::usage/index.adoc[]
 * xref::help/index.adoc[]

--- a/docs/asciidoc/modules/ROOT/pages/import/web-apis.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/web-apis.adoc
@@ -42,9 +42,9 @@ CALL apoc.load.json("https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob
 
 include::partial$s3-protocol.adoc[]
 
-== Using hdfs protocol
+== Using HDFS protocol
 
-To use the hdfs protocol we need to download and copy the additional jars not included in the APOC Library.
+To use the HDFS protocol we need to download and copy the additional jars not included in the APOC Library.
 We can download it from https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/{apoc-release}/apoc-redis-dependencies-{apoc-release}.jar[this link] or locally downloading the apoc repository:
 ----
 git clone http://github.com/neo4j-contrib/neo4j-apoc-procedures

--- a/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
@@ -76,3 +76,22 @@ include::partial$docker.adoc[tags=docker,leveloffset=1]
 == Load and unrestrict procedures/function
 
 include::partial$restricted.adoc[tags=warnings,leveloffset=1]
+
+[[dependencies]]
+== Additional dependencies excluded from the APOC Core jar
+Some functionalities require additional jars in order to be used.
+This includes xref::import/index.adoc[loading] and xref:export/index.adoc[exporting] data when using services such as:
+
+* Amazon S3 (`s3://<path>`)
+* Apache Hadoop (`hdfs://<path>`)
+* Google Cloud Storage (`gs://<path>`)
+
+
+These dependencies are specifically not included in the APOC Core jar, but
+can be added as separate jars as described xref::import/web-apis.adoc[here].
+If the extra dependencies are not included, warnings will show in the debug log file (debug.log)
+that can be ignored if the respective functionality is not needed.
+An example of such a warning would be:
+```
+ Failed to load `apoc.util.s3.S3URLConnection`
+```


### PR DESCRIPTION
improves documentation

cherry-picked: https://github.com/neo4j/docs-apoc/pull/93/files