### PR TITLE
[NOID] Release 5.10.0 (#3455)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "5.10" ]
   pull_request:
-    branches: [ "dev" ]
+    branches: [ "5.10" ]
 
 jobs:
   build:
@@ -25,14 +25,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-
-      - name: Download neo4j dev docker container
-        run: |
-          curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_ENTERPRISE_URL} -o ${ENTERPRISE_TAR} &
-          curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_COMMUNITY_URL} -o ${COMMUNITY_TAR} &
-          wait
-          docker load --input ${ENTERPRISE_TAR}
-          docker load --input ${COMMUNITY_TAR}
 
       - uses: actions/cache@v2
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "apoc-core"]
 	path = apoc-core
 	url = https://github.com/neo4j/apoc
-	branch = dev
+	branch = 5.10

--- a/build.gradle
+++ b/build.gradle
@@ -71,8 +71,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise-debian' : 'neo4j:5.10.0-enterprise-debian',
-                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-debian' : 'neo4j:5.10.0-debian',
+                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise-debian' : 'neo4j:5.10.0-enterprise',
+                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-debian' : 'neo4j:5.10.0',
                 'coreDir': 'apoc-core/core'
 
         maxHeapSize = "8G"

--- a/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/installation/index.adoc
@@ -32,7 +32,7 @@ The version compatibility matrix explains the mapping between Neo4j and APOC ver
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.3.1[5.3.1^] | 5.3.0 (5.3.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.2.0[5.2.0^] | 5.2.0 (5.2.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.1.0[5.1.0^] | 5.1.0 (5.1.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.18[4.4.0.18^] | 4.4.0 (4.4.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.19[4.4.0.19^] | 4.4.0 (4.4.x)
 |===
 
 // end::version-matrix[]

--- a/readme.adoc
+++ b/readme.adoc
@@ -190,7 +190,7 @@ The trailing `<apoc>` part of the version number will be incremented with every 
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.3.1[5.3.1^] | 5.3.0 (5.3.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.2.0[5.2.0^] | 5.2.0 (5.2.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.1.0[5.1.0^] | 5.1.0 (5.1.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.18[4.4.0.18^] | 4.4.0 (4.4.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.19[4.4.0.19^] | 4.4.0 (4.4.x)
 |===
 
 // end::version-matrix[]


### PR DESCRIPTION
-  [x] Waiting for apoc 5.10.0 release
-  [x] Waiting for neo4j mvn 5.10.0 release
-  [x] Waiting for neo4j docker 5.10.0 release

---

Changed `neo4j:5.10.0-enterprise-debian` to `neo4j:5.10.0-enterprise` and `neo4j:5.10.0-debian` to `neo4j:5.10.0`