### PR TITLE
Bump version 5.8.0 (#3456)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ downloadLicenses {
 
 allprojects {
     group = 'org.neo4j.procedure'
-    version = '5.7.0'
+    version = '5.8.0'
     archivesBaseName = 'apoc'
     description = """neo4j-apoc-procedures"""
 }
@@ -71,8 +71,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.7.0-enterprise',
-                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:5.7.0',
+                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise' : 'neo4j:5.8.0-enterprise',
+                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") : 'neo4j:5.8.0',
                 'coreDir': 'apoc-core/core'
 
         maxHeapSize = "8G"
@@ -130,7 +130,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.6.0"
+    neo4jVersion = "5.8.0"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.16.2'

--- a/docs/asciidoc/antora.yml
+++ b/docs/asciidoc/antora.yml
@@ -8,4 +8,4 @@ asciidoc:
     docs-version: "5.0"
     branch: "5.0"
     apoc-release-absolute: "5.0"
-    apoc-release: "5.7.0"
+    apoc-release: "5.8.0"

--- a/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
@@ -22,6 +22,7 @@ The version compatibility matrix explains the mapping between Neo4j and APOC ver
 [opts=header]
 |===
 |apoc version | neo4j version
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.8.0[5.8.0^] | 5.8.0 (5.8.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.7.0[5.7.0^] | 5.7.0 (5.7.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.6.0[5.6.0^] | 5.6.0 (5.6.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.5.0[5.5.0^] | 5.5.0 (5.5.x)
@@ -29,7 +30,7 @@ The version compatibility matrix explains the mapping between Neo4j and APOC ver
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.3.1[5.3.1^] | 5.3.0 (5.3.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.2.0[5.2.0^] | 5.2.0 (5.2.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.1.0[5.1.0^] | 5.1.0 (5.1.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.13[4.4.0.13^] | 4.4.0 (4.4.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.15[4.4.0.15^] | 4.4.0 (4.4.x)
 |===
 
 // end::version-matrix[]

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -29,7 +29,7 @@ plugins {
     id 'org.neo4j.doc.build.docbook' version '1.0-alpha12'
 }
 
-if (!project.hasProperty('apocVersion')) { ext.apocVersion = '5.7.0' }
+if (!project.hasProperty('apocVersion')) { ext.apocVersion = '5.8.0' }
 
 ext {
     versionParts = apocVersion.split('-')

--- a/extra-dependencies/build.gradle
+++ b/extra-dependencies/build.gradle
@@ -14,7 +14,7 @@ configure(subprojects) {
 
 
 subprojects {
-    version = '5.7.0'
+    version = '5.8.0'
     group = 'org.neo4j.contrib'
 }
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,8 +1,8 @@
 :readme:
 :branch: 5.4
 :docs: https://neo4j.com/labs/apoc/5
-:apoc-release: 5.7.0
-:neo4j-version: 5.7.0
+:apoc-release: 5.8.0
+:neo4j-version: 5.8.0
 :img: https://raw.githubusercontent.com/neo4j-contrib/neo4j-apoc-procedures/{branch}/docs/images
 
 https://community.neo4j.com[image:https://img.shields.io/discourse/users?logo=discourse&server=https%3A%2F%2Fcommunity.neo4j.com[Discourse users]]
@@ -180,6 +180,7 @@ The trailing `<apoc>` part of the version number will be incremented with every 
 [opts=header]
 |===
 |apoc version | neo4j version
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.8.0[5.8.0^] | 5.8.0 (5.8.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.7.0[5.7.0^] | 5.7.0 (5.7.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.6.0[5.6.0^] | 5.6.0 (5.6.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.5.0[5.5.0^] | 5.5.0 (5.5.x)
@@ -187,7 +188,7 @@ The trailing `<apoc>` part of the version number will be incremented with every 
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.3.1[5.3.1^] | 5.3.0 (5.3.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.2.0[5.2.0^] | 5.2.0 (5.2.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.1.0[5.1.0^] | 5.1.0 (5.1.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.13[4.4.0.13^] | 4.4.0 (4.4.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.15[4.4.0.15^] | 4.4.0 (4.4.x)
 |===
 
 // end::version-matrix[]


### PR DESCRIPTION
Bump dev version to 5.8.0 
Cherry-pick of https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/ea144746b83416e2eb6367b7567a8ae6d6d71436