### PR TITLE
[f46vahOr] Fix #345 where exported Cypher constraints had wrong type.

### DIFF
--- a/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -9,6 +9,7 @@ import org.neo4j.graphdb.Relationship;
 import java.io.PrintWriter;
 import java.util.Map;
 import java.util.Set;
+import org.neo4j.graphdb.schema.ConstraintType;
 
 /**
  * @author AgileLARUS
@@ -43,7 +44,7 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExists, String name) {
+	public String statementForConstraint(String label, Iterable<String> keys, ConstraintType type, boolean ifNotExists, String name) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -7,6 +7,7 @@ import org.neo4j.graphdb.*;
 import java.io.PrintWriter;
 import java.util.Map;
 import java.util.Set;
+import org.neo4j.graphdb.schema.ConstraintType;
 
 /**
  * @author AgileLARUS
@@ -27,7 +28,7 @@ public interface CypherFormatter {
 
 	String statementForRelationshipFullTextIndex(String name, Iterable<RelationshipType> types, Iterable<String> keys);
 
-	String statementForConstraint(String label, Iterable<String> keys, boolean ifNotExist, String name);
+	String statementForConstraint(String label, Iterable<String> keys, ConstraintType type, boolean ifNotExist, String name);
 
 	String statementForCleanUp(int batchSize);
 

--- a/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -9,6 +9,7 @@ import org.neo4j.graphdb.Relationship;
 import java.io.PrintWriter;
 import java.util.Map;
 import java.util.Set;
+import org.neo4j.graphdb.schema.ConstraintType;
 
 /**
  * @author AgileLARUS
@@ -43,7 +44,7 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	}
 
 	@Override
-	public String statementForConstraint(String label, Iterable<String> key, boolean ifNotExists, String name) {
+	public String statementForConstraint(String label, Iterable<String> key, ConstraintType type, boolean ifNotExists, String name) {
 		return "";
 	}
 

--- a/core/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
+++ b/core/src/main/java/org/neo4j/cypher/export/DatabaseSubGraph.java
@@ -1,5 +1,8 @@
 package org.neo4j.cypher.export;
 
+import java.util.Comparator;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -59,7 +62,8 @@ public class DatabaseSubGraph implements SubGraph
     @Override
     public Iterable<ConstraintDefinition> getConstraints()
     {
-        return transaction.schema().getConstraints();
+        Comparator<ConstraintDefinition> comp = Comparator.comparing(ConstraintDefinition::getName);
+        return StreamSupport.stream( transaction.schema().getConstraints().spliterator(), false ).sorted(comp).collect( Collectors.toList());
     }
 
     @Override

--- a/core/src/test/java/apoc/export/cypher/ExportCypherEnterpriseFeaturesTest.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherEnterpriseFeaturesTest.java
@@ -3,6 +3,8 @@ package apoc.export.cypher;
 import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -18,6 +20,7 @@ import static apoc.util.TestContainerUtil.*;
 import static apoc.util.TestUtil.isRunningInCI;
 import static apoc.util.TestUtil.readFileToString;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
@@ -142,6 +145,11 @@ public class ExportCypherEnterpriseFeaturesTest {
     }
 
     private void assertExportStatement(String expectedStatement, Map<String, Object> result, String fileName) {
-        assertEquals(expectedStatement, isRunningInCI() ? result.get("cypherStatements") : readFileToString(new File(directory, fileName)));
+                // The constraints are exported in arbitrary order, so we cannot assert on the entire file
+        String actual = readFileToString(new File(directory, fileName));
+        MatcherAssert.assertThat(actual, Matchers.containsString(expectedStatement));
+        EXPECTED_CONSTRAINTS.forEach(
+                constraint -> assertTrue(String.format("Constraint '%s' not in result", constraint), actual.contains(constraint))
+        );
     }
 }

--- a/core/src/test/java/apoc/export/cypher/ExportCypherS3Test.java
+++ b/core/src/test/java/apoc/export/cypher/ExportCypherS3Test.java
@@ -1,6 +1,5 @@
 package apoc.export.cypher;
 
-import apoc.graph.Graphs;
 import apoc.util.TestUtil;
 import apoc.util.s3.S3BaseTest;
 import apoc.util.s3.S3TestUtil;
@@ -14,8 +13,6 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 import java.io.IOException;
 import java.util.Map;
 
-import static apoc.ApocConfig.APOC_EXPORT_FILE_ENABLED;
-import static apoc.ApocConfig.apocConfig;
 import static apoc.export.cypher.ExportCypherTest.ExportCypherResults.*;
 import static apoc.util.Util.map;
 import static apoc.util.s3.S3TestUtil.assertStringFileEquals;
@@ -31,32 +28,9 @@ public class ExportCypherS3Test extends S3BaseTest {
     @Rule
     public TestName testName = new TestName();
 
-    private static final String OPTIMIZED = "Optimized";
-    private static final String ODD = "OddDataset";
-
-
     @Before
     public void setUp() throws Exception {
-        apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
-        TestUtil.registerProcedure(db, ExportCypher.class, Graphs.class);
-        db.executeTransactionally("CREATE INDEX ON :Bar(first_name, last_name)");
-        db.executeTransactionally("CREATE INDEX ON :Foo(name)");
-        db.executeTransactionally("CREATE CONSTRAINT ON (b:Bar) ASSERT b.name IS UNIQUE");
-        if (testName.getMethodName().endsWith(OPTIMIZED)) {
-            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})-[:KNOWS {since:2016}]->(b:Bar {name:'bar',age:42}),(c:Bar:Person {age:12}),(d:Bar {age:12})," +
-                    " (t:Foo {name:'foo2', born:date('2017-09-29')})-[:KNOWS {since:2015}]->(e:Bar {name:'bar2',age:44}),({age:99})");
-        } else if (testName.getMethodName().endsWith(ODD)) {
-            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})," +
-                    "(t:Foo {name:'foo2', born:date('2017-09-29')})," +
-                    "(g:Foo {name:'foo3', born:date('2016-03-12')})," +
-                    "(b:Bar {name:'bar',age:42})," +
-                    "(c:Bar {age:12})," +
-                    "(d:Bar {age:4})," +
-                    "(e:Bar {name:'bar2',age:44})," +
-                    "(f)-[:KNOWS {since:2016}]->(b)");
-        } else {
-            db.executeTransactionally("CREATE (f:Foo {name:'foo', born:date('2018-10-31')})-[:KNOWS {since:2016}]->(b:Bar {name:'bar',age:42}),(c:Bar {age:12})");
-        }
+      ExportCypherTestUtils.setUp(db, testName);
     }
 
     // -- Whole file test -- //

--- a/core/src/test/resources/init_neo4j_export_csv.cypher
+++ b/core/src/test/resources/init_neo4j_export_csv.cypher
@@ -1,3 +1,8 @@
+CREATE CONSTRAINT SingleUnique FOR (x:Label) REQUIRE (x.prop) IS UNIQUE;
+CREATE CONSTRAINT CompositeUnique FOR (x:Label) REQUIRE (x.prop1, x.prop2) IS UNIQUE;
+CREATE CONSTRAINT SingleExists FOR (x:Label2) REQUIRE (x.prop) IS NOT NULL;
+CREATE CONSTRAINT SingleExistsRel FOR ()<-[r:TYPE2]-() REQUIRE (r.prop) IS NOT NULL;
+CREATE CONSTRAINT SingleNodeKey FOR (x:Label3) REQUIRE (x.prop) IS NODE KEY;
 CREATE CONSTRAINT ON (t:Person) ASSERT (t.name, t.surname) IS NODE KEY;
 
 CREATE (a:Person {name: 'John', surname: 'Snow'})


### PR DESCRIPTION
Fixes https://github.com/neo4j/apoc/issues/345

`apoc.export.cypher.all` exported some constraints with wrong type or not at all

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Stop classifying composite UNIQUE constraints as NODE KEY.
  - Stop classifying single NODE KEY constraints as UNIQUE.
  - Support existence constraints.
  - Support relationship constraints.
