### PR TITLE
[SGrPWNEf] Fixes backslashes parsing in csv import / export

### DIFF
--- a/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
+++ b/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
@@ -28,6 +28,8 @@ import apoc.util.FileUtils;
 import com.opencsv.CSVParserBuilder;
 import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
+import com.opencsv.RFC4180ParserBuilder;
+
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -99,7 +101,7 @@ public class CsvEntityLoader {
             final Map<String, Mapping> mapping = getMapping(fields);
 
             final CSVReader csv = new CSVReaderBuilder(reader)
-                    .withCSVParser(new CSVParserBuilder()
+                    .withCSVParser(new RFC4180ParserBuilder()
                             .withSeparator(clc.getDelimiter())
                             .withQuoteChar(clc.getQuotationCharacter())
                             .build())

--- a/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
+++ b/core/src/main/java/apoc/export/csv/CsvEntityLoader.java
@@ -29,7 +29,6 @@ import com.opencsv.CSVParserBuilder;
 import com.opencsv.CSVReader;
 import com.opencsv.CSVReaderBuilder;
 import com.opencsv.RFC4180ParserBuilder;
-
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -46,13 +46,11 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -249,23 +247,14 @@ public class ExportCsvTest {
 
     @Test
     public void testCsvBackslashes() {
-        db.executeTransactionally(
-                "CREATE (n:Test {name: 'Test', value: '{\"new\":\"4\\'10\\\\\\\"\"}'})");
+        db.executeTransactionally("CREATE (n:Test {name: 'Test', value: '{\"new\":\"4\\'10\\\\\\\"\"}'})");
 
         String fileName = "test.csv.quotes.csv";
-        final Map<String, Object> params = map(
-                "file",
-                fileName,
-                "query",
-                "MATCH (n: Test) RETURN n",
-                "config",
-                map("quotes", "always"));
+        final Map<String, Object> params =
+                map("file", fileName, "query", "MATCH (n: Test) RETURN n", "config", map("quotes", "always"));
 
         TestUtil.testCall(
-                db,
-                "CALL apoc.export.csv.all($file, $config)",
-                params,
-                (r) -> assertEquals(fileName, r.get("file")));
+                db, "CALL apoc.export.csv.all($file, $config)", params, (r) -> assertEquals(fileName, r.get("file")));
 
         final String deleteQuery = "MATCH (n:Test) DETACH DELETE n";
         db.executeTransactionally(deleteQuery);


### PR DESCRIPTION
## What

Uses `RFC4180Parser` instead of `CSVParser` as suggested [here](https://stackoverflow.com/questions/46139735/why-csvwriter-and-csvreader-uses-different-default-escape-characters)


## Why

Because the case where we have a quote `"` in a value we want to export / import from csv was not working:

```
CREATE (n:Test {name: 'Test', value: '{"new":"4\'10\\\""}'});
CALL apoc.export.csv.all("test.csv", {bulkImport:'true'});
MATCH (n) DETACH DELETE n;
CALL apoc.import.csv([{fileName: 'file:test.nodes.Test.csv', labels: ['Test']}],[],{});
```

```
MATCH (n: Test) RETURN n.value
```

should give us a roundtrip where the result is `"{"new":"4'10\""}"`

