### PR TITLE
[qxkr2RlZ] apoc.load.ldap cant find config value due to missing

### DIFF
--- a/extended/src/main/java/apoc/load/LoadLdap.java
+++ b/extended/src/main/java/apoc/load/LoadLdap.java
@@ -29,9 +29,10 @@ public class LoadLdap {
     public static Map<String, Object> getConnectionMap(Object conn) {
         if (conn instanceof String) {
             //String value = "ldap.forumsys.com cn=read-only-admin,dc=example,dc=com password";
-            String value = apocConfig().getString("apoc.loadldap" + conn.toString() + ".config");
+            String key = "apoc.loadldap.%s.config".formatted(conn);
+            String value = apocConfig().getString(key);
             // format <ldaphost:port> <logindn> <loginpw>
-            if (value == null) throw new RuntimeException("No apoc.loadldap."+conn+".config ldap access configuration specified");
+            if (value == null) throw new RuntimeException("No " + key + " ldap access configuration specified");
             Map<String, Object> config = new HashMap<>();
             String[] sConf = value.split(" ");
             config.put("ldapHost", sConf[0]);

--- a/extended/src/main/java/apoc/load/LoadLdap.java
+++ b/extended/src/main/java/apoc/load/LoadLdap.java
@@ -2,6 +2,8 @@ package apoc.load;
 
 import apoc.Extended;
 import com.novell.ldap.*;
+import org.neo4j.logging.Log;
+import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Mode;
 import org.neo4j.procedure.Name;
@@ -17,22 +19,48 @@ import static apoc.ApocConfig.apocConfig;
 @Extended
 public class LoadLdap {
 
+    @Context
+    public Log log;
+
     @Procedure(name = "apoc.load.ldap", mode = Mode.READ)
     @Description("apoc.load.ldap(\"key\" or {connectionMap},{searchMap}) Load entries from an ldap source (yield entry)")
     public Stream<LDAPResult> ldapQuery(@Name("connection") final Object conn, @Name("search") final Map<String,Object> search) {
 
-        LDAPManager mgr = new LDAPManager(getConnectionMap(conn));
+        LDAPManager mgr = new LDAPManager(getConnectionMap(conn, log));
 
         return mgr.executeSearch(search);
     }
 
-    public static Map<String, Object> getConnectionMap(Object conn) {
+    public static Map<String, Object> getConnectionMap(Object conn, Log log) {
         if (conn instanceof String) {
             //String value = "ldap.forumsys.com cn=read-only-admin,dc=example,dc=com password";
             String key = "apoc.loadldap.%s.config".formatted(conn);
             String value = apocConfig().getString(key);
             // format <ldaphost:port> <logindn> <loginpw>
-            if (value == null) throw new RuntimeException("No " + key + " ldap access configuration specified");
+            if (value == null) {
+                // fallback: if `apoc.loadldap.<LDAP_KEY>.config` is not set
+                // we check for a config with key `apoc.loadldap<LDAP_KEY>.config`
+                String keyOld = "apoc.loadldap%s.config".formatted(conn);
+                value = apocConfig().getString(keyOld);
+
+                // if the value is set and log == null (that is, not from the test LoadLdapTest.testLoadLDAPConfig),
+                // we print a log warn, since the correct way should be with a dot before <LDAP_KEY>
+                if (value != null && log != null) {
+                    log.warn("""
+                            Not to cause breaking-change, the current config `%s` is valid,
+                            but in future releases it will be removed in favor of `%s` (with dot before `%s`),
+                            as documented here: https://neo4j.com/labs/apoc/5/database-integration/load-ldap/#_credentials.
+                            """
+                            .formatted(keyOld, key, conn)
+                    );
+                }
+            }
+
+            // if neither `apoc.loadldap.<LDAP_KEY>.config` nor `apoc.loadldap<LDAP_KEY>.config` is set.
+            // we throw an error
+            if (value == null) {
+                throw new RuntimeException("No " + key + " ldap access configuration specified");
+            }
             Map<String, Object> config = new HashMap<>();
             String[] sConf = value.split(" ");
             config.put("ldapHost", sConf[0]);

--- a/extended/src/test/java/apoc/load/LoadLdapTest.java
+++ b/extended/src/test/java/apoc/load/LoadLdapTest.java
@@ -1,6 +1,7 @@
 package apoc.load;
 
 
+import apoc.util.FileUtils;
 import apoc.util.TestUtil;
 import com.novell.ldap.LDAPEntry;
 import com.novell.ldap.LDAPSearchResults;
@@ -9,17 +10,24 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.neo4j.test.rule.DbmsRule;
-import org.neo4j.test.rule.ImpermanentDbmsRule;
+import org.junit.rules.TemporaryFolder;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.dbms.api.DatabaseManagementService;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 import org.zapodot.junit.ldap.EmbeddedLdapRule;
 import org.zapodot.junit.ldap.EmbeddedLdapRuleBuilder;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 
 import static apoc.ApocConfig.apocConfig;
 import static apoc.util.TestUtil.testCall;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -31,8 +39,10 @@ public class LoadLdapTest {
     public static Map<String, Object> searchParams;
 
     @ClassRule
-    public static DbmsRule db = new ImpermanentDbmsRule();
-    
+    public static TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private static GraphDatabaseService db;
+
     @ClassRule
     public static EmbeddedLdapRule embeddedLdapRule = EmbeddedLdapRuleBuilder
             .newInstance()
@@ -43,6 +53,8 @@ public class LoadLdapTest {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
+        DatabaseManagementService dbms = new TestDatabaseManagementServiceBuilder(tempFolder.getRoot().toPath()).build();
+        db = dbms.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
         TestUtil.registerProcedure(db, LoadLdap.class);
 
         ldapConnection = embeddedLdapRule.unsharedLdapConnection();
@@ -64,15 +76,49 @@ public class LoadLdapTest {
 
     @Test
     public void testLoadLDAPWithApocConfig() {
+        String key = "apoc.loadldap.myldap.config";
+        testWithStringConfigCommon(key);
+
+        // the config with dot after loadldap shouldn't print a log warn
+        String logWarn = "Not to cause breaking-change, the current config `apoc.loadldap.myldap.config` is valid";
+        assertFalse(getLogFileContent().contains(logWarn));
+    }
+
+    @Test
+    public void testLoadLDAPWithApocConfigWithoutDotBeforeLdapKey() {
+        // analogous to `testLoadLDAPWithApocConfig`, but without dot between `loadldap` and `myldap`
+        // it still works not to cause a breaking change
+        String key = "apoc.loadldapmyldap.config";
+        testWithStringConfigCommon(key);
+
+        // the config without dot after loadldap should print a log warn
+        String logWarn = "Not to cause breaking-change, the current config `apoc.loadldapmyldap.config` is valid";
+        assertTrue(getLogFileContent().contains(logWarn));
+    }
+
+    private static String getLogFileContent() {
+        try {
+            File logFile = new File(FileUtils.getLogDirectory(), "debug.log");
+            return Files.readString(logFile.toPath());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void testWithStringConfigCommon(String key) {
+        // set a config `key=localhost:port dns pwd`
         String ldapValue = "%s %s %s".formatted(
                 "localhost:" + ldapConnection.getConnectedPort(),
                 BIND_DSN,
                 BIND_PWD);
-        apocConfig().setProperty("apoc.loadldap.myldap.config", ldapValue);
+        apocConfig().setProperty(key, ldapValue);
 
         testCall(db, "call apoc.load.ldap($conn, $search)",
                 Map.of("conn", "myldap", "search", searchParams),
                 this::testLoadAssertionCommon);
+
+        // remove current config to prevent multiple confs in other tests
+        apocConfig().getConfig().clearProperty(key);
     }
 
     @Test
@@ -104,7 +150,7 @@ public class LoadLdapTest {
 
     @Test
     public void testLoadLDAPConfig() throws Exception {
-        LoadLdap.LDAPManager mgr = new LoadLdap.LDAPManager(LoadLdap.getConnectionMap(connParams));
+        LoadLdap.LDAPManager mgr = new LoadLdap.LDAPManager(LoadLdap.getConnectionMap(connParams, null));
         
         LDAPSearchResults results = mgr.doSearch(searchParams);
         LDAPEntry le = results.next();


### PR DESCRIPTION
- Added support `apoc.loadldap<KEY>.conf` to `apoc.loadldap.<KEY>.conf` (with dot after `loadldap`)
- Added tests with correct and wrong config key
- Added log warn with fallback: `apoc.loadldap<KEY>.conf` and changed `DbsmRule` to `TestDatabaseManagementServiceBuilder` to check logs via `FileUtils.getLogDirectory()`