### PR TITLE
Solve LoadHtml failing test due to string comparison

### DIFF
--- a/extended/src/test/java/apoc/load/LoadHtmlTest.java
+++ b/extended/src/test/java/apoc/load/LoadHtmlTest.java
@@ -39,20 +39,24 @@ import static org.junit.Assert.fail;
 
 public class LoadHtmlTest {
 
-    protected static final String RESULT_QUERY_METADATA = ("{attributes={charset=UTF-8}, tagName=meta}, " +
-            "{attributes={name=ResourceLoaderDynamicStyles}, tagName=meta}, " +
-            "{attributes={name=generator, content=MediaWiki 1.32.0-wmf.18}, tagName=meta}, " +
-            "{attributes={name=referrer, content=origin}, tagName=meta}, " +
-            "{attributes={name=referrer, content=origin-when-crossorigin}, tagName=meta}, " +
-            "{attributes={name=referrer, content=origin-when-cross-origin}, tagName=meta}, " +
-            "{attributes={property=og:image, content=https://upload.wikimedia.org/wikipedia/en/e/ea/Aap_Kaa_Hak_titles.jpg}, tagName=meta}");
+    protected static final List<Map<String, Object>> RESULT_QUERY_METADATA = asList(
+                map("tagName", "meta", "attributes", map("charset", "UTF-8")),
+                map("attributes", map("name", "ResourceLoaderDynamicStyles"), "tagName", "meta"),
+                map("attributes", map("name", "generator", "content", "MediaWiki 1.32.0-wmf.18"), "tagName", "meta"),
+                map("attributes", map("name", "referrer", "content", "origin"), "tagName", "meta"),
+                map("attributes", map("name", "referrer", "content", "origin-when-crossorigin"), "tagName", "meta"),
+                map("attributes", map("name", "referrer", "content", "origin-when-cross-origin"), "tagName", "meta"),
+                map("attributes", map("property", "og:image", "content", "https://upload.wikimedia.org/wikipedia/en/e/ea/Aap_Kaa_Hak_titles.jpg"), "tagName", "meta")
+        );
 
-    protected static final String RESULT_QUERY_H2 = ("{text=Contents, tagName=h2}, " +
-            "{text=Origins[edit], tagName=h2}, " +
-            "{text=Content[edit], tagName=h2}, " +
-            "{text=Legacy[edit], tagName=h2}, " +
-            "{text=References[edit], tagName=h2}, " +
-            "{text=Navigation menu, tagName=h2}");
+    protected static final List<Map<String, Object>> RESULT_QUERY_H2 = asList(
+            map("text", "Contents", "tagName", "h2"),
+            map("text", "Origins[edit]", "tagName", "h2"),
+            map("text", "Content[edit]", "tagName", "h2"),
+            map("text", "Legacy[edit]", "tagName", "h2"),
+            map("text", "References[edit]", "tagName", "h2"),
+            map("text", "Navigation menu", "tagName", "h2")
+    );
 
     private static final String INVALID_PATH = new File("src/test/resources/wikipedia1.html").getName();
     private static final String VALID_PATH = new File("src/test/resources/wikipedia.html").toURI().toString();
@@ -170,7 +174,7 @@ public class LoadHtmlTest {
         testResult(db, "CALL apoc.load.html($url,$query)", map("url",new File("src/test/resources/wikipedia.html").toURI().toString(), "query", query),
                 result -> {
                     Map<String, Object> row = result.next();
-                    assertEquals(map("metadata",asList(RESULT_QUERY_METADATA)).toString().trim(), row.get("value").toString().trim());
+                    assertEquals(map("metadata", RESULT_QUERY_METADATA), row.get("value"));
                     assertFalse(result.hasNext());
                 });
     }
@@ -345,7 +349,7 @@ public class LoadHtmlTest {
         testResult(db, "CALL apoc.load.html($url,$query)", map("url",new File("src/test/resources/wikipedia.html").toURI().toString(), "query", query),
                 result -> {
                     Map<String, Object> row = result.next();
-                    assertEquals(map("h2",asList(RESULT_QUERY_H2)).toString().trim(), row.get("value").toString().trim());
+                    assertEquals(map("h2", RESULT_QUERY_H2), row.get("value"));
                     assertFalse(result.hasNext());
                 });
     }

--- a/extended/src/test/java/apoc/load/LoadHtmlTest.java
+++ b/extended/src/test/java/apoc/load/LoadHtmlTest.java
@@ -528,6 +528,7 @@ public class LoadHtmlTest {
         } catch (RuntimeException e) {
             // The test don't fail if the current chrome/firefox version is incompatible or if the browser is not installed
             Stream<String> notPresentOrIncompatible = Stream.of("cannot find Chrome binary", "Cannot find firefox binary",
+                    "Expected browser binary location",
                     "browser start-up failure",
                     "This version of ChromeDriver only supports Chrome version");
             final String msg = e.getMessage();

--- a/extended/src/test/java/apoc/load/LoadHtmlTestParameterized.java
+++ b/extended/src/test/java/apoc/load/LoadHtmlTestParameterized.java
@@ -27,7 +27,6 @@ import static apoc.load.LoadHtmlTest.skipIfBrowserNotPresentOrCompatible;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testResult;
 import static com.google.common.collect.Lists.newArrayList;
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -79,8 +78,8 @@ public class LoadHtmlTestParameterized {
                         List<Map<String, Object>> metadata = (List<Map<String, Object>>) value.get("metadata");
                         List<Map<String, Object>> h2 = (List<Map<String, Object>>) value.get("h2");
     
-                        assertEquals(asList(RESULT_QUERY_METADATA).toString().trim(), metadata.toString().trim());
-                        assertEquals(asList(RESULT_QUERY_H2).toString().trim(), h2.toString().trim());
+                        assertEquals(RESULT_QUERY_METADATA, metadata);
+                        assertEquals(RESULT_QUERY_H2, h2);
                     });
         });
     }
@@ -97,7 +96,7 @@ public class LoadHtmlTestParameterized {
                     map("url",new File("src/test/resources/wikipedia.html").toURI().toString(), "query", query, "config", config),
                     result -> {
                         Map<String, Object> row = result.next();
-                        assertEquals(map("h2",asList(RESULT_QUERY_H2)).toString().trim(), row.get("value").toString().trim());
+                        assertEquals(map("h2",RESULT_QUERY_H2), row.get("value"));
                         assertFalse(result.hasNext());
                     });
         });


### PR DESCRIPTION

The previous String comparison fails with the latest neo4j version.
Changed to `List<Map>>`
See e.g. https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/7625135414/job/20768752275?pr=3901#step:6:2388

```
apoc.load.LoadHtmlTest > testQueryWithFailsSilentlyWithList FAILED
    org.junit.ComparisonFailure: expected:<[{[attributes={id=correct}, text=test, tagName=h6}, {attributes={id=childIncorrect}, text=incorrecttest, tagName=h6]}]> but was:<[{[tagName=h6, attributes={id=correct}, text=test}, {tagName=h6, attributes={id=childIncorrect}, text=incorrecttest]}]>
```


Other change:
- Added `"Expected browser binary location"` to `skipIfBrowserNotPresentOrCompatible` method, since (most likely due to  the Selenium dep. update), the message error is changed:
```
Caused by: org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Response code 500. Message: Expected browser binary location, but unable to find binary in default location, no 'moz:firefoxOptions.binary' capability provided, and no binary flag set on the command line 
```