### PR TITLE
[qWQ33yT5] apoc.export.cypher.all rel indexes exported incorrectly

### DIFF
--- a/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
+++ b/core/src/main/java/apoc/export/cypher/MultiStatementCypherSubGraphExporter.java
@@ -250,7 +250,8 @@ public class MultiStatementCypherSubGraphExporter {
     private List<String> exportIndexes() {
         return db.executeTransactionally("CALL db.indexes()", Collections.emptyMap(), result -> result.stream()
                 .map(map -> {
-                    if ("LOOKUP".equals(map.get("type"))) {
+                    String indexType = (String) map.get("type");
+                    if ("LOOKUP".equals(indexType)) {
                         return "";
                     }
                     List<String> props = (List<String>) map.get("properties");
@@ -266,7 +267,7 @@ public class MultiStatementCypherSubGraphExporter {
                     }
 
                     boolean isNode = "NODE".equals(map.get("entityType"));
-                    if ("FULLTEXT".equals(map.get("type"))) {
+                    if ("FULLTEXT".equals(indexType)) {
                         if (isNode) {
                             List<Label> labels = toLabels(tokenNames);
                             return this.cypherFormat.statementForNodeFullTextIndex(name, labels, props);
@@ -280,9 +281,9 @@ public class MultiStatementCypherSubGraphExporter {
                     String tokenName = tokenNames.get(0);
                     final boolean ifNotExist = exportConfig.ifNotExists();
                     if (isNode) {
-                        return this.cypherFormat.statementForNodeIndex(tokenName, props, ifNotExist, idxName);
+                        return this.cypherFormat.statementForNodeIndex(indexType, tokenName, props, ifNotExist, idxName);
                     } else {
-                        return this.cypherFormat.statementForIndexRelationship(tokenName, props, ifNotExist, idxName);
+                        return this.cypherFormat.statementForIndexRelationship(indexType, tokenName, props, ifNotExist, idxName);
                     }
 
                 })

--- a/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AbstractCypherFormatter.java
@@ -67,8 +67,9 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 	}
 
 	@Override
-	public String statementForNodeIndex(String label, Iterable<String> keys, boolean ifNotExists, String idxName) {
-		return String.format("CREATE INDEX%s%s FOR (node:%s) ON (%s);",
+	public String statementForNodeIndex(String indexType, String label, Iterable<String> keys, boolean ifNotExists, String idxName) {
+		return String.format("CREATE %s INDEX%s%s FOR (node:%s) ON (%s);",
+				indexType,
 				idxName,
 				getIfNotExists(ifNotExists),
 				Util.quote(label),
@@ -76,8 +77,9 @@ abstract class AbstractCypherFormatter implements CypherFormatter {
 	}
 	
 	@Override
-	public String statementForIndexRelationship(String type, Iterable<String> keys, boolean ifNotExists, String idxName) {
-		return String.format("CREATE INDEX%s%s FOR ()-[rel:%s]-() ON (%s);",
+	public String statementForIndexRelationship(String indexType, String type, Iterable<String> keys, boolean ifNotExists, String idxName) {
+		return String.format("CREATE %s INDEX%s%s FOR ()-[rel:%s]-() ON (%s);",
+				indexType,
 				idxName,
 				getIfNotExists(ifNotExists), 
 				Util.quote(type), 

--- a/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/AddStructureCypherFormatter.java
@@ -52,12 +52,12 @@ public class AddStructureCypherFormatter extends AbstractCypherFormatter impleme
 	}
 
 	@Override
-	public String statementForNodeIndex(String label, Iterable<String> key, boolean ifNotExist, String idxName) {
+	public String statementForNodeIndex(String indexType, String label, Iterable<String> key, boolean ifNotExist, String idxName) {
 		return "";
 	}
 	
 	@Override
-	public String statementForIndexRelationship(String type, Iterable<String> key, boolean ifNotExists, String idxName) {
+	public String statementForIndexRelationship(String indexType, String type, Iterable<String> key, boolean ifNotExists, String idxName) {
 		return "";
 	}
 

--- a/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/CypherFormatter.java
@@ -38,9 +38,9 @@ public interface CypherFormatter {
 
 	String statementForRelationship(Relationship relationship, Map<String, Set<String>> uniqueConstraints, Set<String> indexedProperties, ExportConfig exportConfig);
 
-	String statementForNodeIndex(String label, Iterable<String> keys, boolean ifNotExist, String idxName);
+	String statementForNodeIndex(String indexType, String label, Iterable<String> keys, boolean ifNotExist, String idxName);
 
-	String statementForIndexRelationship(String type, Iterable<String> keys, boolean ifNotExist, String idxName);
+	String statementForIndexRelationship(String indexType, String type, Iterable<String> keys, boolean ifNotExist, String idxName);
 
 	String statementForNodeFullTextIndex(String name, Iterable<Label> labels, Iterable<String> keys);
 

--- a/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
+++ b/core/src/main/java/apoc/export/cypher/formatter/UpdateStructureCypherFormatter.java
@@ -52,12 +52,12 @@ public class UpdateStructureCypherFormatter extends AbstractCypherFormatter impl
 	}
 
 	@Override
-	public String statementForNodeIndex(String label, Iterable<String> key, boolean ifNotExist, String idxName) {
+	public String statementForNodeIndex(String indexType, String label, Iterable<String> key, boolean ifNotExist, String idxName) {
 		return "";
 	}
 
 	@Override
-	public String statementForIndexRelationship(String type, Iterable<String> key, boolean ifNotExists, String idxName) {
+	public String statementForIndexRelationship(String indexType, String type, Iterable<String> key, boolean ifNotExists, String idxName) {
 		return "";
 	}
 


### PR DESCRIPTION
Added index type to nodes and rels.
In 5.x has been implemented [here](https://github.com/neo4j/apoc/commit/3ac9ef43674778f6b54833abc39df4a80b5be22b)