### PR TITLE
[NOID] fixes #3477: apoc.load.html does not always report href

### DIFF
--- a/full/src/main/java/apoc/load/LoadHtml.java
+++ b/full/src/main/java/apoc/load/LoadHtml.java
@@ -5,6 +5,8 @@ import apoc.result.MapResult;
 import apoc.util.MissingDependencyException;
 import apoc.util.FileUtils;
 import java.nio.charset.UnsupportedCharsetException;
+
+import org.apache.commons.lang3.StringUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Document;
@@ -74,7 +76,7 @@ public class LoadHtml {
             }
 
             return Stream.of(new MapResult(output));
-        } catch ( UnsupportedCharsetException e) {
+        } catch (UnsupportedCharsetException e) {
             throw new RuntimeException("Unsupported charset: " + config.getCharset());
         } catch (IllegalArgumentException | ClassCastException e) {
             throw new RuntimeException("Invalid config: " + config);
@@ -137,7 +139,16 @@ public class LoadHtml {
                 final String key = attribute.getKey();
                 // with href/src attribute we prepend baseUri path
                 final boolean attributeHasLink = key.equals("href") || key.equals("src");
-                attributes.put(key, attributeHasLink ? element.absUrl(key) : attribute.getValue());
+                String attr = null;
+                if (attributeHasLink) {
+                    attr = element.absUrl(key);
+                    if (StringUtils.isBlank(attr)) {
+                        attr = attribute.getValue();
+                    }
+                } else {
+                    attr = attribute.getValue();
+                }
+                attributes.put(key, attr);
             }
         }
 

--- a/full/src/test/java/apoc/load/LoadHtmlTest.java
+++ b/full/src/test/java/apoc/load/LoadHtmlTest.java
@@ -3,6 +3,7 @@ package apoc.load;
 import apoc.ApocSettings;
 import apoc.util.TestUtil;
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -350,6 +351,19 @@ public class LoadHtmlTest {
                     assertEquals(Collections.emptyList(), value.get("invalid"));
                     assertNull(value.get(KEY_ERROR));
                     assertFalse(result.hasNext());
+                });
+    }
+
+    @Test
+    public void testHref() {
+        Map<String, Object> query = Map.of("a", "a.image");
+
+        testResult(db, "CALL apoc.load.html($url, $query) YIELD value UNWIND value.a AS row RETURN row",
+                map("url", new File("src/test/resources/wikipedia.html").toURI().toString(), "query", query),
+                result -> {
+                    Map<String, Object> row = (Map<String, Object>) result.next().get("row");
+                    Map<String, Object> attributes = (Map<String, Object>) row.get("attributes");
+                    Assert.assertEquals("/wiki/File:Aap_Kaa_Hak_titles.jpg", attributes.get("href"));
                 });
     }
 


### PR DESCRIPTION
Fixes #3477

If the baseUrl is not defined href is not returned.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Fixed the bug
  - Added test
