### PR TITLE
[NOID] Uses Temurin jdk 11

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
 
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
## Why

Because it's the jdk being used by Neo4j in its docker images.
