### PR TITLE
Fixes #3891: Add IBM Watson Foundation model integration

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/ml/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/index.adoc
@@ -10,3 +10,4 @@ This section includes:
 * xref::ml/vertexai.adoc[]
 * xref::ml/openai.adoc[]
 * xref::ml/bedrock.adoc[]
+* xref::ml/watsonai.adoc[]

--- a/docs/asciidoc/modules/ROOT/pages/ml/watsonai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/watsonai.adoc
@@ -1,12 +1,12 @@
-[[watson-api]]
-= watson API Access
-:description: This section describes procedures that can be used to access the watson API.
+[[Watson-api]]
+= Watson API Access
+:description: This section describes procedures that can be used to access the Watson API.
 
-NOTE: You need to acquire an https://cloud.ibm.com/apidocs/watson-data-api#creating-an-iam-bearer-token[Watson bearer access token] to use these procedures.
+NOTE: You need to acquire an https://cloud.ibm.com/apidocs/Watson-data-api#creating-an-iam-bearer-token[Watson bearer access token] to use these procedures.
 This token must be defined in the second parameter
 
 
-Each procedure can have the following APOC config, i.e. in `apoc.conf` or via docker env variable
+Each procedure can have the following APOC config parameters, i.e. in `apoc.conf` or via docker env variable
 
 .Apoc configuration
 |===
@@ -71,7 +71,7 @@ The following procedure will create, without any config, the following API reque
 .Text Completion Call
 [source,cypher]
 ----
-CALL apoc.ml.watson.completion('What color is the sky? Answer in one word: ', '<apiKey>', {config})
+CALL apoc.ml.watson.completion('What color is the sky? Answer in one word: ', '<apiKey>', {})
 ----
 
 
@@ -143,3 +143,9 @@ With a result like this:
 |===
 
 
+== Generate Embeddings API
+
+Watson does not have built-in embedding APIs, 
+so if we want to use embeddings, we have to use one of the other Apoc ML integrations,
+such as xref::ml/openai.adoc[apoc.ml.openai.embeddings] or xref::ml/vertexai.adoc[apoc.ml.vertexai.embeddings], 
+or https://huggingface.co/docs/hub/sentence-transformers[HuggingFace embeddings as sentence transformers].

--- a/docs/asciidoc/modules/ROOT/pages/ml/watsonai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/watsonai.adoc
@@ -1,0 +1,145 @@
+[[watson-api]]
+= watson API Access
+:description: This section describes procedures that can be used to access the watson API.
+
+NOTE: You need to acquire an https://cloud.ibm.com/apidocs/watson-data-api#creating-an-iam-bearer-token[Watson bearer access token] to use these procedures.
+This token must be defined in the second parameter
+
+
+Each procedure can have the following APOC config, i.e. in `apoc.conf` or via docker env variable
+
+.Apoc configuration
+|===
+|key | description | default
+| apoc.ml.watson.project.id | The project_id | the `project_id` defined in the configuration map
+| apoc.ml.watson.url | The REST API endpoint | https://eu-de.ml.cloud.ibm.com/ml/v1-beta/generation/text?version=2023-05-29
+|===
+
+We can put the body request directly into the configuration parameter, 
+except for the `"input"` key, which will be added through the first parameter of the procedure, as we will see later.
+
+For example, if we want to send a request this request:
+```
+{
+ "model_id": "google/flan-ul2",
+ "input": "my test input",
+ "parameters": {
+  "max_new_tokens": 3
+ },
+ "project_id": "MyProjectId"
+}
+```
+we can create the following configuration map:
+```
+{
+    model_id: "google/flan-ul2",
+    project_id: "MyProjectId",
+    parameters: {
+      max_new_tokens: 3
+    }
+}
+```
+
+Note that the `model_id` is not mandatory, since has a default value `"ibm/granite-13b-chat-v2"`
+
+Also the `project_id` is not mandatory, if it has been defined via APOC configuration,
+or if alternatively is present in the configuration map an entry with the key `space_id` or `wml_instance_crn`; otherwise, an error will be thrown, since the Watson Request APIs require one of these.
+
+In addition, we can put in the configuration map, the entry `endpoint: "ENDPOINT_URL`, 
+which define the REST API endpoint, and takes precedence over the `apoc.watson.url` APOC configuration.
+If neither is specified, the default value `"https://eu-de.ml.cloud.ibm.com/ml/v1-beta/generation/text?version=2023-05-29"` will be used.
+
+
+The following examples assume we have this `apoc.conf`:
+```
+apoc.watson.project.id=MY_PROJECT_ID
+```
+
+== Text Completion API
+
+This procedure `apoc.ml.watson.completion` can continue/complete a given text.
+
+The following procedure will create, without any config, the following API request:
+```
+{
+"model_id": "ibm/granite-13b-chat-v2",
+"input": "What color is the sky? Answer in one word: ,
+"project_id": "<the one explicited in the APOC config>"
+}
+```
+
+.Text Completion Call
+[source,cypher]
+----
+CALL apoc.ml.watson.completion('What color is the sky? Answer in one word: ', '<apiKey>', {config})
+----
+
+
+With a result like this:
+
+.Text Completion Response Example
+[opts="header",cols="1"]
+|===
+| value
+| {"model_id": "ibm/granite-13b-chat-v2",
+    "created_at": "2024-01-11T09:33:46.130Z",
+	"results": [
+        {
+			"generated_text": "\nThe sky is blue.",
+			"generated_token_count": 7,
+			"input_token_count": 12,
+			"stop_reason": "eos_tokens"
+		}
+	]
+}
+|===
+
+
+== Chat Completion API
+
+This procedure `apoc.ml.watson.chat` takes a list of maps of chat messages, and will return the next message in the flow.
+
+The keys `role` and `content` must be specified.
+
+From the `messages` list will be created a string like `<roleValue1>: <contentValue1> \n <roleValue2>: <contentValue2> etc..`.
+
+For example, the following call will create a request with this body:
+```
+{
+ "model_id": "ibm/granite-13b-chat-v2",
+ "input": "system: Only answer with a single word\nuser: What planet do humans live on?",
+ "project_id": "<the one explicited in the APOC config>"
+}
+```
+
+.Chat Completion Call
+[source,cypher]
+----
+CALL apoc.ml.watson.chat([
+    {role:"system", content:"Only answer with a single word"},
+    {role:"user", content:"What planet do humans live on?"}
+],  $apiKey) yield value
+----
+
+
+With a result like this:
+
+.Chat Completion Response Example
+[opts="header",cols="1"]
+|===
+| value
+| {"model_id": "ibm/granite-13b-chat-v2",
+    "created_at": "2024-01-11T09:33:46.130Z",
+    "results": [
+        {
+            "generated_text": "
+                system: Earth",
+            "generated_token_count": 7,
+            "input_token_count": 12,
+            "stop_reason": "eos_tokens"
+        }
+    ]
+}
+|===
+
+

--- a/extended/src/main/java/apoc/ExtendedApocConfig.java
+++ b/extended/src/main/java/apoc/ExtendedApocConfig.java
@@ -33,6 +33,8 @@ public class ExtendedApocConfig extends LifecycleAdapter
     public static final String APOC_ML_OPENAI_URL = "apoc.ml.openai.url";
     public static final String APOC_ML_OPENAI_TYPE = "apoc.ml.openai.type";
     public static final String APOC_ML_OPENAI_AZURE_VERSION = "apoc.ml.azure.api.version";
+    public static final String APOC_ML_WATSON_PROJECT_ID = "apoc.ml.watson.project.id";
+    public static final String APOC_ML_WATSON_URL = "apoc.ml.watson.url";
     public static final String APOC_AWS_KEY_ID = "apoc.aws.key.id";
     public static final String APOC_AWS_SECRET_KEY = "apoc.aws.secret.key";
     public enum UuidFormatType { hex, base64 }

--- a/extended/src/main/java/apoc/ml/Watson.java
+++ b/extended/src/main/java/apoc/ml/Watson.java
@@ -1,0 +1,104 @@
+package apoc.ml;
+
+import apoc.ApocConfig;
+import apoc.Extended;
+import apoc.result.MapResult;
+import apoc.util.JsonUtil;
+import org.neo4j.graphdb.security.URLAccessChecker;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static apoc.ExtendedApocConfig.APOC_ML_WATSON_URL;
+import static apoc.ExtendedApocConfig.APOC_ML_WATSON_PROJECT_ID;
+
+@Extended
+public class Watson {
+    private static final String PROJECT_ID_KEY = "project_id";
+    private static final String SPACE_ID_KEY = "space_id";
+    private static final String WML_INSTANCE_CRN_KEY = "wml_instance_crn";
+    private static final String MODEL_ID_KEY = "model_id";
+    private static final String DEFAULT_MODEL_ID = "ibm/granite-13b-chat-v2";
+
+    @Context
+    public ApocConfig apocConfig;
+
+    @Context
+    public URLAccessChecker urlAccessChecker;
+    
+    public static final String ENDPOINT_CONF_KEY = "endpoint";
+
+    @Procedure("apoc.ml.watson.chat")
+    @Description("apoc.ml.watson.chat(messages, accessToken, $configuration) - prompts the completion API")
+    public Stream<MapResult> chatCompletion(@Name("messages") List<Map<String, Object>> messages, @Name("accessToken") String accessToken, @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
+        String prompt = messages.stream()
+                .map(message -> {
+                    Object role = message.get("role");
+                    Object content = message.get("content");
+                    if (role == null || content == null) {
+                        throw new RuntimeException("The `messages` items must have the keys: `role` and `content`");
+                    }
+                    return role + ": " + content;
+                })
+                .collect(Collectors.joining("\n\n"));
+        
+        return completion(prompt, accessToken, configuration);
+    }
+    
+    @Procedure("apoc.ml.watson.completion")
+    @Description("apoc.ml.watson.completion(prompt, accessToken, $configuration) - prompts the completion API")
+    public Stream<MapResult> completion(@Name("prompt") String prompt, @Name("accessToken") String accessToken, @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
+        return executeRequest(prompt, accessToken, configuration);
+    }
+
+    private Stream<MapResult> executeRequest(Object input, String accessToken, Map<String, Object> configuration) {
+        try {
+            // the body request has to contain space_id or project_id or wml_instance_crn,
+            // in case is missing we put the project_id from apoc.conf, otherwise we throw an exception
+            if (!configuration.containsKey(PROJECT_ID_KEY) && !configuration.containsKey(SPACE_ID_KEY) && !configuration.containsKey(WML_INSTANCE_CRN_KEY)) {
+                String apocConfProjectId = apocConfig.getString(APOC_ML_WATSON_PROJECT_ID, null);
+                if (apocConfProjectId == null) {
+                    String errMessage = "The body request has none of %s, %s, and %s and the APOC config `%s` is not present.%nPlease, define one of these"
+                                             .formatted(PROJECT_ID_KEY, SPACE_ID_KEY, WML_INSTANCE_CRN_KEY, APOC_ML_WATSON_PROJECT_ID);
+                    throw new RuntimeException(errMessage);
+                }
+                configuration.put(PROJECT_ID_KEY, apocConfProjectId);
+            }
+            
+            String endpoint = getEndpoint(configuration);
+
+            var config = new HashMap<>(configuration);
+            config.putIfAbsent(MODEL_ID_KEY, DEFAULT_MODEL_ID);
+            config.put("input", input);
+            
+            Map<String, Object> headers = Map.of("Content-Type", "application/json",
+                    "accept", "application/json",
+                    "Authorization", "Bearer " + accessToken);
+            
+            String payload = JsonUtil.OBJECT_MAPPER.writeValueAsString(config);
+
+            return JsonUtil.loadJson(endpoint, headers, payload, "$", true, List.of(), urlAccessChecker)
+                    .map(v -> (Map<String, Object>) v)
+                    .map(MapResult::new);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    public String getEndpoint(Map<String, Object> config) {
+        Object remove = config.remove(ENDPOINT_CONF_KEY);
+        if (remove != null) {
+            return (String) remove;
+        }
+        return apocConfig.getString(APOC_ML_WATSON_URL, "https://eu-de.ml.cloud.ibm.com/ml/v1-beta/generation/text?version=2023-05-29");
+    }
+
+}

--- a/extended/src/main/resources/extended.txt
+++ b/extended/src/main/resources/extended.txt
@@ -102,6 +102,8 @@ apoc.ml.sagemaker.embedding
 apoc.ml.vertexai.chat
 apoc.ml.vertexai.completion
 apoc.ml.vertexai.embedding
+apoc.ml.watson.chat
+apoc.ml.watson.completion
 apoc.model.jdbc
 apoc.mongo.aggregate
 apoc.mongo.count

--- a/extended/src/test/java/apoc/ml/WatsonIT.java
+++ b/extended/src/test/java/apoc/ml/WatsonIT.java
@@ -1,0 +1,133 @@
+package apoc.ml;
+
+import apoc.ApocConfig;
+import apoc.util.TestUtil;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.List;
+import java.util.Map;
+
+import static apoc.ExtendedApocConfig.APOC_ML_WATSON_URL;
+import static apoc.ExtendedApocConfig.APOC_ML_WATSON_PROJECT_ID;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assume.assumeNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * Generate accessToken via:
+ * ```
+ * curl -X POST 'https://iam.cloud.ibm.com/identity/token' -H 'Content-Type: application/x-www-form-urlencoded' -d 'grant_type=urn:ibm:params:oauth:grant-type:apikey&apikey=<API_KEY>'
+ * ```
+ * 
+ * The `WATSON_ACCESS_TOKEN` (to populate the 2nd parameter) and `WATSON_PROJECT_ID` (to populate the `project_id` request key) env vars are mandatory.
+ * The `WATSON_ENDPOINT_URL` env var (to define the endpoint url) is optional (with default: `https://eu-de.ml.cloud.ibm.com/ml/v1-beta/generation/text?version=2023-05-29`)
+ */
+public class WatsonIT {
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule();
+
+    private static String accessToken;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        String keyIdEnv = "WATSON_ACCESS_TOKEN";
+        String projectIdEnv = "WATSON_PROJECT_ID";
+
+        accessToken = System.getenv(keyIdEnv);
+        String projectId = System.getenv(projectIdEnv);
+        
+        assumeNotNull(keyIdEnv + "environment not configured", accessToken);
+        assumeNotNull(projectIdEnv + "environment not configured", projectId);
+
+        ApocConfig.apocConfig().setProperty(APOC_ML_WATSON_PROJECT_ID, projectId);
+
+
+        String endpointEnv = "WATSON_ENDPOINT_URL";
+        String endpoint = System.getenv(endpointEnv);
+        if (endpoint != null) {
+            ApocConfig.apocConfig().setProperty(APOC_ML_WATSON_URL, projectId);
+        }
+
+        TestUtil.registerProcedure(db, Watson.class);
+    }
+
+    @Test
+    public void completion() {
+        testCall(db, "CALL apoc.ml.watson.completion('What color is the sky? Answer in one word: ', $accessToken)",
+                Map.of("accessToken", accessToken),
+                (row) -> {
+                    commonAssertions(row, "blue", 12L, "eos_token");
+                });
+    }
+
+    @Test
+    public void completionWithParameters() {
+        testCall(db, "CALL apoc.ml.watson.completion('What color is the sky? Answer in one word: ', $accessToken, {parameters: {max_new_tokens: 1}})",
+                Map.of("accessToken", accessToken),
+                (row) -> {
+                    commonAssertions(row, "\n", 12L, "max_tokens");
+                });
+    }
+
+    @Test
+    public void chatCompletion() {
+        testCall(db, """
+                    CALL apoc.ml.watson.chat([
+                        {role:"system", content:"Only answer with a single word"},
+                        {role:"user", content:"What planet do humans live on?"}
+                    ],  $apiKey)""",
+                Map.of("apiKey",accessToken), 
+                (row) -> {
+                    commonAssertions(row, "earth", 19L, "max_tokens");
+                });
+    }
+
+    @Test
+    public void chatCompletionWithParameters() {
+        testCall(db, """
+                    CALL apoc.ml.watson.chat([
+                        {role:"system", content:"Only answer with a single word"},
+                        {role:"user", content:"What planet do humans live on?"}
+                    ],  $apiKey, {parameters: {max_new_tokens: 1}})""",
+                Map.of("apiKey",accessToken), 
+                (row) -> commonAssertions(row, "\n", 19L, "max_tokens"));
+    }
+    
+    @Test
+    public void wrongEndpoint() {
+        try {
+            testCall(db, """
+                            CALL apoc.ml.watson.chat([
+                                {role:"system", content:"Only answer with a single word"},
+                                {role:"user", content:"What planet do humans live on?"}
+                            ],  $apiKey, {endpoint: 'https://wrong/endpoint'})""",
+                    Map.of("apiKey", accessToken),
+                    (row) -> fail());
+        } catch (Exception e) {
+            assertTrue(e.getMessage().contains("nodename nor servname provided, or not known"));
+        }
+    }
+
+    private static void commonAssertions(Map<String, Object> row, String text, long inputTokenCount, String stopReason) {
+        var res = (Map<String, Object>) row.get("value");
+        assertNotNull(res.get("created_at"));
+        assertNotNull(res.get("model_id"));
+
+        List<Map> results = (List<Map>) res.get("results");
+        assertEquals(1, results.size());
+
+        Map result = results.get(0);
+        String generatedText = (String) result.get("generated_text");
+        assertTrue(generatedText.toLowerCase().contains(text));
+        assertEquals(inputTokenCount, result.get("input_token_count"));
+        assertEquals(stopReason, result.get("stop_reason"));
+    }
+}

--- a/extended/src/test/java/apoc/ml/WatsonTest.java
+++ b/extended/src/test/java/apoc/ml/WatsonTest.java
@@ -1,0 +1,110 @@
+package apoc.ml;
+
+import apoc.util.TestUtil;
+import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockserver.integration.ClientAndServer;
+import org.mockserver.model.Header;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
+import static apoc.ApocConfig.apocConfig;
+import static apoc.ExtendedApocConfig.APOC_ML_WATSON_PROJECT_ID;
+import static apoc.ExtendedApocConfig.APOC_ML_WATSON_URL;
+import static apoc.util.TestUtil.getUrlFileName;
+import static apoc.util.TestUtil.testCall;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+
+public class WatsonTest {
+
+    private static ClientAndServer mockServer;
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule();
+
+    private static final String accessToken = "mocked";
+
+    @BeforeClass
+    public static void startServer() throws Exception {
+        TestUtil.registerProcedure(db, Watson.class);
+        
+        String path = "/generation/text";
+        apocConfig().setProperty(APOC_ML_WATSON_URL, "http://localhost:1080" + path);
+        apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
+        apocConfig().setProperty(APOC_ML_WATSON_PROJECT_ID, "fakeProjectId");
+        
+        File urlFileName = new File(getUrlFileName("watson.json").getFile());
+        String body = FileUtils.readFileToString(urlFileName, UTF_8);
+        
+        mockServer = startClientAndServer(1080);
+        mockServer.when(
+                        request()
+                                .withMethod("POST")
+                                .withPath(path)
+                                .withHeader("Authorization", "Bearer " + accessToken)
+                                .withHeader("Content-Type", "application/json")
+                                .withHeader(  "accept", "application/json")
+                )
+                .respond(
+                        response()
+                                .withStatusCode(200)
+                                .withHeaders(
+                                        new Header("Cache-Control", "private, max-age=1000"))
+                                .withBody(body)
+                );
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        mockServer.stop();
+    }
+    
+    
+    @Test
+    public void completion() {
+        testCall(db, "CALL apoc.ml.watson.completion('What color is the sky? Answer in one word: ', $accessToken)",
+                Map.of("accessToken", accessToken),
+                WatsonTest::commonAssertions);
+    }
+    
+    @Test
+    public void chatCompletion() {
+        testCall(db, """
+                    CALL apoc.ml.watson.chat([
+                        {role:"system", content:"Only answer with a single word"},
+                        {role:"user", content:"What planet do humans live on?"}
+                    ],  $apiKey)""",
+                Map.of("apiKey",accessToken),
+                WatsonTest::commonAssertions);
+    }
+
+    private static void commonAssertions(Map<String, Object> row) {
+        var res = (Map<String, Object>) row.get("value");
+        assertNotNull(res.get("created_at"));
+        assertNotNull(res.get("model_id"));
+
+        List<Map> results = (List<Map>) res.get("results");
+        assertEquals(1, results.size());
+
+        Map result = results.get(0);
+        String generatedText = (String) result.get("generated_text");
+        assertTrue(generatedText.toLowerCase().contains("earth"));
+        assertEquals(19L, result.get("input_token_count"));
+        assertEquals("max_tokens", result.get("stop_reason"));
+    }
+}

--- a/extended/src/test/resources/watson.json
+++ b/extended/src/test/resources/watson.json
@@ -1,0 +1,12 @@
+{
+  "model_id": "fakeId",
+  "created_at": "2024-01-11T10:51:48.694Z",
+  "results": [
+    {
+      "generated_text": "\n\nAnswer: Earth\n\nExplanation: The question asks for the system that humans live on",
+      "generated_token_count": 20,
+      "input_token_count": 19,
+      "stop_reason": "max_tokens"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #3891

To emulate chatCompletion API, the `apoc.ml.watson.chat` creates strings of type `<role Value>: <content Value>`, joins the results with `\n` and calls the `apoc.ml.watson.completion`.

Hence, for example, these two are equivalent:
```
# chat
CALL apoc.ml.watson.chat([
     {role:"system", content:"Only answer with a single word"},
     {role:"user", content:"What planet do humans live on?"}
], $apiKey) yield value

#completion
CALL apoc.ml.watson.completion(
"system: Only answer with a single word\nuser: What planet do humans live on?", content:"Only answer with a single word",
$apiKey) yield value
```

Similarly to what is reported on some examples reported on the IBM Prompt Lab:
![Screenshot 2024-01-11 at 12 53 35](https://github.com/vga91/neo4j-apoc-procedures/assets/25103389/d476ab20-a38e-4668-88ec-3d77a709fa4b)



---


I didn't include the `apoc.ml.watson.embeddings` procedure because all [ foundation models ](https://www.ibm.com/products/watsonx-ai/foundation-models) return this kind of result:
```
{
	"model_id": "<model_id>",
	"created_at": "<created_at>",
	"results": [
		{
			"generated_text": "<generated_text>",
			"generated_token_count": <count>,
			"input_token_count": <count>,
			"stop_reason": "<stop_reason>"
		}
	]
}
```

No models return anything like [openAI Embeddings](https://platform.openai.com/docs/guides/embeddings/what-are-embeddings), i.e. lists of doubles.