### PR TITLE
Fixes #3708: Neo4j APOC custom function hangs when nothing is found

### DIFF
--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -399,7 +399,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
                         Transaction tx = ctx.transaction();
                         try (Result result = tx.execute(statement, params)) {
 //                resourceTracker.registerCloseableResource(result); // TODO
-                            if (!result.hasNext()) return null;
+                            if (!result.hasNext()) return Values.NO_VALUE;
                             if (outType.equals(NTAny)) {
                                 return ValueUtils.of(result.stream().collect(Collectors.toList()));
                             }

--- a/extended/src/test/java/apoc/custom/CypherProceduresTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresTest.java
@@ -30,6 +30,8 @@ import static apoc.custom.CypherProceduresHandler.FUNCTION;
 import static apoc.custom.CypherProceduresHandler.PROCEDURE;
 import static apoc.custom.Signatures.SIGNATURE_SYNTAX_ERROR;
 import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testCallEmpty;
+import static apoc.util.TestUtil.testResult;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -830,6 +832,72 @@ public class CypherProceduresTest  {
         ));
     }
 
+    @Test
+    public void testCustomWithEmptyResult() {
+        String query = """
+                MATCH (m:Movie) WITH m.id AS id
+                LIMIT $limit
+                RETURN id""";
+
+        String declareFunctionOne = "CALL apoc.custom.declareFunction('testFunOne(limit :: INTEGER)::LIST OF INTEGER?', $query)";
+        db.executeTransactionally(declareFunctionOne, Map.of("query", query));
+
+        String declareFunctionTwo = "CALL apoc.custom.declareFunction('testFunTwo(limit :: INTEGER):: ANY', $query)";
+        db.executeTransactionally(declareFunctionTwo, Map.of("query", query));
+
+        String declareProcedureOne = "CALL apoc.custom.declareProcedure('testProcOne(limit :: INTEGER):: (id::ANY)', $query)";
+        db.executeTransactionally(declareProcedureOne, Map.of("query", query));
+
+        String declareProcedureTwo = "CALL apoc.custom.declareProcedure('testProcTwo(limit :: INTEGER):: (id::INTEGER)', $query)";
+        db.executeTransactionally(declareProcedureTwo, Map.of("query", query));
+
+        // test customs with no (:Movie) nodes
+        testCall(db, "RETURN custom.testFunOne(0) as id", r -> assertNull(r.get("id")));
+        testCall(db, "RETURN custom.testFunTwo(0) as id", r -> assertNull(r.get("id")));
+        testCallEmpty(db, "CALL custom.testProcOne(0)", Map.of());
+        testCallEmpty(db, "CALL custom.testProcTwo(0)", Map.of());
+
+        // should return nothing
+        testCall(db, "RETURN custom.testFunOne(2) as id", r -> assertNull(r.get("id")));
+        testCall(db, "RETURN custom.testFunTwo(2) as id", r -> assertNull(r.get("id")));
+        testCallEmpty(db, "CALL custom.testProcOne(2)", Map.of());
+        testCallEmpty(db, "CALL custom.testProcTwo(2)", Map.of());
+
+        // test customs with some (:Movie) nodes
+        db.executeTransactionally("create (:Movie {id: 1}), (:Movie {id: 2}), (:Movie {id: 3})");
+
+        testCall(db, "RETURN custom.testFunOne(0) as id", r -> assertNull(r.get("id")));
+        testCall(db, "RETURN custom.testFunTwo(0) as id", r -> assertNull(r.get("id")));
+        testCallEmpty(db, "CALL custom.testProcOne(0)", Map.of());
+        testCallEmpty(db, "CALL custom.testProcTwo(0)", Map.of());
+
+        // should return something
+        testCall(db, "RETURN custom.testFunOne(2) as id", r -> {
+            assertEquals(r.get("id"), List.of(1L, 2L));
+        });
+        testCall(db, "RETURN custom.testFunTwo(2) as id", r -> {
+            Object expected = r.get("id");
+            List<Map> actual = List.of(
+                    Map.of("id", 1L),
+                    Map.of("id", 2L)
+            );
+            assertEquals(expected, actual);
+        });
+        testResult(db, "CALL custom.testProcOne(2)", r -> {
+            Map<String, Object> row = r.next();
+            assertEquals(row.get("id"), 1L);
+            row = r.next();
+            assertEquals(row.get("id"), 2L);
+            assertFalse(r.hasNext());
+        });
+        testResult(db, "CALL custom.testProcTwo(2)", r -> {
+            Map<String, Object> row = r.next();
+            assertEquals(row.get("id"), 1L);
+            row = r.next();
+            assertEquals(row.get("id"), 2L);
+            assertFalse(r.hasNext());
+        });
+    }
 
     private void assertProcedureFails(String expectedMessage, String query) {
         try {


### PR DESCRIPTION
With `if (!result.hasNext()) return null;`, the custom function hangs and logs a:
```
[Neo.DatabaseError.Statement.ExecutionFailed]: null
```