### PR TITLE
[tq7tdrWZ] Update Hadoop and JsonPath dependencies

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     apt group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
     compile group: 'commons-codec', name: 'commons-codec', version: '1.14'
     // when json-path is changed, it have to be changed in json-path-version version in antora.yml as well.
-    compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.7.0'
+    compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.8.0'
     compile group: 'net.minidev', name: 'json-smart', version: '2.4.8'
     compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
 
@@ -126,8 +126,8 @@ dependencies {
 
     testCompile group: 'org.apache.hive', name: 'hive-jdbc', version: '1.2.2', withoutServers
 
-    compileOnly group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.4', withoutServers
-    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.4', withoutServers
+    compileOnly group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.5', withoutServers
+    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.5', withoutServers
 
     compile group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     // explicit update comomns.io version

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -52,7 +52,6 @@ dependencies {
     compile group: 'commons-codec', name: 'commons-codec', version: '1.14'
     // when json-path is changed, it have to be changed in json-path-version version in antora.yml as well.
     compile group: 'com.jayway.jsonpath', name: 'json-path', version: '2.8.0'
-    compile group: 'net.minidev', name: 'json-smart', version: '2.4.8'
     compile group: 'org.hdrhistogram', name: 'HdrHistogram', version: '2.1.9'
 
     antlr "org.antlr:antlr4:4.7.2", {

--- a/docs/asciidoc/antora.yml
+++ b/docs/asciidoc/antora.yml
@@ -9,4 +9,4 @@ asciidoc:
     branch: "4.4"
     apoc-release-absolute: "4.4"
     apoc-release: "4.4.0.16"
-    json-path-version: "2.7.0"
+    json-path-version: "2.8.0"

--- a/extra-dependencies/hadoop/build.gradle
+++ b/extra-dependencies/hadoop/build.gradle
@@ -35,8 +35,8 @@ def commonExclusions = {
 }
 
 dependencies {
-    compile group: 'org.apache.hadoop', name: 'hadoop-hdfs-client', version: '3.3.4', commonExclusions
-    compile group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.4', commonExclusions
+    compile group: 'org.apache.hadoop', name: 'hadoop-hdfs-client', version: '3.3.5', commonExclusions
+    compile group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.5', commonExclusions
 }
 
 

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -20,9 +20,9 @@ dependencies {
         exclude group: 'org.apache.hive', module: 'hive-service'
     }
 
-    compile group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.4', withoutServers
-    compile group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.4', withoutServers
-    compile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.3.4', withoutServers
+    compile group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.5', withoutServers
+    compile group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.5', withoutServers
+    compile group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.3.5', withoutServers
 
     compile group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.4.9'
     compile group: 'org.jetbrains', name: 'annotations', version: "17.0.0"


### PR DESCRIPTION
Updates Hadoop and JsonPath dependencies to their newest releases. The test coverage for these isn't great, but I couldn't see any breaking changes in the changelogs for them.