### PR TITLE
[rF3PTDby] Fix shouldFindDifferencesInTheSameDb

### DIFF
--- a/full/src/main/java/apoc/diff/DiffFull.java
+++ b/full/src/main/java/apoc/diff/DiffFull.java
@@ -324,7 +324,7 @@ public class DiffFull {
             return config.isFindById() ? findEntityById(it, node.getId()) : null;
         }
         Map<String, Object> keys = getNodeKeys(node, constraintDefinition);
-        return StreamSupport.stream(it.spliterator(), true)
+        return StreamSupport.stream(it.spliterator(), false)
                 .filter(entity -> entity.getProperties(Iterables.asArray(String.class, keys.keySet())).equals(keys))
                 .findFirst()
                 .orElse(null);


### PR DESCRIPTION
Changed parallel: false in `DiffFull.java`, 
to prevent occasional concurrency errors.
See: https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/4938604111/jobs/8841865125?pr=3551#step:7:16320


