### PR TITLE
[NOID] 4.4 updated webdrivermanager dep

### DIFF
--- a/extra-dependencies/selenium/build.gradle
+++ b/extra-dependencies/selenium/build.gradle
@@ -21,5 +21,5 @@ dependencies {
     compile group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59', {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    compile group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '4.4.3'
+    compile group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.1.0'
 }


### PR DESCRIPTION
The webdrivermanager in extra-dependencies was a different version from the rest of APOC, update this to fix vulnerabilities associated with this version. 