### PR TITLE
[NOID] Mitigate CVE-2022-42003 by upgrading  org.apache.arrow to version 12.0.1.

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -231,7 +231,6 @@ Apache-2.0
   shiro-crypto-hash-1.11.0.jar
   shiro-event-1.11.0.jar
   shiro-lang-1.11.0.jar
-  snakeyaml-1.32.jar
   snappy-java-1.1.8.2.jar
   token-provider-1.0.1.jar
   websocket-api-9.4.48.v20220622.jar

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -261,7 +261,6 @@ Apache-2.0
   shiro-crypto-hash-1.11.0.jar
   shiro-event-1.11.0.jar
   shiro-lang-1.11.0.jar
-  snakeyaml-1.32.jar
   snappy-java-1.1.8.2.jar
   token-provider-1.0.1.jar
   websocket-api-9.4.48.v20220622.jar

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -144,19 +144,19 @@ dependencies {
 
     compile group: 'xerces', name: 'xercesImpl', version: '2.12.2'
 
-    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '10.0.1', {
+    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '12.0.1', {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
         exclude group: 'io.netty', module: 'netty-common'
     }
-    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '10.0.1', {
+    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '12.0.1', {
         exclude group: 'com.google.guava', module: 'guava'
         exclude group: 'io.netty', module: 'netty-common'
         exclude group: 'io.netty', module: 'netty-buffer'
     }
-    testCompile group: 'org.apache.arrow', name: 'arrow-vector', version: '10.0.1'
-    testCompile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '10.0.1'
+    testCompile group: 'org.apache.arrow', name: 'arrow-vector', version: '12.0.1'
+    testCompile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '12.0.1'
 
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -88,7 +88,6 @@ dependencies {
         exclude module: "commons-lang3"
         exclude module: "commons-text"
     }
-    compile group: 'org.yaml', name: 'snakeyaml', version: '1.32'
     testCompile group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
 
     testCompile 'net.sourceforge.jexcelapi:jxl:2.6.12'

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -42,6 +42,6 @@ dependencies {
     compile group: 'org.testcontainers', name: 'postgresql', version: testContainersVersion
     compile group: 'org.testcontainers', name: 'cassandra', version: testContainersVersion
     compile group: 'org.testcontainers', name: 'localstack', version: testContainersVersion
-    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '10.0.1'
-    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '10.0.1'
+    compile group: 'org.apache.arrow', name: 'arrow-vector', version: '12.0.1'
+    compile group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '12.0.1'
 }


### PR DESCRIPTION
Also removes unused snakeyaml dependency
