### PR TITLE
Fix 5.15 CI errors

### DIFF
--- a/extended/src/main/java/apoc/cypher/CypherExtended.java
+++ b/extended/src/main/java/apoc/cypher/CypherExtended.java
@@ -16,6 +16,7 @@ import org.neo4j.graphdb.QueryExecutionType;
 import org.neo4j.graphdb.QueryStatistics;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
@@ -77,6 +78,9 @@ public class CypherExtended {
 
     @Context
     public Pools pools;
+
+    @Context
+    public URLAccessChecker urlAccessChecker;
 
     @Procedure(mode = WRITE)
     @Description("apoc.cypher.runFile(file or url,[{statistics:true,timeout:10,parameters:{}}]) - runs each statement in the file, all semicolon separated - currently no schema operations")
@@ -306,7 +310,7 @@ public class CypherExtended {
     }
     private Reader readerForFile(@Name("file") String fileName) {
         try {
-            return FileUtils.readerFor(fileName, CompressionAlgo.NONE.name());
+            return FileUtils.readerFor(fileName, CompressionAlgo.NONE.name(), urlAccessChecker);
         } catch (IOException ioe) {
             throw new RuntimeException("Error accessing file "+fileName,ioe);
         }

--- a/extended/src/main/java/apoc/es/ElasticSearch.java
+++ b/extended/src/main/java/apoc/es/ElasticSearch.java
@@ -5,6 +5,8 @@ import apoc.load.LoadJsonUtils;
 import apoc.result.MapResult;
 import apoc.util.UrlResolver;
 import apoc.util.Util;
+import org.neo4j.graphdb.security.URLAccessChecker;
+import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
@@ -25,6 +27,9 @@ import static apoc.util.MapUtil.map;
 @Extended
 public class ElasticSearch {
 
+    @Context
+    public URLAccessChecker urlAccessChecker;
+    
     private final static String fullQueryTemplate = "/%s/%s/%s?%s";
 
     // /{index}/{type}/_search?{query}
@@ -187,7 +192,7 @@ public class ElasticSearch {
         return loadJsonStream(getQueryUrl(hostOrKey, index, type, id, query), map("method", "PUT","content-type",contentType(payload)), toPayload(payload));
     }
 
-    private static Stream<MapResult> loadJsonStream(@Name("url") Object url, @Name("headers") Map<String, Object> headers, @Name("payload") String payload) {
-        return LoadJsonUtils.loadJsonStream(url, headers, payload, "", true, null, null, null);
+    private Stream<MapResult> loadJsonStream(@Name("url") Object url, @Name("headers") Map<String, Object> headers, @Name("payload") String payload) {
+        return LoadJsonUtils.loadJsonStream(url, headers, payload, "", true, null, null, null, urlAccessChecker);
     }
 }

--- a/extended/src/main/java/apoc/gephi/Gephi.java
+++ b/extended/src/main/java/apoc/gephi/Gephi.java
@@ -7,6 +7,8 @@ import apoc.util.ExtendedUtil;
 import apoc.util.JsonUtil;
 import apoc.util.UrlResolver;
 import apoc.util.Util;
+import org.neo4j.graphdb.security.URLAccessChecker;
+import org.neo4j.procedure.Context;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -28,6 +30,9 @@ import static apoc.util.MapUtil.map;
 // https://marketplace.gephi.org/plugin/graph-streaming/
 @Extended
 public class Gephi {
+
+    @Context
+    public URLAccessChecker urlAccessChecker;
 
     public static final int WIDTH = 1000;
     public static final int HEIGHT = 1000;
@@ -57,7 +62,7 @@ public class Gephi {
         propertyNames.removeAll(RESERVED);
         if (GraphsUtils.extract(data, nodes, rels)) {
             String payload = toGephiStreaming(nodes, rels, weightproperty, propertyNames.toArray(new String[propertyNames.size()]));
-            JsonUtil.loadJson(url,map("method","POST","Content-Type","application/json; charset=utf-8"), payload, "", true, null, null).count();
+            JsonUtil.loadJson(url,map("method","POST","Content-Type","application/json; charset=utf-8"), payload, "", true, null, null, urlAccessChecker).count();
             return Stream.of(new ProgressInfo(url,"graph","gephi").update(nodes.size(),rels.size(),nodes.size()).done(start));
         }
         return Stream.empty();

--- a/extended/src/main/java/apoc/load/LoadDirectory.java
+++ b/extended/src/main/java/apoc/load/LoadDirectory.java
@@ -11,6 +11,7 @@ import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
@@ -47,6 +48,9 @@ public class LoadDirectory {
     @Context
     public Transaction tx;
 
+    @Context
+    public URLAccessChecker urlAccessChecker;
+
 
     @Procedure(name="apoc.load.directory.async.add", mode = Mode.WRITE)
     @Description("apoc.load.directory.async.add(name, cypher, pattern, urlDir, {}) YIELD name, status, pattern, cypher, urlDir, config, error - Adds or replaces a folder listener with a specific name, which is triggered for all files with the given pattern and executes the specified Cypher query when triggered. Returns a list of all listeners. It is possible to specify the event type in the config parameter.")
@@ -55,7 +59,7 @@ public class LoadDirectory {
                                                              @Name(value = "pattern", defaultValue = "*") String pattern,
                                                              @Name(value = "urlDir", defaultValue = "") String urlDir,
                                                              @Name(value = "config", defaultValue = "{}") Map<String, Object> config) throws IOException {
-        apocConfig().checkReadAllowed(urlDir);
+        apocConfig().checkReadAllowed(urlDir, urlAccessChecker);
         Util.validateQuery(db, cypher, READ_WRITE, WRITE);
 
         LoadDirectoryItem.LoadDirectoryConfig conf = new LoadDirectoryItem.LoadDirectoryConfig(config);

--- a/extended/src/main/java/apoc/load/LoadHtml.java
+++ b/extended/src/main/java/apoc/load/LoadHtml.java
@@ -13,6 +13,7 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
@@ -49,6 +50,9 @@ public class LoadHtml {
 
     @Context
     public Log log;
+
+    @Context
+    public URLAccessChecker urlAccessChecker;
 
     @Procedure
     @Description("apoc.load.htmlPlainText('urlOrHtml',{name: jquery, name2: jquery}, config) YIELD value - Load Html page and return the result as a Map")
@@ -103,7 +107,7 @@ public class LoadHtml {
             case CHROME:
                 return withSeleniumBrowser(() -> getChromeInputStream(url, query, config, isHeadless, isAcceptInsecureCerts));
             default:
-                return FileUtils.inputStreamFor(url, null, null, null);
+                return FileUtils.inputStreamFor(url, null, null, null, urlAccessChecker);
         }
     }
 

--- a/extended/src/main/java/apoc/load/xls/LoadXls.java
+++ b/extended/src/main/java/apoc/load/xls/LoadXls.java
@@ -8,6 +8,7 @@ import apoc.util.MissingDependencyException;
 import apoc.util.Util;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
@@ -38,6 +39,9 @@ public class LoadXls {
     public static final char DEFAULT_ARRAY_SEP = ';';
     @Context
     public GraphDatabaseService db;
+
+    @Context
+    public URLAccessChecker urlAccessChecker;
 
     enum Results {
         map, list, strings, stringMap
@@ -103,7 +107,7 @@ public class LoadXls {
     @Description("apoc.load.xls('url','selector',{config}) YIELD lineNo, list, map - load XLS fom URL as stream of row values,\n config contains any of: {skip:1,limit:5,header:false,ignore:['tmp'],arraySep:';',mapping:{years:{type:'int',arraySep:'-',array:false,name:'age',ignore:false, dateFormat:'iso_date', dateParse:['dd-MM-yyyy']}}")
     public Stream<XLSResult> xls(@Name("url") String url, @Name("selector") String selector, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) {
         boolean failOnError = booleanValue(config, "failOnError", true);
-        try (CountingInputStream stream = FileUtils.inputStreamFor(url, null, null, null)) {
+        try (CountingInputStream stream = FileUtils.inputStreamFor(url, null, null, null, urlAccessChecker)) {
             Selection selection = new Selection(selector);
 
             char arraySep = separator(config, "arraySep", DEFAULT_ARRAY_SEP);

--- a/extended/src/main/java/apoc/metrics/Metrics.java
+++ b/extended/src/main/java/apoc/metrics/Metrics.java
@@ -10,6 +10,7 @@ import apoc.util.ExtendedFileUtils;
 import apoc.util.FileUtils;
 import apoc.util.SupportedProtocols;
 import apoc.util.Util;
+import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.*;
 
@@ -36,6 +37,9 @@ public class Metrics {
             "This may occur if the path in question is a symlink or other link.";
     @Context
     public Log log;
+
+    @Context
+    public URLAccessChecker urlAccessChecker;
 
     /** Simple DAO that pairs a config setting name with a File path that it refers to */
     public static class StoragePair {
@@ -187,7 +191,7 @@ public class Metrics {
         String url = file.getAbsolutePath();
         CountingReader reader = null;
         try {
-            reader = FileUtils.getStreamConnection(SupportedProtocols.file, url, null, null)
+            reader = FileUtils.getStreamConnection(SupportedProtocols.file, url, null, null, urlAccessChecker)
                     .toCountingInputStream(CompressionAlgo.NONE.name())
                     .asReader();
             return new LoadCsv()

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -4,6 +4,7 @@ import apoc.ApocConfig;
 import apoc.Extended;
 import apoc.util.JsonUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
@@ -27,6 +28,9 @@ import static apoc.ExtendedApocConfig.APOC_OPENAI_KEY;
 public class OpenAI {
     @Context
     public ApocConfig apocConfig;
+
+    @Context
+    public URLAccessChecker urlAccessChecker;
 
     public static final String APOC_ML_OPENAI_URL = "apoc.ml.openai.url";
 
@@ -59,7 +63,7 @@ public class OpenAI {
         String payload = new ObjectMapper().writeValueAsString(config);
 
         var url = new URL(new URL(endpoint), path).toString();
-        return JsonUtil.loadJson(url, headers, payload, jsonPath, true, List.of());
+        return JsonUtil.loadJson(url, headers, payload, jsonPath, true, List.of(), urlAccessChecker);
     }
 
     @Procedure("apoc.ml.openai.embedding")

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -46,7 +46,7 @@ public class OpenAI {
         }
     }
 
-    static Stream<Object> executeRequest(String apiKey, Map<String, Object> configuration, String path, String model, String key, Object inputs, String jsonPath, ApocConfig apocConfig) throws JsonProcessingException, MalformedURLException {
+    static Stream<Object> executeRequest(String apiKey, Map<String, Object> configuration, String path, String model, String key, Object inputs, String jsonPath, ApocConfig apocConfig, URLAccessChecker urlAccessChecker) throws JsonProcessingException, MalformedURLException {
         apiKey = apocConfig.getString(APOC_OPENAI_KEY, apiKey);
         if (apiKey == null || apiKey.isBlank())
             throw new IllegalArgumentException("API Key must not be empty");
@@ -82,7 +82,7 @@ public class OpenAI {
       "model": "text-embedding-ada-002",
       "usage": { "prompt_tokens": 8, "total_tokens": 8 } }
     */
-        Stream<Object> resultStream = executeRequest(apiKey, configuration, "embeddings", "text-embedding-ada-002", "input", texts, "$.data", apocConfig);
+        Stream<Object> resultStream = executeRequest(apiKey, configuration, "embeddings", "text-embedding-ada-002", "input", texts, "$.data", apocConfig, urlAccessChecker);
         return resultStream
                 .flatMap(v -> ((List<Map<String, Object>>) v).stream())
                 .map(m -> {
@@ -103,14 +103,14 @@ public class OpenAI {
       "usage": { "prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12 }
     }
     */
-        return executeRequest(apiKey, configuration, "completions", "text-davinci-003", "prompt", prompt, "$", apocConfig)
+        return executeRequest(apiKey, configuration, "completions", "text-davinci-003", "prompt", prompt, "$", apocConfig, urlAccessChecker)
                 .map(v -> (Map<String,Object>)v).map(MapResult::new);
     }
 
     @Procedure("apoc.ml.openai.chat")
     @Description("apoc.ml.openai.chat(messages, api_key, configuration]) - prompts the completion API")
     public Stream<MapResult> chatCompletion(@Name("messages") List<Map<String, Object>> messages, @Name("api_key") String apiKey, @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return executeRequest(apiKey, configuration, "chat/completions", "gpt-3.5-turbo", "messages", messages, "$", apocConfig)
+        return executeRequest(apiKey, configuration, "chat/completions", "gpt-3.5-turbo", "messages", messages, "$", apocConfig, urlAccessChecker)
                 .map(v -> (Map<String,Object>)v).map(MapResult::new);
         // https://platform.openai.com/docs/api-reference/chat/create
     /*

--- a/extended/src/main/java/apoc/ml/Prompt.java
+++ b/extended/src/main/java/apoc/ml/Prompt.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.jetbrains.annotations.NotNull;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.internal.kernel.api.procs.ProcedureCallContext;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
@@ -34,6 +35,8 @@ public class Prompt {
     public ApocConfig apocConfig;
     @Context
     public ProcedureCallContext procedureCallContext;
+    @Context
+    public URLAccessChecker urlAccessChecker;
 
     public static final String BACKTICKS = "```";
     public static final String EXPLAIN_SCHEMA_PROMPT = """
@@ -155,7 +158,7 @@ public class Prompt {
         String apiKey = (String) conf.get("apiKey");
         String model = (String) conf.getOrDefault("model", "gpt-3.5-turbo");
         String result = OpenAI.executeRequest(apiKey, Map.of(), "chat/completions",
-                        model, "messages", prompt, "$", apocConfig)
+                        model, "messages", prompt, "$", apocConfig, urlAccessChecker)
                 .map(v -> (Map<String, Object>) v)
                 .flatMap(m -> ((List<Map<String, Object>>) m.get("choices")).stream())
                 .map(m -> (String) (((Map<String, Object>) m.get("message")).get("content")))

--- a/extended/src/main/java/apoc/ml/bedrock/Bedrock.java
+++ b/extended/src/main/java/apoc/ml/bedrock/Bedrock.java
@@ -10,6 +10,8 @@ import apoc.Description;
 import apoc.result.MapResult;
 import apoc.util.JsonUtil;
 import apoc.util.Util;
+import org.neo4j.graphdb.security.URLAccessChecker;
+import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
@@ -20,6 +22,9 @@ import static apoc.ml.bedrock.BedrockInvokeResult.*;
 
 
 public class Bedrock {
+    @Context
+    public URLAccessChecker urlAccessChecker;
+    
     // public for testing purpose
     public static final String JURASSIC_2_ULTRA = "ai21.j2-ultra-v1";
     public static final String TITAN_EMBED_TEXT = "amazon.titan-embed-text-v1";
@@ -135,7 +140,7 @@ public class Bedrock {
                 AwsSignatureV4Generator.calculateAuthorizationHeaders(conf, bodyString);
             }
 
-            return JsonUtil.loadJson(conf.getEndpoint(), conf.getHeaders(), bodyString, conf.getJsonPath(), true, List.of());
+            return JsonUtil.loadJson(conf.getEndpoint(), conf.getHeaders(), bodyString, conf.getJsonPath(), true, List.of(), urlAccessChecker);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/extended/src/test/java/apoc/load/LoadCsvTest.java
+++ b/extended/src/test/java/apoc/load/LoadCsvTest.java
@@ -415,7 +415,7 @@ RETURN m.col_1,m.col_2,m.col_3
 
     @Test
     public void testLoadCsvByUrlRedirect() throws Exception {
-        URL url = new URL("http://bit.ly/2nXgHA2");
+        URL url = new URL("https://bit.ly/2nXgHA2");
         testResult(db, "CALL apoc.load.csv($url,{results:['map','list','stringMap','strings']})", map("url", url.toString()),
                 (r) -> {
                     assertRow(r,0L,"name","Selma","age","8");

--- a/extended/src/test/java/apoc/load/LoadS3Test.java
+++ b/extended/src/test/java/apoc/load/LoadS3Test.java
@@ -44,6 +44,8 @@ public class LoadS3Test extends S3BaseTest {
     @Test
     public void testLoadCsvS3() throws Exception {
         String url = s3Container.putFile("src/test/resources/test.csv");
+        url = removeRegionFromUrl(url);
+        
         testResult(db, "CALL apoc.load.csv($url,{failOnError:false})", map("url", url), (r) -> {
             assertRow(r, "Selma", "8", 0L);
             assertRow(r, "Rana", "11", 1L);
@@ -54,6 +56,7 @@ public class LoadS3Test extends S3BaseTest {
 
     @Test public void testLoadJsonS3() throws Exception {
         String url = s3Container.putFile("src/test/resources/map.json");
+        url = removeRegionFromUrl(url);
 
         testCall(db, "CALL apoc.load.json($url,'')",map("url", url),
                 (row) -> {
@@ -63,11 +66,16 @@ public class LoadS3Test extends S3BaseTest {
 
     @Test public void testLoadXmlS3() throws Exception {
         String url = s3Container.putFile("src/test/resources/xml/books.xml");
+        url = removeRegionFromUrl(url);
 
         testCall(db, "CALL apoc.load.xml($url,'/catalog/book[title=\"Maeve Ascendant\"]/.',{failOnError:false}) yield value as result", Util.map("url", url), (r) -> {
             Object value = Iterables.single(r.values());
             Assert.assertEquals(XmlTestUtils.XML_XPATH_AS_NESTED_MAP, value);
         });
+    }
+
+    private String removeRegionFromUrl(String url) {
+        return url.replace(s3Container.getEndpointConfiguration().getSigningRegion() + ".", "");
     }
 
 


### PR DESCRIPTION
- added `@Context URLAccessChecker urlAccessChecker` where needed

Fixes due to [this Core breaking-change](https://github.com/neo4j/apoc/commit/e01a29d66dbd753382581ad20462587330120d5d):
- changed `http://bit.ly` with `https://bit.ly`,
otherwise the [checkUrl](https://github.com/neo4j/apoc/commit/e01a29d66dbd753382581ad20462587330120d5d#diff-320bd28396c4b4bd53b5add80a9df3e893d495562119ac81aeba0aa163fffadbR303) throws a `java.io.FileNotFoundException: http://67.199.248.10/2nXgHA2`

- added `LoadS3Test.removeRegionFromUrl(url)`,
since the URL with the region,
e.g. `s3://us-east-1.127.0.0.1:60082/test-bucket/test.csv?accessKey=accesskey&secretKey=secretkey`, 
throws an `java.net.UnknownHostException: us-east-1.127.0.0.1: nodename nor servname provided, or not known`,
and we cannot change the `s3Container.putFile(<FileName>);` method since is in Core