### PR TITLE
[NOID] Changed bolt driver version

### DIFF
--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -83,7 +83,9 @@ dependencies {
     // These will be dependencies not packaged with the .jar
     // They need to be provided either through the database or in an extra .jar
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
-    compileOnly group: 'org.neo4j.driver', name: 'neo4j-java-driver-slim', version: '4.4.5'
+    // same version as the one included in  neo4j `lib`
+    compileOnly group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '5.5.0'
+
     compileOnly group: 'org.apache.poi', name: 'poi', version: '5.1.0'
     compileOnly group: 'org.apache.poi', name: 'poi-ooxml', version: '5.1.0'
     compileOnly group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59', {


### PR DESCRIPTION
To make sure `apoc.bolt*` works correctly with the version included in neo4j `lib`,
since we no longer use `extra-dependencies/bolt` jar