### PR TITLE
De-ignored tests which fail in dev (5.19.x) but not in 5.18.x

### DIFF
--- a/extended/src/test/java/apoc/custom/CypherProceduresClusterRoutingTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresClusterRoutingTest.java
@@ -63,7 +63,6 @@ public class CypherProceduresClusterRoutingTest {
 
 
     @Test
-    @Ignore
     public void testSetupAndDropCustomsWithUseSystemClause() {
 
         // create a custom procedure and function for each member

--- a/extended/src/test/java/apoc/cypher/CypherEnterpriseExtendedTest.java
+++ b/extended/src/test/java/apoc/cypher/CypherEnterpriseExtendedTest.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-@Ignore
 public class CypherEnterpriseExtendedTest {
     private static final String CREATE_RETURNQUERY_NODES = "UNWIND range(0,3) as id \n" +
                                                            "CREATE (n:ReturnQuery {id:id})-[:REL {idRel: id}]->(:Other {idOther: id})";

--- a/extended/src/test/java/apoc/cypher/CypherExtendedTest.java
+++ b/extended/src/test/java/apoc/cypher/CypherExtendedTest.java
@@ -49,7 +49,6 @@ import static org.neo4j.driver.internal.util.Iterables.count;
  * @since 08.05.16
  */
 
-@Ignore
 public class CypherExtendedTest {
     public static final String IMPORT_DIR = "src/test/resources";
     @ClassRule
@@ -468,6 +467,7 @@ public class CypherExtendedTest {
     }
 
     @Test
+    @Ignore("Fails due to https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/4015")
     public void testRunSchemaFileWithFailingStatement() {
         db.executeTransactionally("CREATE CONSTRAINT uniqueConstraint FOR (n:Person) REQUIRE n.name IS UNIQUE");
         String failingFile = "constraints.cypher";


### PR DESCRIPTION
De-ignored tests which fail in dev (5.19.x) but not in 5.18.x.

Created an issue to solve them in 5.19: https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/3998