### PR TITLE
[NOID] Adds format and license PR bot jobs

### DIFF
--- a/.github/actions/gradle-command-on-pr/action.yaml
+++ b/.github/actions/gradle-command-on-pr/action.yaml
@@ -38,7 +38,9 @@ runs:
     - name: Check for modified files
       shell: bash
       id: git-check
-      run: echo modified=$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi) >> $GITHUB_OUTPUT
+      run: |
+        git update-index --refresh
+        echo modified=$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi) >> $GITHUB_OUTPUT
 
     - name: Commit to the PR branch
       shell: bash

--- a/.github/actions/gradle-command-on-pr/action.yaml
+++ b/.github/actions/gradle-command-on-pr/action.yaml
@@ -1,0 +1,103 @@
+name: "Run gradle command on pull request"
+
+inputs:
+  gradle-command:
+    description: "Gradle command to run"
+    required: true
+  TEAMCITY_DEV_URL:
+    required: true
+  TEAMCITY_USER:
+    required: true
+  TEAMCITY_PASSWORD:
+    required: true
+  SERVICE_ACCOUNT_PAT:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout branch from fork
+      uses: actions/checkout@v3
+      with:
+        persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
+        repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.client_payload.pull_request.head.ref }}
+
+    - uses: ./.github/actions/setup-jdk
+    - uses: ./.github/actions/setup-gradle-cache
+
+    - name: Calls gradle command
+      shell: bash
+      env:
+        TEAMCITY_DEV_URL: ${{ inputs.TEAMCITY_DEV_URL }}
+        TEAMCITY_USER: ${{ inputs.TEAMCITY_USER }}
+        TEAMCITY_PASSWORD: ${{ inputs.TEAMCITY_PASSWORD }}
+      run: |
+        ./gradlew ${{ inputs.gradle-command }}
+
+    - name: Check for modified files
+      shell: bash
+      id: git-check
+      run: echo modified=$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi) >> $GITHUB_OUTPUT
+
+    - name: Commit to the PR branch
+      shell: bash
+      if: steps.git-check.outputs.modified == 'true'
+      run: |
+        git config --global user.name 'neo-technology-build-agent'
+        git config --global user.email 'neo-technology-build-agent@users.noreply.github.com'
+        git add -A
+        git commit -m "Run ${{ inputs.gradle-command }}"
+
+    - name: Push changes
+      uses: ad-m/github-push-action@d91a481090679876dfc4178fef17f286781251df # v0.8.0
+      with:
+        github_token: ${{ inputs.SERVICE_ACCOUNT_PAT }}
+        branch: ${{ github.event.client_payload.pull_request.head.ref }}
+
+    - name: Add reaction on pushed changes
+      if: ${{ success() && steps.git-check.outputs.modified == 'true' }}
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+        reaction-type: hooray
+
+    - name: Add reaction when no update is needed
+      if: ${{ success() && steps.git-check.outputs.modified == 'false' }}
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+        reaction-type: '+1'
+
+    - name: Create URL to the run output for failure report
+      shell: bash
+      if: ${{ !success() }}
+      id: vars
+      run: echo run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID >> $GITHUB_OUTPUT
+
+    - name: Create comment with URL on failure
+      if: ${{ !success() }}
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+        body: |
+          :x: [${{ inputs.gradle-command }} failed][1]
+
+          [1]: ${{ steps.vars.outputs.run-url }}
+
+    - name: Report failure to original comment with a reaction
+      if: ${{ !success() }}
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+        comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
+        reaction-type: '-1'
+
+    - name: Go back to original branch
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ github.event.client_payload.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.client_payload.pull_request.base.ref }}

--- a/.github/actions/gradle-command-on-pr/action.yaml
+++ b/.github/actions/gradle-command-on-pr/action.yaml
@@ -59,6 +59,7 @@ runs:
       if: ${{ success() && steps.git-check.outputs.modified == 'true' }}
       uses: peter-evans/create-or-update-comment@v2
       with:
+        token: ${{ inputs.SERVICE_ACCOUNT_PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
         reaction-type: hooray
@@ -67,6 +68,7 @@ runs:
       if: ${{ success() && steps.git-check.outputs.modified == 'false' }}
       uses: peter-evans/create-or-update-comment@v2
       with:
+        token: ${{ inputs.SERVICE_ACCOUNT_PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
         reaction-type: '+1'
@@ -81,6 +83,7 @@ runs:
       if: ${{ !success() }}
       uses: peter-evans/create-or-update-comment@v2
       with:
+        token: ${{ inputs.SERVICE_ACCOUNT_PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
         body: |
@@ -92,6 +95,7 @@ runs:
       if: ${{ !success() }}
       uses: peter-evans/create-or-update-comment@v2
       with:
+        token: ${{ inputs.SERVICE_ACCOUNT_PAT }}
         repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
         comment-id: ${{ github.event.client_payload.github.payload.comment.id }}
         reaction-type: '-1'

--- a/.github/actions/gradle-command-on-pr/action.yaml
+++ b/.github/actions/gradle-command-on-pr/action.yaml
@@ -47,7 +47,7 @@ runs:
         git config --global user.name 'neo-technology-build-agent'
         git config --global user.email 'neo-technology-build-agent@users.noreply.github.com'
         git add -A
-        git commit -m "Run ${{ inputs.gradle-command }}"
+        git commit -m "[NOID] Run ${{ inputs.gradle-command }}"
 
     - name: Push changes
       uses: ad-m/github-push-action@d91a481090679876dfc4178fef17f286781251df # v0.8.0

--- a/.github/workflows/ChatOps.yml
+++ b/.github/workflows/ChatOps.yml
@@ -15,3 +15,4 @@ jobs:
           token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
           commands: |
             spotlessApply
+            generateLicenses

--- a/.github/workflows/ChatOps.yml
+++ b/.github/workflows/ChatOps.yml
@@ -1,0 +1,17 @@
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+permissions: write-all
+jobs:
+  slashCommandDispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v3
+        with:
+          issue-type: pull-request
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SERVICE_ACCOUNT_PAT }}
+          commands: |
+            spotlessApply

--- a/.github/workflows/generateLicenses-command.yml
+++ b/.github/workflows/generateLicenses-command.yml
@@ -1,0 +1,19 @@
+name: Updates license files
+on:
+  repository_dispatch:
+    types: [generateLicenses-command]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Format and push changes to PR
+        uses: ./.github/actions/gradle-command-on-pr
+        with:
+          gradle-command: generateLicenses
+          TEAMCITY_DEV_URL: ${{ secrets.TEAMCITY_DEV_URL }}
+          TEAMCITY_USER: ${{ secrets.TEAMCITY_USER }}
+          TEAMCITY_PASSWORD: ${{ secrets.TEAMCITY_PASSWORD }}
+          SERVICE_ACCOUNT_PAT: ${{ secrets.SERVICE_ACCOUNT_PAT }}

--- a/.github/workflows/spotlessApply-command.yml
+++ b/.github/workflows/spotlessApply-command.yml
@@ -1,0 +1,19 @@
+name: Formats PR
+on:
+  repository_dispatch:
+    types: [spotlessApply-command]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Format and push changes to PR
+        uses: ./.github/actions/gradle-command-on-pr
+        with:
+          gradle-command: spotlessApply
+          TEAMCITY_DEV_URL: ${{ secrets.TEAMCITY_DEV_URL }}
+          TEAMCITY_USER: ${{ secrets.TEAMCITY_USER }}
+          TEAMCITY_PASSWORD: ${{ secrets.TEAMCITY_PASSWORD }}
+          SERVICE_ACCOUNT_PAT: ${{ secrets.SERVICE_ACCOUNT_PAT }}


### PR DESCRIPTION
Cherry-picks https://github.com/neo4j/apoc/pull/520, https://github.com/neo4j/apoc/pull/524, https://github.com/neo4j/apoc/pull/552, https://github.com/neo4j/apoc/pull/553

## What
Adds a job to run formatting in PRs by writting `/spotlessApply` and `generateLicenses` in it

## Why
Because especially for the licensing it's really annoying to have to update neo4j locally every time the license check fails 😢 .