### PR TITLE
[ZkSGN6PO] apoc.export.graphml.all doesn't accept absolute Windows paths (neo4j/apoc#381)

### DIFF
--- a/core/src/main/java/apoc/util/FileUtils.java
+++ b/core/src/main/java/apoc/util/FileUtils.java
@@ -59,6 +59,17 @@ import static apoc.util.Util.readHttpInputStream;
  */
 public class FileUtils {
 
+    public static String getFileUrl(String fileName) throws MalformedURLException {
+        try {
+            return new URL(fileName).getFile();
+        } catch (MalformedURLException e) {
+            if (e.getMessage().contains("no protocol")) {
+                return fileName;
+            }
+            throw e;
+        }
+    }
+
     public enum SupportedProtocols {
         http(true, null),
         https(true, null),
@@ -95,14 +106,7 @@ public class FileUtils {
                     try {
                         return new StreamConnection.FileStreamConnection(URI.create(urlAddress));
                     } catch (IllegalArgumentException iae) {
-                        try {
-                            return new StreamConnection.FileStreamConnection(new URL(urlAddress).getFile());
-                        } catch (MalformedURLException mue) {
-                            if (mue.getMessage().contains("no protocol")) {
-                                return new StreamConnection.FileStreamConnection(urlAddress);
-                            }
-                            throw mue;
-                        }
+                        return new StreamConnection.FileStreamConnection(getFileUrl(urlAddress));
                     }
             }
         }
@@ -120,8 +124,10 @@ public class FileUtils {
                         outputStream = HDFSUtils.writeFile(fileName);
                         break;
                     default:
-                        final Path path = resolvePath(fileName);
-                        outputStream = new FileOutputStream(path.toFile());
+                        final File file = isImportUsingNeo4jConfig()
+                                ? resolvePath(fileName).toFile()
+                                : new File(getFileUrl(fileName));
+                        outputStream = new FileOutputStream(file);
                 }
                 return new BufferedOutputStream(compressionAlgo.getOutputStream(outputStream));
             } catch (Exception e) {
@@ -152,6 +158,13 @@ public class FileUtils {
                         // otherwise we return unknown protocol: yyyyy
                         return SupportedProtocols.valueOf(new URI(source).getScheme());
                     } catch (Exception ignored) {}
+
+                    // in case a Windows user write an url like `C:/User/...`
+                    if (e.getMessage().contains("unknown protocol") && Util.isWindows()) {
+                        throw new RuntimeException(e.getMessage() +
+                                "\n Please note that for Windows absolute paths they have to be explicit by prepending `file:` or supplied without the drive, " +
+                                "\n e.g. `file:C:/my/path/file` or `/my/path/file`, instead of `C:/my/path/file`");
+                    }
                     throw new RuntimeException(e);
                 }
                 return SupportedProtocols.file;

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -1196,4 +1196,10 @@ public class Util {
         T result = retryInTx(NullLog.getInstance(), db, action, 0, 0, r -> {});
         return rebind(transaction, result);
     }
+
+    public static boolean isWindows() {
+        return System.getProperty("os.name")
+                .toLowerCase()
+                .contains("win");
+    }
 }


### PR DESCRIPTION
Cherry-pick https://github.com/neo4j/apoc/commit/c226380dc5d26787e7ca6d0a196cbbfecfa23728