### PR TITLE
Fix flaky CypherProceduresClusterRoutingTest - dev

### DIFF
--- a/extended/src/test/java/apoc/custom/CypherProceduresClusterRoutingTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresClusterRoutingTest.java
@@ -21,7 +21,6 @@ import static apoc.util.ExtendedTestContainerUtil.singleResultFirstColumn;
 import static apoc.util.ExtendedTestContainerUtil.dbIsWriter;
 import static apoc.util.ExtendedTestContainerUtil.getBoltAddress;
 import static apoc.util.ExtendedTestContainerUtil.getDriverIfNotReplica;
-import static apoc.util.SystemDbTestUtil.TIMEOUT;
 import static apoc.util.ExtendedTestContainerUtil.routingSessionForEachMembers;
 import static apoc.util.TestContainerUtil.testCallEmpty;
 import static apoc.util.TestContainerUtil.testResult;
@@ -33,6 +32,7 @@ import static org.neo4j.configuration.GraphDatabaseSettings.SYSTEM_DATABASE_NAME
 import static org.neo4j.test.assertion.Assert.assertEventually;
 
 public class CypherProceduresClusterRoutingTest {
+    private static final long TIMEOUT = 30L;
     private static final int NUM_CORES = 3;
     private static TestcontainersCausalCluster cluster;
     private static Session clusterSession;


### PR DESCRIPTION
Increased timeout to be used in assertEventually, e.g [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3959/files#diff-36b2342b2cc6ef75cf3dc8d562f1c998f42ce4185b7f8aadb1a61abe7232887fR97), as In clusters, since the changes are sometimes updated more slowly.

It should solve this flaky CI error: https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/8021701219/job/21914372905?pr=3957#step:6:1371