### PR TITLE
Replaced Open AI model

### DIFF
--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -118,7 +118,7 @@ public class OpenAI {
       "usage": { "prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12 }
     }
     */
-        return executeRequest(apiKey, configuration, "completions", "text-davinci-003", "prompt", prompt, "$", apocConfig, urlAccessChecker)
+        return executeRequest(apiKey, configuration, "completions", "gpt-3.5-turbo-instruct", "prompt", prompt, "$", apocConfig, urlAccessChecker)
                 .map(v -> (Map<String,Object>)v).map(MapResult::new);
     }
 

--- a/extended/src/test/java/apoc/ml/OpenAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIIT.java
@@ -41,7 +41,7 @@ public class OpenAIIT {
     public void completion() {
         testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey)",
                 Map.of("apiKey", openaiKey),
-                (row) -> assertCompletion(row, "text-davinci-003"));
+                (row) -> assertCompletion(row, "gpt-3.5-turbo-instruct"));
     }
 
     @Test


### PR DESCRIPTION
Cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/3babd3da147af3b82254bbb6871422714bb05b0f

Replaced Open AI model which will be deprecated, as explained here: https://platform.openai.com/docs/deprecations/instructgpt-models