### PR TITLE
[NOID] apoc.schema.* Fix unique constraint column

### DIFF
--- a/core/src/main/java/apoc/schema/Schemas.java
+++ b/core/src/main/java/apoc/schema/Schemas.java
@@ -136,8 +136,12 @@ public class Schemas {
         Schema schema = tx.schema();
 
         for (ConstraintDefinition definition : schema.getConstraints()) {
+            ConstraintType constraintType = definition.getConstraintType();
             String label = definition.isConstraintType(ConstraintType.RELATIONSHIP_PROPERTY_EXISTENCE) ? definition.getRelationshipType().name() : definition.getLabel().name();
-            AssertSchemaResult info = new AssertSchemaResult(label, Iterables.asList(definition.getPropertyKeys())).unique();
+            AssertSchemaResult info = new AssertSchemaResult(label, Iterables.asList(definition.getPropertyKeys()));
+            if (Util.constraintIsUnique(constraintType)) {
+                info = info.unique();
+            }
             if (!checkIfConstraintExists(label, constraints, info)) {
                 if (dropExisting) {
                     definition.drop();

--- a/core/src/main/java/apoc/util/Util.java
+++ b/core/src/main/java/apoc/util/Util.java
@@ -44,6 +44,7 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionTerminatedException;
+import org.neo4j.graphdb.schema.ConstraintType;
 import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.internal.helpers.collection.Pair;
 import org.neo4j.internal.kernel.api.procs.ProcedureCallContext;
@@ -1230,4 +1231,10 @@ public class Util {
                 (i) -> Util.valueEquals(i, value)
         );
     }
+
+    public static boolean constraintIsUnique(ConstraintType type) {
+        return type == ConstraintType.NODE_KEY ||
+                type == ConstraintType.UNIQUENESS;
+    }
+
 }

--- a/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
+++ b/core/src/test/java/apoc/schema/SchemasEnterpriseFeaturesTest.java
@@ -265,7 +265,7 @@ public class SchemasEnterpriseFeaturesTest {
         testCall(session, "CALL apoc.schema.assert({},{})", (r) -> {
             assertEquals("Movie", r.get("label"));
             assertEquals(expectedKeys("title"), r.get("keys"));
-            assertTrue("should be unique", (boolean) r.get("unique"));
+            assertFalse((boolean) r.get("unique"));
             assertEquals("DROPPED", r.get("action"));
         });
 
@@ -288,7 +288,7 @@ public class SchemasEnterpriseFeaturesTest {
         testCall(session, "CALL apoc.schema.assert({},{})", (r) -> {
             assertEquals("Acted", r.get("label"));
             assertEquals(expectedKeys("since"), r.get("keys"));
-            assertTrue("should be unique", (boolean) r.get("unique"));
+            assertFalse((boolean) r.get("unique"));
             assertEquals("DROPPED", r.get("action"));
         });
 


### PR DESCRIPTION
Cherry Picked: https://github.com/neo4j/apoc/pull/424

Picked only the fix related to 4.4, which was the unique column always being true even if the constraint was not a uniqueness constraint