### PR TITLE
[UNKBKte1] Redacts passwords in CypherInitializer

### DIFF
--- a/core/src/main/java/apoc/util/LogsUtil.java
+++ b/core/src/main/java/apoc/util/LogsUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package apoc.util;
+
+import org.neo4j.cypher.internal.ast.Statement;
+import org.neo4j.cypher.internal.ast.factory.neo4j.JavaCCParser;
+import org.neo4j.cypher.internal.util.AnonymousVariableNameGenerator;
+import org.neo4j.cypher.internal.ast.prettifier.ExpressionStringifier;
+import org.neo4j.cypher.internal.ast.prettifier.ExpressionStringifier.Extension;
+import org.neo4j.cypher.internal.ast.prettifier.ExpressionStringifier$;
+import org.neo4j.cypher.internal.ast.prettifier.Prettifier;
+import org.neo4j.cypher.internal.rewriting.rewriters.sensitiveLiteralReplacement;
+import org.neo4j.cypher.internal.util.OpenCypherExceptionFactory;
+
+public class LogsUtil {
+    private static OpenCypherExceptionFactory exceptionFactory = new OpenCypherExceptionFactory(scala.Option.empty());
+    private static AnonymousVariableNameGenerator nameGenerator = new AnonymousVariableNameGenerator();
+    private static Extension extension = ExpressionStringifier.Extension$.MODULE$.simple((ExpressionStringifier$.MODULE$.failingExtender()));
+    private static ExpressionStringifier stringifier = new ExpressionStringifier(extension, false, false, false, false);
+    private static Prettifier prettifier = new Prettifier(stringifier, Prettifier.EmptyExtension$.MODULE$, true);
+
+    public static String sanitizeQuery(String query) {
+        try {
+            var statement = JavaCCParser.parse(query, exceptionFactory, nameGenerator );
+            var rewriter = sensitiveLiteralReplacement.apply(statement)._1;
+            var res = (Statement) rewriter.apply(statement);
+
+            return prettifier.asString(res);
+        } catch (Exception e) {
+            return query;
+        }
+    }
+}

--- a/core/src/main/java/apoc/util/QueryUtil.java
+++ b/core/src/main/java/apoc/util/QueryUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package apoc.util;
+
+import org.neo4j.cypher.internal.ast.factory.neo4j.JavaCCParser;
+import org.neo4j.cypher.internal.util.AnonymousVariableNameGenerator;
+import org.neo4j.cypher.internal.util.OpenCypherExceptionFactory;
+
+public class QueryUtil {
+    private static OpenCypherExceptionFactory exceptionFactory = new OpenCypherExceptionFactory(scala.Option.empty());
+
+    public static boolean isValidQuery(String query) {
+        try {
+            JavaCCParser.parse(query, exceptionFactory, new AnonymousVariableNameGenerator());
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/core/src/test/java/apoc/util/LogsUtilTest.java
+++ b/core/src/test/java/apoc/util/LogsUtilTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package apoc.util;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class LogsUtilTest {
+
+    @Test
+    public void shouldRedactPasswords() {
+        String sanitized = LogsUtil.sanitizeQuery("CREATE USER dummy IF NOT EXISTS SET PASSWORD 'pass12345' CHANGE NOT REQUIRED");
+        assertEquals(sanitized, "CREATE USER dummy IF NOT EXISTS SET PASSWORD '******' CHANGE NOT REQUIRED");
+    }
+
+    @Test
+    public void shouldReturnInputIfInvalidQuery() {
+        String invalidQuery = "MATCH USER dummy IF NOT EXISTS SET PASSWORD 'pass12345' CHANGE NOT REQUIRED";
+        String sanitized = LogsUtil.sanitizeQuery(invalidQuery);
+
+        assertEquals(sanitized, invalidQuery);
+    }
+}

--- a/core/src/test/java/apoc/util/QueryUtilTest.java
+++ b/core/src/test/java/apoc/util/QueryUtilTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package apoc.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class QueryUtilTest
+{
+
+    @Test
+    public void shouldReturnTrueForValidQueries() {
+        assertTrue(QueryUtil.isValidQuery("CREATE USER dummy IF NOT EXISTS SET PASSWORD 'pass12345' CHANGE NOT REQUIRED"));
+    }
+
+    @Test
+    public void shouldReturnFalseForInvalidQueries() {
+        assertFalse(QueryUtil.isValidQuery("MATCH USER dummy IF NOT EXISTS SET PASSWORD 'pass12345' CHANGE NOT REQUIRED"));
+    }
+}


### PR DESCRIPTION
## What
We should obfuscate passwords when logging information in CypherInitializer

## Why

Because if we used:

```
apoc.initializer.system.1=CREATE USER dummy IF NOT EXISTS SET PASSWORD pass12345
```

we were getting an entry in neo4j.log with the password in plaintext:

```
INFO  [system/00000000] successfully initialized: alter user neo4j SET PASSWORD "pass12345" CHANGE NOT REQUIRED
```

## Expected behaviour

We should get a redacted password instead:

```
INFO  [system/00000000] successfully initialized: alter user neo4j SET PASSWORD "*****" CHANGE NOT REQUIRED
```