### PR TITLE
Fixes #3496: Simple mysql select now(); Throws class java.time.LocalDateTime cannot be cast to class java.sql.Timestamp

### DIFF
--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     implementation group: 'com.unboundid', name: 'unboundid-ldapsdk', version: '6.0.11'
     implementation group: 'org.jsoup', name: 'jsoup', version: '1.15.3'
     implementation group: 'com.opencsv', name: 'opencsv', version: '5.7.1'
-    implementation group: 'us.fatehi', name: 'schemacrawler', version: '15.04.01'
+    implementation group: 'us.fatehi', name: 'schemacrawler', version: '16.20.8'
 
     // These will be dependencies not packaged with the .jar
     // They need to be provided either through the database or in an extra .jar

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -144,7 +144,7 @@ dependencies {
     testImplementation group: 'org.mock-server', name: 'mockserver-netty', version: '5.6.0'
     testImplementation group: 'org.mock-server', name: 'mockserver-client-java', version: '5.6.0'
     testImplementation group: 'com.amazonaws', name: 'aws-java-sdk-comprehend', version: '1.12.353' , withoutJacksons
-    testImplementation group: 'us.fatehi', name: 'schemacrawler-mysql', version: '15.04.01'
+    testImplementation group: 'us.fatehi', name: 'schemacrawler-mysql', version: '16.20.8'
     testImplementation group: 'org.xmlunit', name: 'xmlunit-core', version: '2.2.1'
     testImplementation group: 'com.github.adejanovski', name: 'cassandra-jdbc-wrapper', version: '3.1.0'
     testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-csv', version: '2.13.2'

--- a/extended/src/main/java/apoc/load/Jdbc.java
+++ b/extended/src/main/java/apoc/load/Jdbc.java
@@ -73,7 +73,7 @@ public class Jdbc {
         String url = getUrlOrKey(urlOrKey);
         String query = getSqlOrKey(tableOrSelect);
         try {
-            Connection connection = getConnection(url,loadJdbcConfig);
+            Connection connection = getConnection(url,loadJdbcConfig).get();
             // see https://jdbc.postgresql.org/documentation/91/query.html#query-with-cursors
             connection.setAutoCommit(loadJdbcConfig.isAutoCommit());
             try {
@@ -114,7 +114,7 @@ public class Jdbc {
         String url = getUrlOrKey(urlOrKey);
         LoadJdbcConfig jdbcConfig = new LoadJdbcConfig(config);
         try {
-            Connection connection = getConnection(url,jdbcConfig);
+            Connection connection = getConnection(url,jdbcConfig).get();
             try {
                 PreparedStatement stmt = connection.prepareStatement(query,ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
                 stmt.setFetchSize(5000);

--- a/extended/src/main/java/apoc/load/util/JdbcUtil.java
+++ b/extended/src/main/java/apoc/load/util/JdbcUtil.java
@@ -1,6 +1,9 @@
 package apoc.load.util;
 
 import apoc.util.Util;
+import us.fatehi.utility.datasource.DatabaseConnectionSource;
+import us.fatehi.utility.datasource.DatabaseConnectionSources;
+import us.fatehi.utility.datasource.MultiUseUserCredentials;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.Callback;
@@ -20,7 +23,7 @@ public class JdbcUtil {
 
     private JdbcUtil() {}
 
-    public static Connection getConnection(String jdbcUrl, LoadJdbcConfig config) throws Exception {
+    public static DatabaseConnectionSource getConnection(String jdbcUrl, LoadJdbcConfig config) throws Exception {
         if(config.hasCredentials()) {
             return createConnection(jdbcUrl, config.getCredentials().getUser(), config.getCredentials().getPassword());
         } else {
@@ -31,11 +34,11 @@ public class JdbcUtil {
                 String[] user = userInfo.split(":");
                 return createConnection(cleanUrl, user[0], user[1]);
             }
-            return DriverManager.getConnection(jdbcUrl);
+            return DatabaseConnectionSources.newDatabaseConnectionSource(jdbcUrl, new MultiUseUserCredentials());
         }
     }
 
-    private static Connection createConnection(String jdbcUrl, String userName, String password) throws Exception {
+    private static DatabaseConnectionSource createConnection(String jdbcUrl, String userName, String password) throws Exception {
         if (jdbcUrl.contains(";auth=kerberos")) {
             String client = System.getProperty("java.security.auth.login.config.client", "KerberosClient");
             LoginContext lc = new LoginContext(client, callbacks -> {
@@ -47,12 +50,12 @@ public class JdbcUtil {
             lc.login();
             Subject subject = lc.getSubject();
             try {
-                return Subject.doAs(subject, (PrivilegedExceptionAction<Connection>) () -> DriverManager.getConnection(jdbcUrl, userName, password));
+                return Subject.doAs(subject, (PrivilegedExceptionAction<DatabaseConnectionSource>) () -> DatabaseConnectionSources.newDatabaseConnectionSource(jdbcUrl, new MultiUseUserCredentials(userName, password)));
             } catch (PrivilegedActionException pae) {
                 throw pae.getException();
             }
         } else {
-            return DriverManager.getConnection(jdbcUrl, userName, password);
+            return DatabaseConnectionSources.newDatabaseConnectionSource(jdbcUrl, new MultiUseUserCredentials(userName, password));
         }
     }
 

--- a/extended/src/main/java/apoc/load/util/JdbcUtil.java
+++ b/extended/src/main/java/apoc/load/util/JdbcUtil.java
@@ -13,8 +13,6 @@ import javax.security.auth.login.LoginContext;
 import java.net.URI;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
-import java.sql.Connection;
-import java.sql.DriverManager;
 
 public class JdbcUtil {
 

--- a/extended/src/main/java/apoc/model/Model.java
+++ b/extended/src/main/java/apoc/model/Model.java
@@ -9,8 +9,7 @@ import org.neo4j.procedure.*;
 import schemacrawler.schema.*;
 import schemacrawler.schemacrawler.SchemaCrawlerOptions;
 import schemacrawler.schemacrawler.SchemaCrawlerOptionsBuilder;
-import schemacrawler.schemacrawler.SchemaInfoLevelBuilder;
-import schemacrawler.utility.SchemaCrawlerUtility;
+import schemacrawler.tools.utility.SchemaCrawlerUtility;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,9 +58,7 @@ public class Model {
     public Stream<DatabaseModel> jdbc(@Name("jdbc") String urlOrKey, @Name(value = "config",defaultValue = "{}") Map<String, Object> config) throws Exception {
         String url = getUrlOrKey(urlOrKey);
 
-        SchemaCrawlerOptionsBuilder optionsBuilder = SchemaCrawlerOptionsBuilder.builder()
-                .withSchemaInfoLevel(SchemaInfoLevelBuilder.standard());
-        SchemaCrawlerOptions options = optionsBuilder.toOptions();
+        SchemaCrawlerOptions options = SchemaCrawlerOptionsBuilder.newSchemaCrawlerOptions();
 
         Catalog catalog = SchemaCrawlerUtility.getCatalog(getConnection(url, new LoadJdbcConfig(config)),
                 options);

--- a/extended/src/test/java/apoc/load/MySQLJdbcTest.java
+++ b/extended/src/test/java/apoc/load/MySQLJdbcTest.java
@@ -112,12 +112,14 @@ public class MySQLJdbcTest extends AbstractJdbcTest {
                             "Capital", 5,
                             "Code2", "NL",
                             "myTime", LocalTime.of(1, 0, 0),
-                            "myDateTime", LocalDateTime.parse("2003-01-01T01:00"),
                             "myTimeStamp", ZonedDateTime.parse("2003-01-01T01:00Z"),
                             "myDate", LocalDate.parse("2003-01-01"),
                             "myYear", LocalDate.parse("2003-01-01")
                     );
-                    assertEquals(expected, row.get("row"));
+                    Map actual = (Map) row.get("row");
+                    Object myDateTime = actual.remove("myDateTime");
+                    assertTrue(myDateTime instanceof LocalDateTime);
+                    assertEquals(expected, actual);
                 });
     }
 

--- a/extended/src/test/java/apoc/load/MySQLJdbcTest.java
+++ b/extended/src/test/java/apoc/load/MySQLJdbcTest.java
@@ -7,39 +7,92 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
 import java.util.Map;
 
 import static apoc.util.TestUtil.testCall;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+@RunWith(Enclosed.class)
 public class MySQLJdbcTest extends AbstractJdbcTest {
+    
+    public static class MySQLJdbcLatestVersionTest {
+        
+        @ClassRule
+        public static MySQLContainerExtension mysql = new MySQLContainerExtension("mysql:8.0.31");
 
-    @ClassRule
-    public static MySQLContainerExtension mysql = new MySQLContainerExtension();
+        @ClassRule
+        public static DbmsRule db = new ImpermanentDbmsRule();
+        
+        @BeforeClass
+        public static void setUpContainer() {
+            mysql.start();
+            TestUtil.registerProcedure(db, Jdbc.class);
+        }
 
-    @ClassRule
-    public static DbmsRule db = new ImpermanentDbmsRule();
+        @AfterClass
+        public static void tearDown() {
+            mysql.stop();
+            db.shutdown();
+        }
 
-    @BeforeClass
-    public static void setUpContainer() {
-        mysql.start();
-        TestUtil.registerProcedure(db, Jdbc.class);
+        @Test
+        public void testLoadJdbc() {
+            MySQLJdbcTest.testLoadJdbc(db, mysql);
+        }
+
+        @Test
+        public void testIssue3496() {
+            MySQLJdbcTest.testIssue3496(db, mysql);
+        }
+    }
+    
+    public static class MySQLJdbcFiveVersionTest {
+        
+        @ClassRule
+        public static MySQLContainerExtension mysql = new MySQLContainerExtension("mysql:5.7");
+
+        @ClassRule
+        public static DbmsRule db = new ImpermanentDbmsRule();
+
+        @BeforeClass
+        public static void setUpContainer() {
+            mysql.start();
+            TestUtil.registerProcedure(db, Jdbc.class);
+        }
+
+        @AfterClass
+        public static void tearDown() {
+            mysql.stop();
+            db.shutdown();
+        }
+
+        @Test
+        public void testLoadJdbc() {
+            MySQLJdbcTest.testLoadJdbc(db, mysql);
+        }
+
+        @Test
+        public void testIssue3496() {
+            MySQLJdbcTest.testIssue3496(db, mysql);
+        }
     }
 
-    @AfterClass
-    public static void tearDown() {
-        mysql.stop();
-        db.shutdown();
-    }
-
-    @Test
-    public void testLoadJdbc() {
-        testCall(db, "CALL apoc.load.jdbc($url, $table, [])",
+    private static void testLoadJdbc(DbmsRule db, MySQLContainerExtension mysql) {
+        // with the config {timezone: 'UTC'} and `preserveInstants=true&connectionTimeZone=SERVER` to make the result deterministic,
+        // since `TIMESTAMP` values are automatically converted from the session time zone to UTC for storage, and vice versa.
+        testCall(db, "CALL apoc.load.jdbc($url, $table, [], {timezone: 'UTC'})",
                 Util.map(
-                        "url", mysql.getJdbcUrl(),
+                        "url", mysql.getJdbcUrl() + "&preserveInstants=true&connectionTimeZone=SERVER",
                         "table", "country"),
                 row -> {
                     Map<String, Object> expected = Util.map(
@@ -57,8 +110,34 @@ public class MySQLJdbcTest extends AbstractJdbcTest {
                             "GovernmentForm", "Constitutional Monarchy",
                             "HeadOfState", "Beatrix",
                             "Capital", 5,
-                            "Code2", "NL");
+                            "Code2", "NL",
+                            "myTime", LocalTime.of(1, 0, 0),
+                            "myDateTime", LocalDateTime.parse("2003-01-01T01:00"),
+                            "myTimeStamp", ZonedDateTime.parse("2003-01-01T01:00Z"),
+                            "myDate", LocalDate.parse("2003-01-01"),
+                            "myYear", LocalDate.parse("2003-01-01")
+                    );
                     assertEquals(expected, row.get("row"));
+                });
+    }
+
+    private static void testIssue3496(DbmsRule db, MySQLContainerExtension mysql) {
+        testCall(db, "CALL apoc.load.jdbc($url,'SELECT DATE(NOW()), NOW(), CURDATE(), CURTIME(), UTC_DATE(), UTC_TIME(), UTC_TIMESTAMP(), DATE(UTC_TIMESTAMP());')", 
+                Util.map("url", mysql.getJdbcUrl()),
+                r -> {
+                    Map row = (Map) r.get("row");
+                    assertEquals(8, row.size());
+                    
+                    assertTrue(row.get("UTC_DATE()") instanceof LocalDate);
+                    assertTrue(row.get("CURDATE()") instanceof LocalDate);
+                    
+                    assertTrue(row.get("UTC_TIMESTAMP()") instanceof LocalDateTime);
+                    assertTrue(row.get("NOW()") instanceof LocalDateTime);
+                    assertTrue(row.get("DATE(UTC_TIMESTAMP())") instanceof LocalDate);
+                    assertTrue(row.get("DATE(NOW())") instanceof LocalDate);
+                    
+                    assertTrue(row.get("CURTIME()") instanceof LocalTime);
+                    assertTrue(row.get("UTC_TIME()") instanceof LocalTime);
                 });
     }
 }

--- a/extended/src/test/java/apoc/model/ModelTest.java
+++ b/extended/src/test/java/apoc/model/ModelTest.java
@@ -63,8 +63,8 @@ public class ModelTest {
                     assertEquals(0L, count.longValue());
                     List<Node> nodes = (List<Node>) row.get("nodes");
                     List<Relationship> rels = (List<Relationship>) row.get("relationships");
-                    assertEquals( 28, nodes.size());
-                    assertEquals( 27, rels.size());
+                    assertEquals( 33, nodes.size());
+                    assertEquals( 32, rels.size());
 
                     // schema
                     Node schema = nodes.stream().filter(node -> node.hasLabel(Label.label("Schema"))).findFirst().orElse(null);
@@ -86,10 +86,11 @@ public class ModelTest {
 
                     List<Node> columns = nodes.stream().filter(node -> node.hasLabel(Label.label("Column")))
                             .collect(Collectors.toList());
-                    assertEquals(24, columns.size());
+                    assertEquals(29, columns.size());
 
                     List<String> countryNodes = filterColumnsByTableName(columns, "country");
-                    List<String> expectedCountryCols = Arrays.asList("Code", "Name", "Continent", "Region", "SurfaceArea", "IndepYear", "Population", "LifeExpectancy", "GNP", "GNPOld", "LocalName", "GovernmentForm", "HeadOfState", "Capital", "Code2");
+                    List<String> expectedCountryCols = Arrays.asList("Code", "Name", "Continent", "Region", "SurfaceArea", "IndepYear", "Population", "LifeExpectancy", "GNP", "GNPOld", "LocalName", "GovernmentForm", "HeadOfState", "Capital", "Code2",
+                            "myTime", "myDateTime", "myTimeStamp", "myDate", "myYear");
                     assertEquals(expectedCountryCols, countryNodes);
 
                     List<String> cityNodes = filterColumnsByTableName(columns, "city");
@@ -116,8 +117,8 @@ public class ModelTest {
         try (Transaction tx = db.beginTx()) {
             List<Node> nodes = Iterators.single(tx.execute("MATCH (n) RETURN collect(distinct n) AS nodes").columnAs("nodes"));
             List<Relationship> rels = Iterators.single(tx.execute("MATCH ()-[r]-() RETURN collect(distinct r) AS rels").columnAs("rels"));
-            assertEquals( 28, nodes.size());
-            assertEquals( 27, rels.size());
+            assertEquals( 33, nodes.size());
+            assertEquals( 32, rels.size());
 
             // schema
             Node schema = nodes.stream().filter(node -> node.hasLabel(Label.label("Schema"))).findFirst().orElse(null);
@@ -139,10 +140,11 @@ public class ModelTest {
 
             List<Node> columns = nodes.stream().filter(node -> node.hasLabel(Label.label("Column")))
                     .collect(Collectors.toList());
-            assertEquals(24, columns.size());
+            assertEquals(29, columns.size());
 
             List<String> countryNodes = filterColumnsByTableName(columns, "country");
-            List<String> expectedCountryCols = Arrays.asList("Code", "Name", "Continent", "Region", "SurfaceArea", "IndepYear", "Population", "LifeExpectancy", "GNP", "GNPOld", "LocalName", "GovernmentForm", "HeadOfState", "Capital", "Code2");
+            List<String> expectedCountryCols = Arrays.asList("Code", "Name", "Continent", "Region", "SurfaceArea", "IndepYear", "Population", "LifeExpectancy", "GNP", "GNPOld", "LocalName", "GovernmentForm", "HeadOfState", "Capital", "Code2",
+                    "myTime", "myDateTime", "myTimeStamp", "myDate", "myYear");
             assertEquals(expectedCountryCols, countryNodes);
 
             List<String> cityNodes = filterColumnsByTableName(columns, "city");

--- a/extended/src/test/java/apoc/util/s3/MySQLContainerExtension.java
+++ b/extended/src/test/java/apoc/util/s3/MySQLContainerExtension.java
@@ -7,8 +7,8 @@ import java.time.Duration;
 
 public class MySQLContainerExtension extends MySQLContainer<MySQLContainerExtension> {
 
-    public MySQLContainerExtension() {
-        super("mysql:5.7");
+    public MySQLContainerExtension(String imageName) {
+        super(imageName);
         this.withInitScript("init_mysql.sql");
         this.withUrlParam("user", "test");
         this.withUrlParam("password", "test");

--- a/extended/src/test/resources/init_mysql.sql
+++ b/extended/src/test/resources/init_mysql.sql
@@ -24,6 +24,11 @@ CREATE TABLE `country` (
   `HeadOfState` CHAR(60) DEFAULT NULL,
   `Capital` INT(11) DEFAULT NULL,
   `Code2` CHAR(2) NOT NULL DEFAULT '',
+  `myTime` TIME NOT NULL DEFAULT '0',
+  `myDateTime` DATETIME NOT NULL,
+  `myTimeStamp` TIMESTAMP NOT NULL,
+  `myDate` DATE NOT NULL,
+  `myYear` YEAR NOT NULL,
   PRIMARY KEY (`Code`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
@@ -32,7 +37,13 @@ CREATE TABLE `country` (
 --
 -- ORDER BY:  `Code`
 
-INSERT INTO `country` VALUES ('NLD','Netherlands','Europe','Western Europe',41526.00,1581,15864000,78.3,371362.00,360478.00,'Nederland','Constitutional Monarchy','Beatrix',5,'NL');
+INSERT INTO `country` VALUES ('NLD','Netherlands','Europe','Western Europe',41526.00,1581,15864000,78.3,371362.00,360478.00,'Nederland','Constitutional Monarchy','Beatrix',5,'NL',
+TIME('01:00:00'),
+DATE('2003-01-01 01:00:00'),
+TIMESTAMP('2003-01-01 01:00:00'),
+DATE('2003-01-01 01:00:00'),
+YEAR('2003-01-01 01:00:00')
+);
 COMMIT;
 
 --


### PR DESCRIPTION
Fixes #3496 

The problem occurs with the latest versions of the mysql Jdbc connector

- Updated `schemacrawler-mysql` (which downloads the mysql jdbc connector), 
  also because of the current version has some vulnerable dependencies
- Fixed the problem via code block: `if (value instanceof LocalDateTime ...`
- Added tests for date and time
- Duplicated tests with the latest version of mysql