### PR TITLE
[NOID] Fixes circular docker dependency in TeamCity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country ' : 'US',
-                'neo4jDockerImage' : project.hasProperty("neo4jVersionOverride") ? 'neo4j:' + project.getProperty("neo4jVersionOverride") + '-enterprise' : 'neo4j:4.4.20-enterprise',
-                'neo4jCommunityDockerImage': project.hasProperty("neo4jVersionOverride") ? 'neo4j:' + project.getProperty("neo4jVersionOverride") : 'neo4j:4.4.20'
+                'neo4jDockerImage' : project.hasProperty("neo4jDockerVersionOverride") ? 'neo4j:' + project.getProperty("neo4jDockerVersionOverride") + '-enterprise' : 'neo4j:4.4.20-enterprise',
+                'neo4jCommunityDockerImage': project.hasProperty("neo4jDockerVersionOverride") ? 'neo4j:' + project.getProperty("neo4jDockerVersionOverride") : 'neo4j:4.4.20'
 
         maxHeapSize = "8G"
         forkEvery = 50


### PR DESCRIPTION
## What
A dedicated property `neo4jDockerVersionOverride` has been created in TeamCity so we can pass a different version for neo4j and neo4j docker. This means we could be building with neo4j 4.4.22 when docker is still at 4.4.21

## Why

Because in some instances the docker job will not have the same neo4j version, since there's a circular dependency where in apoc we depend on docker and to build a docker container we depend on apoc been built and packaged with the database.

https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3588 seemed to broke the TeamCity CI for 4.4

