### PR TITLE
Fixed table formatting-removed "|" in bot|user

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/ml/vertexai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/vertexai.adoc
@@ -111,7 +111,7 @@ yield value
 [%autowidth, opts=header]
 |===
 |name | description
-| messages | List of maps of instructions with `{author:"bot|user", content:"text"}`
+| messages | List of maps of instructions with `{author:"bot user", content:"text"}`
 | accessToken | Vertex.AI API access token
 | project | Google Cloud project
 | configuration | optional map for entries like region, model, temperature, topK, topP, maxOutputTokens and other parameters


### PR DESCRIPTION

Removed "|" in bot|user which caused the table to be misaligned and not understandable.

