### PR TITLE
[mIPA5H7K] Avoids double DNS lookup in the load methods (#315)

### DIFF
--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -328,8 +328,7 @@ public class Util {
         }
     }
 
-    public static URLConnection openUrlConnection(String url, Map<String, Object> headers) throws IOException {
-        URL src = new URL(url);
+    public static URLConnection openUrlConnection(URL src, Map<String, Object> headers) throws IOException {
         URLConnection con = src.openConnection();
         con.setRequestProperty("User-Agent", "APOC Procedures for Neo4j");
        if (con instanceof HttpURLConnection) {
@@ -432,8 +431,8 @@ public class Util {
     }
 
     public static StreamConnection readHttpInputStream(String urlAddress, Map<String, Object> headers, String payload, int redirectLimit) throws IOException {
-        ApocConfig.apocConfig().checkReadAllowed(urlAddress);
-        URLConnection con = openUrlConnection(urlAddress, headers);
+        URL url = ApocConfig.apocConfig().checkAllowedUrlAndPinToIP(urlAddress);
+        URLConnection con = openUrlConnection(url, headers);
         writePayload(con, payload);
         String newUrl = handleRedirect(con, urlAddress);
         if (newUrl != null && !urlAddress.equals(newUrl)) {


### PR DESCRIPTION
Cherry picked from https://github.com/neo4j/apoc/pull/315

Avoids an extra DNS resolve by replacing the domain with the resolved ip address.
