### PR TITLE
Fixes #3203: apoc.mongo dependencies are outdated with current mongodb

### DIFF
--- a/docs/asciidoc/modules/ROOT/partials/mongodb-dependencies.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/mongodb-dependencies.adoc
@@ -3,18 +3,3 @@ The Mongo procedures have dependencies on a client library that is not included 
 This dependency is included in https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/{apoc-release}/apoc-mongodb-dependencies-{apoc-release}-all.jar[apoc-mongodb-dependencies-{apoc-release}-all.jar^], which can be downloaded from the https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/tag/{apoc-release}[releases page^].
 Once that file is downloaded, it should be placed in the `plugins` directory and the Neo4j Server restarted.
 
-
-
-Alternatively, you could copy these jars into the plugins directory:
-
-* bson-3.4.2.jar
-* mongo-java-driver-3.4.2.jar, 
-* mongodb-driver-3.4.2.jar
-* mongodb-driver-core-3.4.2.jar
-
-You should be able to get them from the following links:
-
-- https://mvnrepository.com/artifact/org.mongodb/mongo-java-driver/3.4.2[mongo-java-driver]
-- https://mvnrepository.com/artifact/org.mongodb/mongodb-driver/3.4.2[mongodb-driver]
-- https://mvnrepository.com/artifact/org.mongodb/mongodb-driver-core/3.4.2[mongodb-driver-core]
-- https://mvnrepository.com/artifact/org.mongodb/bson/3.4.2[BSON]

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -94,7 +94,7 @@ dependencies {
     compileOnly group: 'io.github.bonigarcia', name: 'webdrivermanager', version: '5.4.0', {
         exclude group: 'com.google.guava', module: 'guava'
     }
-    compileOnly 'org.mongodb:mongodb-driver:3.2.2', {
+    compileOnly group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.11.1', {
         exclude group: 'io.netty'
     }
     compileOnly group: 'com.couchbase.client', name: 'java-client', version: '3.3.0', withoutJacksons
@@ -130,7 +130,7 @@ dependencies {
     testImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib-jdk8', version: '1.6.0'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '1.3'
     testImplementation group: 'org.apache.derby', name: 'derby', version: '10.12.1.1'
-    testImplementation group: 'org.mongodb', name: 'mongodb-driver', version: '3.2.2', {
+    testImplementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.11.1', {
         exclude group: 'io.netty'
     }
     testImplementation group: 'com.couchbase.client', name: 'java-client', version: '3.3.0', withoutJacksons

--- a/extended/src/main/java/apoc/mongodb/MongoDBColl.java
+++ b/extended/src/main/java/apoc/mongodb/MongoDBColl.java
@@ -3,10 +3,10 @@ package apoc.mongodb;
 import apoc.util.Util;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientURI;
-import com.mongodb.MongoCommandException;
+import com.mongodb.ConnectionString;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.MongoIterable;
@@ -56,8 +56,7 @@ class MongoDBColl implements MongoDbCollInterface {
     public static final String ERROR_MESSAGE = "The connection string must have %s name";
 
     private MongoDBColl(String url, String db, String coll) {
-        MongoClientURI connectionString = new MongoClientURI(url);
-        mongoClient = new MongoClient(connectionString);
+        mongoClient = MongoClients.create(url);
         database = mongoClient.getDatabase(db);
         collection = database.getCollection(coll);
     }
@@ -78,13 +77,12 @@ class MongoDBColl implements MongoDbCollInterface {
     /**
      *
      * @param uri the string Uri to convert in connectionString
-     * @see MongoClientURI
      * @param conf the configuration
      * @see MongoDbConfig
      */
     public MongoDBColl(String uri, MongoDbConfig conf) {
 
-        MongoClientURI connectionString = new MongoClientURI(uri);
+        ConnectionString connectionString = new ConnectionString(uri);
 
         if (connectionString.getDatabase() == null) {
             throw new RuntimeException(format(ERROR_MESSAGE, "db"));
@@ -102,13 +100,13 @@ class MongoDBColl implements MongoDbCollInterface {
             collectionName = collectionFromUri;
         }
 
-        mongoClient = new MongoClient(connectionString);
+        mongoClient = MongoClients.create(connectionString);
         database = mongoClient.getDatabase(connectionString.getDatabase());
 
         try {
             // check if correctly authenticated
             database.runCommand(new Document("listCollections", 1));
-        } catch (MongoCommandException e) {
+        } catch (Exception e) {
             mongoClient.close();
             throw new RuntimeException(e);
         }
@@ -247,12 +245,12 @@ class MongoDBColl implements MongoDbCollInterface {
 
     @Override
     public long count(Map<String, Object> query) {
-        return query == null ? collection.count() : collection.count(new Document(query));
+        return query == null ? collection.countDocuments() : collection.countDocuments(new Document(query));
     }
 
     @Override
     public long count(Document query) {
-        return collection.count(query);
+        return collection.countDocuments(query);
     }
 
     @Override

--- a/extended/src/main/java/apoc/mongodb/MongoDBUtils.java
+++ b/extended/src/main/java/apoc/mongodb/MongoDBUtils.java
@@ -19,9 +19,23 @@ public class MongoDBUtils {
         if (query == null) {
             return new Document();
         }
-        return Document.parse(query instanceof String
+        String json = query instanceof String
                 ? (String) query
-                : JsonUtil.writeValueAsString(query));
+                : JsonUtil.writeValueAsString(query);
+        
+        json = adaptLegacyDocuments(json);
+        
+        Document document = Document.parse(json);
+        
+        return document;
+    }
+
+    /**
+     * In case someone use an old notation, e.g. {`$binary`: $bytes, `$subType`: '00'}
+     */
+    private static String adaptLegacyDocuments(String json) {
+        return json.replace("'$subType'", "'$type'")
+                .replace("\"$subType\"", "\"$type\"");
     }
 
     protected static List<Document> getDocuments(List<Map<String, Object>> pipeline) {

--- a/extended/src/test/java/apoc/mongodb/MongoDBTest.java
+++ b/extended/src/test/java/apoc/mongodb/MongoDBTest.java
@@ -4,13 +4,15 @@ import apoc.graph.Graphs;
 import apoc.util.MapUtil;
 import apoc.util.TestUtil;
 import apoc.util.UrlResolver;
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import org.bson.types.ObjectId;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.text.ParseException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
@@ -32,16 +34,18 @@ import static org.junit.Assert.assertTrue;
  * @since 30.06.16
  */
 public class MongoDBTest extends MongoTestBase {
-    private static Map<String, Object> params;
 
     private static String HOST = null;
 
     @BeforeClass
     public static void setUp() throws Exception {
-        createContainer(false);
-        MongoClient mongoClient = new MongoClient(mongo.getContainerIpAddress(), mongo.getMappedPort(MONGO_DEFAULT_PORT));
+        beforeClassCommon(MongoVersion.LATEST);
+    }
+
+    static void beforeClassCommon(MongoVersion mongoVersion) throws ParseException {
+        createContainer(false, mongoVersion);
         HOST = String.format("mongodb://%s:%s", mongo.getContainerIpAddress(), mongo.getMappedPort(MONGO_DEFAULT_PORT));
-        params = map("host", HOST, "db", "test", "collection", "test");
+        MongoClient mongoClient = MongoClients.create(HOST);
 
         fillDb(mongoClient);
 
@@ -121,7 +125,7 @@ public class MongoDBTest extends MongoTestBase {
                     Map doc = (Map) r.get("value");
                     assertTrue(doc.get("_id") instanceof Map);
                     assertEquals(
-                            Set.of("date", "machineIdentifier", "processIdentifier", "counter", "time", "timestamp", "timeSecond"),
+                            Set.of("date", "timestamp"),
                             ((Map<String, Object>) doc.get("_id")).keySet()
                     );
                     assertEquals("Sherlock", doc.get("name"));
@@ -140,7 +144,7 @@ public class MongoDBTest extends MongoTestBase {
                     Map doc = (Map) r.get("value");
                     assertTrue(doc.get("_id") instanceof Map);
                     assertEquals(
-                            Set.of("date", "machineIdentifier", "processIdentifier", "counter", "time", "timestamp", "timeSecond"),
+                            Set.of("date", "timestamp"),
                             ((Map<String, Object>) doc.get("_id")).keySet()
                     );
                     assertEquals(40L, doc.get("age"));

--- a/extended/src/test/java/apoc/mongodb/MongoDBVersion4Test.java
+++ b/extended/src/test/java/apoc/mongodb/MongoDBVersion4Test.java
@@ -1,0 +1,15 @@
+package apoc.mongodb;
+
+import org.junit.BeforeClass;
+
+/**
+ * To check that, with the latest mongodb java driver,
+ * the {@link MongoDBTest} works correctly with mongoDB 4
+ */
+public class MongoDBVersion4Test extends MongoDBTest {
+    
+    @BeforeClass
+    public static void setUp() throws Exception {
+        MongoDBTest.beforeClassCommon(MongoVersion.FOUR);
+    }
+}

--- a/extended/src/test/java/apoc/mongodb/MongoVersion4Test.java
+++ b/extended/src/test/java/apoc/mongodb/MongoVersion4Test.java
@@ -1,0 +1,15 @@
+package apoc.mongodb;
+
+import org.junit.BeforeClass;
+
+/**
+ * To check that, with the latest mongodb java driver,
+ * the {@link MongoTest} works correctly with mongoDB 4
+ */
+public class MongoVersion4Test extends MongoTest {
+    
+    @BeforeClass
+    public static void setUp() throws Exception {
+        beforeClassCommon(MongoVersion.FOUR);
+    }
+}

--- a/extra-dependencies/mongodb/build.gradle
+++ b/extra-dependencies/mongodb/build.gradle
@@ -17,7 +17,7 @@ jar {
 }
 
 dependencies {
-    implementation 'org.mongodb:mongodb-driver:3.2.2', {
+    implementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.11.1', {
         exclude group: 'io.netty'
     }
 }


### PR DESCRIPTION
Fixes #3203

- Updated java driver and API
- Changed [`MongoCommandException` to `Exception`](https://github.com/vga91/neo4j-apoc-procedures/pull/411/files#diff-7a0bb39849237cd94862ba6b51f30b78a7b80de77d130b061778e6509b7de5d4R108), otherwise the client is not closed on exception
- Added [adaptLegacyDocument](https://github.com/vga91/neo4j-apoc-procedures/pull/411/files#diff-f083578af56ec4397c0a59e00584ae8fe68cac67eebfd78db094e914b530c4f0R26) in case someone uses `$sub Type` for binaries (which is no longer compatible, replaced with `$type`). Alternatively you could write a `NOTE` on the documentation
- Added tests with mongodb 7 and created test classes to check compatibility with mongodb 4
- Code clean