### PR TITLE
Fix CodeQl error

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,6 +48,13 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
 
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+
     - name: Init gradle
       run: ./gradlew --init-script init.gradle shadow
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,6 +24,14 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    env:
+      DOCKER_ENTERPRISE_URL: ${{ secrets.DOCKER_ENTERPRISE_DEV_URL }}
+      DOCKER_COMMUNITY_URL: ${{ secrets.DOCKER_COMMUNITY_DEV_URL }}
+      TEAMCITY_DEV_URL: ${{ secrets.TEAMCITY_DEV_URL }}
+      TEAMCITY_USER: ${{ secrets.TEAMCITY_USER }}
+      TEAMCITY_PASSWORD: ${{ secrets.TEAMCITY_PASSWORD }}
+      ENTERPRISE_TAR: enterprise-docker.tar
+      COMMUNITY_TAR: community-docker.tar
     permissions:
       actions: read
       contents: read
@@ -47,6 +55,14 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
+
+    - name: Download neo4j dev docker container
+      run: |
+        curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_ENTERPRISE_URL} -o ${ENTERPRISE_TAR} &
+        curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_COMMUNITY_URL} -o ${COMMUNITY_TAR} &
+        wait
+        docker load --input ${ENTERPRISE_TAR}
+        docker load --input ${COMMUNITY_TAR}
 
     - uses: actions/cache@v2
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,8 +42,8 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
-#    - name: Init gradle
-#      run: ./gradlew --no-daemon --init-script init.gradle clean
+    - name: Init gradle
+      run: ./gradlew --init-script init.gradle clean
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -62,7 +62,7 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
-      run: ./gradlew --no-daemon --init-script init.gradle clean
+#      run: ./gradlew --no-daemon --init-script init.gradle clean
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,32 +48,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
-
-    - name: Set up JDK 17
-      uses: actions/setup-java@v2
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-
-    #    - name: Download neo4j dev docker container
-    #      run: |
-    #        curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_ENTERPRISE_URL} -o ${ENTERPRISE_TAR} &
-    #        curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_COMMUNITY_URL} -o ${COMMUNITY_TAR} &
-    #        wait
-    #        docker load --input ${ENTERPRISE_TAR}
-    #        docker load --input ${COMMUNITY_TAR}
-
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+      uses: actions/checkout@v3
 
     - name: Compile Java
       run: ./gradlew --no-daemon --init-script init.gradle clean
-      # compileJava compileTestJava
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -92,7 +70,6 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
-    #      run: ./gradlew --no-daemon --init-script init.gradle clean
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,7 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
     - name: Init gradle
-      run: ./gradlew --init-script init.gradle shadow
+      run: ./gradlew --no-daemon --init-script init.gradle clean
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,14 +24,14 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    env:
-      DOCKER_ENTERPRISE_URL: ${{ secrets.DOCKER_ENTERPRISE_DEV_URL }}
-      DOCKER_COMMUNITY_URL: ${{ secrets.DOCKER_COMMUNITY_DEV_URL }}
-      TEAMCITY_DEV_URL: ${{ secrets.TEAMCITY_DEV_URL }}
-      TEAMCITY_USER: ${{ secrets.TEAMCITY_USER }}
-      TEAMCITY_PASSWORD: ${{ secrets.TEAMCITY_PASSWORD }}
-      ENTERPRISE_TAR: enterprise-docker.tar
-      COMMUNITY_TAR: community-docker.tar
+#    env:
+#      DOCKER_ENTERPRISE_URL: ${{ secrets.DOCKER_ENTERPRISE_DEV_URL }}
+#      DOCKER_COMMUNITY_URL: ${{ secrets.DOCKER_COMMUNITY_DEV_URL }}
+#      TEAMCITY_DEV_URL: ${{ secrets.TEAMCITY_DEV_URL }}
+#      TEAMCITY_USER: ${{ secrets.TEAMCITY_USER }}
+#      TEAMCITY_PASSWORD: ${{ secrets.TEAMCITY_PASSWORD }}
+#      ENTERPRISE_TAR: enterprise-docker.tar
+#      COMMUNITY_TAR: community-docker.tar
     permissions:
       actions: read
       contents: read
@@ -71,8 +71,8 @@ jobs:
           ~/.gradle/wrapper
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
-#    - name: Compile Java
-#      run: ./gradlew --no-daemon --init-script init.gradle clean
+    - name: Compile Java
+      run: ./gradlew --no-daemon --init-script init.gradle clean
       # compileJava compileTestJava
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,6 +42,9 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    - name: Init gradle
+      run: ./gradlew --no-daemon --init-script init.gradle clean
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,6 +62,7 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
+      run: ./gradlew --no-daemon --init-script init.gradle clean
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,13 +56,13 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
 
-    - name: Download neo4j dev docker container
-      run: |
-        curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_ENTERPRISE_URL} -o ${ENTERPRISE_TAR} &
-        curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_COMMUNITY_URL} -o ${COMMUNITY_TAR} &
-        wait
-        docker load --input ${ENTERPRISE_TAR}
-        docker load --input ${COMMUNITY_TAR}
+#    - name: Download neo4j dev docker container
+#      run: |
+#        curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_ENTERPRISE_URL} -o ${ENTERPRISE_TAR} &
+#        curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_COMMUNITY_URL} -o ${COMMUNITY_TAR} &
+#        wait
+#        docker load --input ${ENTERPRISE_TAR}
+#        docker load --input ${COMMUNITY_TAR}
 
     - uses: actions/cache@v2
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,7 +72,8 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
     - name: Compile Java
-      run: ./gradlew --no-daemon --init-script init.gradle compileJava compileTestJava
+      run: ./gradlew --no-daemon --init-script init.gradle clean
+      # compileJava compileTestJava
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -89,9 +90,9 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-#    - name: Autobuild
-#      uses: github/codeql-action/autobuild@v2
-#      run: ./gradlew --no-daemon --init-script init.gradle clean
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+      run: ./gradlew --no-daemon --init-script init.gradle clean
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,10 +40,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v2
 
-    - name: Init gradle
-      run: ./gradlew --no-daemon --init-script init.gradle clean
+#    - name: Init gradle
+#      run: ./gradlew --no-daemon --init-script init.gradle clean
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,14 +24,14 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-    env:
-      DOCKER_ENTERPRISE_URL: ${{ secrets.DOCKER_ENTERPRISE_DEV_URL }}
-      DOCKER_COMMUNITY_URL: ${{ secrets.DOCKER_COMMUNITY_DEV_URL }}
-      TEAMCITY_DEV_URL: ${{ secrets.TEAMCITY_DEV_URL }}
-      TEAMCITY_USER: ${{ secrets.TEAMCITY_USER }}
-      TEAMCITY_PASSWORD: ${{ secrets.TEAMCITY_PASSWORD }}
-      ENTERPRISE_TAR: enterprise-docker.tar
-      COMMUNITY_TAR: community-docker.tar
+#    env:
+#      DOCKER_ENTERPRISE_URL: ${{ secrets.DOCKER_ENTERPRISE_DEV_URL }}
+#      DOCKER_COMMUNITY_URL: ${{ secrets.DOCKER_COMMUNITY_DEV_URL }}
+#      TEAMCITY_DEV_URL: ${{ secrets.TEAMCITY_DEV_URL }}
+#      TEAMCITY_USER: ${{ secrets.TEAMCITY_USER }}
+#      TEAMCITY_PASSWORD: ${{ secrets.TEAMCITY_PASSWORD }}
+#      ENTERPRISE_TAR: enterprise-docker.tar
+#      COMMUNITY_TAR: community-docker.tar
     permissions:
       actions: read
       contents: read
@@ -71,8 +71,8 @@ jobs:
           ~/.gradle/wrapper
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
-    - name: Compile Java
-      run: ./gradlew --no-daemon --init-script init.gradle clean
+#    - name: Compile Java
+#      run: ./gradlew --no-daemon --init-script init.gradle clean
       # compileJava compileTestJava
 
     # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,8 +55,8 @@ jobs:
           ~/.gradle/wrapper
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
-    - name: Init gradle
-      run: ./gradlew --init-script init.gradle shadow
+    - name: Compile Java
+      run: ./gradlew --no-daemon compileJava compileTestJava
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -73,8 +73,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, Go, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+#    - name: Autobuild
+#      uses: github/codeql-action/autobuild@v2
 #      run: ./gradlew --no-daemon --init-script init.gradle clean
 
     # ℹ️ Command-line programs to run using the OS shell.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,7 +56,7 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
     - name: Init gradle
-      run: ./gradlew --no-daemon --init-script init.gradle clean
+      run: ./gradlew --init-script init.gradle shadow
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,7 +72,7 @@ jobs:
         key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
     - name: Compile Java
-      run: ./gradlew --no-daemon compileJava compileTestJava
+      run: ./gradlew --no-daemon --init-script init.gradle compileJava compileTestJava
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,24 +48,32 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
-#      uses: actions/checkout@v2
+      uses: actions/checkout@v2
 
-#    - name: Set up JDK 17
-#      uses: actions/setup-java@v2
-#      with:
-#        java-version: '17'
-#        distribution: 'temurin'
-#
-#    - uses: actions/cache@v2
-#      with:
-#        path: |
-#          ~/.gradle/caches
-#          ~/.gradle/wrapper
-#        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+    - name: Set up JDK 17
+      uses: actions/setup-java@v2
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    #    - name: Download neo4j dev docker container
+    #      run: |
+    #        curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_ENTERPRISE_URL} -o ${ENTERPRISE_TAR} &
+    #        curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_COMMUNITY_URL} -o ${COMMUNITY_TAR} &
+    #        wait
+    #        docker load --input ${ENTERPRISE_TAR}
+    #        docker load --input ${COMMUNITY_TAR}
+
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
     - name: Compile Java
       run: ./gradlew --no-daemon --init-script init.gradle clean
+      # compileJava compileTestJava
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -84,6 +92,7 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
+    #      run: ./gradlew --no-daemon --init-script init.gradle clean
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,32 +48,24 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
+#      uses: actions/checkout@v2
 
-    - name: Set up JDK 17
-      uses: actions/setup-java@v2
-      with:
-        java-version: '17'
-        distribution: 'temurin'
-
-#    - name: Download neo4j dev docker container
-#      run: |
-#        curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_ENTERPRISE_URL} -o ${ENTERPRISE_TAR} &
-#        curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_COMMUNITY_URL} -o ${COMMUNITY_TAR} &
-#        wait
-#        docker load --input ${ENTERPRISE_TAR}
-#        docker load --input ${COMMUNITY_TAR}
-
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+#    - name: Set up JDK 17
+#      uses: actions/setup-java@v2
+#      with:
+#        java-version: '17'
+#        distribution: 'temurin'
+#
+#    - uses: actions/cache@v2
+#      with:
+#        path: |
+#          ~/.gradle/caches
+#          ~/.gradle/wrapper
+#        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
     - name: Compile Java
       run: ./gradlew --no-daemon --init-script init.gradle clean
-      # compileJava compileTestJava
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -92,7 +84,6 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
-#      run: ./gradlew --no-daemon --init-script init.gradle clean
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,8 +42,14 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    - name: Set up JDK 17
+      uses: actions/setup-java@v2
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
     - name: Init gradle
-      run: ./gradlew --init-script init.gradle clean
+      run: ./gradlew --init-script init.gradle shadow
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -92,7 +92,7 @@ jobs:
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
-      run: ./gradlew --no-daemon --init-script init.gradle clean
+#      run: ./gradlew --no-daemon --init-script init.gradle clean
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,14 +24,14 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
-#    env:
-#      DOCKER_ENTERPRISE_URL: ${{ secrets.DOCKER_ENTERPRISE_DEV_URL }}
-#      DOCKER_COMMUNITY_URL: ${{ secrets.DOCKER_COMMUNITY_DEV_URL }}
-#      TEAMCITY_DEV_URL: ${{ secrets.TEAMCITY_DEV_URL }}
-#      TEAMCITY_USER: ${{ secrets.TEAMCITY_USER }}
-#      TEAMCITY_PASSWORD: ${{ secrets.TEAMCITY_PASSWORD }}
-#      ENTERPRISE_TAR: enterprise-docker.tar
-#      COMMUNITY_TAR: community-docker.tar
+    env:
+      DOCKER_ENTERPRISE_URL: ${{ secrets.DOCKER_ENTERPRISE_DEV_URL }}
+      DOCKER_COMMUNITY_URL: ${{ secrets.DOCKER_COMMUNITY_DEV_URL }}
+      TEAMCITY_DEV_URL: ${{ secrets.TEAMCITY_DEV_URL }}
+      TEAMCITY_USER: ${{ secrets.TEAMCITY_USER }}
+      TEAMCITY_PASSWORD: ${{ secrets.TEAMCITY_PASSWORD }}
+      ENTERPRISE_TAR: enterprise-docker.tar
+      COMMUNITY_TAR: community-docker.tar
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
To make green the `CodeQL / Analyze (java) (pull_request)` CI job.
 
See here: https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/5109791018/jobs/9184959523?pr=3584#step:4:166
```
  Error: 5-29 07:59:43] [ERROR] Spawned process exited abnormally (code 1; tried to run: [./gradlew, --no-daemon, -S, -Dorg.gradle.dependency.verification=off, --init-script, /tmp/semmleTempDir/init.gradle, clean])
  Error: We were unable to automatically build your code. Please replace the call to the autobuild action with your custom build steps. Failure invoking /opt/hostedtoolcache/CodeQL/2.13.1-20230428/x64/codeql/java/tools/autobuild.sh with arguments .
```

----

### Changes: 
- Added env variable like in `ci.yaml` file
- Workaround as explained here: https://github.com/github/codeql-action/issues/824#issuecomment-977166148, by adding `--init-script` too, in order to fetch latest core changes



----

- [x] Waiting for bump
- [x] Waiting for https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3660 

