### PR TITLE
Fixes #3858: Allow configuration of openai base URL as parameter

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
@@ -2,17 +2,21 @@
 = OpenAI API Access
 :description: This section describes procedures that can be used to access the OpenAI API.
 
-NOTE: You need to acquire an https://platform.openai.com/account/api-keys[OpenAI API key^] to use these procedures. Using them will incur costs on your OpenAI account. You can set the api key globally by defining the `apoc.openai.key` configuration in `apoc.conf`
+[NOTE]
+====
+You need to acquire an https://platform.openai.com/account/api-keys[OpenAI API key^] to use these procedures. Using them will incur costs on your OpenAI account. You can set the api key globally by defining the `apoc.openai.key` configuration in `apoc.conf`
 
-
+But you can also use these procedures to call OpenAI-compatible APIs, which will therefore have their own API key (or even without API Key). 
+See the paragraph <<openai_compatible_provider>> below.
+====
 
 All the following procedures can have the following APOC config, i.e. in `apoc.conf` or via docker env variable
 .Apoc configuration
 |===
 |key | description | default
-| apoc.ml.openai.type | "AZURE" or "OPENAI", indicates whether the API is Azure or not | "OPENAI" 
+| apoc.ml.openai.type | "AZURE", "HUGGINGFACE", "OPENAI", indicates whether the API is Azure, HuggingFace or another one | "OPENAI" 
 | apoc.ml.openai.url | the OpenAI endpoint base url | https://api.openai.com/v1 
-    (or empty string if `apoc.ml.openai.type=AZURE`)
+    (or empty string if `apoc.ml.openai.type=<AZURE OR HUGGINGFACE>`)
 | apoc.ml.azure.api.version | in case of `apoc.ml.openai.type=AZURE`, indicates the `api-version` to be passed after the `?api-version=` url
 |===
 
@@ -27,6 +31,10 @@ If present, they take precedence over the analogous APOC configs.
 | apiType | analogous to `apoc.ml.openai.type` APOC config
 | endpoint | analogous to `apoc.ml.openai.url` APOC config
 | apiVersion | analogous to `apoc.ml.azure.api.version` APOC config
+| path | To customize the url portion added to the base url (defined by the `endpoint` config).
+    By default, is `/embeddings`, `/completions` and `/chat/completions` for respectively the `apoc.ml.openai.embedding`, `apoc.ml.openai.completion` and `apoc.ml.openai.chat` procedures.
+| jsonPath | To customize https://github.com/json-path/JsonPath[JSONPath] of the response. 
+    The default is `$` for the `apoc.ml.openai.chat` and `apoc.ml.openai.completion` procedures, and `$.data` for the `apoc.ml.openai.embedding` procedure.
 |===
 
 
@@ -142,6 +150,29 @@ CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $a
 | value | result entry from OpenAI (containing)
 |===
 
+
+=== OpenLM API
+
+We can also call the Completion API of HuggingFace and Cohere, similar to the https://github.com/r2d4/openlm[OpenLM] library, as below.
+
+For the https://huggingface.co/[HuggingFace API], we have to define the config `apiType: 'HUGGINGFACE'`, since we have to transform the body request.
+Unlike the default behavior, under-the-hood the `/completions` suffix is not added to the URL.
+
+For example:
+[source,cypher]
+----
+CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $huggingFaceApiKey, 
+{endpoint: 'https://api-inference.huggingface.co/models/gpt2', apiType: 'HUGGINGFACE', model: 'gpt2'})
+----
+
+Or also, by using the https://docs.cohere.com/docs[Cohere API], where we have to define `path: '''` not to add the `/completions` suffix to the URL:
+[source,cypher]
+----
+CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $cohereApiKey, 
+{endpoint: 'https://api.cohere.ai/v1/generate', path: '', model: 'command'})
+----
+
+
 == Chat Completion API
 
 This procedure `apoc.ml.openai.chat` takes a list of maps of chat exchanges between assistant and user (with optional system message), and will return the next message in the flow.
@@ -182,6 +213,35 @@ choices=[{finish_reason="stop", index=0, message={role="assistant", content="Ear
 |name | description
 | value | result entry from OpenAI (containing created, id, model, object, usage(tokens), choices(message, index, finish_reason))
 |===
+
+
+[[openai_compatible_provider]]
+== OpenAI-compatible provider
+
+We can also use these procedures to call OpenAI-compatible APIs,
+by defining the `endpoint` config, and possibly the `model`, `path` and `jsonPath` configs.
+
+For example, we can call the https://app.endpoints.anyscale.com/[Anyscale Endpoints]:
+[source,cypher]
+----
+CALL apoc.ml.openai.embedding(['Some Text'], $anyScaleApiKey, 
+{endpoint: 'https://api.endpoints.anyscale.com/v1', model: 'thenlper/gte-large'})
+----
+
+
+Or via https://localai.io/[LocalAI APIs] (note that the apiKey is `null` by default):
+[source,cypher]
+----
+CALL apoc.ml.openai.embedding(['Some Text'], "ignored", 
+{endpoint: 'http://localhost:8080/v1', model: 'text-embedding-ada-002'})
+----
+
+Or also, by using https://github.com/fardjad/node-llmatic[LLMatic Library]:
+[source,cypher]
+----
+CALL apoc.ml.openai.embedding(['Some Text'], "ignored", 
+{endpoint: 'http://localhost:3000/v1', model: 'thenlper/gte-large'})
+----
 
 
 == Query with natural language

--- a/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
@@ -156,13 +156,12 @@ CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $a
 We can also call the Completion API of HuggingFace and Cohere, similar to the https://github.com/r2d4/openlm[OpenLM] library, as below.
 
 For the https://huggingface.co/[HuggingFace API], we have to define the config `apiType: 'HUGGINGFACE'`, since we have to transform the body request.
-Unlike the default behavior, under-the-hood the `/completions` suffix is not added to the URL.
 
 For example:
 [source,cypher]
 ----
 CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $huggingFaceApiKey, 
-{endpoint: 'https://api-inference.huggingface.co/models/gpt2', apiType: 'HUGGINGFACE', model: 'gpt2'})
+{endpoint: 'https://api-inference.huggingface.co/models/gpt2', apiType: 'HUGGINGFACE', model: 'gpt2', path: ''})
 ----
 
 Or also, by using the https://docs.cohere.com/docs[Cohere API], where we have to define `path: '''` not to add the `/completions` suffix to the URL:

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -20,7 +20,6 @@ import java.util.stream.Stream;
 
 import static apoc.ExtendedApocConfig.APOC_ML_OPENAI_TYPE;
 import static apoc.ExtendedApocConfig.APOC_OPENAI_KEY;
-import static apoc.util.ExtendedUtil.isLocalAddress;
 
 
 @Extended

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 
 import static apoc.ExtendedApocConfig.APOC_ML_OPENAI_TYPE;
 import static apoc.ExtendedApocConfig.APOC_OPENAI_KEY;
+import static apoc.util.ExtendedUtil.isLocalAddress;
 
 
 @Extended
@@ -28,7 +29,10 @@ public class OpenAI {
     public static final String APIKEY_CONF_KEY = "apiKey";
     public static final String ENDPOINT_CONF_KEY = "endpoint";
     public static final String API_VERSION_CONF_KEY = "apiVersion";
-    
+    public static final String JSON_PATH_CONF_KEY = "jsonPath";
+    public static final String PATH_CONF_KEY = "path";
+    public static final String MODEL_CONF_KEY = "model";
+
     @Context
     public ApocConfig apocConfig;
 
@@ -57,20 +61,31 @@ public class OpenAI {
         String apiTypeString = (String) configuration.getOrDefault(API_TYPE_CONF_KEY,
                 apocConfig.getString(APOC_ML_OPENAI_TYPE, OpenAIRequestHandler.Type.OPENAI.name())
         );
-        OpenAIRequestHandler apiType = OpenAIRequestHandler.Type.valueOf(apiTypeString.toUpperCase(Locale.ENGLISH))
-                .get();
+        OpenAIRequestHandler.Type type = OpenAIRequestHandler.Type.valueOf(apiTypeString.toUpperCase(Locale.ENGLISH));
+        
+        var config = new HashMap<>(configuration);
+        // we remove these keys from config, since the json payload is calculated starting from the config map
+        Stream.of(ENDPOINT_CONF_KEY, API_TYPE_CONF_KEY, API_VERSION_CONF_KEY, APIKEY_CONF_KEY).forEach(config::remove);
+        
+        switch (type) {
+            case HUGGINGFACE -> {
+                config.putIfAbsent("inputs", inputs);
+                jsonPath = "$[0]";
+            }
+            default -> {
+                config.putIfAbsent(MODEL_CONF_KEY, model);
+                config.put(key, inputs);
+            }
+        }
+        
+        OpenAIRequestHandler apiType = type.get();
 
-        String endpoint = apiType.getEndpoint(configuration, apocConfig);
+        jsonPath = (String) configuration.getOrDefault(JSON_PATH_CONF_KEY, jsonPath);
+        path = (String) configuration.getOrDefault(PATH_CONF_KEY, path);
         
         final Map<String, Object> headers = new HashMap<>();
         headers.put("Content-Type", "application/json");
         apiType.addApiKey(headers, apiKey);
-
-        var config = new HashMap<>(configuration);
-        // we remove these keys from config, since the json payload is calculated starting from the config map
-        Stream.of(ENDPOINT_CONF_KEY, API_TYPE_CONF_KEY, API_VERSION_CONF_KEY, APIKEY_CONF_KEY).forEach(config::remove);
-        config.putIfAbsent("model", model);
-        config.put(key, inputs);
 
         String payload = JsonUtil.OBJECT_MAPPER.writeValueAsString(config);
         

--- a/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
+++ b/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
@@ -3,6 +3,7 @@ package apoc.ml;
 
 import apoc.ApocConfig;
 import org.apache.commons.lang3.StringUtils;
+import org.neo4j.graphdb.security.URLAccessChecker;
 
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -39,7 +40,9 @@ abstract class OpenAIRequestHandler {
     }
 
     enum Type {
-        AZURE(new Azure(null)), OPENAI(new OpenAi("https://api.openai.com/v1"));
+        AZURE(new Azure(null)),
+        HUGGINGFACE(new HuggingFace()),
+        OPENAI(new OpenAi("https://api.openai.com/v1"));
 
         private final OpenAIRequestHandler handler;
         Type(OpenAIRequestHandler handler) {
@@ -48,6 +51,12 @@ abstract class OpenAIRequestHandler {
 
         public OpenAIRequestHandler get() {
             return handler;
+        }
+    }
+    
+    private static class HuggingFace extends OpenAi {
+        public HuggingFace() {
+            super(null);
         }
     }
 

--- a/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
+++ b/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
@@ -3,7 +3,6 @@ package apoc.ml;
 
 import apoc.ApocConfig;
 import org.apache.commons.lang3.StringUtils;
-import org.neo4j.graphdb.security.URLAccessChecker;
 
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -41,7 +40,7 @@ abstract class OpenAIRequestHandler {
 
     enum Type {
         AZURE(new Azure(null)),
-        HUGGINGFACE(new HuggingFace()),
+        HUGGINGFACE(new OpenAi(null)),
         OPENAI(new OpenAi("https://api.openai.com/v1"));
 
         private final OpenAIRequestHandler handler;
@@ -51,12 +50,6 @@ abstract class OpenAIRequestHandler {
 
         public OpenAIRequestHandler get() {
             return handler;
-        }
-    }
-    
-    private static class HuggingFace extends OpenAi {
-        public HuggingFace() {
-            super(null);
         }
     }
 

--- a/extended/src/main/java/apoc/util/ExtendedUtil.java
+++ b/extended/src/main/java/apoc/util/ExtendedUtil.java
@@ -4,6 +4,11 @@ import static apoc.export.cypher.formatter.CypherFormatterUtils.formatProperties
 import static apoc.export.cypher.formatter.CypherFormatterUtils.formatToString;
 
 import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.net.URI;
+import java.net.UnknownHostException;
 import java.time.Duration;
 import java.time.temporal.TemporalAccessor;
 import java.util.Map;
@@ -42,5 +47,19 @@ public class ExtendedUtil
     public static String toCypherMap( Map<String, Object> map) {
         final StringBuilder builder = formatProperties(map);
         return "{" + formatToString(builder) + "}";
+    }
+
+    public static boolean isLocalAddress(String url) {
+        try {
+            String host = URI.create(url).getHost();
+                    
+            InetAddress address = InetAddress.getByName(host);
+            return address.isAnyLocalAddress()
+                   || address.isLoopbackAddress()
+                   || NetworkInterface.getByInetAddress(address) != null;
+        } catch (UnknownHostException | SocketException e) {
+            // ignored
+        }
+        return false;
     }
 }

--- a/extended/src/main/java/apoc/util/ExtendedUtil.java
+++ b/extended/src/main/java/apoc/util/ExtendedUtil.java
@@ -4,11 +4,6 @@ import static apoc.export.cypher.formatter.CypherFormatterUtils.formatProperties
 import static apoc.export.cypher.formatter.CypherFormatterUtils.formatToString;
 
 import java.math.BigInteger;
-import java.net.InetAddress;
-import java.net.NetworkInterface;
-import java.net.SocketException;
-import java.net.URI;
-import java.net.UnknownHostException;
 import java.time.Duration;
 import java.time.temporal.TemporalAccessor;
 import java.util.Map;
@@ -47,19 +42,5 @@ public class ExtendedUtil
     public static String toCypherMap( Map<String, Object> map) {
         final StringBuilder builder = formatProperties(map);
         return "{" + formatToString(builder) + "}";
-    }
-
-    public static boolean isLocalAddress(String url) {
-        try {
-            String host = URI.create(url).getHost();
-                    
-            InetAddress address = InetAddress.getByName(host);
-            return address.isAnyLocalAddress()
-                   || address.isLoopbackAddress()
-                   || NetworkInterface.getByInetAddress(address) != null;
-        } catch (UnknownHostException | SocketException e) {
-            // ignored
-        }
-        return false;
     }
 }

--- a/extended/src/test/java/apoc/ml/OpenAIAnyScaleIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIAnyScaleIT.java
@@ -1,0 +1,95 @@
+package apoc.ml;
+
+import apoc.util.TestUtil;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.List;
+import java.util.Map;
+
+import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
+import static apoc.ml.OpenAI.MODEL_CONF_KEY;
+import static apoc.ml.OpenAITestResultUtils.*;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class OpenAIAnyScaleIT {
+
+    private String openaiKey;
+
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
+
+
+    @Before
+    public void setUp() throws Exception {
+        openaiKey = System.getenv("OPENAI_ANYSCALE_KEY");
+        Assume.assumeNotNull("No OPENAI_ANYSCALE_KEY environment configured", openaiKey);
+        TestUtil.registerProcedure(db, OpenAI.class);
+    }
+
+    @Test
+    public void getEmbedding() {
+        testCall(db, EMBEDDING_QUERY,
+                getParams("thenlper/gte-large"),
+                row -> {
+                    assertEquals(0L, row.get("index"));
+                    assertEquals("Some Text", row.get("text"));
+                    var embedding = (List<Double>) row.get("embedding");
+                    assertEquals(1024, embedding.size());
+                });
+    }
+
+    @Test
+    public void completion() {
+        String modelId = "Meta-Llama/Llama-Guard-7b";
+        testCall(db, COMPLETION_QUERY,
+                getParams(modelId),
+                (row) -> {
+                    var result = (Map<String,Object>) row.get("value");
+                    assertTrue(result.get("created") instanceof Number);
+                    assertTrue(result.containsKey("choices"));
+                    var finishReason = (String)((List<Map>) result.get("choices")).get(0).get("finish_reason");
+                    assertTrue(finishReason.matches("stop|length"));
+                    String text = (String) ((List<Map>) result.get("choices")).get(0).get("text");
+                    assertTrue(text != null && !text.isBlank());
+
+                    assertEquals(modelId, result.get("model"));
+                });
+    }
+
+    @Test
+    public void chatCompletion() {
+        String modelId = "meta-llama/Llama-2-70b-chat-hf";
+        testCall(db, CHAT_COMPLETION_QUERY, 
+                getParams(modelId),
+                (row) -> {
+                    var result = (Map<String,Object>) row.get("value");
+                    assertTrue(result.get("created") instanceof Number);
+                    assertTrue(result.containsKey("choices"));
+
+                    Map message = ((List<Map<String,Map>>) result.get("choices")).get(0).get("message");
+                    assertEquals("assistant", message.get("role"));
+                    String text = (String) message.get("content");
+                    assertTrue(text != null && !text.isBlank());
+
+                    assertTrue(result.containsKey("usage"));
+                    assertTrue(((Map) result.get("usage")).get("prompt_tokens") instanceof Number);
+
+                    assertTrue(result.get("model").toString().startsWith(modelId));
+                });
+    }
+
+    private Map<String, Object> getParams(String model) {
+        return Map.of("apiKey", openaiKey,
+                "conf", Map.of(ENDPOINT_CONF_KEY, "https://api.endpoints.anyscale.com/v1",
+                        MODEL_CONF_KEY, model
+                )
+        );
+    }
+}

--- a/extended/src/test/java/apoc/ml/OpenAIAzureIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIAzureIT.java
@@ -14,6 +14,9 @@ import java.util.stream.Stream;
 import static apoc.ml.OpenAI.API_TYPE_CONF_KEY;
 import static apoc.ml.OpenAI.API_VERSION_CONF_KEY;
 import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
+import static apoc.ml.OpenAITestResultUtils.CHAT_COMPLETION_QUERY;
+import static apoc.ml.OpenAITestResultUtils.COMPLETION_QUERY;
+import static apoc.ml.OpenAITestResultUtils.EMBEDDING_QUERY;
 import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
 import static apoc.ml.OpenAITestResultUtils.assertCompletion;
 import static apoc.util.TestUtil.testCall;
@@ -34,11 +37,11 @@ public class OpenAIAzureIT {
 
     @BeforeClass
     public static void setUp() throws Exception {
-        OPENAI_KEY = System.getenv("OPENAI_KEY");
+        OPENAI_KEY = System.getenv("OPENAI_AZURE_KEY");
         // Azure OpenAI base URLs
-        OPENAI_EMBEDDING_URL = System.getenv("OPENAI_EMBEDDING_URL");
-        OPENAI_CHAT_URL = System.getenv("OPENAI_CHAT_URL");
-        OPENAI_COMPLETION_URL = System.getenv("OPENAI_COMPLETION_URL");
+        OPENAI_EMBEDDING_URL = System.getenv("OPENAI_AZURE_EMBEDDING_URL");
+        OPENAI_CHAT_URL = System.getenv("OPENAI_AZURE_CHAT_URL");
+        OPENAI_COMPLETION_URL = System.getenv("OPENAI_AZURE_COMPLETION_URL");
 
         // Azure OpenAI query url (`<baseURL>/<type>/?api-version=<OPENAI_AZURE_API_VERSION>`)
         OPENAI_AZURE_API_VERSION = System.getenv("OPENAI_AZURE_API_VERSION");
@@ -56,7 +59,7 @@ public class OpenAIAzureIT {
 
     @Test
     public void embedding() {
-        testCall(db, "CALL apoc.ml.openai.embedding(['Some Text'], $apiKey, $conf)",
+        testCall(db, EMBEDDING_QUERY,
                 getParams(OPENAI_EMBEDDING_URL),
                 OpenAITestResultUtils::assertEmbeddings);
     }
@@ -65,19 +68,14 @@ public class OpenAIAzureIT {
     @Test
     @Ignore("It returns wrong answers sometimes")
     public void completion() {
-        testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)",
+        testCall(db, COMPLETION_QUERY,
                 getParams(OPENAI_CHAT_URL),
                 (row) -> assertCompletion(row, "gpt-35-turbo"));
     }
 
     @Test
     public void chatCompletion() {
-        testCall(db, """
-            CALL apoc.ml.openai.chat([
-            {role:"system", content:"Only answer with a single word"},
-            {role:"user", content:"What planet do humans live on?"}
-            ], $apiKey, $conf)
-            """, getParams(OPENAI_COMPLETION_URL),
+        testCall(db, CHAT_COMPLETION_QUERY, getParams(OPENAI_COMPLETION_URL),
                 (row) -> assertChatCompletion(row, "gpt-35-turbo"));
     }
 

--- a/extended/src/test/java/apoc/ml/OpenAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIIT.java
@@ -10,9 +10,9 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.util.Map;
 
-import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
-import static apoc.ml.OpenAITestResultUtils.assertCompletion;
+import static apoc.ml.OpenAITestResultUtils.*;
 import static apoc.util.TestUtil.testCall;
+import static java.util.Collections.emptyMap;
 
 public class OpenAIIT {
 
@@ -33,25 +33,20 @@ public class OpenAIIT {
 
     @Test
     public void getEmbedding() {
-        testCall(db, "CALL apoc.ml.openai.embedding(['Some Text'], $apiKey)", Map.of("apiKey",openaiKey),
+        testCall(db, EMBEDDING_QUERY, Map.of("apiKey",openaiKey, "conf", emptyMap()),
                 OpenAITestResultUtils::assertEmbeddings);
     }
 
     @Test
     public void completion() {
-        testCall(db, "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey)",
-                Map.of("apiKey", openaiKey),
+        testCall(db, COMPLETION_QUERY,
+                Map.of("apiKey", openaiKey, "conf", emptyMap()),
                 (row) -> assertCompletion(row, "gpt-3.5-turbo-instruct"));
     }
 
     @Test
     public void chatCompletion() {
-        testCall(db, """
-CALL apoc.ml.openai.chat([
-{role:"system", content:"Only answer with a single word"},
-{role:"user", content:"What planet do humans live on?"}
-],  $apiKey)
-""", Map.of("apiKey",openaiKey),
+        testCall(db, CHAT_COMPLETION_QUERY, Map.of("apiKey",openaiKey, "conf", emptyMap()),
                 (row) -> assertChatCompletion(row, "gpt-3.5-turbo"));
 
         /*

--- a/extended/src/test/java/apoc/ml/OpenAILLMaticIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAILLMaticIT.java
@@ -1,0 +1,133 @@
+package apoc.ml;
+
+import apoc.util.TestUtil;
+import apoc.util.Util;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.test.assertion.Assert;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import static apoc.ApocConfig.apocConfig;
+import static apoc.ml.OpenAI.APIKEY_CONF_KEY;
+import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
+import static apoc.ml.OpenAI.MODEL_CONF_KEY;
+import static apoc.ml.OpenAITestResultUtils.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+
+
+/**
+ * To start the tests, follow the instructions in this video: https://www.youtube.com/watch?v=V_baaAZMY44.
+ *
+ * NB: The APIs, especially the `/completions` one, are extremely unstable (i.e. we could get many SocketTimeoutExceptions), also via e.g. Insomnia or PostMan,
+ * even with `assertEventually` and `apoc.http.timeout.*` configs increased.
+ * So it's better to change the `nTokPredict` value, placed in `llmatic.config.json`, to a low value, like `128`,
+ * before executing `npx llmatic start`.
+ * 
+ * Finally, set the env var `LLM_MATIC_URL=http://localhost:3000/v1`
+ */
+public class OpenAILLMaticIT {
+    public static final String MODEL_ID = "meta-llama/Llama-2-70b-chat-hf";
+    private String localAIUrl;
+
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
+
+
+    @Before
+    public void setUp() throws Exception {
+        apocConfig().setProperty("apoc.http.timeout.connect", 30_000);
+        apocConfig().setProperty("apoc.http.timeout.read", 30_000);
+        
+        localAIUrl = System.getenv("LLM_MATIC_URL");
+        Assume.assumeNotNull("No LLM_MATIC_URL environment configured", localAIUrl);
+        TestUtil.registerProcedure(db, OpenAI.class);
+    }
+
+    @Test
+    public void getEmbedding() {
+        assertEventually(() -> db.executeTransactionally(EMBEDDING_QUERY,
+                getParams("thenlper/gte-large"),
+                r -> {
+                    Map<String, Object> row = r.next();
+                    assertEquals(0L, row.get("index"));
+                    assertEquals("Some Text", row.get("text"));
+                    var embedding = (List<Double>) row.get("embedding");
+                    assertEquals(5120, embedding.size());
+                    assertFalse(r.hasNext());
+                    return true;
+                }
+        ));
+    }
+
+    @Test
+    public void completion() {
+        assertEventually(() -> db.executeTransactionally(COMPLETION_QUERY,
+                getParams(MODEL_ID),
+                (r) -> {
+                    Map<String, Object> row = r.next();
+                    var result = (Map<String,Object>) row.get("value");
+                    assertTrue(result.get("created") instanceof Number);
+                    assertTrue(result.containsKey("choices"));
+                    var finishReason = (String)((List<Map>) result.get("choices")).get(0).get("finish_reason");
+                    assertTrue(finishReason.matches("stop|length"));
+                    assertEquals(MODEL_ID, result.get("model"));
+                    
+                    assertFalse(r.hasNext());
+                    return true;
+                }
+        ));
+    }
+
+    @Test
+    public void chatCompletion() {
+        assertEventually(() -> db.executeTransactionally(CHAT_COMPLETION_QUERY, 
+                getParams(MODEL_ID),
+                (r) -> {
+                    Map<String, Object> row = r.next();
+                    var result = (Map<String,Object>) row.get("value");
+                    assertTrue(result.get("created") instanceof Number);
+                    assertTrue(result.containsKey("choices"));
+
+                    Map message = ((List<Map<String,Map>>) result.get("choices")).get(0).get("message");
+                    assertEquals("assistant", message.get("role"));
+                    String text = (String) message.get("content");
+                    assertTrue(text != null && !text.isBlank());
+                    assertTrue(result.get("model").toString().startsWith(MODEL_ID));
+                    
+                    assertFalse(r.hasNext());
+                    return true;
+                }
+        ));
+    }
+
+
+    private void assertEventually(Callable<Boolean> booleanCallable) {
+        Assert.assertEventually(() -> {
+            try {
+                return booleanCallable.call();
+            } catch (RuntimeException e) {
+                return false;
+            }
+        }, val -> val, 60, TimeUnit.SECONDS);
+    }
+
+    private Map<String, Object> getParams(String model) {
+        return Util.map(APIKEY_CONF_KEY, "ignored",
+                "conf", Map.of(
+                        ENDPOINT_CONF_KEY, localAIUrl,
+                        MODEL_CONF_KEY, model
+                )
+        );
+    }
+}

--- a/extended/src/test/java/apoc/ml/OpenAILocalAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAILocalAIIT.java
@@ -1,0 +1,74 @@
+package apoc.ml;
+
+import apoc.util.TestUtil;
+import apoc.util.Util;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.List;
+import java.util.Map;
+
+import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
+import static apoc.ml.OpenAI.MODEL_CONF_KEY;
+import static apoc.ml.OpenAITestResultUtils.*;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+/**
+ * To start the tests, follow the instructions provided here: https://localai.io/basics/build/
+ * Then, download the embedding model, as explained here: https://localai.io/models/#embeddings-bert 
+ * Finally, set the env var `LOCAL_AI_URL=http://localhost:<portNumber>/v1`, default is `LOCAL_AI_URL=http://localhost:8080/v1`
+ */
+public class OpenAILocalAIIT {
+
+    private String localAIUrl;
+
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
+
+
+    @Before
+    public void setUp() throws Exception {
+        localAIUrl = System.getenv("LOCAL_AI_URL");
+        Assume.assumeNotNull("No LOCAL_AI_URL environment configured", localAIUrl);
+        TestUtil.registerProcedure(db, OpenAI.class);
+    }
+
+    @Test
+    public void getEmbedding() {
+        testCall(db, EMBEDDING_QUERY,
+                getParams("text-embedding-ada-002"),
+                row -> {
+                    assertEquals(0L, row.get("index"));
+                    assertEquals("Some Text", row.get("text"));
+                    var embedding = (List<Double>) row.get("embedding");
+                    assertEquals(384, embedding.size());
+                });
+    }
+
+    @Test
+    public void completion() {
+        testCall(db, COMPLETION_QUERY,
+                getParams("ggml-gpt4all-j"),
+                (row) -> assertCompletion(row, "ggml-gpt4all-j"));
+    }
+
+    @Test
+    public void chatCompletion() {
+        testCall(db, CHAT_COMPLETION_QUERY, 
+                getParams("ggml-gpt4all-j"),
+                (row) -> assertChatCompletion(row, "ggml-gpt4all-j"));
+    }
+
+    private Map<String, Object> getParams(String model) {
+        return Util.map("apiKey", "x",
+                "conf", Map.of(ENDPOINT_CONF_KEY, localAIUrl,
+                        MODEL_CONF_KEY, model)
+        );
+    }
+}

--- a/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
@@ -1,0 +1,94 @@
+package apoc.ml;
+
+import apoc.util.TestUtil;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static apoc.ml.OpenAI.API_TYPE_CONF_KEY;
+import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
+import static apoc.ml.OpenAI.MODEL_CONF_KEY;
+import static apoc.ml.OpenAI.PATH_CONF_KEY;
+import static apoc.ml.OpenAITestResultUtils.*;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * OpenLM-like tests for Cohere and HuggingFace, see here: https://github.com/r2d4/openlm
+ * 
+ * NB: It works only for `Completion` API, as described in the README.md:
+ * https://github.com/r2d4/openlm/blob/main/README.md?plain=1#L36
+ */
+public class OpenAIOpenLMIT {
+    
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
+
+
+    @Before
+    public void setUp() throws Exception {
+        TestUtil.registerProcedure(db, OpenAI.class);
+    }
+
+    /**
+     * Request converter similar to: https://github.com/r2d4/openlm/blob/main/openlm/llm/huggingface.py
+     */
+    @Test
+    public void completionWithHuggingFace() {
+        String huggingFaceApiKey = System.getenv("HF_API_TOKEN");
+        Assume.assumeNotNull("No HF_API_TOKEN environment configured", huggingFaceApiKey);
+        
+        String modelId = "gpt2";
+        Map<String, String> conf = Map.of(ENDPOINT_CONF_KEY, "https://api-inference.huggingface.co/models/" + modelId,
+                API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.HUGGINGFACE.name(),
+                PATH_CONF_KEY, "",
+                MODEL_CONF_KEY, modelId
+        );
+        testCall(db, COMPLETION_QUERY,
+                Map.of("conf", conf, "apiKey", huggingFaceApiKey),
+                (row) -> {
+                    var result = (Map<String,Object>) row.get("value");
+                    String generatedText = (String) result.get("generated_text");
+                    assertTrue(generatedText.toLowerCase().contains("blue"),
+                            "Actual generatedText is " + generatedText);
+                });
+    }
+
+    /**
+     * Request converter similar to: https://github.com/r2d4/openlm/blob/main/openlm/llm/cohere.py
+     */
+    @Test
+    public void completionWithCohere() {
+        String cohereApiKey = System.getenv("COHERE_API_TOKEN");
+        Assume.assumeNotNull("No COHERE_API_TOKEN environment configured", cohereApiKey);
+        
+        String modelId = "command";
+        Map<String, String> conf = Map.of(ENDPOINT_CONF_KEY, "https://api.cohere.ai/v1/generate",
+                PATH_CONF_KEY, "",
+                MODEL_CONF_KEY, modelId
+        );
+        
+        testCall(db, COMPLETION_QUERY,
+                Map.of("conf", conf, "apiKey", cohereApiKey),
+                (row) -> {
+                    var result = (Map<String,Object>) row.get("value");
+                    Map meta = (Map) result.get("meta");
+                    assertEquals(Set.of("warnings", "billed_units", "api_version"), meta.keySet());
+
+                    List<Map> generations = (List<Map>) result.get("generations");
+                    assertEquals(1, generations.size());
+                    assertEquals(Set.of("finish_reason", "id", "text"), generations.get(0).keySet());
+                    
+                    assertTrue(result.get("id") instanceof String);
+                    assertTrue(result.get("prompt") instanceof String);
+                });
+    }
+}

--- a/extended/src/test/java/apoc/ml/OpenAITest.java
+++ b/extended/src/test/java/apoc/ml/OpenAITest.java
@@ -33,7 +33,7 @@ public class OpenAITest {
         // openaiKey = System.getenv("OPENAI_KEY");
         // Assume.assumeNotNull("No OPENAI_KEY environment configured", openaiKey);
         var path = Paths.get(getUrlFileName("embeddings").toURI()).getParent().toUri();
-        System.setProperty(APOC_ML_OPENAI_URL, path.toString());
+        apocConfig().setProperty(APOC_ML_OPENAI_URL, path.toString());
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         TestUtil.registerProcedure(db, OpenAI.class);
     }

--- a/extended/src/test/java/apoc/ml/OpenAITestResultUtils.java
+++ b/extended/src/test/java/apoc/ml/OpenAITestResultUtils.java
@@ -7,6 +7,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OpenAITestResultUtils {
+    public static final String EMBEDDING_QUERY = "CALL apoc.ml.openai.embedding(['Some Text'], $apiKey, $conf)";
+    public static final String CHAT_COMPLETION_QUERY = """
+            CALL apoc.ml.openai.chat([
+            {role:"system", content:"Only answer with a single word"},
+            {role:"user", content:"What planet do humans live on?"}
+            ], $apiKey, $conf)
+            """;
+    public static final String COMPLETION_QUERY = "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)";
+    
     public static void assertEmbeddings(Map<String, Object> row) {
         assertEquals(0L, row.get("index"));
         assertEquals("Some Text", row.get("text"));


### PR DESCRIPTION
Fixes #3858


- Added path configurations to manipulate the url suffix (which by default is /embeddings, /completions and /chat/completions)

- Added tests for https://app.endpoints.anyscale.com/

- Added tests for Local AI

- Added tests for LLMatic (with assertEventually as they are very slow and often go into SocketTimeout)

- Added tests to simulate the behavior of https://github.com/r2d4/openlm, which manipulates APIs to have an OpenAI-compatible format. Tested with Cohere and HuggingFace. As with the library, only test for the Completions API

- An OpenAIRequestHandler.Type has been added for HuggingFace, to transform the input into a format consistent with the HuggingFace Api (i.e. `{"inputs": ["text...."]}`) and change the jsonPath to `$[0]`. With this API, we need to explicit the config `path: ''`
- For Cohere, added note on the documentation to explain to make explicit path: '', otherwise it adds /completions to the url, which is not foreseen by the cohere API

- Changed `System.setProperty` to `apocConfig().setProperty` in `OpenAITest.java` not to interfere with other ml tests, if we run them all