### PR TITLE
Fixes #3952: check if the new openai embedding models work in an integration test

### DIFF
--- a/extended/src/test/java/apoc/ml/OpenAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIIT.java
@@ -10,6 +10,7 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.util.Map;
 
+import static apoc.ml.OpenAI.MODEL_CONF_KEY;
 import static apoc.ml.OpenAITestResultUtils.*;
 import static apoc.util.TestUtil.testCall;
 import static java.util.Collections.emptyMap;
@@ -35,6 +36,36 @@ public class OpenAIIT {
     public void getEmbedding() {
         testCall(db, EMBEDDING_QUERY, Map.of("apiKey",openaiKey, "conf", emptyMap()),
                 OpenAITestResultUtils::assertEmbeddings);
+    }
+
+    @Test
+    public void getEmbedding3Small() {
+        Map<String, Object> conf = Map.of(MODEL_CONF_KEY, "text-embedding-3-small");
+        testCall(db, EMBEDDING_QUERY, Map.of("apiKey", openaiKey, "conf", conf),
+                OpenAITestResultUtils::assertEmbeddings);
+    }
+
+    @Test
+    public void getEmbedding3Large() {
+        Map<String, Object> conf = Map.of(MODEL_CONF_KEY, "text-embedding-3-large");
+        testCall(db, EMBEDDING_QUERY, Map.of("apiKey", openaiKey, "conf", conf),
+                r -> assertEmbeddings(r, 3072));
+    }
+
+    @Test
+    public void getEmbedding3SmallWithDimensionsRequestParameter() {
+        Map<String, Object> conf = Map.of(MODEL_CONF_KEY, "text-embedding-3-small",
+                "dimensions", 256);
+        testCall(db, EMBEDDING_QUERY, Map.of("apiKey", openaiKey, "conf", conf),
+                r -> assertEmbeddings(r, 256));
+    }
+
+    @Test
+    public void getEmbedding3LargeWithDimensionsRequestParameter() {
+        Map<String, Object> conf = Map.of(MODEL_CONF_KEY, "text-embedding-3-large",
+                "dimensions", 256);
+        testCall(db, EMBEDDING_QUERY, Map.of("apiKey", openaiKey, "conf", conf),
+                r -> assertEmbeddings(r, 256));
     }
 
     @Test

--- a/extended/src/test/java/apoc/ml/OpenAITestResultUtils.java
+++ b/extended/src/test/java/apoc/ml/OpenAITestResultUtils.java
@@ -15,12 +15,16 @@ public class OpenAITestResultUtils {
             ], $apiKey, $conf)
             """;
     public static final String COMPLETION_QUERY = "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)";
-    
+
     public static void assertEmbeddings(Map<String, Object> row) {
+        assertEmbeddings(row, 1536);
+    }
+    
+    public static void assertEmbeddings(Map<String, Object> row, int embeddingSize) {
         assertEquals(0L, row.get("index"));
         assertEquals("Some Text", row.get("text"));
         var embedding = (List<Double>) row.get("embedding");
-        assertEquals(1536, embedding.size());
+        assertEquals(embeddingSize, embedding.size());
     }
 
     public static void assertCompletion(Map<String, Object> row, String expectedModel) {


### PR DESCRIPTION
Fixes #3952

Added integration tests with default parameters 
and with custom embedding size by adding `dimensions: 256`to the configuration
