### PR TITLE
Fixes #3218: java.lang.NullPointerException when setting the type of a property to datetime in the mapping config of apoc.load.csv()

### DIFF
--- a/extended/src/test/java/apoc/load/LoadCsvTest.java
+++ b/extended/src/test/java/apoc/load/LoadCsvTest.java
@@ -15,12 +15,14 @@ import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
+import org.neo4j.values.storable.*;
 import org.testcontainers.containers.GenericContainer;
 
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -29,6 +31,7 @@ import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
 import static apoc.util.BinaryTestUtil.fileToBinary;
 import static apoc.util.CompressionConfig.COMPRESSION;
+import static apoc.util.ExtendedTestUtil.assertMapEquals;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.*;
 import static java.util.Arrays.asList;
@@ -37,6 +40,7 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.matchers.Times.exactly;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
+import static org.neo4j.configuration.GraphDatabaseSettings.db_temporal_timezone;
 
 public class LoadCsvTest {
 
@@ -309,6 +313,113 @@ RETURN m.col_1,m.col_2,m.col_3
                     assertEquals(false, r.hasNext());
                 });
     }
+    
+
+    @Test
+    public void testMappingWithManyTypes() {
+        ZoneId defaultTimezone = ZoneId.of(apocConfig().getString(db_temporal_timezone.name()));
+
+        String url = "test-mapping-many-types.csv";
+        Map<String, Object> mapping = map(
+                "localDateTimeField", map("type", "localDateTime"),
+                "localTimeField", map("type", "localTime"),
+                "timeField", map("type", "time"),
+                "dateField", map("type", "date"),
+                "dateTimeField", map("type", "dateTime"),
+                "durationField", map("type", "duration"),
+                "boolField", map("type", "boolean"),
+                "pointField", map("type", "point"),
+                "listDatesField", map("array", true, "arraySep", ",", "type", "date")
+        );
+        testMappingWithManyTypesCommon(defaultTimezone, url, mapping);
+    }
+
+    @Test
+    public void testMappingWithManyTypesWithOptionalData() {
+        ZoneId timezone = ZoneId.of("UTC-8");
+
+        String url = "test-mapping-many-types.csv";
+        Map<String, Object> mapping = map(
+                "localDateTimeField", map("type", "localDateTime"),
+                "localTimeField", map("type", "localTime"),
+                "timeField", map("type", "time", "optionalData", map("timezone", timezone.getId())),
+                "dateField", map("type", "date"),
+                "dateTimeField", map("type", "dateTime", "optionalData", map("timezone", timezone.getId())),
+                "durationField", map("type", "duration"),
+                "boolField", map("type", "boolean"),
+                "pointField", map("type", "point"),
+                "listDatesField", map("array", true, "arraySep", ",", "type", "date")
+        );
+        
+        testMappingWithManyTypesCommon(timezone, url, mapping);
+    }
+
+    private void testMappingWithManyTypesCommon(ZoneId zoneId, String url, Map<String, Object> mapping) {
+        testResult(db, "CALL apoc.load.csv($url,{results:['map','list','stringMap','strings'],mapping:$mapping})",
+                map("url", url, "mapping", mapping),
+                (r) -> {
+                    Map<String, Object> row = r.next();
+                    Map<String, Object> expectedFirstRow = map("localDateTimeField", LocalDateTimeValue.parse("1999").asObject(),
+                            "localTimeField", LocalTimeValue.parse("10:01").asObject(),
+                            "timeField", TimeValue.parse("10:01:00Z", () -> zoneId).asObject(),
+                            "dateField", DateValue.parse("2024-01-18").asObject(),
+                            "dateTimeField", DateTimeValue.parse("2024-01-18T14:22:59", () -> zoneId).asObject(),
+                            "durationField", DurationValue.parse("P5M1.5D"),
+                            "boolField", true,
+                            "pointField", PointValue.parse("{x: 56.7, y: 12.78, crs: 'wgs-84'}"),
+                            "listDatesField", asList(DateValue.parse("2000").asObject(), DateValue.parse("2001").asObject(), DateValue.parse("2002").asObject())
+                    );
+                    assertMapEquals(expectedFirstRow, (Map<String, Object>) row.get("map"));
+
+
+                    Map<String, Object> expectedFirstStringRow = map("localDateTimeField", "1999",
+                            "localTimeField","10:01",
+                            "timeField", "10:01:00Z",
+                            "dateField", "2024-01-18",
+                            "dateTimeField", "2024-01-18T14:22:59",
+                            "durationField", "P5M1.5D",
+                            "boolField", "true",
+                            "pointField", "{x: 56.7,y: 12.78, crs: 'wgs-84'}",
+                            "listDatesField", "2000,2001,2002"
+                    );
+                    assertMapEquals(expectedFirstStringRow, (Map<String, Object>) row.get("stringMap"));
+                    assertEquals(Set.copyOf(expectedFirstRow.values()), Set.copyOf((List) row.get("list")));
+                    assertEquals(Set.copyOf(expectedFirstStringRow.values()), Set.copyOf((List) row.get("strings")));
+
+                    row = r.next();
+
+                    Map<String, Object> expectedSecondRow = map("localDateTimeField", LocalDateTimeValue.parse("2000").asObject(),
+                            "localTimeField", LocalTimeValue.parse("11:01").asObject(),
+                            "timeField", TimeValue.parse("11:01:00Z", () -> zoneId).asObject(),
+                            "dateField", DateValue.parse("2023-01-18").asObject(),
+                            "dateTimeField", DateTimeValue.parse("2023-01-18T14:22:59", () -> zoneId).asObject(),
+                            "durationField", DurationValue.parse("P6M1.5D"),
+                            "boolField", false,
+                            "pointField", PointValue.parse("{x: 57.7, y: 11.78, crs: 'wgs-84'}"),
+                            "listDatesField", asList(DateValue.parse("2000").asObject(), DateValue.parse("2001").asObject(), DateValue.parse("2002").asObject())
+                    );
+                    assertMapEquals(expectedSecondRow, (Map<String, Object>) row.get("map"));
+
+                    Map<String, Object> expectedSecondStringRow = map("localDateTimeField", "2000",
+                            "localTimeField", "11:01",
+                            "timeField", "11:01:00Z",
+                            "dateField", "2023-01-18",
+                            "dateTimeField", "2023-01-18T14:22:59",
+                            "durationField", "P6M1.5D",
+                            "boolField", "false",
+                            "pointField", "{x: 57.7,y: 11.78, crs: 'wgs-84'}",
+                            "listDatesField", "2000,2001,2002"
+                    );
+                    assertMapEquals(expectedSecondStringRow, (Map<String, Object>) row.get("stringMap"));
+
+                    assertEquals(Set.copyOf(expectedSecondRow.values()), Set.copyOf((List) row.get("list")));
+                    assertEquals(Set.copyOf(expectedSecondStringRow.values()), Set.copyOf((List) row.get("strings")));
+
+                    assertFalse(r.hasNext());
+                });
+    }
+
+
 
     @Test
     public void testLoadCsvByUrl() throws Exception {

--- a/extended/src/test/java/apoc/util/ExtendedTestUtil.java
+++ b/extended/src/test/java/apoc/util/ExtendedTestUtil.java
@@ -11,10 +11,28 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static apoc.util.TestUtil.testCallAssertions;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.neo4j.test.assertion.Assert.assertEventually;
 
 public class ExtendedTestUtil {
 
+    public static void assertMapEquals(Map<String, Object> expected, Map<String, Object> actual) {
+        if (expected == null) {
+            assertNull(actual);
+        } else {
+            assertEquals(expected.keySet(), actual.keySet());
+
+            actual.forEach((key, value) -> {
+                if (value instanceof Map mapVal) {
+                    assertMapEquals((Map<String, Object>) expected.get(key), mapVal);
+                } else {
+                    assertEquals(expected.get(key), value);
+                }
+            });
+        }
+    }
+    
     /**
      * similar to @link {@link TestUtil#testCallEventually(GraphDatabaseService, String, Consumer, long)}
      * but re-execute the {@link GraphDatabaseService#executeTransactionally(String, Map, ResultTransformer)} in case of error

--- a/extended/src/test/resources/test-mapping-many-types.csv
+++ b/extended/src/test/resources/test-mapping-many-types.csv
@@ -1,0 +1,3 @@
+localDateTimeField,localTimeField,timeField,dateField,dateTimeField,durationField,boolField,pointField,listDatesField
+1999,10:01,10:01:00Z,2024-01-18,2024-01-18T14:22:59,P5M1.5D,true,"{x: 56.7,y: 12.78, crs: 'wgs-84'}","2000,2001,2002"
+2000,11:01,11:01:00Z,2023-01-18,2023-01-18T14:22:59,P6M1.5D,false,"{x: 57.7,y: 11.78, crs: 'wgs-84'}","2000,2001,2002"


### PR DESCRIPTION

Fixes https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3218

- [x] Waiting for APOC Core PR: https://github.com/neo4j/apoc/pull/571


Up to 5.16 we had to use a workaround not to throw a NullPointerException with datetime/time mappings, since the bug is in Core. 
E.g.
```
CALL apoc.load.csv('test.csv', {mapping:{name:{type: "datetime", optionalData: {}}}})
```


But, as this PR https://github.com/neo4j/apoc/pull/571 is merged,
we can use `datetime` without `optionalData: {}` workaround, e.g.:
```
CALL apoc.load.csv('test.csv', {mapping:{name:{type: "datetime"}}})
```


## Changes:
- added test with multiple types and optionalData
- added test with multiple types and without optionalData, to check that the APOC Core's fix works correctly
- added `assertMapEquals` util, to check more easily the possible failied entry map
