### PR TITLE
[aNcPaEFK] Fix LoadLdapTest.testLoadLDAP

### DIFF
--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -127,6 +127,8 @@ dependencies {
     testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: '2.13.2'
     testImplementation group: 'com.sun.mail', name: 'javax.mail', version: '1.6.0'
     testImplementation group: 'org.postgresql', name: 'postgresql', version: '42.1.4'
+    testImplementation group: 'org.zapodot', name: 'embedded-ldap-junit', version: '0.9.0'
+
 
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'

--- a/extended/src/test/java/apoc/load/LoadLdapTest.java
+++ b/extended/src/test/java/apoc/load/LoadLdapTest.java
@@ -1,38 +1,83 @@
 package apoc.load;
 
 
+import apoc.util.TestUtil;
 import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPSearchResults;
+import com.unboundid.ldap.sdk.LDAPConnection;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+import org.zapodot.junit.ldap.EmbeddedLdapRule;
+import org.zapodot.junit.ldap.EmbeddedLdapRuleBuilder;
 
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import static apoc.util.TestUtil.testCall;
 import static org.junit.Assert.assertEquals;
 
 public class LoadLdapTest {
+    public static final String BIND_DSN = "uid=admin,cn=users,cn=accounts,dc=demo1,dc=freeipa";
+    public static final String BIND_PWD = "testPwd";
+    public static LDAPConnection ldapConnection;
+    public static Map<String, Object> connParams;
+    public static Map<String, Object> searchParams;
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule();
+    
+    @ClassRule
+    public static EmbeddedLdapRule embeddedLdapRule = EmbeddedLdapRuleBuilder
+            .newInstance()
+            .usingBindDSN(BIND_DSN)
+            .usingBindCredentials(BIND_PWD)
+            .importingLdifs("ldap/example.ldif")
+            .build();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        TestUtil.registerProcedure(db, LoadLdap.class);
+
+        ldapConnection = embeddedLdapRule.unsharedLdapConnection();
+
+        connParams = Map.of("ldapHost", "localhost:" + ldapConnection.getConnectedPort(),
+                "loginDN", BIND_DSN,
+                "loginPW", BIND_PWD);
+
+        searchParams = Map.of("searchBase", "dc=example,dc=com",
+                "searchScope", "SCOPE_ONE",
+                "searchFilter", "(objectClass=*)",
+                "attributes", List.of("uid") );
+    }
+
+    @AfterClass
+    public static void afterClass()  {
+        ldapConnection.close();
+    }
 
     @Test
-    public void testLoadLDAP() throws Exception {
-        Map<String, Object> connParms = new HashMap<>();
-        connParms.put("ldapHost", "ipa.demo1.freeipa.org");
-        connParms.put("ldapPort", 389l);
-        connParms.put("loginDN", "uid=admin,cn=users,cn=accounts,dc=demo1,dc=freeipa,dc=org");
-        connParms.put("loginPW", "Secret123");
-        LoadLdap.LDAPManager mgr = new LoadLdap.LDAPManager(LoadLdap.getConnectionMap(connParms));
-        Map<String, Object> searchParms = new HashMap<>();
-        searchParms.put("searchBase", "dc=demo1,dc=freeipa,dc=org");
-        searchParms.put("searchScope", "SCOPE_ONE");
-        searchParms.put("searchFilter", "(&(objectclass=*)(cn=alt))");
-        ArrayList<String> ats = new ArrayList<>();
-        final String attrName = "cn";
-        ats.add(attrName);
-        searchParms.put("attributes", ats);
-        LDAPSearchResults results = mgr.doSearch(searchParms);
+    public void testLoadLDAP() {
+        testCall(db, "call apoc.load.ldap($conn, $search)",
+                Map.of("conn", connParams, "search", searchParams), r -> {
+                    final Map<String, String> expected = Map.of("uid", "training",
+                            "dn", "uid=training,dc=example,dc=com");
+                    assertEquals(expected, r.get("entry"));
+                });
+    }
+
+    @Test
+    public void testLoadLDAPConfig() throws Exception {
+        LoadLdap.LDAPManager mgr = new LoadLdap.LDAPManager(LoadLdap.getConnectionMap(connParams));
+        
+        LDAPSearchResults results = mgr.doSearch(searchParams);
         LDAPEntry le = results.next();
-        assertEquals("cn=alt,dc=demo1,dc=freeipa,dc=org", le.getDN());
-        assertEquals("alt", le.getAttribute(attrName).getStringValue());
+        assertEquals("uid=training,dc=example,dc=com", le.getDN());
+        assertEquals("training", le.getAttribute("uid").getStringValue());
+
     }
 
 }

--- a/extended/src/test/resources/ldap/example.ldif
+++ b/extended/src/test/resources/ldap/example.ldif
@@ -1,0 +1,11 @@
+version: 1
+
+dn: dc=example,dc=com
+objectClass: domain
+objectClass: top
+dc: embedded
+
+dn: uid=training,dc=example,dc=com
+objectclass: top
+objectclass: organizationalUnit
+uid: training


### PR DESCRIPTION
The new extended PRs fail both on 4.x and 5.x,
it seems for the same reason as this other pr: https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3022.

To avoid other problems in the future, 
I created an embedded mock server instead of using remote url.

Also I noticed that the actual procedure (ie `call apoc.load.ldap($conn, $search)`) is not tested,
but just the internal method calling the config is checked,
so I added a test that does the procedure query, to verify that it really works.