### PR TITLE
Fixes #3964: Solve flaky mongodb test

### DIFF
--- a/extended/src/test/java/apoc/mongodb/MongoTestBase.java
+++ b/extended/src/test/java/apoc/mongodb/MongoTestBase.java
@@ -97,17 +97,20 @@ public class MongoTestBase {
 
     @Before
     public void before() {
-        numConnections = (long) getNumConnections(mongo, commands).get("current");
+        Map<String, Object> numConnectionsMap = getNumConnections(mongo, commands);
+        System.out.println("numConnectionsMap = " + numConnectionsMap);
+        numConnections = (long) numConnectionsMap.get("current");
     }
 
     @After
     public void after() {
         // the connections active before must be equal to the connections active after
         assertEventually(() -> {
-            long numConnectionsAfter = (long) getNumConnections(mongo, commands).get("current");
+            Map<String, Object> numConnectionsMap = getNumConnections(mongo, commands);
+            long numConnectionsAfter = (long) numConnectionsMap.get("current");
             return numConnections == numConnectionsAfter;
         },
-        v -> v, 10, TimeUnit.SECONDS);
+        v -> v, 30, TimeUnit.SECONDS);
     }
 
     public static void createContainer(boolean withAuth, MongoVersion mongoVersion) {


### PR DESCRIPTION
Fixes #3964

Now the problem seems not to be present anymore.
Hence, increased the timeout of the assertEventually and added the output of `db.serverStatus().connections` as a println, to check in case of potential future similar problems.