### PR TITLE
Fixes #3367: Test to check return type of apoc.any.rebind with a Path (#3848)

### DIFF
--- a/extended/src/test/java/apoc/nodes/NodesExtendedTest.java
+++ b/extended/src/test/java/apoc/nodes/NodesExtendedTest.java
@@ -51,10 +51,28 @@ public class NodesExtendedTest {
                     final List<Path> rebindList = (List<Path>) row.get("rebind");
                     assertEquals(2, rebindList.size());
                     final Path firstPath = rebindList.get(0);
-                    assertPath(firstPath, List.of("Foo", "Bar"), List.of("MY_REL"));
+                    assertFooBarPath(firstPath);
                     final Path secondPath = rebindList.get(1);
                     assertPath(secondPath, List.of("Bar", "Baz"), List.of("ANOTHER_REL"));
                 });
+
+        // check via `valueType()` that, even if the return type is Object, 
+        // the output of a rebound Path is also a Path (i.e.: `PATH NOT NULL`)
+        TestUtil.testCall(db, """
+                        CREATE path=(a:Foo)-[r1:MY_REL]->(b:Bar)\s
+                        WITH apoc.any.rebind(path) AS rebind
+                        RETURN rebind, valueType(rebind) as valueType""",
+                (row) -> {
+                    final String valueType = (String) row.get("valueType");
+                    assertEquals("PATH NOT NULL", valueType);
+                    
+                    final Path pathRebind = (Path) row.get("rebind");
+                    assertFooBarPath(pathRebind);
+                });
+    }
+
+    private void assertFooBarPath(Path pathRebind) {
+        assertPath(pathRebind, List.of("Foo", "Bar"), List.of("MY_REL"));
     }
 
     private void assertPath(Path rebind, List<String> labels, List<String> relTypes) {


### PR DESCRIPTION
Cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/38a3479bcb82ecf04808174aa79722195b06b056