### PR TITLE
[6R2yEhGU] No procedure with name xxxx registered for this database instance

### DIFF
--- a/full/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/full/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -223,7 +223,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
         ), statement, forceSingle);
     }
 
-    public void restoreProceduresAndFunctions() {
+    public synchronized void restoreProceduresAndFunctions() {
         lastUpdate = System.currentTimeMillis();
         Set<ProcedureSignature> currentProceduresToRemove = new HashSet<>(registeredProcedureSignatures);
         Set<UserFunctionSignature> currentUserFunctionsToRemove = new HashSet<>(registeredUserFunctionSignatures);
@@ -268,9 +268,10 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             node.setProperty(SystemPropertyKeys.forceSingle.name(), forceSingle);
 
             setLastUpdate(tx);
-            registerFunction(signature, statement, forceSingle);
             return null;
         });
+
+        restoreProceduresAndFunctions();
     }
 
     public void storeProcedure(ProcedureSignature signature, String statement) {
@@ -286,9 +287,10 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             node.setProperty(SystemPropertyKeys.outputs.name(), serializeSignatures(signature.outputSignature()));
             node.setProperty(SystemPropertyKeys.mode.name(), signature.mode().name());
             setLastUpdate(tx);
-            registerProcedure(signature, statement);
             return null;
         });
+
+        restoreProceduresAndFunctions();
     }
 
     private String serializeSignatures(List<FieldSignature> signatures) {

--- a/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
+++ b/full/src/test/java/apoc/custom/CypherProceduresStorageTest.java
@@ -113,8 +113,7 @@ public class CypherProceduresStorageTest {
             );
         });
 
-        // check that the previous overwrite works correctly after the `db.clearQueryCaches`
-        db.executeTransactionally("call db.clearQueryCaches");
+        // check that the previous overwrite works correctly
         listProcNames.forEach(name -> TestUtil.testCall(db,
                     String.format("call custom.%s", name),
                     (row) -> assertEquals(1L, row.get("answer"))
@@ -160,8 +159,7 @@ public class CypherProceduresStorageTest {
             );
         });
 
-        // check that the previous overwrite works correctly after the `db.clearQueryCaches`
-        db.executeTransactionally("call db.clearQueryCaches");
+        // check that the previous overwrite works correctly
         listFunNames.forEach(name -> TestUtil.testCall(db,
                         String.format(funQuery, name),
                         (row) -> assertEquals(1L, row.get("row"))

--- a/test-utils/src/main/java/apoc/util/TestcontainersCausalCluster.java
+++ b/test-utils/src/main/java/apoc/util/TestcontainersCausalCluster.java
@@ -127,8 +127,6 @@ public class TestcontainersCausalCluster {
             container.withEnv("NEO4J_dbms_routing_listen__address", "0.0.0.0:7618")
                     .withEnv("NEO4J_dbms_routing_default__router", "SERVER")
                     .withEnv("NEO4J_dbms_routing_advertised__address", name + ":7618");
-        } else {
-            container.withoutDriver();
         }
         neo4jConfig.forEach((conf, value) -> container.withNeo4jConfig(conf, String.valueOf(value)));
         container.withEnv(envSettings);


### PR DESCRIPTION
WIP: maybe can be related to Trello id: `XWc7tBAb`


- added synchronized to avoid potential conflict
- removed `registerFunction(signature, statement, forceSingle);` and `registerProcedure(signature, statement);` from the system-node merge, to prevent erroneous proc/func deletion before the sys-node is actually created/updated (on lines 224-226, with comment `// de-register removed procs/functions`)
- added tests with multiple procedure/function updates