### PR TITLE
[xEcl2dHs] Fix some flaky tests in UUIDClusterRoutingTest

### DIFF
--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -29,6 +29,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static apoc.util.TestUtil.printFullStackTrace;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -262,10 +263,15 @@ public class TestContainerUtil {
                             "WITH databases.neo4j AS neo4j, databases.system AS system\n" +
                             "WHERE neo4j = 'LEADER' OR system = 'LEADER'\n" +
                             "RETURN count(*)";
-
-                    return (long) singleResultFirstColumn(session, query);
+                    try {
+                        long count = singleResultFirstColumn(session, query);
+                        assertEquals(2L, count);
+                        return true;
+                    } catch (Exception e) {
+                        return false;
+                    }
                 },
-                (value) -> value == 2L, 30L, TimeUnit.SECONDS);
+                (value) -> value, 30L, TimeUnit.SECONDS);
     }
 
     /**


### PR DESCRIPTION
To solve the card with id `xEcl2dHs`:
- moved the `CREATE CONSTRAINT ..` only where needed (i.e. `apoc.uuid.install`) and added an assertEventually to check that the constraint is really propagated to the current core member

----
Attempts to solve the other flaky tests:
- changed number of cores to 3,  to decrease the failure probablity
- in `TestContainerUtil.checkLeadershipBalanced()` added a try-catch to prevent from potential errors (e.g. `NullPointer`)
- in `TestcontainersCausalCluster.java` added `causal_clustering.minimum_core_cluster_size_at_formation` and `causal_clustering.minimum_core_cluster_size_at_runtime` configs