### PR TITLE
Added mockServer.stop() to  in VertexAITest

### DIFF
--- a/extended/src/test/java/apoc/ml/VertexAITest.java
+++ b/extended/src/test/java/apoc/ml/VertexAITest.java
@@ -2,6 +2,7 @@ package apoc.ml;
 
 import apoc.util.TestUtil;
 import org.apache.commons.io.FileUtils;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -57,6 +58,11 @@ public class VertexAITest {
 
         Stream.of(EMBEDDINGS, COMPLETION, CHAT_COMPLETION)
                 .forEach(VertexAITest::setRequestResponse);
+    }
+
+    @AfterClass
+    public static void stopServer() {
+        mockServer.stop();
     }
 
     private static void setRequestResponse(String path) {


### PR DESCRIPTION
Added `mockServer.stop()` to `@AfterClass` in `VertexAITest, like other tests e.g. OpenAITest.

To fix these CI errors: https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/8018948759/job/21905882192?pr=3957#step:6:1518

Most likely the [VertexAITest PR](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3940) did not fail because, in that case, the VertexAITest was the last test with mockServer launched.

