### PR TITLE
[NOID] Remove SnakeYaml as not used and vulnerable

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -77,7 +77,6 @@ dependencies {
             strictly '3.12.0'
         }
     }
-    compile group: 'org.yaml', name: 'snakeyaml', version: '1.32'
     compile group: 'com.github.seancfoley', name: 'ipaddress', version: '5.3.3'
     testCompile group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
 


### PR DESCRIPTION
Snakeyaml looks unused, and as it contains vulnerabilities it looks bad to keep it in core for no reason