### PR TITLE
[NOID] Excluded duplicated libs in extra-dependencies

### DIFF
--- a/extra-dependencies/hadoop/build.gradle
+++ b/extra-dependencies/hadoop/build.gradle
@@ -30,6 +30,8 @@ shadowJar {
 def commonExclusions = {
     exclude group: 'io.netty'
     exclude group: 'com.sun.jersey'
+    exclude group: 'org.slf4j'
+    exclude group: 'org.apache.commons', module: 'commons-compress'
 }
 
 dependencies {

--- a/extra-dependencies/selenium/build.gradle
+++ b/extra-dependencies/selenium/build.gradle
@@ -16,10 +16,14 @@ jar {
     }
 }
 
+def commonExclusions = {
+    exclude group: 'com.google.guava', module: 'guava'
+    exclude group: 'commons-beanutils', module: 'commons-beanutils'
+    exclude group: 'org.slf4j'
+}
+
 dependencies {
     // currently we cannot update to the latest version due to guava minimum version required (31.0.1-jre)
-    implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59', {
-        exclude group: 'com.google.guava', module: 'guava'
-    }
-    implementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.1.0'
+    implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59', commonExclusions
+    implementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.1.0', commonExclusions
 }

--- a/extra-dependencies/xls/build.gradle
+++ b/extra-dependencies/xls/build.gradle
@@ -32,5 +32,4 @@ dependencies {
         exclude group: 'org.apache.logging.log4j'
     }
     implementation group: 'com.github.virtuald', name: 'curvesapi', version: '1.06'
-    implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
 }


### PR DESCRIPTION
- Excluded some depencendies from hadoop and selenium jars, 
to prevent some warn logs which could mean potential conflict errors, 
that is:

```
INFO org.apache.commons.beanutils.FluentPropertyBeanIntrospector - Error when creating PropertyDescriptor for public final void org.apache.commons.configuration2.AbstractConfiguration.setProperty(java.lang.String,java.lang.Object)! Ignoring this property.

INFO org.apache.commons.beanutils.FluentPropertyBeanIntrospector - Error when creating PropertyDescriptor for public final void org.apache.commons.configuration2.AbstractConfiguration.setProperty(java.lang.String,java.lang.Object)! Ignoring this property.
```

and:
```
SLF4J: Class path contains multiple SLF4J bindings.
SLF4J: Found binding in [jar:file:/plugins/apoc-5.5.0-extended.jar!/org/slf4j/impl/StaticLoggerBinder.class]
SLF4J: Found binding in [jar:file:/plugins/apoc-hadoop-dependencies-5.5.0-all.jar!/org/slf4j/impl/StaticLoggerBinder.class]
```

---

- Excluded `commons-collections4` from xls (not necessary, as it is already included in `apoc-core`'s `commons/build.gradle`)