### PR TITLE
[NOID] Update selenium extra-deps' webdrivermanager

### DIFF
--- a/extra-dependencies/selenium/build.gradle
+++ b/extra-dependencies/selenium/build.gradle
@@ -21,5 +21,5 @@ dependencies {
     implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59', {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    implementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '4.4.3'
+    implementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.1.0'
 }


### PR DESCRIPTION
Updated `webdrivermanager` to prevent the following error with apoc 5.4+, with `apoc.load.html(url, {..}, {browser: 'CHROME'})`

```
Failed to invoke procedure `apoc.load.html`: Caused by: java.lang.NoSuchMethodError: 'io.github.bonigarcia.wdm.WebDriverManager io.github.bonigarcia.wdm.WebDriverManager.gitHubToken(java.lang.String)'
```