### PR TITLE
Fix UUID bug

### DIFF
--- a/full/src/main/java/apoc/uuid/UUIDHandlerNewProcedures.java
+++ b/full/src/main/java/apoc/uuid/UUIDHandlerNewProcedures.java
@@ -118,12 +118,4 @@ public class UUIDHandlerNewProcedures {
     public static ResourceIterator<Node> getUuidNodes(Transaction tx, String databaseName, Map<String, Object> props) {
         return getSystemNodes(tx, databaseName, SystemLabels.ApocUuid, props);
     }
-
-    public static void createConstraintUuid(Transaction tx, String label, String propertyName) {
-        tx.execute(
-                String.format("CREATE CONSTRAINT IF NOT EXISTS FOR (n:%s) REQUIRE (n.%s) IS UNIQUE",
-                        Util.quote(label),
-                        Util.quote(propertyName))
-        );
-    }
 }

--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -144,7 +144,6 @@ public class TestContainerUtil {
 
         Neo4jContainerExtension neo4jContainer = new Neo4jContainerExtension(dockerImage)
                 .withPlugins(MountableFile.forHostPath(pluginsFolder.toPath()))
-                .withTmpFs(Map.of("/logs", "rw", "/data", "rw", pluginsFolder.toPath().toAbsolutePath().toString(), "rw"))
                 .withAdminPassword(password)
                 .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
                 .withEnv("apoc.export.file.enabled", "true")


### PR DESCRIPTION
- Stop using tmpfs, it is known to cause issues with neo4j (https://github.com/neo4j/apoc/pull/512).
- Fix bug in `apoc.uuid.*` procedures (similar to https://github.com/neo4j/apoc/pull/513).

https://trello.com/c/zH04aIIy/2382-flaky-test-apocfullituuidmultidbtesttestwithdefaultdatabasewithuuidenabled-is-flaky-on-several-44-builds