### PR TITLE
[NOID] Uses Temurin jdk 11

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - uses: actions/cache@v2
         with:
           path: |


### PR DESCRIPTION
## Why

Because it's the jdk being used by Neo4j in its docker images.
