### PR TITLE
[NOID] Clean up APOC matrix list

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -183,25 +183,10 @@ The trailing `<apoc>` part of the version number will be incremented with every 
 [opts=header]
 |===
 |apoc version | neo4j version
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.3.0[5.3.0^] | 5.3.0 (5.3.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.3.1[5.3.1^] | 5.3.0 (5.3.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.2.0[5.2.0^] | 5.2.0 (5.2.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.1.0[5.1.0^] | 5.1.0 (5.1.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.1[4.4.0.1^] | 4.4.0 (4.3.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.3.0.4[4.3.0.4^] | 4.3.7 (4.3.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.2.0.9[4.2.0.9^] | 4.2.11 (4.2.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.1.0.10[4.1.0.10^] | 4.1.11 (4.1.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.0.0.18[4.0.0.18^] | 4.0.12 (4.0.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/3.5.0.15[3.5.0.15^] | 3.5.30 (3.5.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/3.4.0.8[3.4.0.8^] | 3.4.18 (3.4.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/3.3.0.4[3.3.0.4^] | 3.3.9 (3.3.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/3.2.3.6[3.2.3.6^] | 3.2.14 (3.2.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/3.1.3.9[3.1.3.9^] | 3.1.9 (3.1.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/3.0.8.6[3.0.8.6^] | 3.0.12 (3.0.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/3.5.0.0[3.5.0.0^] | 3.5.0-beta01
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/3.4.0.2[3.4.0.2^] | 3.4.5
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/3.3.0.3[3.3.0.3^] | 3.3.5
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/3.2.3.5[3.2.3.5^] | 3.2.3
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/3.1.3.8[3.1.3.8^] | 3.1.5
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.12[4.4.0.12^] | 4.4.0 (4.4.x)
 |===
 
 // end::version-matrix[]


### PR DESCRIPTION
Remove old unsupported versions and fix typo for 4.4.x series