### PR TITLE
Fix HelpExtendedTest not to edit extended.txt when executed

### DIFF
--- a/extended/src/test/java/apoc/help/HelpExtendedTest.java
+++ b/extended/src/test/java/apoc/help/HelpExtendedTest.java
@@ -14,9 +14,11 @@ import org.reflections.scanners.SubTypesScanner;
 import org.reflections.scanners.TypeAnnotationsScanner;
 import org.reflections.util.ConfigurationBuilder;
 
-import java.io.*;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static apoc.util.Util.map;
 import static org.junit.Assert.assertEquals;
@@ -61,39 +63,37 @@ public class HelpExtendedTest {
     }
 
     @Test
-    public void indicateNotCore() throws IOException {
-        File extendedFile = new File("src/main/resources/extended.txt");
-        FileOutputStream fos = new FileOutputStream(extendedFile);
-
-        try (BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(fos))) {
-            db.executeTransactionally("SHOW PROCEDURES YIELD name WHERE name STARTS WITH 'apoc' AND name <> 'apoc.help' RETURN name", Collections.emptyMap(),
-                    result -> {
-                        result.stream().forEach(record -> {
-                            try {
-                                bw.write(record.get("name").toString());
-                                bw.newLine();
-                            } catch (IOException ignored) {
-                            }
-                        });
-                        return null;
-                    });
-
-            db.executeTransactionally("SHOW FUNCTIONS YIELD name WHERE name STARTS WITH 'apoc'  AND name <> 'apoc.help' RETURN name", Collections.emptyMap(),
-                    result -> {
-                        result.stream().forEach(record -> {
-                            try {
-                                bw.write(record.get("name").toString());
-                                bw.newLine();
-                            } catch (IOException ignored) {
-                            }
-                        });
-                        return null;
-                    });
-        }
+    public void indicateNotCore() {
+        List<String> expected = listHelpExtendedProcsAndFuncs();
+        List<String> actual = listCypherCommandsProcsAndFuncs();
+        assertEquals(expected, actual);
 
         TestUtil.testCall(db, "CALL apoc.help($text)", map("text", "expireIn"), (row) -> {
             assertEquals(false, row.get("core"));
         });
+    }
+    
+    private List<String> listHelpExtendedProcsAndFuncs() {
+        String query = "CALL apoc.help('') YIELD name, core WHERE core = false RETURN name";
+        List<String> helpExtendedProcedures = getNames(query);
+        Collections.sort(helpExtendedProcedures);
+        return helpExtendedProcedures;
+    }
+
+    private List<String> listCypherCommandsProcsAndFuncs() {
+        String commonReturnStatement = " YIELD name WHERE name STARTS WITH 'apoc' AND name <> 'apoc.help' RETURN name";
+        List<String> procsAndFuncs = getNames("SHOW FUNCTIONS" + commonReturnStatement);
+        List<String> procedures = getNames("SHOW PROCEDURES" + commonReturnStatement);
+
+        procsAndFuncs.addAll(procedures);
+        Collections.sort(procsAndFuncs);
+        return procsAndFuncs;
+    }
+
+    private List<String> getNames(String query) {
+        return db.executeTransactionally(query, Collections.emptyMap(),
+                result -> result.<String>columnAs("name").stream()
+                        .collect(Collectors.toCollection(ArrayList::new)));
     }
 
 }


### PR DESCRIPTION
The [HelpExtendedTest.indicateNotCore()](https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/dev/extended/src/test/java/apoc/help/HelpExtendedTest.java#L68) test currently changes the `extended.txt` file when executed.

Therefore, if some classes have / do not have the `@Extended` annotation, [like in this case](https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/83199902017ac9e89d699954a6f581147fa7e8b6),
the result of `StartupExtendedTest` (which [leverage the extended.txt](https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/dev/extended/src/test/java/apoc/StartupExtendedTest.java#L39))
may change if it is run before (which happens with gh action) or after (with TC) HelpExtendedTest.


Changed the HelpExtendedTest so that doesn't change the txt file, 
but checks that `apoc.help('')` and `SHOW FUNCTION/PROCEDURE` coincide.

---

Maybe the extended.txt file could be generated automatically via reflection, using the @Extended annotation, but it should be done every time we compile / build / run test. So can be hardily feasible and error-prone.
I think it's better to leave it as it is, adding the procedures/functions manually.