### PR TITLE
[VpC8nqNz] Adds license and notice validation to the CI (#451)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -41,6 +41,17 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
 
+  license-checks:
+    runs-on: ubuntu-latest
+    needs: compile
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-jdk
+      - uses: ./.github/actions/setup-gradle-cache
+      - name: Check LICENSE and NOTICE files
+        run: ./gradlew validateLicenses generateLicensesFiles
+
   tests:
     strategy:
       fail-fast: false

--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -96,23 +96,18 @@ Apache-2.0
   j2objc-annotations-2.8.jar
   jPowerShell-3.0.jar
   jProcesses-1.6.5.jar
-  jackson-annotations-2.13.4.jar
-  jackson-annotations-2.15.1.jar
-  jackson-core-2.13.4.jar
-  jackson-core-2.15.1.jar
+  jackson-annotations-2.15.2.jar
+  jackson-core-2.15.2.jar
   jackson-core-asl-1.9.13.jar
-  jackson-databind-2.13.4.2.jar
-  jackson-databind-2.15.1.jar
-  jackson-dataformat-cbor-2.15.1.jar
-  jackson-dataformat-csv-2.15.1.jar
+  jackson-databind-2.15.2.jar
+  jackson-dataformat-cbor-2.15.2.jar
+  jackson-dataformat-csv-2.15.2.jar
   jackson-datatype-jsr310-2.15.1.jar
-  jackson-jaxrs-base-2.13.4.jar
-  jackson-jaxrs-base-2.15.1.jar
-  jackson-jaxrs-json-provider-2.13.4.jar
-  jackson-jaxrs-json-provider-2.15.1.jar
+  jackson-datatype-jsr310-2.15.2.jar
+  jackson-jaxrs-base-2.15.2.jar
+  jackson-jaxrs-json-provider-2.15.2.jar
   jackson-mapper-asl-1.9.13.jar
-  jackson-module-jaxb-annotations-2.13.4.jar
-  jackson-module-jaxb-annotations-2.15.1.jar
+  jackson-module-jaxb-annotations-2.15.2.jar
   jakarta.validation-api-2.0.2.jar
   jamm-0.3.3.jar
   java-util-1.9.0.jar
@@ -124,15 +119,15 @@ Apache-2.0
   jcip-annotations-1.0-1.jar
   jctools-core-3.3.0.jar
   jettison-1.5.4.jar
-  jetty-http-9.4.48.v20220622.jar
-  jetty-io-9.4.48.v20220622.jar
-  jetty-security-9.4.48.v20220622.jar
-  jetty-server-9.4.48.v20220622.jar
-  jetty-servlet-9.4.48.v20220622.jar
-  jetty-util-9.4.48.v20220622.jar
-  jetty-util-ajax-9.4.48.v20220622.jar
-  jetty-webapp-9.4.48.v20220622.jar
-  jetty-xml-9.4.48.v20220622.jar
+  jetty-http-9.4.51.v20230217.jar
+  jetty-io-9.4.51.v20230217.jar
+  jetty-security-9.4.51.v20230217.jar
+  jetty-server-9.4.51.v20230217.jar
+  jetty-servlet-9.4.51.v20230217.jar
+  jetty-util-9.4.51.v20230217.jar
+  jetty-util-ajax-9.4.51.v20230217.jar
+  jetty-webapp-9.4.51.v20230217.jar
+  jetty-xml-9.4.51.v20230217.jar
   jffi-1.2.16-native.jar
   jffi-1.2.16.jar
   jmespath-java-1.12.425.jar

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -126,23 +126,18 @@ Apache-2.0
   j2objc-annotations-2.8.jar
   jPowerShell-3.0.jar
   jProcesses-1.6.5.jar
-  jackson-annotations-2.13.4.jar
-  jackson-annotations-2.15.1.jar
-  jackson-core-2.13.4.jar
-  jackson-core-2.15.1.jar
+  jackson-annotations-2.15.2.jar
+  jackson-core-2.15.2.jar
   jackson-core-asl-1.9.13.jar
-  jackson-databind-2.13.4.2.jar
-  jackson-databind-2.15.1.jar
-  jackson-dataformat-cbor-2.15.1.jar
-  jackson-dataformat-csv-2.15.1.jar
+  jackson-databind-2.15.2.jar
+  jackson-dataformat-cbor-2.15.2.jar
+  jackson-dataformat-csv-2.15.2.jar
   jackson-datatype-jsr310-2.15.1.jar
-  jackson-jaxrs-base-2.13.4.jar
-  jackson-jaxrs-base-2.15.1.jar
-  jackson-jaxrs-json-provider-2.13.4.jar
-  jackson-jaxrs-json-provider-2.15.1.jar
+  jackson-datatype-jsr310-2.15.2.jar
+  jackson-jaxrs-base-2.15.2.jar
+  jackson-jaxrs-json-provider-2.15.2.jar
   jackson-mapper-asl-1.9.13.jar
-  jackson-module-jaxb-annotations-2.13.4.jar
-  jackson-module-jaxb-annotations-2.15.1.jar
+  jackson-module-jaxb-annotations-2.15.2.jar
   jakarta.validation-api-2.0.2.jar
   jamm-0.3.3.jar
   java-util-1.9.0.jar
@@ -154,15 +149,15 @@ Apache-2.0
   jcip-annotations-1.0-1.jar
   jctools-core-3.3.0.jar
   jettison-1.5.4.jar
-  jetty-http-9.4.48.v20220622.jar
-  jetty-io-9.4.48.v20220622.jar
-  jetty-security-9.4.48.v20220622.jar
-  jetty-server-9.4.48.v20220622.jar
-  jetty-servlet-9.4.48.v20220622.jar
-  jetty-util-9.4.48.v20220622.jar
-  jetty-util-ajax-9.4.48.v20220622.jar
-  jetty-webapp-9.4.48.v20220622.jar
-  jetty-xml-9.4.48.v20220622.jar
+  jetty-http-9.4.51.v20230217.jar
+  jetty-io-9.4.51.v20230217.jar
+  jetty-security-9.4.51.v20230217.jar
+  jetty-server-9.4.51.v20230217.jar
+  jetty-servlet-9.4.51.v20230217.jar
+  jetty-util-9.4.51.v20230217.jar
+  jetty-util-ajax-9.4.51.v20230217.jar
+  jetty-webapp-9.4.51.v20230217.jar
+  jetty-xml-9.4.51.v20230217.jar
   jffi-1.2.16-native.jar
   jffi-1.2.16.jar
   jmespath-java-1.12.425.jar
@@ -357,15 +352,15 @@ Eclipse Distribution License - v 1.0
 Eclipse Public License - Version 1.0
   javax-websocket-client-impl-9.4.51.v20230217.jar
   javax-websocket-server-impl-9.4.51.v20230217.jar
-  jetty-http-9.4.48.v20220622.jar
-  jetty-io-9.4.48.v20220622.jar
-  jetty-security-9.4.48.v20220622.jar
-  jetty-server-9.4.48.v20220622.jar
-  jetty-servlet-9.4.48.v20220622.jar
-  jetty-util-9.4.48.v20220622.jar
-  jetty-util-ajax-9.4.48.v20220622.jar
-  jetty-webapp-9.4.48.v20220622.jar
-  jetty-xml-9.4.48.v20220622.jar
+  jetty-http-9.4.51.v20230217.jar
+  jetty-io-9.4.51.v20230217.jar
+  jetty-security-9.4.51.v20230217.jar
+  jetty-server-9.4.51.v20230217.jar
+  jetty-servlet-9.4.51.v20230217.jar
+  jetty-util-9.4.51.v20230217.jar
+  jetty-util-ajax-9.4.51.v20230217.jar
+  jetty-webapp-9.4.51.v20230217.jar
+  jetty-xml-9.4.51.v20230217.jar
   websocket-api-9.4.51.v20230217.jar
   websocket-client-9.4.51.v20230217.jar
   websocket-common-9.4.51.v20230217.jar


### PR DESCRIPTION
Chery-picks https://github.com/neo4j/apoc/pull/451

## Why
`./gradlew check` has this wired, but since the checks are done per project in the CI, the global check is never run 😢, so we need to add this manually.