### PR TITLE
Update vertexai.adoc

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/ml/vertexai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/vertexai.adoc
@@ -9,12 +9,15 @@ NOTE: You need to create a Google Cloud project in your account an enable the Ve
 This procedure `apoc.ml.vertexai.embedding` can take a list of text strings, and will return one row per string, with the embedding data as a 768 element vector.
 It uses the embedding endpoint which is https://cloud.google.com/vertex-ai/docs/generative-ai/embeddings/get-text-embeddings[documented here^].
 
+API Quotas are per project/per region and you can over-ride the default us-central1 in the configuration map e.g. {region:'us-east4'}.
+GCP Regions can be found here: https://cloud.google.com/about/locations 
+
 Additional configuration is passed to the API, the default model used is `textembedding-gecko`.
 
 .Generate Embeddings Call
 [source,cypher]
 ----
-CALL apoc.ml.vertexai.embedding(['Some Text'], $accessToken, $project, {}) yield index, text, embedding;
+CALL apoc.ml.vertexai.embedding(['Some Text'], $accessToken, $project, {region:'<region>'}) yield index, text, embedding;
 ----
 
 .Generate Embeddings Response


### PR DESCRIPTION
The default is us-central1 - folks don't know how to over-ride it - I looked at the code to figure out how to change the region, others aren't so diligent.  The end result is you run out of quota in us-central1 because everyone used the default

Fixes #3834

One sentence summary of the change.

## Proposed Changes


Add text to describe where to discover where GCP regions are
Add the configuration map that demonstrates the map

