### PR TITLE
[zH04aIIy] Fix UUID bug

### DIFF
--- a/full/src/main/java/apoc/uuid/UUIDHandlerNewProcedures.java
+++ b/full/src/main/java/apoc/uuid/UUIDHandlerNewProcedures.java
@@ -118,12 +118,4 @@ public class UUIDHandlerNewProcedures {
     public static ResourceIterator<Node> getUuidNodes(Transaction tx, String databaseName, Map<String, Object> props) {
         return getSystemNodes(tx, databaseName, SystemLabels.ApocUuid, props);
     }
-
-    public static void createConstraintUuid(Transaction tx, String label, String propertyName) {
-        tx.execute(
-                String.format("CREATE CONSTRAINT IF NOT EXISTS FOR (n:%s) REQUIRE (n.%s) IS UNIQUE",
-                        Util.quote(label),
-                        Util.quote(propertyName))
-        );
-    }
 }

--- a/full/src/main/java/apoc/uuid/UuidHandler.java
+++ b/full/src/main/java/apoc/uuid/UuidHandler.java
@@ -43,11 +43,9 @@ import org.neo4j.scheduler.Group;
 import org.neo4j.scheduler.JobHandle;
 import org.neo4j.scheduler.JobScheduler;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;

--- a/full/src/main/java/apoc/uuid/UuidHandler.java
+++ b/full/src/main/java/apoc/uuid/UuidHandler.java
@@ -310,6 +310,7 @@ public class UuidHandler extends LifecycleAdapter implements TransactionEventLis
                     .forEachRemaining(node -> node.delete());
             tx.commit();
         }
+        refresh();
         return retval;
     }
 

--- a/full/src/test/java/apoc/uuid/UUIDTest.java
+++ b/full/src/test/java/apoc/uuid/UUIDTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 
 import static junit.framework.TestCase.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -294,15 +295,13 @@ public class UUIDTest {
         db.executeTransactionally("CALL apoc.uuid.install('Test', {addToExistingNodes: false, uuidProperty: 'foo'}) YIELD label RETURN label");
 
         // when
-        TestUtil.testResult(db, "CALL apoc.uuid.removeAll()",
-                (result) -> {
+
+        TestUtil.testResult(db, "CALL apoc.uuid.removeAll()", (result) -> {
                     // then
-                    Map<String, Object> row = result.next();
-                    assertResult(row, "Test", false,
-                            Util.map("uuidProperty", "foo", "addToSetLabels", false));
-                    row = result.next();
-                    assertResult(row, "Bar", false,
-                            Util.map("uuidProperty", "uuid", "addToSetLabels", false));
+                    assertThat(result.stream()).containsExactlyInAnyOrder(
+                            Map.of("label", "Test", "installed", false, "properties", Map.of("uuidProperty", "foo", "addToSetLabels", false)),
+                            Map.of("label", "Bar", "installed", false, "properties", Map.of("uuidProperty", "uuid", "addToSetLabels", false))
+                    );
                 });
     }
 

--- a/test-utils/src/main/java/apoc/util/TestContainerUtil.java
+++ b/test-utils/src/main/java/apoc/util/TestContainerUtil.java
@@ -144,7 +144,6 @@ public class TestContainerUtil {
 
         Neo4jContainerExtension neo4jContainer = new Neo4jContainerExtension(dockerImage)
                 .withPlugins(MountableFile.forHostPath(pluginsFolder.toPath()))
-                .withTmpFs(Map.of("/logs", "rw", "/data", "rw", pluginsFolder.toPath().toAbsolutePath().toString(), "rw"))
                 .withAdminPassword(password)
                 .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
                 .withEnv("apoc.export.file.enabled", "true")


### PR DESCRIPTION
- Stop using tmpfs, it is known to cause issues with neo4j (https://github.com/neo4j/apoc/pull/512).
- Fix bug in `apoc.uuid.*` procedures (similar to https://github.com/neo4j/apoc/pull/513).