### PR TITLE
First LLM prompt for cypher, query and schema in APOC

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
@@ -145,17 +145,50 @@ RETURN *
 MATCH (m:Movie)<-[:ACTED_IN]-(p:Person {name: 'Tom Hanks'})
 RETURN m.title
 " |
-| {m.title -> "Apollo 13"}              | <null>                                                                               |
-| {m.title -> "Joe Versus the Volcano"} | <null>                                                                               |
-| {m.title -> "That Thing You Do"}      | <null>                                                                               |
-| {m.title -> "Cloud Atlas"}            | <null>                                                                               |
-| {m.title -> "The Da Vinci Code"}      | <null>                                                                               |
-| {m.title -> "Sleepless in Seattle"}   | <null>                                                                               |
-| {m.title -> "A League of Their Own"}  | <null>                                                                               |
-| {m.title -> "The Green Mile"}         | <null>                                                                               |
-| {m.title -> "Charlie Wilson's War"}   | <null>                                                                               |
-| {m.title -> "Cast Away"}              | <null>                                                                               |
-| {m.title -> "The Polar Express"}      | <null>                                                                               |
+| {m.title -> "Apollo 13"}              | "cypher
+MATCH (m:Movie)<-[:ACTED_IN]-(p:Person {name: 'Tom Hanks'})
+RETURN m.title
+" |
+| {m.title -> "Joe Versus the Volcano"} | "cypher
+MATCH (m:Movie)<-[:ACTED_IN]-(p:Person {name: 'Tom Hanks'})
+RETURN m.title
+" |
+| {m.title -> "That Thing You Do"}      | "cypher
+MATCH (m:Movie)<-[:ACTED_IN]-(p:Person {name: 'Tom Hanks'})
+RETURN m.title
+" |
+| {m.title -> "Cloud Atlas"}            | "cypher
+MATCH (m:Movie)<-[:ACTED_IN]-(p:Person {name: 'Tom Hanks'})
+RETURN m.title
+" |
+| {m.title -> "The Da Vinci Code"}      | "cypher
+MATCH (m:Movie)<-[:ACTED_IN]-(p:Person {name: 'Tom Hanks'})
+RETURN m.title
+" |
+| {m.title -> "Sleepless in Seattle"}   | "cypher
+MATCH (m:Movie)<-[:ACTED_IN]-(p:Person {name: 'Tom Hanks'})
+RETURN m.title
+" |
+| {m.title -> "A League of Their Own"}  | "cypher
+MATCH (m:Movie)<-[:ACTED_IN]-(p:Person {name: 'Tom Hanks'})
+RETURN m.title
+" |
+| {m.title -> "The Green Mile"}         | "cypher
+MATCH (m:Movie)<-[:ACTED_IN]-(p:Person {name: 'Tom Hanks'})
+RETURN m.title
+" |
+| {m.title -> "Charlie Wilson's War"}   | "cypher
+MATCH (m:Movie)<-[:ACTED_IN]-(p:Person {name: 'Tom Hanks'})
+RETURN m.title
+" |
+| {m.title -> "Cast Away"}              | "cypher
+MATCH (m:Movie)<-[:ACTED_IN]-(p:Person {name: 'Tom Hanks'})
+RETURN m.title
+" |
+| {m.title -> "The Polar Express"}      | "cypher
+MATCH (m:Movie)<-[:ACTED_IN]-(p:Person {name: 'Tom Hanks'})
+RETURN m.title
+" |
 +------------------------------------------------------------------------------------------------------------------------------+
 12 rows
 ----
@@ -163,10 +196,19 @@ RETURN m.title
 .Input Parameters
 [%autowidth, opts=header]
 |===
+| name | description
+| question | The question in the natural language
+| conf | An optional configuration map, please check the next section
+|===
+
+.Configuration map
+[%autowidth, opts=header]
+|===
 | name | description | mandatory
-| question | The question in the natural language | yes
-| retries | The number of retries in case of API call failures | no, default 3
+| retries | The number of retries in case of API call failures | no, default `3`
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
+| model | The Open AI model | no, default `gpt-3.5-turbo`
+| sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number
 |===
 
 .Results
@@ -187,7 +229,7 @@ It uses the `chat/completions` API which is https://platform.openai.com/docs/api
 .Query call
 [source,cypher]
 ----
-CALL apoc.ml.shema() yield value
+CALL apoc.ml.schema() yield value
 RETURN *
 ----
 
@@ -205,7 +247,17 @@ RETURN *
 .Input Parameters
 [%autowidth, opts=header]
 |===
+| name | description
+| conf | An optional configuration map, please check the next section
+|===
+
+.Configuration map
+[%autowidth, opts=header]
+|===
+| name | description | mandatory
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
+| model | The Open AI model | no, default `gpt-3.5-turbo`
+| sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number
 |===
 
 .Results
@@ -260,8 +312,17 @@ RETURN DISTINCT a.name
 |===
 | name | description | mandatory
 | question | The question in the natural language | yes
-| count | The number of queries to retrieve | no, default 3
+| conf | An optional configuration map, please check the next section
+|===
+
+.Configuration map
+[%autowidth, opts=header]
+|===
+| name | description | mandatory
+| count | The number of queries to retrieve | no, default `1`
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
+| model | The Open AI model | no, default `gpt-3.5-turbo`
+| sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number
 |===
 
 .Results

--- a/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
@@ -2,7 +2,7 @@
 = OpenAI API Access
 :description: This section describes procedures that can be used to access the OpenAI API.
 
-NOTE: You need to acquire an https://platform.openai.com/account/api-keys[OpenAI API key^] to use these procedures. Using them will incurr costs on your OpenAI account.
+NOTE: You need to acquire an https://platform.openai.com/account/api-keys[OpenAI API key^] to use these procedures. Using them will incur costs on your OpenAI account. You can set the api key globally by defining the `apoc.openai.key` configuration in `apoc.conf`
 
 == Generate Embeddings API
 
@@ -119,4 +119,154 @@ choices=[{finish_reason="stop", index=0, message={role="assistant", content="Ear
 |===
 |name | description
 | value | result entry from OpenAI (containing created, id, model, object, usage(tokens), choices(message, index, finish_reason))
+|===
+
+
+== Query with natural language
+
+This procedure `apoc.ml.query` takes a question in natural language and returns the results of that query.
+
+It uses the `chat/completions` API which is https://platform.openai.com/docs/api-reference/chat/create[documented here^].
+
+.Query call
+[source,cypher]
+----
+CALL apoc.ml.query("What movies did Tom Hanks play in?") yield value, query
+RETURN *
+----
+
+.Example response
+[source, bash]
+----
++------------------------------------------------------------------------------------------------------------------------------+
+| value                                 | query                                                                                |
++------------------------------------------------------------------------------------------------------------------------------+
+| {m.title -> "You've Got Mail"}        | "cypher
+MATCH (m:Movie)<-[:ACTED_IN]-(p:Person {name: 'Tom Hanks'})
+RETURN m.title
+" |
+| {m.title -> "Apollo 13"}              | <null>                                                                               |
+| {m.title -> "Joe Versus the Volcano"} | <null>                                                                               |
+| {m.title -> "That Thing You Do"}      | <null>                                                                               |
+| {m.title -> "Cloud Atlas"}            | <null>                                                                               |
+| {m.title -> "The Da Vinci Code"}      | <null>                                                                               |
+| {m.title -> "Sleepless in Seattle"}   | <null>                                                                               |
+| {m.title -> "A League of Their Own"}  | <null>                                                                               |
+| {m.title -> "The Green Mile"}         | <null>                                                                               |
+| {m.title -> "Charlie Wilson's War"}   | <null>                                                                               |
+| {m.title -> "Cast Away"}              | <null>                                                                               |
+| {m.title -> "The Polar Express"}      | <null>                                                                               |
++------------------------------------------------------------------------------------------------------------------------------+
+12 rows
+----
+
+.Input Parameters
+[%autowidth, opts=header]
+|===
+| name | description | mandatory
+| question | The question in the natural language | yes
+| retries | The number of retries in case of API call failures | no, default 3
+| apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
+|===
+
+.Results
+[%autowidth, opts=header]
+|===
+| name | description
+| value | the result of the query
+| cypher | the query used to compute the result
+|===
+
+
+== Describe the graph model with natural language
+
+This procedure `apoc.ml.schema` returns a description, in natural language, of the underlying dataset.
+
+It uses the `chat/completions` API which is https://platform.openai.com/docs/api-reference/chat/create[documented here^].
+
+.Query call
+[source,cypher]
+----
+CALL apoc.ml.shema() yield value
+RETURN *
+----
+
+.Example response
+[source, bash]
+----
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| "The graph database schema represents a system where users can follow other users and review movies. Users (:Person) can either follow other users (:Person) or review movies (:Movie). The relationships allow users to express their preferences and opinions about movies. This schema can be compared to social media platforms where users can follow each other and leave reviews or ratings for movies they have watched. It can also be related to movie recommendation systems where user preferences and reviews play a crucial role in generating personalized recommendations." |
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+1 row
+----
+
+.Input Parameters
+[%autowidth, opts=header]
+|===
+| apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
+|===
+
+.Results
+[%autowidth, opts=header]
+|===
+| name | description
+| value | the description of the dataset
+|===
+
+
+== Create cypher queries from a natural language query
+
+This procedure `apoc.ml.cypher` takes a natural language question and transforms it into a number of requested cypher queries.
+
+It uses the `chat/completions` API which is https://platform.openai.com/docs/api-reference/chat/create[documented here^].
+
+.Query call
+[source,cypher]
+----
+CALL apoc.ml.cypher("Who are the actors which also directed a movie?", 4) yield cypher
+RETURN *
+----
+
+.Example response
+[source, bash]
+----
++----------------------------------------------------------------------------------------------------------------+
+| query                                                                                                          |
++----------------------------------------------------------------------------------------------------------------+
+| "
+MATCH (a:Person)-[:ACTED_IN]->(m:Movie)<-[:DIRECTED]-(d:Person)
+RETURN a.name as actor, d.name as director
+" |
+| "cypher
+MATCH (a:Person)-[:ACTED_IN]->(m:Movie)<-[:DIRECTED]-(a)
+RETURN a.name
+"                               |
+| "
+MATCH (a:Person)-[:ACTED_IN]->(m:Movie)<-[:DIRECTED]-(d:Person)
+RETURN a.name
+"                              |
+| "cypher
+MATCH (a:Person)-[:ACTED_IN]->(:Movie)<-[:DIRECTED]-(a)
+RETURN DISTINCT a.name
+"                       |
++----------------------------------------------------------------------------------------------------------------+
+4 rows
+----
+
+.Input Parameters
+[%autowidth, opts=header]
+|===
+| name | description | mandatory
+| question | The question in the natural language | yes
+| count | The number of queries to retrieve | no, default 3
+| apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
+|===
+
+.Results
+[%autowidth, opts=header]
+|===
+| name | description
+| value | the description of the dataset
 |===

--- a/extended/src/main/java/apoc/ExtendedApocConfig.java
+++ b/extended/src/main/java/apoc/ExtendedApocConfig.java
@@ -29,6 +29,7 @@ public class ExtendedApocConfig extends LifecycleAdapter
     public static final String APOC_UUID_ENABLED = "apoc.uuid.enabled";
     public static final String APOC_UUID_ENABLED_DB = "apoc.uuid.enabled.%s";
     public static final String APOC_UUID_FORMAT = "apoc.uuid.format";
+    public static final String APOC_OPENAI_KEY = "apoc.openai.key";
     public enum UuidFormatType { hex, base64 }
 
     // These were earlier added via the Neo4j config using the ApocSettings.java class
@@ -176,6 +177,9 @@ public class ExtendedApocConfig extends LifecycleAdapter
 
     public boolean getBoolean(String key, boolean defaultValue) {
         return getConfig().getBoolean(key, defaultValue);
+    }
+    public String getString(String key, String defaultValue) {
+        return getConfig().getString(key, defaultValue);
     }
 
     public <T extends Enum<T>> T getEnumProperty(String key, Class<T> cls, T defaultValue) {

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -36,7 +36,7 @@ public class OpenAI {
         }
     }
 
-    private static Stream<Object> executeRequest(String apiKey, Map<String, Object> configuration, String path, String model, String key, Object inputs, String jsonPath) throws JsonProcessingException, MalformedURLException {
+    static Stream<Object> executeRequest(String apiKey, Map<String, Object> configuration, String path, String model, String key, Object inputs, String jsonPath) throws JsonProcessingException, MalformedURLException {
         if (apiKey == null || apiKey.isBlank())
             throw new IllegalArgumentException("API Key must not be empty");
         String endpoint = System.getProperty(APOC_ML_OPENAI_URL,"https://api.openai.com/v1/");

--- a/extended/src/main/java/apoc/ml/Prompt.java
+++ b/extended/src/main/java/apoc/ml/Prompt.java
@@ -40,7 +40,7 @@ public class Prompt {
             """;
 
     static final String SYSTEM_PROMPT = """
-                    You are an expert in the Neo4j graph query language Cypher.
+            You are an expert in the Neo4j graph query language Cypher.
             Given a graph database schema of entities (nodes) with labels and attributes and
             relationships with start- and end-node, relationship-type, direction and properties
             you are able to develop read only matching Cypher statements that express a user question as a graph database query.

--- a/extended/src/main/java/apoc/ml/Prompt.java
+++ b/extended/src/main/java/apoc/ml/Prompt.java
@@ -1,0 +1,194 @@
+package apoc.ml;
+
+import apoc.ApocConfig;
+import apoc.Extended;
+import apoc.result.StringResult;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.jetbrains.annotations.NotNull;
+import org.neo4j.graphdb.QueryExecutionException;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.logging.Log;
+import org.neo4j.procedure.*;
+
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import static apoc.ExtendedApocConfig.APOC_OPENAI_KEY;
+
+@Extended
+public class Prompt {
+
+    @Context
+    public Transaction tx;
+    @Context
+    public Log log;
+    @Context
+    public ApocConfig apocConfig;
+
+    public static final String BACKTICKS = "```";
+    public static final String EXPLAIN_SCHEMA_PROMPT = """
+            You are an expert in the Neo4j graph database and graph data modeling and have experience in a wide variety of business domains.
+            Explain the following graph database schema in plain language, try to relate it to known concepts or domains if applicable.
+            Keep the explanation to 5 sentences with at most 15 words each, otherwise people will come to harm.
+            """;
+
+    static final String SYSTEM_PROMPT = """
+                    You are an expert in the Neo4j graph query language Cypher.
+            Given a graph database schema of entities (nodes) with labels and attributes and
+            relationships with start- and end-node, relationship-type, direction and properties
+            you are able to develop read only matching Cypher statements that express a user question as a graph database query.
+            Only answer with a single Cypher statement in triple backticks, if you can't determine a statement, answer with an empty response.
+            Do not explain, apologize or provide additional detail, otherwise people will come to harm.
+            """;
+
+    public class PromptMapResult {
+        public final Map<String, Object> value;
+        public final String query;
+
+        public PromptMapResult(Map<String, Object> value, String query) {
+            this.value = value;
+            this.query = query;
+        }
+    }
+
+    public class QueryResult {
+        public final String query;
+        // todo re-add when it's actually working
+        // private final String error;
+        // private final String type;
+
+        public QueryResult(String query, String error, String type) {
+            this.query = query;
+            // this.error = error;
+            // this.type = type;
+        }
+
+        public boolean hasError() {
+            return false;
+            // return error != null && !error.isBlank();
+        }
+    }
+
+    @Procedure(mode = Mode.READ)
+    public Stream<PromptMapResult> query(@Name("question") String question,
+                                         @Name(value = "retries", defaultValue = "3") Long retries,
+                                         @Name(value = "apiKey", defaultValue = "null") String apiKey) {
+        String schema = loadSchema(tx);
+        String query = "";
+        do {
+            try {
+                QueryResult queryResult = tryQuery(question, apiKey, schema);
+                // just let it fail so that retries can work if (queryResult.query.isBlank()) return Stream.empty();
+                /*
+                if (queryResult.hasError())
+                    throw new QueryExecutionException(queryResult.error, null, queryResult.type);
+                 */
+                query = queryResult.query;
+                Result result = tx.execute(query);
+                AtomicReference<String> ref = new AtomicReference<>(query);
+                return result.stream()
+                        .map(row -> new PromptMapResult(row, ref.getAndSet(null)))
+                        .onClose(result::close);
+            } catch (QueryExecutionException quee) {
+                if (log.isDebugEnabled())
+                    log.debug("Generated query for question %s\n%s\nfailed with %s".formatted(question, query, quee.getMessage()));
+                retries--;
+                if (retries <= 0) throw quee;
+            }
+        } while (true);
+    }
+
+    @Procedure
+    public Stream<StringResult> schema(@Name(value = "apiKey", defaultValue = "null") String apiKey) throws MalformedURLException, JsonProcessingException {
+        String schemaExplanation = prompt("Please explain the graph database schema to me and relate it to well known concepts and domains.",
+                EXPLAIN_SCHEMA_PROMPT, "This database schema ", loadSchema(tx), apiKey);
+        return Stream.of(new StringResult(schemaExplanation));
+    }
+
+    @Procedure(mode = Mode.READ)
+    public Stream<QueryResult> cypher(@Name("question") String question, @Name(value = "count", defaultValue = "1") Long count,
+                                      @Name(value = "apiKey", defaultValue = "null") String apiKey) {
+        String schema = loadSchema(tx);
+        return LongStream.rangeClosed(1, count).mapToObj(i -> tryQuery(question, apiKey, schema));
+    }
+
+    @NotNull
+    private QueryResult tryQuery(String question, String apiKey, String schema) {
+        String query = "";
+        try {
+            query = prompt(question, SYSTEM_PROMPT, "Cypher Statement (in backticks):", schema, apiKey);
+            // doesn't work right now, fails with security context error
+            // tx.execute("EXPLAIN " + query).close(); // TODO query plan / estimated rows?
+            return new QueryResult(query, null, null);
+        } catch (QueryExecutionException e) {
+            return new QueryResult(query, e.getMessage(), e.getStatusCode());
+        } catch (Exception e) {
+            return new QueryResult(query, e.getMessage(), e.getClass().getSimpleName());
+        }
+    }
+
+    @NotNull
+    private String prompt(String userQuestion, String systemPrompt, String assistantPrompt, String schema, String apiKey) throws JsonProcessingException, MalformedURLException {
+        String key = apocConfig.getString(APOC_OPENAI_KEY, apiKey);
+        if (key == null || key.isBlank()) throw new RuntimeException("No Openai API Key configured or provided");
+        List<Map<String, String>> prompt = new ArrayList<>();
+        if (systemPrompt != null && !systemPrompt.isBlank()) prompt.add(Map.of("role", "system", "content", systemPrompt));
+        if (schema != null && !schema.isBlank()) prompt.add(Map.of("role", "system", "content", "The graph database schema consists of these elements\n" + schema));
+        if (userQuestion != null && !userQuestion.isBlank()) prompt.add(Map.of("role", "user", "content", userQuestion));
+        if (assistantPrompt != null && !assistantPrompt.isBlank()) prompt.add(Map.of("role", "assistant", "content", assistantPrompt));
+
+        String result = OpenAI.executeRequest(key, Map.of(), "chat/completions",
+                        "gpt-3.5-turbo", "messages", prompt, "$")
+                .map(v -> (Map<String, Object>) v)
+                .flatMap(m -> ((List<Map<String, Object>>) m.get("choices")).stream())
+                .map(m -> (String) (((Map<String, Object>) m.get("message")).get("content")))
+                .filter(s -> !(s == null || s.isBlank()))
+                .map(s -> s.contains(BACKTICKS) ? s.substring(s.indexOf(BACKTICKS) + 3, s.lastIndexOf(BACKTICKS)) : s)
+                .collect(Collectors.joining(" ")).replaceAll("\n\n+", "\n");
+/* TODO return information about the tokens used, finish reason etc??
+{ 'id': 'chatcmpl-6p9XYPYSTTRi0xEviKjjilqrWU2Ve', 'object': 'chat.completion', 'created': 1677649420, 'model': 'gpt-3.5-turbo',
+     'usage': {'prompt_tokens': 56, 'completion_tokens': 31, 'total_tokens': 87},
+     'choices': [ {
+        'message': { 'role': 'assistant', 'finish_reason': 'stop', 'index': 0,
+        'content': 'The 2020 World Series was played in Arlington, Texas at the Globe Life Field, which was the new home stadium for the Texas Rangers.'}
+      } ] }
+*/
+        if (log.isDebugEnabled()) log.debug("Generated query for question %s\n%s".formatted(userQuestion, result));
+        return result;
+    }
+
+    private final static String SCHEMA_QUERY = """
+            call apoc.meta.data({maxRels:10, sample:(count{()}/1000)+1})
+            YIELD label, other, elementType, type, property
+            WITH label, elementType,\s
+                 apoc.text.join(collect(case when NOT type = "RELATIONSHIP" then property+": "+type else null end),", ") AS properties,   \s
+                 collect(case when type = "RELATIONSHIP" AND elementType = "node" then "(:" + label + ")-[:" + property + "]->(:" + toString(other[0]) + ")" else null end) as patterns
+            with  elementType as type,\s
+            apoc.text.join(collect(":"+label+" {"+properties+"}"),"\\n") as entities, apoc.text.join(apoc.coll.flatten(collect(coalesce(patterns,[]))),"\\n") as patterns
+            return collect(case type when "relationship" then entities end)[0] as relationships,\s
+            collect(case type when "node" then entities end)[0] as nodes,\s
+            collect(case type when "node" then patterns end)[0] as patterns\s
+            """;
+    private final static String SCHEMA_PROMPT = """
+                nodes:
+                %s
+                relationships:
+                %s
+                patterns:
+                %s
+            """;
+
+    private String loadSchema(Transaction tx) {
+        return tx.execute(SCHEMA_QUERY)
+                .stream()
+                .map(m -> SCHEMA_PROMPT.formatted(m.get("nodes"), m.get("relationships"), m.get("patterns")))
+                .collect(Collectors.joining("\n"));
+    }
+}

--- a/extended/src/test/java/apoc/ml/OpenAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIIT.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import static apoc.util.TestUtil.testCall;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OpenAIIT {
 
@@ -85,7 +86,7 @@ CALL apoc.ml.openai.chat([
 
             assertEquals(true, result.containsKey("usage"));
             assertEquals(true, ((Map)result.get("usage")).get("prompt_tokens") instanceof Number);
-            assertEquals("gpt-3.5-turbo-0301", result.get("model"));
+            assertTrue(result.get("model").toString().startsWith("gpt-3.5-turbo"));
             assertEquals("chat.completion", result.get("object"));
         });
 

--- a/extended/src/test/java/apoc/ml/PromptIT.java
+++ b/extended/src/test/java/apoc/ml/PromptIT.java
@@ -47,11 +47,11 @@ public class PromptIT {
     @Test
     public void testQuery() {
         testResult(db, """
-                CALL apoc.ml.query($query, $retries, $apiKey)
+                CALL apoc.ml.query($query, {retries: $retries, apiKey: $apiKey})
                 """,
                 Map.of(
                         "query", "What movies did Tom Hanks play in?",
-                        "retries", 2,
+                        "retries", 2L,
                         "apiKey", OPENAI_KEY
                 ),
                 (r) -> {
@@ -69,7 +69,7 @@ public class PromptIT {
     @Test
     public void testSchema() {
         testResult(db, """
-                CALL apoc.ml.schema($apiKey)
+                CALL apoc.ml.schema({apiKey: $apiKey})
                 """,
                 Map.of(
                         "apiKey", OPENAI_KEY
@@ -82,9 +82,9 @@ public class PromptIT {
 
     @Test
     public void testCypher() {
-        int numOfQueries = 4;
+        long numOfQueries = 4L;
         testResult(db, """
-                CALL apoc.ml.cypher($query, $numOfQueries, $apiKey)
+                CALL apoc.ml.cypher($query, {count: $numOfQueries, apiKey: $apiKey})
                 """,
                 Map.of(
                         "query", "Who are the actors which also directed a movie?",
@@ -93,13 +93,13 @@ public class PromptIT {
                 ),
                 (r) -> {
                     List<Map<String, Object>> list = r.stream().toList();
-                    Assertions.assertThat(list).hasSize(numOfQueries);
+                    Assertions.assertThat(list).hasSize((int) numOfQueries);
                     Assertions.assertThat(list.stream()
                                     .map(m -> m.get("query"))
                                     .filter(Objects::nonNull)
                                     .map(Object::toString)
                                     .filter(StringUtils::isNotEmpty))
-                            .hasSize(numOfQueries);
+                            .hasSize((int) numOfQueries);
                 });
     }
 

--- a/extended/src/test/java/apoc/ml/PromptIT.java
+++ b/extended/src/test/java/apoc/ml/PromptIT.java
@@ -1,0 +1,99 @@
+package apoc.ml;
+
+import apoc.coll.Coll;
+import apoc.meta.Meta;
+import apoc.text.Strings;
+import apoc.util.TestUtil;
+import apoc.util.Util;
+import org.apache.commons.lang3.StringUtils;
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static apoc.util.TestUtil.testResult;
+
+public class PromptIT {
+
+    private static final String OPENAI_KEY = System.getenv("OPENAI_KEY");
+
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
+
+    @Before
+    public void setUp() {
+        TestUtil.registerProcedure(db, Prompt.class, Meta.class, Strings.class, Coll.class);
+        String movies = Util.readResourceFile("movies.cypher");
+        try (Transaction tx = db.beginTx()) {
+            tx.execute(movies);
+            tx.commit();
+        }
+    }
+
+    @Test
+    public void testQuery() {
+        testResult(db, """
+                CALL apoc.ml.query($query, $retries, $apiKey)
+                """,
+                Map.of(
+                        "query", "What movies did Tom Hanks play in?",
+                        "retries", 2,
+                        "apiKey", OPENAI_KEY
+                ),
+                (r) -> {
+                    List<Map<String, Object>> list = r.stream().toList();
+                    Assertions.assertThat(list).hasSize(12);
+                    Assertions.assertThat(list.stream()
+                                    .map(m -> m.get("query"))
+                                    .filter(Objects::nonNull)
+                                    .map(Object::toString)
+                                    .map(String::trim))
+                            .isNotEmpty();
+                });
+    }
+
+    @Test
+    public void testSchema() {
+        testResult(db, """
+                CALL apoc.ml.schema($apiKey)
+                """,
+                Map.of(
+                        "apiKey", OPENAI_KEY
+                ),
+                (r) -> {
+                    List<Map<String, Object>> list = r.stream().toList();
+                    Assertions.assertThat(list).hasSize(1);
+                });
+    }
+
+    @Test
+    public void testCypher() {
+        int numOfQueries = 3;
+        testResult(db, """
+                CALL apoc.ml.cypher($query, $numOfQueries, $apiKey)
+                """,
+                Map.of(
+                        "query", "Who are the actors which also directed a movie?",
+                        "numOfQueries", numOfQueries,
+                        "apiKey", OPENAI_KEY
+                ),
+                (r) -> {
+                    List<Map<String, Object>> list = r.stream().toList();
+                    Assertions.assertThat(list).hasSize(numOfQueries);
+                    Assertions.assertThat(list.stream()
+                                    .map(m -> m.get("query"))
+                                    .filter(Objects::nonNull)
+                                    .map(Object::toString)
+                                    .filter(StringUtils::isNotEmpty))
+                            .hasSize(numOfQueries);
+                });
+    }
+
+}

--- a/extended/src/test/java/apoc/ml/PromptIT.java
+++ b/extended/src/test/java/apoc/ml/PromptIT.java
@@ -7,7 +7,9 @@ import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.Assertions;
+import org.junit.Assume;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.neo4j.graphdb.Transaction;
@@ -26,6 +28,11 @@ public class PromptIT {
 
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
+
+    @BeforeClass
+    public static void check() {
+        Assume.assumeNotNull("No OPENAI_KEY environment configured", OPENAI_KEY);
+    }
 
     @Before
     public void setUp() {
@@ -75,7 +82,7 @@ public class PromptIT {
 
     @Test
     public void testCypher() {
-        int numOfQueries = 3;
+        int numOfQueries = 4;
         testResult(db, """
                 CALL apoc.ml.cypher($query, $numOfQueries, $apiKey)
                 """,


### PR DESCRIPTION
For review

Uses OpenAI with a potentially configured API (`apoc.openai.key`) in `apoc.conf` (e.g. for Sandbox)

Extracts the database schema using `apoc.meta.data`

- Uses a system prompt for base grounding
- Adds a schema prompt
- Provides the user question
- adds `apoc.ml.schema` for describing  the schema of the database
- adds `apoc.ml.cypher` for generating N cypher queries for the user question
- adds `apoc.ml.query` for generating and executing cypher queries (with generation-retries (3 by default) if the query failed)  
- Still needs docs and tests (a bit tricky due to the probabalistic nature)

<img width="1118" alt="apoc-llm-prompt" src="https://github.com/neo4j-contrib/neo4j-apoc-procedures/assets/67427/466f702d-11b2-4ba0-adb8-3458208ace7f">
