### PR TITLE
Fixes #4002: In case of the llm generates a wrong query, improve by sending the query with the error

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
@@ -335,6 +335,8 @@ RETURN m.title
 |===
 | name | description | mandatory
 | retries | The number of retries in case of API call failures | no, default `3`
+| retryWithError | If true, in case of error retry the api adding the following messages to the body request:
+{`"role":"user", "content": "The previous Cypher Statement throws the following error, consider it to return the correct statement: `<errorMessage>`"}, {"role":"assistant", "content":"Cypher Statement (in backticks):"}` | no, default `false`
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
 | model | The Open AI model | no, default `gpt-3.5-turbo`
 | sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number

--- a/extended/src/main/java/apoc/ml/Prompt.java
+++ b/extended/src/main/java/apoc/ml/Prompt.java
@@ -109,7 +109,7 @@ public class Prompt {
         String schema = loadSchema(tx, conf);
         
         String schemaExplanation = prompt("Please explain the graph database schema to me and relate it to well known concepts and domains.",
-                FROM_CYPHER_PROMPT, "This database schema ", schema, conf);
+                FROM_CYPHER_PROMPT, "This database schema ", schema, conf, List.of());
         return Stream.of(new StringResult(schemaExplanation));
     }
     

--- a/extended/src/main/java/apoc/ml/Prompt.java
+++ b/extended/src/main/java/apoc/ml/Prompt.java
@@ -3,8 +3,11 @@ package apoc.ml;
 import apoc.ApocConfig;
 import apoc.Extended;
 import apoc.result.StringResult;
+import apoc.util.Util;
+import apoc.util.collection.Iterators;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.jetbrains.annotations.NotNull;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.security.URLAccessChecker;
@@ -30,6 +33,8 @@ public class Prompt {
 
     @Context
     public Transaction tx;
+    @Context
+    public GraphDatabaseService db;
     @Context
     public Log log;
     @Context
@@ -115,25 +120,44 @@ public class Prompt {
         String schema = loadSchema(tx, conf);
         String query = "";
         long retries = (long) conf.getOrDefault("retries", 3L);
+        boolean retryWithError = Util.toBoolean(conf.get("retryWithError"));
         boolean containsField = procedureCallContext
                 .outputFields()
                 .collect(Collectors.toSet())
                 .contains("query");
+        
+        List<Map<String,String>> otherPrompts = new ArrayList<>();
+        
         do {
-            try {
-                QueryResult queryResult = tryQuery(question, conf, schema);
+            try(var transaction = db.beginTx()) {
+                QueryResult queryResult = tryQuery(question, conf, schema, otherPrompts);
                 query = queryResult.query;
                 // just let it fail so that retries can work if (queryResult.query.isBlank()) return Stream.empty();
                 /*
                 if (queryResult.hasError())
                     throw new QueryExecutionException(queryResult.error, null, queryResult.type);
                  */
-                return tx.execute(queryResult.query)
+                List<Map<String, Object>> maps = Iterators.asList(transaction.execute(queryResult.query));
+                transaction.commit();
+                Stream<PromptMapResult> mapResultStream = maps
                         .stream()
                         .map(row -> containsField ? new PromptMapResult(row, queryResult.query) : new PromptMapResult(row));
+                return mapResultStream;
             } catch (QueryExecutionException quee) {
                 if (log.isDebugEnabled())
                     log.debug("Generated query for question %s\n%s\nfailed with %s".formatted(question, query, quee.getMessage()));
+
+                if (retryWithError) {
+                    otherPrompts.addAll(
+                            List.of(
+                                    Map.of("role", "user",
+                                            "content", "The previous Cypher Statement throws the following error, consider it to return the correct statement: `%s`".formatted(quee.getMessage())),
+                                    Map.of("role", "assistant",
+                                            "content", "Cypher Statement (in backticks):")
+                            )
+                    );
+                }
+
                 retries--;
                 if (retries <= 0) throw quee;
             }
@@ -143,7 +167,7 @@ public class Prompt {
     @Procedure
     public Stream<StringResult> schema(@Name(value = "conf", defaultValue = "{}") Map<String, Object> conf) throws MalformedURLException, JsonProcessingException {
         String schemaExplanation = prompt("Please explain the graph database schema to me and relate it to well known concepts and domains.",
-                EXPLAIN_SCHEMA_PROMPT, "This database schema ", loadSchema(tx, conf), conf);
+                EXPLAIN_SCHEMA_PROMPT, "This database schema ", loadSchema(tx, conf), conf, List.of());
         return Stream.of(new StringResult(schemaExplanation));
     }
 
@@ -152,14 +176,14 @@ public class Prompt {
                                       @Name(value = "conf", defaultValue = "{}") Map<String, Object> conf) {
         String schema = loadSchema(tx, conf);
         long count = (long) conf.getOrDefault("count", 1L);
-        return LongStream.rangeClosed(1, count).mapToObj(i -> tryQuery(question, conf, schema));
+        return LongStream.rangeClosed(1, count).mapToObj(i -> tryQuery(question, conf, schema, List.of()));
     }
 
     @NotNull
-    private QueryResult tryQuery(String question, Map<String, Object> conf, String schema) {
+    private QueryResult tryQuery(String question, Map<String, Object> conf, String schema, List<Map<String,String>> otherPrompts) {
         String query = "";
         try {
-            query = prompt(question, SYSTEM_PROMPT, "Cypher Statement (in backticks):", schema, conf);
+            query = prompt(question, SYSTEM_PROMPT, "Cypher Statement (in backticks):", schema, conf, otherPrompts);
             // doesn't work right now, fails with security context error
             // tx.execute("EXPLAIN " + query).close(); // TODO query plan / estimated rows?
             return new QueryResult(query, null, null);
@@ -170,13 +194,15 @@ public class Prompt {
         }
     }
 
-    @NotNull
-    private String prompt(String userQuestion, String systemPrompt, String assistantPrompt, String schema, Map<String, Object> conf) throws JsonProcessingException, MalformedURLException {
+    private String prompt(String userQuestion, String systemPrompt, String assistantPrompt, String schema, Map<String, Object> conf, List<Map<String,String>> otherPrompts) throws JsonProcessingException, MalformedURLException {
         List<Map<String, String>> prompt = new ArrayList<>();
         if (systemPrompt != null && !systemPrompt.isBlank()) prompt.add(Map.of("role", "system", "content", systemPrompt));
         if (schema != null && !schema.isBlank()) prompt.add(Map.of("role", "system", "content", "The graph database schema consists of these elements\n" + schema));
         if (userQuestion != null && !userQuestion.isBlank()) prompt.add(Map.of("role", "user", "content", userQuestion));
         if (assistantPrompt != null && !assistantPrompt.isBlank()) prompt.add(Map.of("role", "assistant", "content", assistantPrompt));
+
+        prompt.addAll(otherPrompts);
+        
         String apiKey = (String) conf.get("apiKey");
         String model = (String) conf.getOrDefault("model", "gpt-3.5-turbo");
         String result = OpenAI.executeRequest(apiKey, Map.of(), "chat/completions",

--- a/extended/src/test/java/apoc/ml/PromptIT.java
+++ b/extended/src/test/java/apoc/ml/PromptIT.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;

--- a/extended/src/test/java/apoc/ml/PromptIT.java
+++ b/extended/src/test/java/apoc/ml/PromptIT.java
@@ -5,6 +5,7 @@ import apoc.meta.Meta;
 import apoc.text.Strings;
 import apoc.util.TestUtil;
 import apoc.util.Util;
+import apoc.util.collection.Iterators;
 import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.Assume;
@@ -19,10 +20,13 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Stream;
 
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 public class PromptIT {
 
@@ -65,6 +69,23 @@ public class PromptIT {
                                     .map(Object::toString)
                                     .map(String::trim))
                             .isNotEmpty();
+                });
+    }
+
+    @Test
+    public void testQueryUsingRetryWithError() {
+        testResult(db, """
+                CALL apoc.ml.query($query, {retries: $retries, apiKey: $apiKey, retryWithError: true})
+                """,
+                Map.of(
+                        "query", UUID.randomUUID().toString(),
+                        "retries", 10L,
+                        "apiKey", OPENAI_KEY
+                ),
+                (r) -> {
+                    // check that it returns a Cypher result, also empty, without errors
+                    List<Map<String, Object>> maps = Iterators.asList(r);
+                    assertNotNull(maps);
                 });
     }
 


### PR DESCRIPTION
Fixes #4002

- In case of error, add the error messages in the `otherPrompts` list

### Bug fix

- Used `transaction.execute` via `var transaction = db.beginTx()` instead of `tx.execute`, since the latter throws an error `The transaction has been terminated. Retry your operation in a new transaction, and you should see a successful result.`, in case of retried prompt.