### PR TITLE
Restored configuration.getOrDefault(APIKEY_CONF_KEY, ...)

### DIFF
--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -51,7 +51,7 @@ public class OpenAI {
     }
 
     static Stream<Object> executeRequest(String apiKey, Map<String, Object> configuration, String path, String model, String key, Object inputs, String jsonPath, ApocConfig apocConfig, URLAccessChecker urlAccessChecker) throws JsonProcessingException, MalformedURLException {
-        apiKey = apocConfig.getString(APOC_OPENAI_KEY, apiKey);
+        apiKey = (String) configuration.getOrDefault(APIKEY_CONF_KEY, apocConfig.getString(APOC_OPENAI_KEY, apiKey));
         if (apiKey == null || apiKey.isBlank())
             throw new IllegalArgumentException("API Key must not be empty");
 


### PR DESCRIPTION
Added this code https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/0ad5ecd2b29d9b1e931288dcd5f5a0bc13443df8#diff-1ffff1937373b4ee7110a07d75c545ff173f521fd6e830c9ac04ace3240fc167R53,

mistakenly not inserted in the PR of the cherry-pick, 
after having done the rebase with the other ml PRs