### PR TITLE
[NOID] fixes #3477: apoc.load.html does not always report href (#3478)

### DIFF
--- a/extended/src/main/java/apoc/load/LoadHtml.java
+++ b/extended/src/main/java/apoc/load/LoadHtml.java
@@ -5,6 +5,8 @@ import apoc.result.MapResult;
 import apoc.util.MissingDependencyException;
 import apoc.util.FileUtils;
 import java.nio.charset.UnsupportedCharsetException;
+
+import org.apache.commons.lang3.StringUtils;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Attribute;
 import org.jsoup.nodes.Document;
@@ -76,7 +78,7 @@ public class LoadHtml {
             }
 
             return Stream.of(new MapResult(output));
-        } catch ( UnsupportedCharsetException e) {
+        } catch (UnsupportedCharsetException e) {
             throw new RuntimeException(UNSUPPORTED_CHARSET_ERR + config.getCharset());
         } catch (IllegalArgumentException | ClassCastException e) {
             throw new RuntimeException(INVALID_CONFIG_ERR + config);
@@ -139,7 +141,16 @@ public class LoadHtml {
                 final String key = attribute.getKey();
                 // with href/src attribute we prepend baseUri path
                 final boolean attributeHasLink = key.equals("href") || key.equals("src");
-                attributes.put(key, attributeHasLink ? element.absUrl(key) : attribute.getValue());
+                String attr = null;
+                if (attributeHasLink) {
+                    attr = element.absUrl(key);
+                    if (StringUtils.isBlank(attr)) {
+                        attr = attribute.getValue();
+                    }
+                } else {
+                    attr = attribute.getValue();
+                }
+                attributes.put(key, attr);
             }
         }
 

--- a/extended/src/test/java/apoc/load/LoadHtmlTest.java
+++ b/extended/src/test/java/apoc/load/LoadHtmlTest.java
@@ -2,6 +2,7 @@ package apoc.load;
 
 import apoc.util.TestUtil;
 import org.apache.commons.lang.exception.ExceptionUtils;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -362,6 +363,19 @@ public class LoadHtmlTest {
                     assertEquals(Collections.emptyList(), value.get("invalid"));
                     assertNull(value.get(KEY_ERROR));
                     assertFalse(result.hasNext());
+                });
+    }
+
+    @Test
+    public void testHref() {
+        Map<String, Object> query = Map.of("a", "a.image");
+
+        testResult(db, "CALL apoc.load.html($url, $query) YIELD value UNWIND value.a AS row RETURN row",
+                map("url", new File("src/test/resources/wikipedia.html").toURI().toString(), "query", query),
+                result -> {
+                    Map<String, Object> row = (Map<String, Object>) result.next().get("row");
+                    Map<String, Object> attributes = (Map<String, Object>) row.get("attributes");
+                    Assert.assertEquals("/wiki/File:Aap_Kaa_Hak_titles.jpg", attributes.get("href"));
                 });
     }
 


### PR DESCRIPTION
Cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/fdcc1e5284ef7966debe0fe4ba5092cd40f89b83