### PR TITLE
[BqvAC2FK] Update selenium dependencies

### DIFF
--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -132,7 +132,7 @@ dependencies {
     testImplementation group: 'com.sun.mail', name: 'javax.mail', version: '1.6.0'
     testImplementation group: 'org.postgresql', name: 'postgresql', version: '42.1.4'
     testImplementation group: 'org.zapodot', name: 'embedded-ldap-junit', version: '0.9.0'
-
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.4.0'
 
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -87,10 +87,12 @@ dependencies {
 
     compileOnly group: 'org.apache.poi', name: 'poi', version: '5.1.0'
     compileOnly group: 'org.apache.poi', name: 'poi-ooxml', version: '5.1.0'
-    compileOnly group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59', {
+    compileOnly group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.10.0', {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    compileOnly group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.1.0'
+    compileOnly group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.4.0', {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
     compileOnly 'org.mongodb:mongodb-driver:3.2.2', {
         exclude group: 'io.netty'
     }
@@ -107,8 +109,8 @@ dependencies {
     testImplementation project(':core')
     testImplementation group: 'org.apache.poi', name: 'poi', version: '5.1.0'
     testImplementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.1.0'
-    testImplementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59'
-    testImplementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.1.0'
+    testImplementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.10.0'
+    testImplementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.4.0'
     testImplementation group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0'
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.11.270'
     testImplementation group: 'org.reflections', name: 'reflections', version: '0.9.12'

--- a/extended/src/main/java/apoc/load/LoadHtml.java
+++ b/extended/src/main/java/apoc/load/LoadHtml.java
@@ -81,7 +81,7 @@ public class LoadHtml {
         } catch (UnsupportedCharsetException e) {
             throw new RuntimeException(UNSUPPORTED_CHARSET_ERR + config.getCharset());
         } catch (IllegalArgumentException | ClassCastException e) {
-            throw new RuntimeException(INVALID_CONFIG_ERR + config);
+            throw new RuntimeException(INVALID_CONFIG_ERR + e.getMessage());
         } catch (FileNotFoundException e) {
             throw new RuntimeException("File not found from: " + url);
         } catch(Exception e) {

--- a/extended/src/main/java/apoc/load/LoadHtmlBrowser.java
+++ b/extended/src/main/java/apoc/load/LoadHtmlBrowser.java
@@ -16,6 +16,7 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.Map;
 
 import static java.util.Optional.ofNullable;
@@ -26,7 +27,7 @@ public class LoadHtmlBrowser {
         setupWebDriverManager(WebDriverManager.chromedriver(), config);
 
         ChromeOptions chromeOptions = new ChromeOptions();
-        chromeOptions.setHeadless(isHeadless);
+        chromeOptions.addArguments("--headless=new");
         chromeOptions.setAcceptInsecureCerts(isAcceptInsecureCerts);
         return getInputStreamWithBrowser(url, query, config, new ChromeDriver(chromeOptions));
     }
@@ -35,7 +36,7 @@ public class LoadHtmlBrowser {
         setupWebDriverManager(WebDriverManager.firefoxdriver(), config);
         
         FirefoxOptions firefoxOptions = new FirefoxOptions();
-        firefoxOptions.setHeadless(isHeadless);
+        firefoxOptions.addArguments("-headless");
         firefoxOptions.setAcceptInsecureCerts(isAcceptInsecureCerts);
         return getInputStreamWithBrowser(url, query, config, new FirefoxDriver(firefoxOptions));
     }
@@ -132,7 +133,7 @@ public class LoadHtmlBrowser {
 
         final long wait = config.getWait();
         if (wait > 0) {
-            Wait<WebDriver> driverWait = new WebDriverWait(driver, wait);
+            Wait<WebDriver> driverWait = new WebDriverWait(driver, Duration.ofSeconds(wait));
             try {
                 driverWait.until(webDriver -> query.values().stream()
                         .noneMatch(selector -> webDriver.findElements(By.cssSelector(selector)).isEmpty()));

--- a/extended/src/test/java/apoc/load/LoadHtmlTest.java
+++ b/extended/src/test/java/apoc/load/LoadHtmlTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
 
 import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
@@ -523,8 +524,11 @@ public class LoadHtmlTest {
             runnable.run();
         } catch (RuntimeException e) {
             // The test don't fail if the current chrome/firefox version is incompatible or if the browser is not installed
+            Stream<String> notPresentOrIncompatible = Stream.of("cannot find Chrome binary", "Cannot find firefox binary",
+                    "browser start-up failure",
+                    "This version of ChromeDriver only supports Chrome version");
             final String msg = e.getMessage();
-            if (!msg.contains("cannot find Chrome binary") && !msg.contains("Cannot find firefox binary") && !msg.contains("browser start-up failure")) {
+            if (notPresentOrIncompatible.noneMatch(msg::contains)) {
                 throw e;
             }
         }

--- a/extended/src/test/java/apoc/load/LoadHtmlTest.java
+++ b/extended/src/test/java/apoc/load/LoadHtmlTest.java
@@ -84,19 +84,19 @@ public class LoadHtmlTest {
 
     @Test
     public void testParseGeneratedJs() {
-        testCallGeneratedJsWithBrowser("FIREFOX");
-        testCallGeneratedJsWithBrowser("CHROME");
+        testCallGeneratedJsWithBrowser(FIREFOX);
+        testCallGeneratedJsWithBrowser(CHROME);
     }
 
     @Test
     public void testParseGeneratedJsWrongConfigs() {
-        assertWrongConfig(INVALID_CONFIG_ERR,
+        assertWrongConfig(INVALID_CONFIG_ERR + "No enum constant io.github.bonigarcia.wdm.config.OperatingSystem.dunno",
                 map("browser", CHROME, "operatingSystem", "dunno"));
 
-        assertWrongConfig(INVALID_CONFIG_ERR,
+        assertWrongConfig(INVALID_CONFIG_ERR + "No enum constant io.github.bonigarcia.wdm.config.Architecture.dunno",
                 map("browser", FIREFOX, "architecture", "dunno"));
 
-        assertWrongConfig("Error HTTP 401 executing",
+        assertWrongConfig("Error HTTP 404 executing https://raw.githubusercontent.com/bonigarcia/webdrivermanager/master/docs/mirror/geckodriver",
                 map("browser", FIREFOX,
                         "gitHubToken", "12345",
                         "forceDownload", true));
@@ -107,8 +107,9 @@ public class LoadHtmlTest {
             testCall(db, "CALL apoc.load.html($url, $query, $config)",
                     map("url", URL_HTML_JS, "query", map("a", "a"), "config", config),
                     r -> fail("Should fails due to wrong configuration"));
-        } catch (RuntimeException e) {
-            assertTrue(e.getMessage().contains(msgError));
+        } catch (Exception e) {
+            String message = e.getMessage();
+            assertTrue("Curr message is: " + message, message.contains(msgError));
         }
     }
 
@@ -497,7 +498,7 @@ public class LoadHtmlTest {
             testCall(db, "CALL apoc.load.html($url,$query,$config)",
                     map("url", URL_HTML_JS,
                             "query", map("td", "td", "strong", "strong"),
-                            "config", map("browser", browser, "driverVersion", "0.30.0")),
+                            "config", map("browser", browser)),
                     result -> {
                         Map<String, Object> value = (Map<String, Object>) result.get("value");
                         List<Map<String, Object>> tdList = (List<Map<String, Object>>) value.get("td");
@@ -523,7 +524,7 @@ public class LoadHtmlTest {
         } catch (RuntimeException e) {
             // The test don't fail if the current chrome/firefox version is incompatible or if the browser is not installed
             final String msg = e.getMessage();
-            if (!msg.contains("cannot find Chrome binary") && !msg.contains("Cannot find firefox binary")) {
+            if (!msg.contains("cannot find Chrome binary") && !msg.contains("Cannot find firefox binary") && !msg.contains("browser start-up failure")) {
                 throw e;
             }
         }

--- a/extended/src/test/java/apoc/load/LoadHtmlTestParameterized.java
+++ b/extended/src/test/java/apoc/load/LoadHtmlTestParameterized.java
@@ -12,9 +12,12 @@ import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
@@ -31,6 +34,7 @@ import static org.junit.Assert.assertFalse;
 
 @RunWith(Parameterized.class)
 public class LoadHtmlTestParameterized {
+    private static final String NOT_SET = "notSet";
     // Tests taken from LoadHtmlTest.java.
     // To check that `browser` configuration preserve the result.
 
@@ -45,8 +49,14 @@ public class LoadHtmlTestParameterized {
 
 
     @Parameters
-    public static Collection<Object> data() {
-        return List.of("notSet", "NONE", "CHROME", "FIREFOX");
+    public static Collection<String> data() {
+        // list of browser configs
+        ArrayList<String> browsers = Arrays.stream(LoadHtmlConfig.Browser.values())
+                .map(Enum::name)
+                .collect(Collectors.toCollection(ArrayList::new));
+        // test case if config browser not set
+        browsers.add(NOT_SET);
+        return browsers;
     }
 
     @Parameter
@@ -131,6 +141,6 @@ public class LoadHtmlTestParameterized {
     }
 
     private boolean browserSet() {
-        return !browser.equals("notSet");
+        return !browser.equals(NOT_SET);
     }
 }

--- a/extra-dependencies/selenium/build.gradle
+++ b/extra-dependencies/selenium/build.gradle
@@ -17,9 +17,11 @@ jar {
 }
 
 dependencies {
-    // currently we cannot update to the latest version due to guava minimum version required (31.0.1-jre)
-    implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '3.141.59', {
+    implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.10.0' , {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    implementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.1.0'
+    implementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.4.0', {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
+
 }


### PR DESCRIPTION
- Cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3663

- Added skip if ChromeDriver is incompatible with Chrome version (to cherry-pick in dev)

- Forced `mockito` version to fix the following error (to cherry-pick in dev). See [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/5642032860/job/15282309661#step:5:591): 
```
apoc.load.LoadHdfsTest > testLoadCsvFromHDFS FAILED
    java.lang.IncompatibleClassChangeError: class org.apache.hadoop.hdfs.server.namenode.NameNodeAdapter$2 can not implement org.mockito.ArgumentMatcher, because it is not an interface (org.mockito.ArgumentMatcher is in unnamed module of loader 'app')
```
