### PR TITLE
[wbVWvi0y] Solves apoc.meta.data bug with reserved names for relationships and nodes

### DIFF
--- a/core/src/test/java/apoc/meta/MetaTest.java
+++ b/core/src/test/java/apoc/meta/MetaTest.java
@@ -984,6 +984,15 @@ public class MetaTest {
     }
 
     @Test
+    public void testRelationshipAndNodeNames() {
+        db.executeTransactionally("CREATE (a:NODE)-[r:RELATIONSHIP]->(m:Movie)");
+        TestUtil.testResult(db, "CALL apoc.meta.data()", (r) -> {
+            Assertions.assertThat(r.stream().map(m -> m.get("label"))).contains("RELATIONSHIP", "NODE");
+            r.close();
+        });
+    }
+
+    @Test
     public void testMetaDataWithSample5() throws Exception {
         db.executeTransactionally("create index on :Person(name)");
         db.executeTransactionally("CREATE (:Person {name:'John', surname:'Brown'})");


### PR DESCRIPTION
Cherry-picks https://github.com/neo4j/apoc/pull/584

## Why

Because a node named `NODE` or a relationship named `RELATIONSHIP` could not be used.

When doing

```
CREATE (a:NODE)-[r:RELATIONSHIP]->(m:Movie)
CALL apoc.meta.data()
```

we were getting:

```
java.lang.IllegalArgumentException: duplicate element: RELATIONSHIP
```


