### PR TITLE
DETACH DELETE in TTLLifeCycle.java

### DIFF
--- a/extended/src/main/java/apoc/ttl/TTLLifeCycle.java
+++ b/extended/src/main/java/apoc/ttl/TTLLifeCycle.java
@@ -64,7 +64,7 @@ public class TTLLifeCycle extends LifecycleAdapter {
             );
 
             long nodesDeleted = db.executeTransactionally(
-                    "CALL apoc.periodic.iterate($queryNodes, 'MATCH (n) WHERE id(n) = id DELETE n', {batchSize: $batchSize})",
+                    "CALL apoc.periodic.iterate($queryNodes, 'MATCH (n) WHERE id(n) = id DETACH DELETE n', {batchSize: $batchSize})",
                     params,
                     result -> Iterators.single(result.columnAs("total"))
             );


### PR DESCRIPTION
Fixes #3607

For the nodes deletion statement, just to be safe if any new relationships have sneaked in since the rel-deletion that they would be caught as well.