### PR TITLE
[iBQzFOoI] Adds sts to the list of aws extra-dependencies

### DIFF
--- a/extra-dependencies/aws/build.gradle
+++ b/extra-dependencies/aws/build.gradle
@@ -19,4 +19,5 @@ jar {
 
 dependencies {
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.425'
+    implementation group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: '1.12.425'
 }


### PR DESCRIPTION
Depends on the answer from https://github.com/neo4j/apoc/issues/482

## Why
For the service accounts to work sts needs to be in the classpath, as described in https://github.com/aws/aws-sdk-java/issues/2136.

