### PR TITLE
Release 5.14.0 (#3803)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "5.14" ]
   pull_request:
-    branches: [ "dev" ]
+    branches: [ "5.14" ]
 
 jobs:
   build:
@@ -25,14 +25,6 @@ jobs:
         with:
           java-version: '17.0.8'
           distribution: 'temurin'
-
-      - name: Download neo4j dev docker container
-        run: |
-          curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_ENTERPRISE_URL} -o ${ENTERPRISE_TAR} &
-          curl -s -L0 -u "${TEAMCITY_USER}:${TEAMCITY_PASSWORD}" -X GET ${DOCKER_COMMUNITY_URL} -o ${COMMUNITY_TAR} &
-          wait
-          docker load --input ${ENTERPRISE_TAR}
-          docker load --input ${COMMUNITY_TAR}
 
       - uses: actions/cache@v2
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "apoc-core"]
 	path = apoc-core
 	url = https://github.com/neo4j/apoc
-	branch = dev
+	branch = 5.14

--- a/build.gradle
+++ b/build.gradle
@@ -71,8 +71,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise-debian' : 'neo4j:5.14.0-enterprise-debian',
-                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-debian' : 'neo4j:5.14.0-debian',
+                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise-debian' : 'neo4j:5.14.0-enterprise',
+                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-debian' : 'neo4j:5.14.0',
                 'coreDir': 'apoc-core/core'
 
         maxHeapSize = "5G"

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ subprojects {
         archiveClassifier = 'javadoc'
     }
     test {
-        //exclude '**/CypherProceduresClusterTest.class'//, '**/AtomicTest.class'
+        include '**/StartupExtendedTest.class'//, '**/AtomicTest.class'
 
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ subprojects {
         archiveClassifier = 'javadoc'
     }
     test {
-        include '**/StartupExtendedTest.class'//, '**/AtomicTest.class'
+        //exclude '**/CypherProceduresClusterTest.class'//, '**/AtomicTest.class'
 
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,

--- a/docs/antora/publish.yml
+++ b/docs/antora/publish.yml
@@ -6,7 +6,7 @@ site:
 content:
   sources:
   - url: https://github.com/neo4j-contrib/neo4j-apoc-procedures
-    branches: ['5.11', '4.4', '4.3', '4.2', '4.1', '4.0']
+    branches: ['5.14', '4.4', '4.3', '4.2', '4.1', '4.0']
     start_path: docs/asciidoc
     exclude:
     - '!**/_includes/*'

--- a/docs/asciidoc/modules/ROOT/partials/neo4j-server.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/neo4j-server.adoc
@@ -38,7 +38,7 @@ The version compatibility matrix explains the mapping between Neo4j and APOC ver
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.3.1[5.3.1^] | 5.3.0 (5.3.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.2.0[5.2.0^] | 5.2.0 (5.2.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.1.0[5.1.0^] | 5.1.0 (5.1.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.18[4.4.0.18^] | 4.4.0 (4.4.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.23[4.4.0.23^] | 4.4.0 (4.4.x)
 |===
 
 // end::version-matrix[]

--- a/extended/src/test/java/apoc/StartupExtendedTest.java
+++ b/extended/src/test/java/apoc/StartupExtendedTest.java
@@ -1,5 +1,6 @@
 package apoc;
 
+import apoc.util.ExtendedTestContainerUtil;
 import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
 import apoc.util.TestContainerUtil.Neo4jVersion;
@@ -90,7 +91,7 @@ public class StartupExtendedTest {
 
             try (final Neo4jContainerExtension neo4jContainer = neo4jContainerCreation.apply(version)) {
                 // add extra-deps before starting it
-//                ExtendedTestContainerUtil.addExtraDependencies();
+                ExtendedTestContainerUtil.addExtraDependencies();
 
                 Collection<File> files = FileUtils.listFiles(TestContainerUtil.pluginsFolder, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
                 System.out.println("files = " + files);

--- a/extended/src/test/java/apoc/StartupExtendedTest.java
+++ b/extended/src/test/java/apoc/StartupExtendedTest.java
@@ -5,14 +5,12 @@ import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
 import apoc.util.TestContainerUtil.Neo4jVersion;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.junit.Test;
 import org.neo4j.driver.Session;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -92,10 +90,6 @@ public class StartupExtendedTest {
             try (final Neo4jContainerExtension neo4jContainer = neo4jContainerCreation.apply(version)) {
                 // add extra-deps before starting it
                 ExtendedTestContainerUtil.addExtraDependencies();
-
-                Collection<File> files = FileUtils.listFiles(TestContainerUtil.pluginsFolder, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
-                System.out.println("files = " + files);
-
                 neo4jContainer.start();
                 assertTrue("Neo4j Instance should be up-and-running", neo4jContainer.isRunning());
 

--- a/extended/src/test/java/apoc/StartupExtendedTest.java
+++ b/extended/src/test/java/apoc/StartupExtendedTest.java
@@ -5,7 +5,6 @@ import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
 import apoc.util.TestContainerUtil.Neo4jVersion;
 import org.apache.commons.io.FileUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.driver.Session;
 
@@ -29,7 +28,6 @@ import static org.junit.Assert.fail;
 /*
  This test is just to verify if the APOC procedures and functions are correctly deployed into a Neo4j instance without any startup issue.
  */
-@Ignore
 public class StartupExtendedTest {
     private static final String APOC_HELP_QUERY = "CALL apoc.help('') YIELD core, type, name WHERE core = $core and type = $type RETURN name";
     private static final List<String> EXPECTED_EXTENDED_NAMES;

--- a/extended/src/test/java/apoc/StartupExtendedTest.java
+++ b/extended/src/test/java/apoc/StartupExtendedTest.java
@@ -1,6 +1,5 @@
 package apoc;
 
-import apoc.util.ExtendedTestContainerUtil;
 import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
 import apoc.util.TestContainerUtil.Neo4jVersion;
@@ -91,7 +90,7 @@ public class StartupExtendedTest {
 
             try (final Neo4jContainerExtension neo4jContainer = neo4jContainerCreation.apply(version)) {
                 // add extra-deps before starting it
-                ExtendedTestContainerUtil.addExtraDependencies();
+//                ExtendedTestContainerUtil.addExtraDependencies();
 
                 Collection<File> files = FileUtils.listFiles(TestContainerUtil.pluginsFolder, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
                 System.out.println("files = " + files);

--- a/extended/src/test/java/apoc/StartupExtendedTest.java
+++ b/extended/src/test/java/apoc/StartupExtendedTest.java
@@ -5,12 +5,14 @@ import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
 import apoc.util.TestContainerUtil.Neo4jVersion;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.junit.Test;
 import org.neo4j.driver.Session;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -90,6 +92,10 @@ public class StartupExtendedTest {
             try (final Neo4jContainerExtension neo4jContainer = neo4jContainerCreation.apply(version)) {
                 // add extra-deps before starting it
                 ExtendedTestContainerUtil.addExtraDependencies();
+
+                Collection<File> files = FileUtils.listFiles(TestContainerUtil.pluginsFolder, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
+                System.out.println("files = " + files);
+
                 neo4jContainer.start();
                 assertTrue("Neo4j Instance should be up-and-running", neo4jContainer.isRunning());
 

--- a/extended/src/test/java/apoc/util/ExtendedTestContainerUtil.java
+++ b/extended/src/test/java/apoc/util/ExtendedTestContainerUtil.java
@@ -34,7 +34,7 @@ public class ExtendedTestContainerUtil
 
         // add all extra deps to the plugin docker folder
         final File directory = new File(extraDepsDir, "build/allJars");
-        final IOFileFilter instance = new WildcardFileFilter("*-all.jar");
+        final IOFileFilter instance = new WildcardFileFilter("*.jar");
         copyFilesToPlugin(directory, instance, TestContainerUtil.pluginsFolder);
     }
 

--- a/extra-dependencies/build.gradle
+++ b/extra-dependencies/build.gradle
@@ -17,6 +17,9 @@ ext {
     commonExclusions = {
         // guava
         exclude group: 'com.google.guava', module: 'guava'
+        
+        // gson
+        exclude group: 'com.google.code.gson', module: 'gson'
 
         // apache commons
         exclude group: 'org.apache.commons', module: 'commons-beanutils'

--- a/extra-dependencies/build.gradle
+++ b/extra-dependencies/build.gradle
@@ -12,6 +12,60 @@ configure(subprojects) {
     apply plugin: 'java'
 }
 
+ext {
+    // packages included in `$NEO4j/lib` folder
+    commonExclusions = {
+        // guava
+        exclude group: 'com.google.guava', module: 'guava'
+
+        // apache commons
+        exclude group: 'org.apache.commons', module: 'commons-beanutils'
+        exclude group: 'org.apache.commons', module: 'commons-collections'
+        exclude group: 'org.apache.commons', module: 'commons-compress'
+        exclude group: 'org.apache.commons', module: 'commons-configuration2'
+        exclude group: 'org.apache.commons', module: 'commons-io'
+        exclude group: 'org.apache.commons', module: 'commons-lang3'
+        exclude group: 'org.apache.commons', module: 'commons-logging'
+        exclude group: 'org.apache.commons', module: 'commons-text'
+
+        // reactor-core
+        exclude group: 'io.projectreactor', module: 'reactor-core'
+
+        // org.eclipse.jetty
+        exclude group: 'org.eclipse.jetty'
+        exclude group: 'org.eclipse.jetty.aggregate'
+        
+        // com.sun.jersey
+        exclude group: 'com.sun.jersey'
+        
+        // slf4j
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+
+        // jackson
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+
+        // io.netty
+        exclude group: 'io.netty', module: 'netty-codec'
+        exclude group: 'io.netty', module: 'netty-codec-http'
+        exclude group: 'io.netty', module: 'netty-codec-http2'
+        exclude group: 'io.netty', module: 'netty-codec-socks'
+        exclude group: 'io.netty', module: 'netty-common'
+        exclude group: 'io.netty', module: 'netty-handler'
+        exclude group: 'io.netty', module: 'netty-handler-proxy'
+        exclude group: 'io.netty', module: 'netty-resolver'
+        exclude group: 'io.netty', module: 'netty-transport'
+        exclude group: 'io.netty', module: 'netty-transport-classes-epoll'
+        exclude group: 'io.netty', module: 'netty-transport-classes-kqueue'
+        exclude group: 'io.netty', module: 'netty-transport-native-epoll'
+        exclude group: 'io.netty', module: 'netty-transport-native-epoll'
+        exclude group: 'io.netty', module: 'netty-transport-native-kqueue'
+        exclude group: 'io.netty', module: 'netty-transport-native-kqueue'
+        exclude group: 'io.netty', module: 'netty-transport-native-unix-common'
+        exclude group: 'io.netty', module: 'netty-tcnative-classes'
+    }
+}
+
 
 subprojects {
     version = '5.14.0'

--- a/extra-dependencies/couchbase/build.gradle
+++ b/extra-dependencies/couchbase/build.gradle
@@ -17,9 +17,7 @@ jar {
 }
 
 dependencies {
-    implementation group: 'com.couchbase.client', name: 'java-client', version: '3.3.0', {
-        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
-    }
+    implementation group: 'com.couchbase.client', name: 'java-client', version: '3.3.0', commonExclusions
 }
 
 

--- a/extra-dependencies/gcs/build.gradle
+++ b/extra-dependencies/gcs/build.gradle
@@ -18,7 +18,5 @@ jar {
 }
 
 dependencies {
-    implementation group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.22.3', {
-        exclude group: 'com.google.guava', module: 'guava'
-    }
+    implementation group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.22.3', commonExclusions
 }

--- a/extra-dependencies/gcs/build.gradle
+++ b/extra-dependencies/gcs/build.gradle
@@ -18,5 +18,7 @@ jar {
 }
 
 dependencies {
-    implementation group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.22.3'
+    implementation group: 'com.google.cloud', name: 'google-cloud-storage', version: '2.22.3', {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
 }

--- a/extra-dependencies/hadoop/build.gradle
+++ b/extra-dependencies/hadoop/build.gradle
@@ -33,6 +33,19 @@ def commonExclusions = {
     exclude group: 'org.eclipse.jetty'
     exclude group: 'org.eclipse.jetty.aggregate'
     exclude group: 'org.slf4j', module: 'slf4j-api'
+    
+    exclude group: 'org.apache.commons', module: 'commons-beanutils'
+    exclude group: 'org.apache.commons', module: 'commons-collections'
+    exclude group: 'org.apache.commons', module: 'commons-compress'
+    exclude group: 'org.apache.commons', module: 'commons-configuration2'
+    exclude group: 'org.apache.commons', module: 'commons-io'
+    exclude group: 'org.apache.commons', module: 'commons-lang3'
+    exclude group: 'org.apache.commons', module: 'commons-logging'
+    exclude group: 'org.apache.commons', module: 'commons-text'
+
+    exclude group: 'org.ow2.asm', module: 'asm'
+    
+    exclude group: 'com.google.guava', module: 'guava'
 }
 
 dependencies {

--- a/extra-dependencies/hadoop/build.gradle
+++ b/extra-dependencies/hadoop/build.gradle
@@ -27,27 +27,6 @@ shadowJar {
     mergeServiceFiles()
 }
 
-def commonExclusions = {
-    exclude group: 'io.netty'
-    exclude group: 'com.sun.jersey'
-    exclude group: 'org.eclipse.jetty'
-    exclude group: 'org.eclipse.jetty.aggregate'
-    exclude group: 'org.slf4j', module: 'slf4j-api'
-    
-    exclude group: 'org.apache.commons', module: 'commons-beanutils'
-    exclude group: 'org.apache.commons', module: 'commons-collections'
-    exclude group: 'org.apache.commons', module: 'commons-compress'
-    exclude group: 'org.apache.commons', module: 'commons-configuration2'
-    exclude group: 'org.apache.commons', module: 'commons-io'
-    exclude group: 'org.apache.commons', module: 'commons-lang3'
-    exclude group: 'org.apache.commons', module: 'commons-logging'
-    exclude group: 'org.apache.commons', module: 'commons-text'
-
-    exclude group: 'org.ow2.asm', module: 'asm'
-    
-    exclude group: 'com.google.guava', module: 'guava'
-}
-
 dependencies {
     implementation group: 'org.apache.hadoop', name: 'hadoop-hdfs-client', version: '3.3.5', commonExclusions
     implementation group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.5', commonExclusions

--- a/extra-dependencies/mongodb/build.gradle
+++ b/extra-dependencies/mongodb/build.gradle
@@ -17,9 +17,7 @@ jar {
 }
 
 dependencies {
-    implementation 'org.mongodb:mongodb-driver:3.2.2', {
-        exclude group: 'io.netty'
-    }
+    implementation 'org.mongodb:mongodb-driver:3.2.2', commonExclusions
 }
 
 

--- a/extra-dependencies/nlp/build.gradle
+++ b/extra-dependencies/nlp/build.gradle
@@ -17,14 +17,9 @@ jar {
     }
 }
 
-def withoutJacksons = {
-    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
-    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
-}
-
 dependencies {
-    implementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.353' , withoutJacksons
-    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.14.0', withoutJacksons
+    implementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.353' , commonExclusions
+    implementation group: 'com.fasterxml.jackson.module', name: 'jackson-module-kotlin', version: '2.14.0', commonExclusions
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.6.0'
 }
 

--- a/extra-dependencies/redis/build.gradle
+++ b/extra-dependencies/redis/build.gradle
@@ -19,5 +19,6 @@ jar {
 dependencies {
     implementation group: 'io.lettuce', name: 'lettuce-core', version: '6.1.1.RELEASE', {
         exclude group: 'io.netty'
+        exclude group: 'io.projectreactor', module: 'reactor-core'
     }
 }

--- a/extra-dependencies/redis/build.gradle
+++ b/extra-dependencies/redis/build.gradle
@@ -17,8 +17,5 @@ jar {
 }
 
 dependencies {
-    implementation group: 'io.lettuce', name: 'lettuce-core', version: '6.1.1.RELEASE', {
-        exclude group: 'io.netty'
-        exclude group: 'io.projectreactor', module: 'reactor-core'
-    }
+    implementation group: 'io.lettuce', name: 'lettuce-core', version: '6.1.1.RELEASE', commonExclusions
 }

--- a/extra-dependencies/selenium/build.gradle
+++ b/extra-dependencies/selenium/build.gradle
@@ -16,12 +16,22 @@ jar {
     }
 }
 
-dependencies {
-    implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.10.0' , {
-        exclude group: 'com.google.guava', module: 'guava'
-    }
-    implementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.4.0', {
-        exclude group: 'com.google.guava', module: 'guava'
-    }
+def commonExclusions = {
+    exclude group: 'com.google.guava', module: 'guava'
 
+    exclude group: 'org.apache.commons', module: 'commons-beanutils'
+    exclude group: 'org.apache.commons', module: 'commons-collections'
+    exclude group: 'org.apache.commons', module: 'commons-compress'
+    exclude group: 'org.apache.commons', module: 'commons-configuration2'
+    exclude group: 'org.apache.commons', module: 'commons-io'
+    exclude group: 'org.apache.commons', module: 'commons-lang3'
+    exclude group: 'org.apache.commons', module: 'commons-logging'
+    exclude group: 'org.apache.commons', module: 'commons-text'
+
+    exclude group: 'io.projectreactor'
+}
+
+dependencies {
+    implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.10.0' , commonExclusions
+    implementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.4.0', commonExclusions
 }

--- a/extra-dependencies/selenium/build.gradle
+++ b/extra-dependencies/selenium/build.gradle
@@ -16,21 +16,6 @@ jar {
     }
 }
 
-def commonExclusions = {
-    exclude group: 'com.google.guava', module: 'guava'
-
-    exclude group: 'org.apache.commons', module: 'commons-beanutils'
-    exclude group: 'org.apache.commons', module: 'commons-collections'
-    exclude group: 'org.apache.commons', module: 'commons-compress'
-    exclude group: 'org.apache.commons', module: 'commons-configuration2'
-    exclude group: 'org.apache.commons', module: 'commons-io'
-    exclude group: 'org.apache.commons', module: 'commons-lang3'
-    exclude group: 'org.apache.commons', module: 'commons-logging'
-    exclude group: 'org.apache.commons', module: 'commons-text'
-
-    exclude group: 'io.projectreactor'
-}
-
 dependencies {
     implementation group: 'org.seleniumhq.selenium', name: 'selenium-java', version: '4.10.0' , commonExclusions
     implementation group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.4.0', commonExclusions

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,5 +1,5 @@
 :readme:
-:branch: 5.4
+:branch: 5.14
 :docs: https://neo4j.com/labs/apoc/5
 :apoc-release: 5.14.0
 :neo4j-version: 5.14.0


### PR DESCRIPTION
- Bump 5.14.0 (Manual cherry-pick of: https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/1f0e07eb55e6b8c85a433e0a5f28638bd23f5fd1)
- de-ignored StartupExtendedTest
- added `commonExclusions` to `extra-dependencies/build.gradle` to solve various conflicts with Neo4j `/lib` jars, (alternatively, they can be excluded individually as done in [this commit](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3844/commits/f12ee49ab4ee8df51fd2b6befd82b4e06ffdc1aa), but there are several). That is:
  - hadoop: apache-commons and gson
  - redis: projectreactor
  - selenium: apache-commons and projectreactor
  - gcs: guava
  

- Added `io-netty` and `com.sun.jersey` with subpackages to prevent wrong exclusion.




