### PR TITLE
[Fb3ZFQbn] Fixes bug in cypher initializer to wait for systemdb

### DIFF
--- a/core/src/main/java/apoc/cypher/CypherInitializer.java
+++ b/core/src/main/java/apoc/cypher/CypherInitializer.java
@@ -60,6 +60,8 @@ public class CypherInitializer implements AvailabilityListener {
                 final boolean isSystemDatabase = db.databaseName().equals(GraphDatabaseSettings.SYSTEM_DATABASE_NAME);
                 if (!isSystemDatabase) {
                     awaitApocProceduresRegistered();
+                } else {
+                    awaitDbmsComponentsProcedureRegistered();
                 }
 
                 if (defaultDb.equals(db.databaseName())) {
@@ -132,14 +134,20 @@ public class CypherInitializer implements AvailabilityListener {
     }
 
     private void awaitApocProceduresRegistered() {
-        while (!areApocProceduresRegistered()) {
+        while (!areProceduresRegistered("apoc")) {
             Util.sleep(100);
         }
     }
 
-    private boolean areApocProceduresRegistered() {
+    private void awaitDbmsComponentsProcedureRegistered() {
+        while (!areProceduresRegistered("dbms.components")) {
+            Util.sleep(100);
+        }
+    }
+
+    private boolean areProceduresRegistered(String procStart) {
         try {
-            return procs.getAllProcedures().stream().anyMatch(signature -> signature.name().toString().startsWith("apoc"));
+            return procs.getAllProcedures().stream().anyMatch(signature -> signature.name().toString().startsWith(procStart));
         } catch (ConcurrentModificationException e) {
             // if a CME happens (possible during procedure scanning)
             // we return false and the caller will try again


### PR DESCRIPTION
## What
This PR waits for the dbms procedures to be completely initialized in `CypherInitializer`

## Why
When doing:

```
docker run --restart always --publish=7474:7474 --publish=7687:7687  --env NEO4JLABS_PLUGINS='["apoc"]' \
--env apoc.import.file.use_neo4j_config=true \
--env apoc.initializer.system.0='CREATE USER neo4j IF NOT EXISTS SET PASSWORD "pass" CHANGE NOT REQUIRED' \
--env apoc.initializer.system.1='CREATE USER dummy IF NOT EXISTS SET PASSWORD "pass" CHANGE NOT REQUIRED' \
--env apoc.initializer.system.2='GRANT ROLE reader TO dummy' \
--env=NEO4J_ACCEPT_LICENSE_AGREEMENT=yes \
neo4j:4.4.17-enterprise
```

we were failing in the `CypherInitializer` because it could not find the built-in role:

```
2023-03-23 13:15:51.229+0000 INFO  This instance is ServerId{40d2109e} (40d2109e-00ec-40b6-a733-8a3681d28ff8)
2023-03-23 13:15:53.640+0000 INFO  ======== Neo4j 4.4.17 ========
2023-03-23 13:16:00.870+0000 INFO  [system/00000000] successfully initialized: CREATE USER neo4j IF NOT EXISTS SET PASSWORD "${DUMMY_PASSWORD}" CHANGE NOT REQUIRED
2023-03-23 13:16:01.117+0000 INFO  [system/00000000] successfully initialized: CREATE USER dummy IF NOT EXISTS SET PASSWORD "${DUMMY_PASSWORD}" CHANGE NOT REQUIRED
2023-03-23 13:16:02.198+0000 WARN  [system/00000000] Retrying operation 0 of 5
2023-03-23 13:16:02.303+0000 WARN  [system/00000000] Retrying operation 1 of 5
2023-03-23 13:16:02.426+0000 WARN  [system/00000000] Retrying operation 2 of 5
2023-03-23 13:16:02.541+0000 WARN  [system/00000000] Retrying operation 3 of 5
2023-03-23 13:16:02.654+0000 WARN  [system/00000000] Retrying operation 4 of 5
2023-03-23 13:16:02.760+0000 ERROR [system/00000000] error upon initialization, running: GRANT ROLE reader TO dummy
org.neo4j.graphdb.QueryExecutionException: Failed to grant role 'reader' to user 'dummy': Role does not exist.
```

So it seems the roles are populated after the native procedures are available in the database. It seems the first procedures that we load are the external jars ones, so waiting for those to be available (aka. waiting for apoc to be available is not enough)