### PR TITLE
[4cnpX39y] Bump mockserver-netty version and org.apache.arrow version

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -115,8 +115,8 @@ dependencies {
 
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
 
-    testCompile 'org.mock-server:mockserver-netty:5.13.0'
-    testCompile 'org.mock-server:mockserver-client-java:5.13.0'
+    testCompile 'org.mock-server:mockserver-netty:5.15.0'
+    testCompile 'org.mock-server:mockserver-client-java:5.15.0'
 
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.353' , withoutJacksons
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.353' , withoutJacksons
@@ -155,19 +155,19 @@ dependencies {
 
     compile group: 'xerces', name: 'xercesImpl', version: '2.12.2'
 
-    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '10.0.0', {
+    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '10.0.1', {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
         exclude group: 'io.netty', module: 'netty-common'
     }
-    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '10.0.0', {
+    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '10.0.1', {
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'io.netty', module: 'netty-common'
         exclude group: 'io.netty', module: 'netty-buffer'
     }
-    testCompile group: 'org.apache.arrow', name: 'arrow-vector', version: '10.0.0'
-    testCompile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '10.0.0'
+    testCompile group: 'org.apache.arrow', name: 'arrow-vector', version: '10.0.1'
+    testCompile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '10.0.1'
 
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -134,8 +134,8 @@ dependencies {
     testCompile group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.14.0', withoutJacksons
     testCompile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0'
 
-    testCompile 'org.mock-server:mockserver-netty:5.13.0'
-    testCompile 'org.mock-server:mockserver-client-java:5.13.0'
+    testCompile 'org.mock-server:mockserver-netty:5.15.0'
+    testCompile 'org.mock-server:mockserver-client-java:5.15.0'
 
     compileOnly group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.353' , withoutJacksons
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.353' , withoutJacksons

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -37,6 +37,6 @@ dependencies {
     compile group: 'org.testcontainers', name: 'postgresql', version: testContainersVersion
     compile group: 'org.testcontainers', name: 'cassandra', version: testContainersVersion
     compile group: 'org.testcontainers', name: 'localstack', version: testContainersVersion
-    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '10.0.0'
-    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '10.0.0'
+    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '10.0.1'
+    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '10.0.1'
 }


### PR DESCRIPTION
cherry-pick: https://github.com/neo4j/apoc/pull/308