### PR TITLE
[NOID] Fixes failing path traversal TeamCity tests

### DIFF
--- a/.github/actions/setup-jdk/action.yaml
+++ b/.github/actions/setup-jdk/action.yaml
@@ -6,5 +6,5 @@ runs:
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '11.0.20'
         distribution: 'temurin'

--- a/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
+++ b/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
@@ -155,10 +155,10 @@ public class ExportCoreSecurityTest {
         // non-failing cases, with apoc.import.file.use_neo4j_config=false
         public static final List<String> casesAllowed = Arrays.asList(case03, case04, case05);
 
-        private static final String case08 = "tests/../../" + FILENAME;
-        private static final String case09 = "tests/..//..//" + FILENAME;
+        private static final String case07 = "tests/../../" + FILENAME;
+        private static final String case08 = "tests/..//..//" + FILENAME;
 
-        public static final List<String> casesOutsideDir = Arrays.asList(case01, case02, case03, case04, case05, case08, case09);
+        public static final List<String> casesOutsideDir = Arrays.asList(case01, case02, case03, case04, case05, case07, case08);
 
         /*
          All of these will resolve to a local path after normalization which will point to

--- a/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
+++ b/core/src/test/java/apoc/export/ExportCoreSecurityTest.java
@@ -155,13 +155,10 @@ public class ExportCoreSecurityTest {
         // non-failing cases, with apoc.import.file.use_neo4j_config=false
         public static final List<String> casesAllowed = Arrays.asList(case03, case04, case05);
 
-        private static final String case06 = "file:///%2e%2e%2f%2f%2e%2e%2f%2f%2e%2e%2f%2f%2e%2e%2f%2fapoc/" + FILENAME;
-        public static final String case07 = "file:///%2e%2e%2f%2f" + FILENAME;
         private static final String case08 = "tests/../../" + FILENAME;
         private static final String case09 = "tests/..//..//" + FILENAME;
 
-        public static final List<String> casesOutsideDir = Arrays.asList(case01, case02, case03, case04, case05,
-                case06, case07, case08, case09);
+        public static final List<String> casesOutsideDir = Arrays.asList(case01, case02, case03, case04, case05, case08, case09);
 
         /*
          All of these will resolve to a local path after normalization which will point to
@@ -229,10 +226,6 @@ public class ExportCoreSecurityTest {
         }
 
         private void testWithUseNeo4jConfFalse() {
-            // with `apoc.import.file.use_neo4j_config=false` this file export could outside the project
-            if (fileName.equals(case07)) {
-                return;
-            }
 
             try {
                 assertPathTraversalWithoutErrors();
@@ -285,8 +278,10 @@ public class ExportCoreSecurityTest {
         private static final String case06 = "file:///tests//..//" + FILENAME;
         private static final String case07 = "" + FILENAME;
         private static final String case08 = "file:///..//..//..//..//" + FILENAME;
+        private static final String case09 = "file:///%2e%2e%2f%2f%2e%2e%2f%2f%2e%2e%2f%2f%2e%2e%2f%2f/" + FILENAME;
+        public static final String case10 = "file:///%2e%2e%2f%2f" + FILENAME;
 
-        public static final List<String> mainDirCases = Arrays.asList(caseBase, case01, case02, case03, case04, case05, case06, case07, case08);
+        public static final List<String> mainDirCases = Arrays.asList(caseBase, case01, case02, case03, case04, case05, case06, case07, case08, case09, case10);
 
         /*
          These tests normalize the path to be within the import directory and step into a subdirectory

--- a/core/src/test/java/apoc/export/arrow/ExportArrowSecurityTest.java
+++ b/core/src/test/java/apoc/export/arrow/ExportArrowSecurityTest.java
@@ -46,7 +46,7 @@ import java.util.stream.Collectors;
 
 import static apoc.export.ExportCoreSecurityTest.FILENAME;
 import static apoc.export.ExportCoreSecurityTest.PARAM_NAMES;
-import static apoc.export.ExportCoreSecurityTest.TestIllegalExternalFSAccess.case07;
+import static apoc.export.ExportCoreSecurityTest.TestPathTraversalIsNormalisedWithinDirectory.case10;
 import static apoc.export.ExportCoreSecurityTest.TestIllegalExternalFSAccess.EXCEPTION_NOT_FOUND_CONSUMER;
 import static apoc.export.ExportCoreSecurityTest.TestIllegalExternalFSAccess.dataPairs;
 import static apoc.export.ExportCoreSecurityTest.TestPathTraversalIsNormalisedWithinDirectory.MAIN_DIR_CONSUMER;
@@ -153,7 +153,7 @@ public class ExportArrowSecurityTest {
 
         private void testWithUseNeo4jConfFalse() {
             // with `apoc.import.file.use_neo4j_config=false` this file export could outside the project
-            if (fileName.equals(case07)) {
+            if (fileName.equals(case10)) {
                 return;
             }
 

--- a/full/src/test/java/apoc/export/ExportFullSecurityTest.java
+++ b/full/src/test/java/apoc/export/ExportFullSecurityTest.java
@@ -202,13 +202,11 @@ public class ExportFullSecurityTest {
             this.apocProcedure = "apoc.export." + exportMethod + "." + exportMethodType + "(" + exportMethodArguments + ")";
         }
 
-        private static final String case1 = "'file:///%2e%2e%2f%2f%2e%2e%2f%2f%2e%2e%2f%2f%2e%2e%2f%2fapoc/test.txt'";
-        private static final String case2 = "'file:///%2e%2e%2f%2ftest.txt'";
         private static final String case3 = "'../test.txt'";
         private static final String case4 = "'tests/../../test.txt'";
         private static final String case5 = "'tests/..//..//test.txt'";
 
-        private static final List<String> cases = Arrays.asList(case1, case2, case3, case4, case5);
+        private static final List<String> cases = Arrays.asList(case3, case4, case5);
 
         private static final Map<String, List<String>> METHOD_ARGUMENTS = Map.of(
                 "query",  cases.stream().map(
@@ -263,8 +261,9 @@ public class ExportFullSecurityTest {
         private static final String case4 = "'file:///..//..//..//..//apoc/test.txt'";
         private static final String case5 = "'file://" + directory.getAbsolutePath() + "//..//..//..//..//apoc/test.txt'";
         private static final String case6 = "'file:///%252e%252e%252f%252e%252e%252f%252e%252e%252f%252e%252e%252f/apoc/test.txt'";
+        private static final String case7 = "'file:///%2e%2e%2f%2f%2e%2e%2f%2f%2e%2e%2f%2f%2e%2e%2f%2fapoc/test.txt'";
 
-        private static final List<String> cases = Arrays.asList(case1, case2, case3, case4, case5, case6);
+        private static final List<String> cases = Arrays.asList(case1, case2, case3, case4, case5, case6, case7);
 
         private static final Map<String, List<String>> METHOD_ARGUMENTS = Map.of(
                 "query", cases.stream().map(
@@ -320,8 +319,9 @@ public class ExportFullSecurityTest {
         private static final String case6 = "'file:///tests//..//test.txt'";
         private static final String case7 = "'test.txt'";
         private static final String case8 = "'file:///..//..//..//..//test.txt'";
+        private static final String case9 = "'file:///%2e%2e%2f%2ftest.txt'";
 
-        private static final List<String> cases = Arrays.asList(case1, case2, case3, case4, case5, case6, case7, case8);
+        private static final List<String> cases = Arrays.asList(case1, case2, case3, case4, case5, case6, case7, case8, case9);
 
         private static final Map<String, List<String>> METHOD_ARGUMENTS = Map.of(
                 "query", cases.stream().map(

--- a/full/src/test/java/apoc/export/ExportFullSecurityTest.java
+++ b/full/src/test/java/apoc/export/ExportFullSecurityTest.java
@@ -202,11 +202,11 @@ public class ExportFullSecurityTest {
             this.apocProcedure = "apoc.export." + exportMethod + "." + exportMethodType + "(" + exportMethodArguments + ")";
         }
 
-        private static final String case3 = "'../test.txt'";
-        private static final String case4 = "'tests/../../test.txt'";
-        private static final String case5 = "'tests/..//..//test.txt'";
+        private static final String case1 = "'../test.txt'";
+        private static final String case2 = "'tests/../../test.txt'";
+        private static final String case3 = "'tests/..//..//test.txt'";
 
-        private static final List<String> cases = Arrays.asList(case3, case4, case5);
+        private static final List<String> cases = Arrays.asList(case1, case2, case3);
 
         private static final Map<String, List<String>> METHOD_ARGUMENTS = Map.of(
                 "query",  cases.stream().map(


### PR DESCRIPTION
## What
Checks sequences of `%e%e%f%f%e%e` do not fail but stay on the same directory when trying to do path traversals.

Commit [0421c2b](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3703/commits/0421c2b632e60af3f008496ff85b0808c0ff675f) reproduces the problem, [eec4def](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3703/commits/eec4def43b334fac0ea8793948af61b1e8b4a6de) amends the tests to solve it.

## Why
The tests were failing in our TeamCity CI. This treats them as we were treating sequences like `..//..//`

They've solved an issue with OpenJDK where it wasn't properly detecting double slashes in a path and turning them into a single one: https://github.com/openjdk/jdk11u-dev/commit/18939b76259456e85cfa051dc595e57242ca4ef8, https://nvd.nist.gov/vuln/detail/CVE-2023-22049

This fix has gone in Eclipse Temurin 11.0.20, all distributions of [Zulu](https://docs.azul.com/core/zulu-openjdk/release-notes/july-2023) or [Oracle v17](https://linux.oracle.com/errata/ELSA-2023-4159.html). The rationale to change it is that most of the JDKs should catch up with this fix, but also if they don't we were still protected throwing a failure.