### PR TITLE
Fixes #3640: Custom procedures declaration fails in 5.x

### DIFF
--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -179,6 +179,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                 false,
                 false,
                 false,
+                false,
                 false), statement);
     }
 

--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -173,7 +173,6 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                 Mode.valueOf((String) node.getProperty(ExtendedSystemPropertyKeys.mode.name())),
                 false,
                 null,
-                new String[0],
                 description,
                 null,
                 false,

--- a/extended/src/main/java/apoc/custom/Signatures.java
+++ b/extended/src/main/java/apoc/custom/Signatures.java
@@ -254,12 +254,13 @@ public class Signatures {
             final Constructor<?>[] constructors = clazz.getConstructors();
             for (Constructor c: constructors) {
                 System.out.println("c.getParameters() = " + Arrays.toString(c.getParameters()));
+                System.out.println("c.getParameters Names() = " + Arrays.stream(c.getParameters()).map(i -> i.getName()).collect(Collectors.joining(", ")));
             }
         } catch (Exception e) {
             System.out.println("e = " + e);
         }
         return null;
-
+//
 //        return new ProcedureSignature(name,
 //                inputSignature,
 //                outputSignature,

--- a/extended/src/main/java/apoc/custom/Signatures.java
+++ b/extended/src/main/java/apoc/custom/Signatures.java
@@ -7,6 +7,7 @@ import org.neo4j.procedure.Mode;
 
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -85,11 +86,10 @@ public class Signatures {
         List<FieldSignature> inputSignatures = signature.parameter().stream().map(p -> getInputField(name(p.name()), type(p.type()), defaultValue(p.defaultValue(), type(p.type())))).collect(Collectors.toList());
         boolean admin = false;
         String deprecated = "";
-        String[] allowed = new String[0];
         String warning = null; // "todo warning";
         boolean eager = false;
         boolean caseInsensitive = true;
-        return createProcedureSignature(name, inputSignatures, outputSignature, mode, admin, deprecated, allowed, description, warning, eager, caseInsensitive, false, false, false);
+        return createProcedureSignature(name, inputSignatures, outputSignature, mode, admin, deprecated, description, warning, eager, caseInsensitive, false, false, false);
     }
 
     public List<String> namespace(SignatureParser.NamespaceContext namespaceContext) {
@@ -237,7 +237,6 @@ public class Signatures {
                                                               Mode mode,
                                                               boolean admin,
                                                               String deprecated,
-                                                              String[] allowed,
                                                               String description,
                                                               String warning,
                                                               boolean eager,
@@ -253,56 +252,26 @@ public class Signatures {
             // in Neo4j 4.3 another boolean was added
             final Class<?> clazz = Class.forName("org.neo4j.internal.kernel.api.procs.ProcedureSignature");
             final Constructor<?>[] constructors = clazz.getConstructors();
-            for (int i = 0; i < constructors.length; i++) {
-                final Constructor<?> constructor = constructors[i];
-                switch (constructor.getParameterCount()) {
-                    case 14:
-                        return (ProcedureSignature) constructor.newInstance(name,
-                                inputSignature,
-                                outputSignature,
-                                mode,
-                                admin,
-                                deprecated,
-                                allowed,
-                                description,
-                                warning,
-                                eager,
-                                caseInsensitive,
-                                systemProcedure,
-                                internal,
-                                allowExpiredCredentials);
-                    case 13:
-                        return (ProcedureSignature) constructor.newInstance(name,
-                                inputSignature,
-                                outputSignature,
-                                mode,
-                                admin,
-                                deprecated,
-                                allowed,
-                                description,
-                                warning,
-                                eager,
-                                caseInsensitive,
-                                systemProcedure,
-                                internal);
-                    case 12:
-                        return (ProcedureSignature) constructor.newInstance(name,
-                                inputSignature,
-                                outputSignature,
-                                mode,
-                                admin,
-                                deprecated,
-                                allowed,
-                                description,
-                                warning,
-                                eager,
-                                caseInsensitive,
-                                systemProcedure);
-                }
+            for (Constructor c: constructors) {
+                System.out.println("c.getParameters() = " + Arrays.toString(c.getParameters()));
             }
-            throw new RuntimeException("Constructor of org.neo4j.internal.kernel.api.procs.ProcedureSignature not found");
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            System.out.println("e = " + e);
         }
+        return null;
+
+//        return new ProcedureSignature(name,
+//                inputSignature,
+//                outputSignature,
+//                mode,
+//                admin,
+//                deprecated,
+//                description,
+//                warning,
+//                eager,
+//                caseInsensitive,
+//                systemProcedure,
+//                internal,
+//                allowExpiredCredentials);
     }
 }

--- a/extended/src/main/java/apoc/custom/Signatures.java
+++ b/extended/src/main/java/apoc/custom/Signatures.java
@@ -5,9 +5,7 @@ import org.antlr.v4.runtime.*;
 import org.neo4j.internal.kernel.api.procs.*;
 import org.neo4j.procedure.Mode;
 
-import java.lang.reflect.Constructor;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -89,7 +87,7 @@ public class Signatures {
         String warning = null; // "todo warning";
         boolean eager = false;
         boolean caseInsensitive = true;
-        return createProcedureSignature(name, inputSignatures, outputSignature, mode, admin, deprecated, description, warning, eager, caseInsensitive, false, false, false);
+        return createProcedureSignature(name, inputSignatures, outputSignature, mode, admin, deprecated, description, warning, eager, caseInsensitive, false, false, false, false);
     }
 
     public List<String> namespace(SignatureParser.NamespaceContext namespaceContext) {
@@ -243,36 +241,21 @@ public class Signatures {
                                                               boolean caseInsensitive,
                                                               boolean systemProcedure,
                                                               boolean internal,
-                                                              boolean allowExpiredCredentials) {
-        try {
-            // in Neo4j 4.0.5 org.neo4j.internal.kernel.api.procs.ProcedureSignature
-            // changed the signature adding a boolean at the end and without leaving the old signature
-            // in order to maintain the backwards compatibility with version prior to 4.0.5 we use the
-            // reflection to create a new instance of the class
-            // in Neo4j 4.3 another boolean was added
-            final Class<?> clazz = Class.forName("org.neo4j.internal.kernel.api.procs.ProcedureSignature");
-            final Constructor<?>[] constructors = clazz.getConstructors();
-            for (Constructor c: constructors) {
-                System.out.println("c.getParameters() = " + Arrays.toString(c.getParameters()));
-                System.out.println("c.getParameters Names() = " + Arrays.stream(c.getParameters()).map(i -> i.getName()).collect(Collectors.joining(", ")));
-            }
-        } catch (Exception e) {
-            System.out.println("e = " + e);
-        }
-        return null;
-//
-//        return new ProcedureSignature(name,
-//                inputSignature,
-//                outputSignature,
-//                mode,
-//                admin,
-//                deprecated,
-//                description,
-//                warning,
-//                eager,
-//                caseInsensitive,
-//                systemProcedure,
-//                internal,
-//                allowExpiredCredentials);
+                                                              boolean allowExpiredCredentials,
+                                                              boolean threadSafe) {
+        return new ProcedureSignature(name,
+                inputSignature,
+                outputSignature,
+                mode,
+                admin,
+                deprecated,
+                description,
+                warning,
+                eager,
+                caseInsensitive,
+                systemProcedure,
+                internal,
+                allowExpiredCredentials,
+                threadSafe);
     }
 }


### PR DESCRIPTION
~WIP: in 5.10.0 the Signature is changed again. Waiting for release to check what is changed~


Fixes #3640

The issue affects any `5.x` version.

Sporadically [the reflection](https://github.com/vga91/neo4j-apoc-procedures/compare/dev...vga91:neo4j-apoc-procedures:issue-3640?expand=1#diff-7a6794bc38939217b5b8ca0f55b06b9cfd4bfd59ebd1be9e2a4709f12c2c3304L248) finds 2 constructors and cycles starting with the one having 13 parameters, but in that case the following error is thrown, because it finds [this constructor](https://github.com/neo4j/neo4j/blob/5.9.0/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/ProcedureSignature.java#L54) (which is btw `Deprecated`) before the next non-deprecated one.
```
Caused by: java.lang.RuntimeException: java.lang.IllegalArgumentException: argument type mismatch
```

Anyway, reflection should no longer be needed, since previously we could have e.g. an APOC 4.x compatible with Neo4j 4.x.y (with ProcedureSignature having 14 elements) and 4.x.z (with ProcedureSignature having 13 elements).

In Neo4j 5 it shouldn't happen, because, for example, APOC 5.9.0 is compatible with Neo4j 5.9.x, and theoretically, as it says [here](https://neo4j.com/developer/kb/neo4j-supported-versions/), the `x` version increments only in case of hotfixes, therefore should not cause breaking changes.

---

Tried adding some junit tests, with both enterprise and docker, but it always works as it starts cycling starting the 14-element one first, even if you try restarting the database several times