### PR TITLE
Add core vs extended warning

### DIFF
--- a/docs/antora/package-lock.json
+++ b/docs/antora/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@antora/cli": "^3.1.1",
         "@antora/site-generator-default": "^3.1.1",
+        "@neo4j-antora/antora-add-notes": "^0.3.0",
         "@neo4j-documentation/macros": "^1.0.0",
         "@neo4j-documentation/remote-include": "^1.0.0",
         "express": "^4.17.1",
@@ -291,6 +292,11 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+    },
+    "node_modules/@neo4j-antora/antora-add-notes": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@neo4j-antora/antora-add-notes/-/antora-add-notes-0.3.0.tgz",
+      "integrity": "sha512-aHPErkKLZxe8yOtUuthLVf1mC0Pta3JZhGoX4SN6HRnroNBTaa5i3/JSSorFrB3F+XuVJXZDxnRUCubFvGLkUg=="
     },
     "node_modules/@neo4j-documentation/macros": {
       "version": "1.0.2",
@@ -3082,6 +3088,11 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
+    },
+    "@neo4j-antora/antora-add-notes": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@neo4j-antora/antora-add-notes/-/antora-add-notes-0.3.0.tgz",
+      "integrity": "sha512-aHPErkKLZxe8yOtUuthLVf1mC0Pta3JZhGoX4SN6HRnroNBTaa5i3/JSSorFrB3F+XuVJXZDxnRUCubFvGLkUg=="
     },
     "@neo4j-documentation/macros": {
       "version": "1.0.2",

--- a/docs/antora/package.json
+++ b/docs/antora/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@antora/cli": "^3.1.1",
     "@antora/site-generator-default": "^3.1.1",
+    "@neo4j-antora/antora-add-notes": "^0.3.0",
     "@neo4j-documentation/macros": "^1.0.0",
     "@neo4j-documentation/remote-include": "^1.0.0",
     "express": "^4.17.1",

--- a/docs/antora/preview.yml
+++ b/docs/antora/preview.yml
@@ -13,15 +13,18 @@ content:
     - '!**/README.adoc'
 ui:
   bundle:
-    url: https://s3-eu-west-1.amazonaws.com/static-content.neo4j.com/build/ui-bundle.zip
+    url: https://static-content.neo4j.com/build/ui-bundle.zip
     snapshot: true
 
 urls:
   html_extension_style: indexify
 asciidoc:
   extensions:
+  - "@neo4j-antora/antora-add-notes"
   - "@neo4j-documentation/remote-include"
   - "@neo4j-documentation/macros"
   attributes:
     page-theme: labs
     page-disabletracking: true
+    page-add-notes-module: notes@
+    page-add-notes-tags: core-warning@

--- a/docs/asciidoc/modules/ROOT/pages/deprecations-and-additions/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/deprecations-and-additions/index.adoc
@@ -2,12 +2,6 @@
 = Deprecations and additions
 :description: This chapter lists all the features that have been removed, deprecated, added or extended in the recent versions of APOC.
 
-[WARNING]
-====
-This is the page for APOC Extended documentation.
-For the officially supported APOC Core, go to the https://neo4j.com/docs/apoc/{branch}/deprecations-and-additions/[APOC Core page].
-====
-
 This chapter lists all the features that have been removed, deprecated, added or extended in the recent versions of APOC.
 
 [[apoc-deprecations-additions-removals-5.0]]

--- a/docs/asciidoc/modules/ROOT/pages/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/index.adoc
@@ -10,11 +10,6 @@
 :gh-docs: https://neo4j-contrib.github.io/neo4j-apoc-procedures
 :description: This is the user guide for Neo4j APOC {docs-version}, authored by the Neo4j Labs Team.
 
-[WARNING]
-====
-This is the page for APOC Extended documentation.
-For the officially supported APOC Core, go to the https://neo4j.com/docs/apoc/{branch}/[APOC Core page].
-====
 
 The guide covers the following areas:
 

--- a/docs/asciidoc/modules/ROOT/pages/overview/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/overview/index.adoc
@@ -2,11 +2,4 @@
 = Procedures & Functions
 :description: This chapter provides a reference of all the procedures and functions in the APOC Extended library.
 
-
-[WARNING]
-====
-This is the page for APOC Extended documentation.
-For the officially supported APOC Core, go to the https://neo4j.com/docs/apoc/{branch}/overview/[APOC Core page].
-====
-
 include::partial$generated-documentation/documentation.adoc[]

--- a/docs/asciidoc/modules/notes/partials/notes.adoc
+++ b/docs/asciidoc/modules/notes/partials/notes.adoc
@@ -1,9 +1,9 @@
 # tag::core-warning[]
 [WARNING]
 ====
-This is the APOC Extended documentation.
+This is the *APOC Extended* documentation.
 
 APOC Extended is not supported by Neo4j.
-For the officially supported APOC Core, go to the link:https://neo4j.com/docs/apoc/[APOC Core page].
+For the officially supported *APOC Core*, go to the link:https://neo4j.com/docs/apoc/[APOC Core page].
 ====
 # end::core-warning[]

--- a/docs/asciidoc/modules/notes/partials/notes.adoc
+++ b/docs/asciidoc/modules/notes/partials/notes.adoc
@@ -1,0 +1,9 @@
+# tag::core-warning[]
+[WARNING]
+====
+This is the APOC Extended documentation.
+
+APOC Extended is not supported by Neo4j.
+For the officially supported APOC Core, go to the link:https://neo4j.com/docs/apoc/[APOC Core page].
+====
+# end::core-warning[]


### PR DESCRIPTION

## Proposed Changes (Mandatory)

APOC extended is not supported. APOC Core is supported, and documented separately. This PR adds a warning to this effect to every page in the APOC extended docs, and provides a link to the APOC Core documentation.

The warning is added by the [antora-add-notes extension](https://www.npmjs.com/package/@neo4j-antora/antora-add-notes).