### PR TITLE
Fix flaky CypherProceduresClusterRoutingTest

### DIFF
--- a/extended/src/test/java/apoc/custom/CypherProceduresClusterRoutingTest.java
+++ b/extended/src/test/java/apoc/custom/CypherProceduresClusterRoutingTest.java
@@ -94,13 +94,28 @@ public class CypherProceduresClusterRoutingTest {
                 .toList();
         for (Neo4jContainerExtension member : members) {
             Session session = member.getSession();
+            session.executeWrite(tx->tx.run("call db.clearQueryCaches()").consume());
 
             for (String name: customNames) {
-                assertEventually(() -> (long) singleResultFirstColumn(session, "CALL custom.%s".formatted(name)),
-                        (v) -> v == 42L, TIMEOUT, SECONDS);
+                assertEventually(() -> {
+                            try {
+                                long res = singleResultFirstColumn(session, "CALL custom.%s".formatted(name));
+                                return 42L == res;
+                            } catch (Exception e) {
+                                return false;
+                            }
+                        },
+                        (v) -> v, TIMEOUT, SECONDS);
 
-                assertEventually(() -> (long) singleResultFirstColumn(session, "RETURN custom.%s() AS answer".formatted(name)),
-                        (v) -> v == 42L, TIMEOUT, SECONDS);
+                assertEventually(() -> {
+                            try {
+                                long res = singleResultFirstColumn(session, "RETURN custom.%s() AS answer".formatted(name));
+                                return 42L == res;
+                            } catch (Exception e) {
+                                return false;
+                            }
+                        },
+                        (v) -> v, TIMEOUT, SECONDS);
             }
         }
 


### PR DESCRIPTION
To stabilize the test, added `db.clearQueryCaches()` before assertions, 
and improved assertEventually(..) with a try-catch which doesn't fail in case of procedure/function not found exception:

 https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/8021701219/job/21914372905?pr=3957#step:6:1371