### PR TITLE
Upgrade driver and syntax to 5.16.0

### DIFF
--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     // They need to be provided either through the database or in an extra .jar
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
     // same version as the one included in  neo4j `lib`
-    compileOnly group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '5.5.0'
+    compileOnly group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '5.16.0'
 
     compileOnly group: 'org.apache.poi', name: 'poi', version: '5.1.0'
     compileOnly group: 'org.apache.poi', name: 'poi-ooxml', version: '5.1.0'

--- a/extended/src/test/java/apoc/bolt/BoltTest.java
+++ b/extended/src/test/java/apoc/bolt/BoltTest.java
@@ -12,7 +12,6 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.neo4j.driver.Result;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;

--- a/extended/src/test/java/apoc/bolt/BoltTest.java
+++ b/extended/src/test/java/apoc/bolt/BoltTest.java
@@ -12,6 +12,7 @@ import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.neo4j.driver.Result;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -411,8 +412,8 @@ public class BoltTest {
                 "remoteStatement", remoteStatement,
                 "config", Util.map("readOnly", false));
         db.executeTransactionally("call apoc.bolt.load.fromLocal($url, $localStatement, $remoteStatement, $config) YIELD row return row", map);
-        final long remoteCount = neo4jContainer.getSession().readTransaction(tx ->
-                (long) tx.run("MATCH (n: TestLoadFromLocalNode { m: 'foobar' }) RETURN count(n) AS count").next().asMap().get("count"));
+        final long remoteCount = neo4jContainer.getSession().executeRead(tx ->
+                (long) tx.run("MATCH (n: TestLoadFromLocalNode { m: 'foobar' }) RETURN count(n) AS count").single().asMap().get("count"));
         assertEquals(1L, remoteCount);
     }
 
@@ -425,8 +426,8 @@ public class BoltTest {
                 "remoteStatement", null,
                 "config", Util.map("readOnly", false, "streamStatements", true));
         db.executeTransactionally("call apoc.bolt.load.fromLocal($url, $localStatement, $remoteStatement, $config)", map);
-        final long remoteCount = neo4jContainer.getSession().readTransaction(tx ->
-                (long) tx.run("MATCH (n: TestLoadFromLocalStream) RETURN count(n) AS count").next().asMap().get("count"));
+        final long remoteCount = neo4jContainer.getSession().executeRead(tx ->
+                (long) tx.run("MATCH (n: TestLoadFromLocalStream) RETURN count(n) AS count").single().asMap().get("count"));
         assertEquals(1L, remoteCount);
     }
 

--- a/extended/src/test/java/apoc/custom/CypherProceduresClusterTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresClusterTest.java
@@ -46,7 +46,7 @@ public class CypherProceduresClusterTest {
         // given
         
         try(Session session = cluster.getDriver().session()) {
-            session.writeTransaction(tx -> tx.run("call apoc.custom.declareFunction('answer1() :: (output::LONG)', 'RETURN 42 as answer')")); // we create a function
+            session.executeWrite(tx -> tx.run("call apoc.custom.declareFunction('answer1() :: (output::LONG)', 'RETURN 42 as answer')").consume()); // we create a function
         }
 
         // whencypher procedures
@@ -67,11 +67,11 @@ public class CypherProceduresClusterTest {
     @Ignore
     public void shouldUpdateCustomFunctionsOnOtherClusterMembers() throws InterruptedException {
         // given
-        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.declareFunction('answer2() :: (output::LONG)', 'RETURN 42 as answer')")); // we create a function
+        cluster.getSession().executeWrite(tx -> tx.run("call apoc.custom.declareFunction('answer2() :: (output::LONG)', 'RETURN 42 as answer')").consume()); // we create a function
         TestContainerUtil.testCall(cluster.getSession(), "return custom.answer2() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
 
         // when
-        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.declareFunction('answer2() :: (output::LONG)', 'RETURN 52 as answer')")); // we update the function
+        cluster.getSession().executeWrite(tx -> tx.run("call apoc.custom.declareFunction('answer2() :: (output::LONG)', 'RETURN 52 as answer')").consume()); // we update the function
         Thread.sleep(1000);
 
         // then
@@ -83,7 +83,7 @@ public class CypherProceduresClusterTest {
     @Ignore
     public void shouldRegisterSimpleStatementOnOtherClusterMembers() throws InterruptedException {
         // given
-        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.declareProcedure('answerProcedure1() :: LONG', 'RETURN 33 as answer', 'read'")); // we create a procedure
+        cluster.getSession().executeWrite(tx -> tx.run("call apoc.custom.declareProcedure('answerProcedure1() :: LONG', 'RETURN 33 as answer', 'read'").consume()); // we create a procedure
 
         // when
         TestContainerUtil.testCall(cluster.getSession(), "call custom.answerProcedure1()", (row) -> Assert.assertEquals(33L, row.get("answer")));
@@ -96,11 +96,11 @@ public class CypherProceduresClusterTest {
     @Ignore
     public void shouldUpdateSimpleStatementOnOtherClusterMembers() throws InterruptedException {
         // given
-        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.declareProcedure('answerProcedure2() :: LONG', 'RETURN 33 as answer')")); // we create a procedure
+        cluster.getSession().executeWrite(tx -> tx.run("call apoc.custom.declareProcedure('answerProcedure2() :: LONG', 'RETURN 33 as answer')").consume()); // we create a procedure
         TestContainerUtil.testCall(cluster.getSession(), "call custom.answerProcedure2()", (row) -> Assert.assertEquals(33L, row.get("answer")));
 
         // when
-        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.declareProcedure('answerProcedure2() :: LONG', 'RETURN 55 as answer')")); // we create a procedure
+        cluster.getSession().executeWrite(tx -> tx.run("call apoc.custom.declareProcedure('answerProcedure2() :: LONG', 'RETURN 55 as answer')").consume()); // we create a procedure
 
         Thread.sleep(1000);
         // then
@@ -111,7 +111,7 @@ public class CypherProceduresClusterTest {
     @Ignore
     public void shouldRemoveProcedureOnOtherClusterMembers() throws InterruptedException {
         // given
-        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.declareProcedure('answerToRemove() :: LONG', 'RETURN 33 as answer')")); // we create a procedure
+        cluster.getSession().executeWrite(tx -> tx.run("call apoc.custom.declareProcedure('answerToRemove() :: LONG', 'RETURN 33 as answer')").consume()); // we create a procedure
         Thread.sleep(1000);
         try {
             ExtendedTestContainerUtil.testCallInReadTransaction(cluster.getSession(), "call custom.answerToRemove()", (row) -> Assert.assertEquals(33L, row.get("answer")));
@@ -120,7 +120,7 @@ public class CypherProceduresClusterTest {
         }
 
         // when
-        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.removeProcedure('answerToRemove')")); // we remove procedure
+        cluster.getSession().executeWrite(tx -> tx.run("call apoc.custom.removeProcedure('answerToRemove')").consume()); // we remove procedure
 
         // then
         Thread.sleep(1000);
@@ -138,7 +138,7 @@ public class CypherProceduresClusterTest {
     @Ignore
     public void shouldRemoveFunctionOnOtherClusterMembers() throws InterruptedException {
         // given
-        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.declareFunction('answerFunctionToRemove()', 'RETURN 42 as answer')")); // we create a function
+        cluster.getSession().executeWrite(tx -> tx.run("call apoc.custom.declareFunction('answerFunctionToRemove()', 'RETURN 42 as answer')").consume()); // we create a function
         Thread.sleep(1000);
         try {
             ExtendedTestContainerUtil.testCallInReadTransaction(cluster.getSession(), "return custom.answerFunctionToRemove() as row", (row) -> assertEquals(42L, ((Map)((List)row.get("row")).get(0)).get("answer")));
@@ -147,7 +147,7 @@ public class CypherProceduresClusterTest {
         }
 
         // when
-        cluster.getSession().writeTransaction(tx -> tx.run("call apoc.custom.removeFunction('answerFunctionToRemove')")); // we remove procedure
+        cluster.getSession().executeWrite(tx -> tx.run("call apoc.custom.removeFunction('answerFunctionToRemove')").consume()); // we remove procedure
 
         // then
         Thread.sleep(1000);

--- a/extended/src/test/java/apoc/cypher/CypherEnterpriseExtendedTest.java
+++ b/extended/src/test/java/apoc/cypher/CypherEnterpriseExtendedTest.java
@@ -93,7 +93,7 @@ public class CypherEnterpriseExtendedTest {
 
     @After
     public void after() {
-        session.writeTransaction(tx -> tx.run("MATCH (n) DETACH DELETE n"));
+        session.executeWrite(tx -> tx.run("MATCH (n) DETACH DELETE n").consume());
     }
 
     @Test
@@ -111,7 +111,7 @@ public class CypherEnterpriseExtendedTest {
         } catch (Exception ignored) {}
 
         // then
-        boolean anyLingeringParallelTx = neo4jContainer.getSession().readTransaction(tx -> {
+        boolean anyLingeringParallelTx = neo4jContainer.getSession().executeRead(tx -> {
             var currentTxs = tx.run("SHOW TRANSACTIONS").stream();
             return currentTxs.anyMatch( record -> record.get( "currentQuery" ).toString().contains(parallelQuery));
         });
@@ -153,7 +153,7 @@ public class CypherEnterpriseExtendedTest {
 
     @Test
     public void testCypherParallelWithSetAndResults() {
-        session.writeTransaction(tx -> tx.run(CREATE_RESULT_NODES));
+        session.executeWrite(tx -> tx.run(CREATE_RESULT_NODES).consume());
 
         String query = "CALL apoc.cypher.parallel($file, {a: range(1,4)}, 'a')";
         Map<String, Object> params = Map.of("file", SET_NODE);
@@ -167,7 +167,7 @@ public class CypherEnterpriseExtendedTest {
 
     @Test
     public void testCypherParallel2WithSetAndResults() {
-        session.writeTransaction(tx -> tx.run(CREATE_RESULT_NODES));
+        session.executeWrite(tx -> tx.run(CREATE_RESULT_NODES).consume());
 
         String query = "CALL apoc.cypher.parallel2($file, {a: range(1,4)}, 'a')";
         Map<String, Object> params = Map.of("file", SET_NODE);
@@ -196,7 +196,7 @@ public class CypherEnterpriseExtendedTest {
     }
 
     private void testCypherParallelCommon(String query, Map<String, Object> params) {
-        session.writeTransaction(tx -> tx.run(CREATE_RETURNQUERY_NODES));
+        session.executeWrite(tx -> tx.run(CREATE_RETURNQUERY_NODES).consume());
 
         testResult(session, query, params, r -> {
             assertBatchCypherParallel(r);
@@ -241,7 +241,7 @@ public class CypherEnterpriseExtendedTest {
             Map<String, Object> params = Map.of("file", SIMPLE_RETURN_QUERIES);
             testCypherMapParallelCommon(query, params);
 
-            session.writeTransaction(tx -> tx.run("MATCH (n) DETACH DELETE n"));
+            session.executeWrite(tx -> tx.run("MATCH (n) DETACH DELETE n").consume());
         }
 
         // Check that `SHOW TRANSACTIONS` just returns itself 
@@ -251,7 +251,7 @@ public class CypherEnterpriseExtendedTest {
     }
 
     public void testRunProcedureWithSimpleReturnResults(String query, Map<String, Object> params) {
-        session.writeTransaction(tx -> tx.run(CREATE_RETURNQUERY_NODES));
+        session.executeWrite(tx -> tx.run(CREATE_RETURNQUERY_NODES).consume());
         testResult(session, query, params,
                 r -> {
                     // check that all results from the 1st statement are correctly returned
@@ -276,7 +276,7 @@ public class CypherEnterpriseExtendedTest {
     }
 
     public void testRunProcedureWithSetAndReturnResults(String query, Map<String, Object> params) {
-        session.writeTransaction(tx -> tx.run(CREATE_RESULT_NODES));
+        session.executeWrite(tx -> tx.run(CREATE_RESULT_NODES).consume());
 
         testResult(session, query, params,
                 r -> {
@@ -341,7 +341,7 @@ public class CypherEnterpriseExtendedTest {
     }
 
     private void testCypherMapParallelCommon(String query, Map<String, Object> params) {
-        session.writeTransaction(tx -> tx.run(CREATE_RETURNQUERY_NODES));
+        session.executeWrite(tx -> tx.run(CREATE_RETURNQUERY_NODES).consume());
 
         testResult(session, query, params, r -> {
             Map<String, Object> next = r.next();

--- a/extended/src/test/java/apoc/metrics/MetricsTest.java
+++ b/extended/src/test/java/apoc/metrics/MetricsTest.java
@@ -67,7 +67,7 @@ public class MetricsTest {
     @Test
     @Ignore
     public void shouldGetMetrics() {
-        session.readTransaction(tx -> tx.run("RETURN 1 AS num;"));
+        session.executeRead(tx -> tx.run("RETURN 1 AS num;").consume());
         String metricKey = "neo4j.system.check_point.total_time";
         assertEventually(() -> {
                     try {

--- a/extended/src/test/java/apoc/trigger/TriggerClusterTest.java
+++ b/extended/src/test/java/apoc/trigger/TriggerClusterTest.java
@@ -60,7 +60,7 @@ public class TriggerClusterTest {
         cluster.getSession().run("CALL apoc.trigger.add('timestamp','UNWIND apoc.trigger.nodesByLabel($assignedNodeProperties,null) AS n SET n.ts = timestamp()',{})");
         // Test that the trigger is present in another instance
         org.neo4j.test.assertion.Assert.assertEventually(() -> cluster.getDriver().session()
-                        .readTransaction(tx -> tx.run("CALL apoc.trigger.list() YIELD name RETURN name").single().get("name").asString()),
+                        .executeRead(tx -> tx.run("CALL apoc.trigger.list() YIELD name RETURN name").single().get("name").asString()),
                 (value) -> "timestamp".equals(value), 30, TimeUnit.SECONDS);
     }
 

--- a/extended/src/test/java/apoc/ttl/TTLMultiDbTest.java
+++ b/extended/src/test/java/apoc/ttl/TTLMultiDbTest.java
@@ -50,10 +50,10 @@ public class TTLMultiDbTest {
 
     @After
     public void cleanDb() {
-        neo4jSession.writeTransaction(tx -> tx.run("MATCH (n) DETACH DELETE n;"));
-        testSession.writeTransaction(tx -> tx.run("MATCH (n) DETACH DELETE n;"));
-        fooSession.writeTransaction(tx -> tx.run("MATCH (n) DETACH DELETE n;"));
-        barSession.writeTransaction(tx -> tx.run("MATCH (n) DETACH DELETE n;"));
+        neo4jSession.executeWrite(tx -> tx.run("MATCH (n) DETACH DELETE n;").consume());
+        testSession.executeWrite(tx -> tx.run("MATCH (n) DETACH DELETE n;").consume());
+        fooSession.executeWrite(tx -> tx.run("MATCH (n) DETACH DELETE n;").consume());
+        barSession.executeWrite(tx -> tx.run("MATCH (n) DETACH DELETE n;").consume());
     }
 
     @AfterClass
@@ -115,10 +115,10 @@ public class TTLMultiDbTest {
 
     private static void createDatabases() {
         try(Session systemSession = driver.session(SessionConfig.forDatabase("system"))) {
-            systemSession.writeTransaction(tx -> {
-                tx.run("CREATE DATABASE " + DB_TEST + " WAIT;");
-                tx.run("CREATE DATABASE " + DB_FOO + " WAIT;");
-                return tx.run("CREATE DATABASE " + DB_BAR + " WAIT;");
+            systemSession.executeWrite(tx -> {
+                tx.run("CREATE DATABASE " + DB_TEST + " WAIT;").consume();
+                tx.run("CREATE DATABASE " + DB_FOO + " WAIT;").consume();
+                return tx.run("CREATE DATABASE " + DB_BAR + " WAIT;").consume();
             });
         }
 

--- a/extended/src/test/java/apoc/util/ExtendedTestContainerUtil.java
+++ b/extended/src/test/java/apoc/util/ExtendedTestContainerUtil.java
@@ -20,7 +20,7 @@ public class ExtendedTestContainerUtil
     }
 
     public static <T> T singleResultFirstColumn(Session session, String cypher) {
-        return (T) session.writeTransaction(tx -> tx.run(cypher).single().fields().get(0).value().asObject());
+        return (T) session.executeWrite(tx -> tx.run(cypher).single().fields().get(0).value().asObject());
     }
 
     public static void testCallInReadTransaction(Session session, String call, Consumer<Map<String, Object>> consumer) {

--- a/extended/src/test/java/apoc/uuid/UUIDClusterRoutingTest.java
+++ b/extended/src/test/java/apoc/uuid/UUIDClusterRoutingTest.java
@@ -63,7 +63,7 @@ public class UUIDClusterRoutingTest {
                 testCall(session, query, params,
                     row -> assertEquals(label, row.get("label"))
                 );
-                session.writeTransaction(tx -> tx.run("CALL apoc.uuid.drop($label)", params));
+                session.executeWrite(tx -> tx.run("CALL apoc.uuid.drop($label)", params).consume());
                 }
         );
     }
@@ -91,7 +91,7 @@ public class UUIDClusterRoutingTest {
         final List<Neo4jContainerExtension> members = cluster.getClusterMembers();
         assertEquals(NUM_CORES, members.size());
         final String label = UUID.randomUUID().toString();
-        clusterSession.writeTransaction(tx -> tx.run(format("CREATE CONSTRAINT IF NOT EXISTS FOR (n:`%s`) REQUIRE n.uuid IS UNIQUE", label)));
+        clusterSession.executeWrite(tx -> tx.run(format("CREATE CONSTRAINT IF NOT EXISTS FOR (n:`%s`) REQUIRE n.uuid IS UNIQUE", label)).consume());
         for (Neo4jContainerExtension container: members) {
             // we skip READ_REPLICA members with write operations
             // instead, we consider all members with a read only operations


### PR DESCRIPTION
Equivalent to APOC Core PR: https://github.com/neo4j/apoc/pull/579.

- Updated the java-driver to 5.16.0
- Migrated deprecated `readTransaction` and `writeTransaction` to `executeRead` and `executeWrite` 
- Added `consume()` where needed
- Removed `tx.commit()` as in the Core PR 
- Changed `next()` to `single()`, to make sure the queries are consumed