### PR TITLE
Change start page title

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/index.adoc
@@ -1,4 +1,4 @@
-= APOC Extended User Guide {apoc-release-absolute}
+= APOC Extended user guide (Labs project)
 //:toc: left
 :experimental:
 :sectid:
@@ -8,7 +8,7 @@
 //{imagesdir}
 :script: https://raw.githubusercontent.com/neo4j-contrib/neo4j-apoc-procedures/{branch}/docs/script
 :gh-docs: https://neo4j-contrib.github.io/neo4j-apoc-procedures
-:description: This is the user guide for Neo4j APOC {docs-version}, authored by the Neo4j Labs Team.
+:description: This is the APOC Extended user guide, authored by the Neo4j Labs Team.
 
 [WARNING]
 ====


### PR DESCRIPTION
Fixes #<Replace with the number of the issue, Mandatory>

Trello: https://trello.com/c/KCe7hriJ/5150-rename-the-apoc-extended-documentation-title
The current confusion between APOC Core and APOC Extended

## Proposed Changes (Mandatory)

Remove mention of Neo4j in title of start page, and make the status of APOC Extended as a "Labs project" explicit

