### PR TITLE
Fixes #3751: Failed to invoke procedure apoc.cypher.mapParallel2: Caused by:RuntimeException: Error polling, timeout

### DIFF
--- a/extended/src/test/java/apoc/cypher/CypherEnterpriseExtendedTest.java
+++ b/extended/src/test/java/apoc/cypher/CypherEnterpriseExtendedTest.java
@@ -231,13 +231,23 @@ public class CypherEnterpriseExtendedTest {
 
     @Test
     public void testCypherMapParallel2WithResults() {
-        String query = """
-                MATCH (n:ReturnQuery) WITH COLLECT(n) AS list
-                CALL apoc.cypher.mapParallel2('MATCH (_)-[r:REL]->(o:Other) RETURN r, o', {}, list, 1)
-                YIELD value RETURN value""";
-        Map<String, Object> params = Map.of("file", SIMPLE_RETURN_QUERIES);
+        // this test could cause flaky errors, 
+        // so we need to run the query several times to make sure it always works
+        for (int i = 0; i < 30; i++) {
+            String query = """
+                    MATCH (n:ReturnQuery) WITH COLLECT(n) AS list
+                    CALL apoc.cypher.mapParallel2('MATCH (_)-[r:REL]->(o:Other) RETURN r, o', {}, list, 1)
+                    YIELD value RETURN value""";
+            Map<String, Object> params = Map.of("file", SIMPLE_RETURN_QUERIES);
+            testCypherMapParallelCommon(query, params);
 
-        testCypherMapParallelCommon(query, params);
+            session.writeTransaction(tx -> tx.run("MATCH (n) DETACH DELETE n"));
+        }
+
+        // Check that `SHOW TRANSACTIONS` just returns itself 
+        String showTransactionsQuery = "SHOW TRANSACTIONS";
+        testCall(session, showTransactionsQuery,
+                r -> assertEquals(showTransactionsQuery, r.get("currentQuery")));
     }
 
     public void testRunProcedureWithSimpleReturnResults(String query, Map<String, Object> params) {

--- a/extended/src/test/resources/parallel.cypher
+++ b/extended/src/test/resources/parallel.cypher
@@ -1,0 +1,1 @@
+MATCH (n:Polling) SET n.test = date() RETURN n;


### PR DESCRIPTION
Fixes #3751

- Added fix like https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3810
- Changed transaction handling from try-with-res to [`transactions.add(transaction);`](https://github.com/vga91/neo4j-apoc-procedures/pull/420/files#diff-0be321a488b8e1a039cef51ff786b8142a2eac4a76f7585ff6121e4fc588dfc9R383)
- Added `SHOW TRANSACTIONS` tests
- Tested the `https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3899` case as well