### PR TITLE
Bump version 5.14.0 (#3726)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ downloadLicenses {
 
 allprojects {
     group = 'org.neo4j.procedure'
-    version = '5.13.0'
+    version = '5.14.0'
     archivesBaseName = 'apoc'
     description = """neo4j-apoc-procedures"""
 }
@@ -71,8 +71,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise-debian' : 'neo4j:5.13.0-enterprise-debian',
-                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-debian' : 'neo4j:5.13.0-debian',
+                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise-debian' : 'neo4j:5.14.0-enterprise-debian',
+                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-debian' : 'neo4j:5.14.0-debian',
                 'coreDir': 'apoc-core/core'
 
         maxHeapSize = "8G"
@@ -130,7 +130,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.13.0"
+    neo4jVersion = "5.14.0"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.18.3'

--- a/docs/asciidoc/antora.yml
+++ b/docs/asciidoc/antora.yml
@@ -8,4 +8,4 @@ asciidoc:
     docs-version: "5.0"
     branch: "5.0"
     apoc-release-absolute: "5.0"
-    apoc-release: "5.13.0"
+    apoc-release: "5.14.0"

--- a/docs/asciidoc/modules/ROOT/partials/neo4j-server.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/neo4j-server.adoc
@@ -24,6 +24,7 @@ The version compatibility matrix explains the mapping between Neo4j and APOC ver
 [opts=header]
 |===
 |apoc version | neo4j version
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.14.0[5.14.0^] | 5.14.0 (5.14.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.13.0[5.13.0^] | 5.13.0 (5.13.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.12.0[5.12.0^] | 5.12.0 (5.12.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.11.0[5.11.0^] | 5.11.0 (5.11.x)

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -29,7 +29,7 @@ plugins {
     id 'org.neo4j.doc.build.docbook' version '1.0-alpha12'
 }
 
-if (!project.hasProperty('apocVersion')) { ext.apocVersion = '5.13.0' }
+if (!project.hasProperty('apocVersion')) { ext.apocVersion = '5.14.0' }
 
 ext {
     versionParts = apocVersion.split('-')

--- a/extra-dependencies/build.gradle
+++ b/extra-dependencies/build.gradle
@@ -14,7 +14,7 @@ configure(subprojects) {
 
 
 subprojects {
-    version = '5.13.0'
+    version = '5.14.0'
     group = 'org.neo4j.contrib'
 }
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,8 +1,8 @@
 :readme:
 :branch: 5.4
 :docs: https://neo4j.com/labs/apoc/5
-:apoc-release: 5.13.0
-:neo4j-version: 5.13.0
+:apoc-release: 5.14.0
+:neo4j-version: 5.14.0
 :img: https://raw.githubusercontent.com/neo4j-contrib/neo4j-apoc-procedures/{branch}/docs/images
 
 https://community.neo4j.com[image:https://img.shields.io/discourse/users?logo=discourse&server=https%3A%2F%2Fcommunity.neo4j.com[Discourse users]]


### PR DESCRIPTION
Bump dev version to 5.14.0

Cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/11c94f34b339cbe475bb92a9f122e06456342de4