### PR TITLE
Solve flaky test 5.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ subprojects {
                 'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-debian' : 'neo4j:5.12.0',
                 'coreDir': 'apoc-core/core'
 
-        maxHeapSize = "8G"
+        maxHeapSize = "5G"
         forkEvery = 50
         maxParallelForks = 1
         minHeapSize = "128m"

--- a/extended/src/test/java/apoc/CoreExtendedTest.java
+++ b/extended/src/test/java/apoc/CoreExtendedTest.java
@@ -27,11 +27,9 @@ import static org.junit.Assert.fail;
 public class CoreExtendedTest {
     @Test
     public void checkForCoreAndExtended() {
-        try {
-            Neo4jContainerExtension neo4jContainer = createEnterpriseDB(List.of(ApocPackage.CORE, ApocPackage.EXTENDED), true)
-                    .withNeo4jConfig("dbms.transaction.timeout", "60s")
-                    .withEnv(APOC_IMPORT_FILE_ENABLED, "true");
-
+        try(Neo4jContainerExtension neo4jContainer = createEnterpriseDB(List.of(ApocPackage.CORE, ApocPackage.EXTENDED), true)
+                .withNeo4jConfig("dbms.transaction.timeout", "60s")
+                .withEnv(APOC_IMPORT_FILE_ENABLED, "true")) {
             neo4jContainer.start();
 
             Session session = neo4jContainer.getSession();
@@ -41,7 +39,6 @@ public class CoreExtendedTest {
             assertTrue(coreCount > 0);
             assertTrue(extendedCount > 0);
 
-            neo4jContainer.close();
         } catch (Exception ex) {
             if (TestContainerUtil.isDockerImageAvailable(ex)) {
                 ex.printStackTrace();
@@ -52,10 +49,9 @@ public class CoreExtendedTest {
 
     @Test
     public void matchesSpreadsheet() {
-        try {
-            Neo4jContainerExtension neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.CORE, TestContainerUtil.ApocPackage.EXTENDED), true)
-                    .withNeo4jConfig("dbms.transaction.timeout", "60s")
-                    .withEnv(APOC_IMPORT_FILE_ENABLED, "true");
+        try(Neo4jContainerExtension neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.CORE, TestContainerUtil.ApocPackage.EXTENDED), true)
+                .withNeo4jConfig("dbms.transaction.timeout", "60s")
+                .withEnv(APOC_IMPORT_FILE_ENABLED, "true")) {
 
             neo4jContainer.start();
 
@@ -78,8 +74,7 @@ public class CoreExtendedTest {
             List<Map.Entry<String, String>> different = spreadsheet.entrySet().stream().filter(entry -> actual.containsKey(entry.getKey()) && !actual.get(entry.getKey()).equals(entry.getValue())).collect(Collectors.toList());
 
             assertEquals(different.toString(), 0, different.size());
-
-            neo4jContainer.close();
+            
         } catch (Exception ex) {
             if (TestContainerUtil.isDockerImageAvailable(ex)) {
                 ex.printStackTrace();


### PR DESCRIPTION
Sometimes the CI fails without specifying a test, with a generic ["The Operation was canceled"](https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/6249290975/job/16969904191?pr=3778#step:5:2891).
Usually during or right after a Docker test.

Maybe it can be a heap memory issue.


- Added auto-close to StartupTest, 
otherwise the `neo4jContainer` would not be closed in case of uncaught exception, 
and could flakily cause other CI failures.


- Decreased `maxHeapSize` [as in Core](https://github.com/neo4j/apoc/blob/dev/build.gradle#L77)
