### PR TITLE
[NOID]  fix uuid flaky routing test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ subprojects {
         archiveClassifier = 'javadoc'
     }
     test {
-        //exclude '**/CypherProceduresClusterTest.class'//, '**/AtomicTest.class'
+        include '**/UUIDClusterRoutingTest.class'//, '**/AtomicTest.class'
 
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,

--- a/build.gradle
+++ b/build.gradle
@@ -65,7 +65,7 @@ subprojects {
         archiveClassifier = 'javadoc'
     }
     test {
-        include '**/UUIDClusterRoutingTest.class'//, '**/AtomicTest.class'
+        //exclude '**/CypherProceduresClusterTest.class'//, '**/AtomicTest.class'
 
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,

--- a/full-it/src/test/java/apoc/full/it/CoreExtendedTest.java
+++ b/full-it/src/test/java/apoc/full/it/CoreExtendedTest.java
@@ -46,9 +46,9 @@ import static org.junit.Assume.assumeTrue;
 public class CoreExtendedTest {
     @Test
     public void checkForCoreAndExtended() {
-        try {
-            Neo4jContainerExtension neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.FULL), !TestUtil.isRunningInCI())
-                    .withNeo4jConfig("dbms.transaction.timeout", "60s")
+        try (Neo4jContainerExtension neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.FULL), !TestUtil.isRunningInCI())) {
+
+            neo4jContainer.withNeo4jConfig("dbms.transaction.timeout", "60s")
                     .withNeo4jConfig(APOC_IMPORT_FILE_ENABLED, "true");
 
             neo4jContainer.start();
@@ -62,7 +62,6 @@ public class CoreExtendedTest {
             assertTrue(coreCount > 0);
             assertTrue(extendedCount > 0);
 
-            neo4jContainer.close();
         } catch (Exception ex) {
             if (TestContainerUtil.isDockerImageAvailable(ex)) {
                 ex.printStackTrace();
@@ -73,9 +72,9 @@ public class CoreExtendedTest {
 
     @Test
     public void matchesSpreadsheet() {
-        try {
-            Neo4jContainerExtension neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.FULL), !TestUtil.isRunningInCI())
-                    .withNeo4jConfig("dbms.transaction.timeout", "5s");
+        try(Neo4jContainerExtension neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.FULL), !TestUtil.isRunningInCI())) {
+
+            neo4jContainer.withNeo4jConfig("dbms.transaction.timeout", "5s");
 
             neo4jContainer.start();
 
@@ -101,7 +100,6 @@ public class CoreExtendedTest {
 
             assertEquals(different.toString(), 0, different.size());
 
-            neo4jContainer.close();
         } catch (Exception ex) {
             if (TestContainerUtil.isDockerImageAvailable(ex)) {
                 ex.printStackTrace();

--- a/full-it/src/test/java/apoc/full/it/UUIDClusterRoutingTest.java
+++ b/full-it/src/test/java/apoc/full/it/UUIDClusterRoutingTest.java
@@ -23,7 +23,6 @@ import apoc.util.TestContainerUtil;
 import apoc.util.TestcontainersCausalCluster;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.driver.*;
 import org.neo4j.internal.helpers.collection.Iterators;
@@ -52,7 +51,7 @@ import static org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAM
 import static org.neo4j.configuration.GraphDatabaseSettings.SYSTEM_DATABASE_NAME;
 import static org.neo4j.test.assertion.Assert.assertEventually;
 
-@Ignore
+
 public class UUIDClusterRoutingTest {
     private static final int NUM_CORES = 3;
     private static TestcontainersCausalCluster cluster;

--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -297,11 +297,10 @@ public class TestContainerUtil {
                         assertEquals(2L, count);
                         return true;
                     } catch (Exception e) {
-                        System.out.println("UUID err = " + e);
                         return false;
                     }
                 },
-                (value) -> value, 30L, TimeUnit.SECONDS);
+                (value) -> value, 60L, TimeUnit.SECONDS);
     }
 
     /**

--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -297,10 +297,11 @@ public class TestContainerUtil {
                         assertEquals(2L, count);
                         return true;
                     } catch (Exception e) {
+                        System.out.println("UUID err = " + e);
                         return false;
                     }
                 },
-                (value) -> value, 60L, TimeUnit.SECONDS);
+                (value) -> value, 30L, TimeUnit.SECONDS);
     }
 
     /**

--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -6,6 +6,7 @@ import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.awaitility.core.ConditionTimeoutException;
 import org.gradle.tooling.BuildLauncher;
 import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.ProjectConnection;
@@ -286,7 +287,7 @@ public class TestContainerUtil {
      *
      * @param session
      */
-    public static void checkLeadershipBalanced(Session session) {
+    public static void checkLeadershipBalanced(Session session) throws ConditionTimeoutException {
         assertEventually(() -> {
                     String query = "CALL dbms.cluster.overview() YIELD databases\n" +
                             "WITH databases.neo4j AS neo4j, databases.system AS system\n" +
@@ -300,7 +301,7 @@ public class TestContainerUtil {
                         return false;
                     }
                 },
-                (value) -> value, 60L, TimeUnit.SECONDS);
+                (value) -> value, 30L, TimeUnit.SECONDS);
     }
 
     /**


### PR DESCRIPTION
- Added try-catch mechanism to retrieve cluster balancing

- Added auto-close to StartupTest, otherwise the CI could fail with TimeoutException in case of errors.