### PR TITLE
Update apoc.log.info.adoc

### DIFF
--- a/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.log.info.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/usage/config/apoc.log.info.adoc
@@ -6,9 +6,9 @@ The procedure support the following properties in the APOC configuration file (`
 | name | type | default | description
 | apoc.user.log.type | String | `safe` a| Type of logging.
 
-* `node`: disable the procedures
+* `none`: disable logging
 * `safe`: replace all `.` and whitespace (space and tab) with underscore and lowercase all characters
-* `raw`: left the messages as-is
+* `raw`: leave messages as-is
 
 | apoc.user.log.window.ops | Long | 10 | Number of log messages permitted in a time-window. If this quota is exceeded, log messags will be skipped.
 | apoc.user.log.window.time | Long | 10000 | Length (in milliseconds) of the time-window.


### PR DESCRIPTION
Fixes # NA

Fix typo in "apoc.user.log.type" value "node" -- it should be "none"; and fix awkward descriptions.

## Proposed Changes (Mandatory)

A brief list of proposed changes in order to fix the issue:

  - Fix typo: "node" --> "none".
  - Fix wording of descriptions for "none" and "raw".
