### PR TITLE
Fixes #3972: Add support for Groq AI for ml procedures

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
@@ -242,6 +242,14 @@ CALL apoc.ml.openai.embedding(['Some Text'], "ignored",
 {endpoint: 'http://localhost:3000/v1', model: 'thenlper/gte-large'})
 ----
 
+Furthermore, we can use the https://console.groq.com/docs/quickstart[Groq API], e.g.:
+[source,cypher]
+----
+CALL apoc.ml.openai.chat([{"role": "user", "content": "Explain the importance of low latency LLMs"}], 
+    '<apiKey>',
+    {endpoint: 'https://api.groq.com/openai/v1', model: 'mixtral-8x7b-32768'})
+----
+
 
 == Query with natural language
 

--- a/extended/src/test/java/apoc/ml/OpenAIGroqAPIsIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIGroqAPIsIT.java
@@ -1,0 +1,68 @@
+package apoc.ml;
+
+import apoc.util.TestUtil;
+import apoc.util.Util;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.List;
+import java.util.Map;
+
+import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
+import static apoc.ml.OpenAI.MODEL_CONF_KEY;
+import static apoc.ml.OpenAITestResultUtils.CHAT_COMPLETION_QUERY;
+import static apoc.ml.OpenAITestResultUtils.COMPLETION_QUERY;
+import static apoc.ml.OpenAITestResultUtils.EMBEDDING_QUERY;
+import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
+import static apoc.ml.OpenAITestResultUtils.assertCompletion;
+import static apoc.util.TestUtil.testCall;
+import static java.util.Collections.emptyMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+/**
+ * Tests with Groq API: https://console.groq.com/docs/quickstart 
+ */
+public class OpenAIGroqAPIsIT {
+
+    private String groqApiKey;
+
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
+
+
+    @Before
+    public void setUp() throws Exception {
+        groqApiKey = System.getenv("GROQ_API_KEY");
+        Assume.assumeNotNull("No GROQ_API_KEY environment configured", groqApiKey);
+        TestUtil.registerProcedure(db, OpenAI.class);
+    }
+
+    @Test
+    public void chatCompletionWithLlama2() {
+        String model = "llama2-70b-4096";
+        testCall(db, CHAT_COMPLETION_QUERY,
+                getParams(model),
+                (row) -> assertChatCompletion(row, model));
+    }
+
+    @Test
+    public void chatCompletionWithMixtral() {
+        String model = "mixtral-8x7b-32768";
+        testCall(db, CHAT_COMPLETION_QUERY,
+                getParams(model),
+                (row) -> assertChatCompletion(row, model));
+    }
+    
+    private Map<String, Object> getParams(String model) {
+        Map<String, String> conf = Map.of(ENDPOINT_CONF_KEY, "https://api.groq.com/openai/v1",
+                MODEL_CONF_KEY, model);
+        
+        return Map.of("apiKey", groqApiKey, "conf", conf);
+    }
+}

--- a/extended/src/test/java/apoc/ml/OpenAIGroqAPIsIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIGroqAPIsIT.java
@@ -1,8 +1,6 @@
 package apoc.ml;
 
 import apoc.util.TestUtil;
-import apoc.util.Util;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
@@ -10,19 +8,13 @@ import org.junit.Test;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
-import java.util.List;
 import java.util.Map;
 
 import static apoc.ml.OpenAI.ENDPOINT_CONF_KEY;
 import static apoc.ml.OpenAI.MODEL_CONF_KEY;
 import static apoc.ml.OpenAITestResultUtils.CHAT_COMPLETION_QUERY;
-import static apoc.ml.OpenAITestResultUtils.COMPLETION_QUERY;
-import static apoc.ml.OpenAITestResultUtils.EMBEDDING_QUERY;
 import static apoc.ml.OpenAITestResultUtils.assertChatCompletion;
-import static apoc.ml.OpenAITestResultUtils.assertCompletion;
 import static apoc.util.TestUtil.testCall;
-import static java.util.Collections.emptyMap;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 /**


### PR DESCRIPTION
Fixes #3972

The procedures are completely compatible with OpenAI, 
both the endpoint final parts (i.e. `/chat/completions` and `/embeddings`) and the headers,
so the integration test has just been created.