### PR TITLE
[BqvAC2FK] Update selenium dependencies

### DIFF
--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -138,7 +138,6 @@ dependencies {
     testImplementation group: 'com.sun.mail', name: 'javax.mail', version: '1.6.0'
     testImplementation group: 'org.postgresql', name: 'postgresql', version: '42.1.4'
     testImplementation group: 'org.zapodot', name: 'embedded-ldap-junit', version: '0.9.0'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.4.0'
     testImplementation group: 'org.apache.parquet', name: 'parquet-hadoop', version: '1.13.1', withoutServers
 
 

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -88,10 +88,10 @@ dependencies {
 
     compileOnly group: 'org.apache.poi', name: 'poi', version: '5.1.0'
     compileOnly group: 'org.apache.poi', name: 'poi-ooxml', version: '5.1.0'
-    compileOnly group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59', {
+    compileOnly group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.10.0', {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    compileOnly group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.1.0'
+    compileOnly group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.4.0'
     compileOnly 'org.mongodb:mongodb-driver:3.2.2', {
         exclude group: 'io.netty'
     }
@@ -113,8 +113,8 @@ dependencies {
     testImplementation project(':core')
     testImplementation group: 'org.apache.poi', name: 'poi', version: '5.1.0'
     testImplementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.1.0'
-    testImplementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59'
-    testImplementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.1.0'
+    testImplementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.10.0'
+    testImplementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.4.0'
     testImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
     testImplementation group: 'org.reflections', name: 'reflections', version: '0.9.12'

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -138,6 +138,7 @@ dependencies {
     testImplementation group: 'com.sun.mail', name: 'javax.mail', version: '1.6.0'
     testImplementation group: 'org.postgresql', name: 'postgresql', version: '42.1.4'
     testImplementation group: 'org.zapodot', name: 'embedded-ldap-junit', version: '0.9.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.4.0'
     testImplementation group: 'org.apache.parquet', name: 'parquet-hadoop', version: '1.13.1', withoutServers
 
 

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -91,7 +91,9 @@ dependencies {
     compileOnly group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.10.0', {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    compileOnly group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.4.0'
+    compileOnly group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.4.0', {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
     compileOnly 'org.mongodb:mongodb-driver:3.2.2', {
         exclude group: 'io.netty'
     }

--- a/extended/src/main/java/apoc/load/LoadHtml.java
+++ b/extended/src/main/java/apoc/load/LoadHtml.java
@@ -81,7 +81,7 @@ public class LoadHtml {
         } catch (UnsupportedCharsetException e) {
             throw new RuntimeException(UNSUPPORTED_CHARSET_ERR + config.getCharset());
         } catch (IllegalArgumentException | ClassCastException e) {
-            throw new RuntimeException(INVALID_CONFIG_ERR + config);
+            throw new RuntimeException(INVALID_CONFIG_ERR + e.getMessage());
         } catch (FileNotFoundException e) {
             throw new RuntimeException("File not found from: " + url);
         } catch(Exception e) {

--- a/extended/src/main/java/apoc/load/LoadHtmlBrowser.java
+++ b/extended/src/main/java/apoc/load/LoadHtmlBrowser.java
@@ -16,6 +16,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.Map;
 
 import static java.util.Optional.ofNullable;
@@ -132,7 +133,7 @@ public class LoadHtmlBrowser {
 
         final long wait = config.getWait();
         if (wait > 0) {
-            Wait<WebDriver> driverWait = new WebDriverWait(driver, wait);
+            Wait<WebDriver> driverWait = new WebDriverWait(driver, Duration.ofSeconds(wait));
             try {
                 driverWait.until(webDriver -> query.values().stream()
                         .noneMatch(selector -> webDriver.findElements(By.cssSelector(selector)).isEmpty()));

--- a/extended/src/main/java/apoc/load/LoadHtmlBrowser.java
+++ b/extended/src/main/java/apoc/load/LoadHtmlBrowser.java
@@ -27,7 +27,7 @@ public class LoadHtmlBrowser {
         setupWebDriverManager(WebDriverManager.chromedriver(), config);
 
         ChromeOptions chromeOptions = new ChromeOptions();
-        chromeOptions.setHeadless(isHeadless);
+        chromeOptions.addArguments("--headless=new");
         chromeOptions.setAcceptInsecureCerts(isAcceptInsecureCerts);
         return getInputStreamWithBrowser(url, query, config, new ChromeDriver(chromeOptions));
     }
@@ -36,7 +36,7 @@ public class LoadHtmlBrowser {
         setupWebDriverManager(WebDriverManager.firefoxdriver(), config);
         
         FirefoxOptions firefoxOptions = new FirefoxOptions();
-        firefoxOptions.setHeadless(isHeadless);
+        firefoxOptions.addArguments("-headless");
         firefoxOptions.setAcceptInsecureCerts(isAcceptInsecureCerts);
         return getInputStreamWithBrowser(url, query, config, new FirefoxDriver(firefoxOptions));
     }

--- a/extended/src/test/java/apoc/load/LoadHtmlTestParameterized.java
+++ b/extended/src/test/java/apoc/load/LoadHtmlTestParameterized.java
@@ -12,9 +12,12 @@ import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
@@ -31,6 +34,7 @@ import static org.junit.Assert.assertFalse;
 
 @RunWith(Parameterized.class)
 public class LoadHtmlTestParameterized {
+    private static final String NOT_SET = "notSet";
     // Tests taken from LoadHtmlTest.java.
     // To check that `browser` configuration preserve the result.
 
@@ -45,8 +49,14 @@ public class LoadHtmlTestParameterized {
 
 
     @Parameters
-    public static Collection<Object> data() {
-        return List.of("notSet", "NONE", "CHROME", "FIREFOX");
+    public static Collection<String> data() {
+        // list of browser configs
+        ArrayList<String> browsers = Arrays.stream(LoadHtmlConfig.Browser.values())
+                .map(Enum::name)
+                .collect(Collectors.toCollection(ArrayList::new));
+        // test case if config browser not set
+        browsers.add(NOT_SET);
+        return browsers;
     }
 
     @Parameter
@@ -131,6 +141,6 @@ public class LoadHtmlTestParameterized {
     }
 
     private boolean browserSet() {
-        return !browser.equals("notSet");
+        return !browser.equals(NOT_SET);
     }
 }

--- a/extra-dependencies/selenium/build.gradle
+++ b/extra-dependencies/selenium/build.gradle
@@ -20,5 +20,8 @@ dependencies {
     implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.10.0' , {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    implementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.4.0'
+    implementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.4.0', {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
+
 }

--- a/extra-dependencies/selenium/build.gradle
+++ b/extra-dependencies/selenium/build.gradle
@@ -17,9 +17,8 @@ jar {
 }
 
 dependencies {
-    // currently we cannot update to the latest version due to guava minimum version required (31.0.1-jre)
-    implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59', {
+    implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.10.0' , {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    implementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.1.0'
+    implementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.4.0'
 }


### PR DESCRIPTION
~Waiting for CI error fixes: https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3666~


---

The selenium version can be updated as it was previously blocked due to the guava version: https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/2013 .

Now that problem is not present anymore.

---

- Update to the latest selenium
  - Update to the latest `webdrivermanager` package
  - Removed `0.30.0` version, not compatible with the new firefox webdriver version
  - Changed error message on line 99
  - `new WebDriverWait(...)`
  - changed `.setHeadless(isHeadless);` which are deprecated and throw an error `NoSuchMethodError: '...irefoxOptions.setHeadless(boolean)`
  - excluded guava from webdrivermanager plugin, otherwise a `java.lang.NoSuchMethodError: 'void com.google.common.base.Throwables.throwIfUnchecked` is thrown

- Other changes
  - Added `browser start-up failure` to ignored error, in order to skip if browser version on the running machine is not compatible with the latest webdriver 
  - Improved "wrong config" error message, previously was a generic `"Invalid config: LoadHtmlConfig@123123"`
  - De-mocked list of browser config in `LoadHtmlTestParameterized.java`
