### PR TITLE
Parallelize test if not in TeamCity

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew --init-script init.gradle
-          ./gradlew build
+          ./gradlew build --parallel
 
       - name: Clean neo4j artifacts
         if: always() # run this step even if previous step failed

--- a/build.gradle
+++ b/build.gradle
@@ -77,9 +77,7 @@ subprojects {
 
         maxHeapSize = "5G"
         forkEvery = 50
-        maxParallelForks = System.env.TEAMCITY_VERSION != null
-                ? 1
-                : (Runtime.runtime.availableProcessors().intdiv(2) ?: 1)
+        maxParallelForks = 1
         minHeapSize = "128m"
 
         // This would apply only to TeamCity

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,9 @@ subprojects {
 
         maxHeapSize = "5G"
         forkEvery = 50
-        maxParallelForks = 1
+        maxParallelForks = System.env.TEAMCITY_VERSION != null
+                ? 1
+                : (Runtime.runtime.availableProcessors().intdiv(2) ?: 1)
         minHeapSize = "128m"
 
         // This would apply only to TeamCity


### PR DESCRIPTION
Restore parallelization if not in TeamCity (where it could cause problems).
See [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/2825/commits/005a4a44975ae36c1ef0fb583155daac0e470c13)

Added the flag `--parallel` to `gradlew build` command