### PR TITLE
Update playbooks for docs publish

### DIFF
--- a/docs/antora/publish.yml
+++ b/docs/antora/publish.yml
@@ -5,8 +5,8 @@ site:
 
 content:
   sources:
-  - url: ../../
-    branches: ['HEAD']
+  - url: https://github.com/neo4j-contrib/neo4j-apoc-procedures
+    branches: ['5.11', '4.4', '4.3', '4.2', '4.1', '4.0']
     start_path: docs/asciidoc
     exclude:
     - '!**/_includes/*'

--- a/docs/antora/publish.yml
+++ b/docs/antora/publish.yml
@@ -30,3 +30,4 @@ asciidoc:
     page-disabletracking: true
     page-add-notes-module: notes@
     page-add-notes-tags: core-warning@
+    page-add-notes-versions: ['5']


### PR DESCRIPTION
Updates the `preview.yml` playbook to allow for local building in a consistent way with neo4j.com/docs content.

Adds a new `publish.yml` playbook to allow for publishing in a consistent way with neo4j.com/docs content.