### PR TITLE
[4Bece3wd] Use Neo4j home to determine default config location.

### DIFF
--- a/extended/src/main/java/apoc/ExtendedApocConfigExtensionFactory.java
+++ b/extended/src/main/java/apoc/ExtendedApocConfigExtensionFactory.java
@@ -1,6 +1,7 @@
 package apoc;
 
 import org.neo4j.annotations.service.ServiceProvider;
+import org.neo4j.configuration.Config;
 import org.neo4j.kernel.api.procedure.GlobalProcedures;
 import org.neo4j.kernel.extension.ExtensionFactory;
 import org.neo4j.kernel.extension.ExtensionType;
@@ -8,12 +9,16 @@ import org.neo4j.kernel.extension.context.ExtensionContext;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.logging.internal.LogService;
 
+import static org.neo4j.configuration.GraphDatabaseSettings.neo4j_home;
+
 @ServiceProvider
 public class ExtendedApocConfigExtensionFactory extends ExtensionFactory<ExtendedApocConfigExtensionFactory.Dependencies>
 {
     public interface Dependencies {
         LogService log();
         GlobalProcedures globalProceduresRegistry();
+
+        Config config();
     }
 
     public ExtendedApocConfigExtensionFactory() {
@@ -23,7 +28,11 @@ public class ExtendedApocConfigExtensionFactory extends ExtensionFactory<Extende
     @Override
     public Lifecycle newInstance( ExtensionContext context, Dependencies dependencies )
     {
-        return new ExtendedApocConfig(dependencies.log(), dependencies.globalProceduresRegistry());
+        String defaultConfigPath = dependencies.config()
+                .get(neo4j_home)
+                .resolve(Config.DEFAULT_CONFIG_DIR_NAME)
+                .toString();
+        return new ExtendedApocConfig(dependencies.log(), dependencies.globalProceduresRegistry(), defaultConfigPath);
 
     }
 }

--- a/extended/src/main/java/apoc/dv/DataVirtualizationCatalog.java
+++ b/extended/src/main/java/apoc/dv/DataVirtualizationCatalog.java
@@ -87,7 +87,11 @@ public class DataVirtualizationCatalog {
                 .stream()
                 .map(m -> (Node) m.get(("node")))
                 .map(n -> new VirtualRelationship(node, n, relationshipType))
-                .map(r -> new VirtualPath.Builder(r.getStartNode()).push(r).build())
+                .map(r -> {
+                    VirtualPath virtualPath =  new VirtualPath(r.getStartNode());
+                    virtualPath.addRel(r);
+                    return virtualPath;
+                })
                 .map(PathResult::new);
     }
 }

--- a/extended/src/test/java/apoc/ExtendedApocConfigTest.java
+++ b/extended/src/test/java/apoc/ExtendedApocConfigTest.java
@@ -20,13 +20,13 @@ public class ExtendedApocConfigTest {
     public void setup() {
         InternalLogProvider logProvider = new AssertableLogProvider();
         GlobalProceduresRegistry registry = mock(GlobalProceduresRegistry.class);
-        cut = new ExtendedApocConfig(new SimpleLogService(logProvider), registry);
+        cut = new ExtendedApocConfig(new SimpleLogService(logProvider), registry, "C:/neo4j/neo4j-enterprise-5.x.0/conf");
     }
 
     @Test
     public void testDetermineNeo4jConfFolderDefault() {
         System.setProperty(SUN_JAVA_COMMAND, "");
-        assertEquals(".", cut.determineNeo4jConfFolder());
+        assertEquals("C:/neo4j/neo4j-enterprise-5.x.0/conf", cut.determineNeo4jConfFolder());
     }
 
     @Test


### PR DESCRIPTION
On Windows service, 'sun.java.command' is not supported. The fallback default path to the config folder was set to '.' which is not the actual default. With this solution, the home folder of Neo4j is instead used to calculate the default.

This is the extended version of the APOC core fix from https://github.com/neo4j/apoc/pull/586