### PR TITLE
[3f8zK8nS] Upgrade hadoop from 3.3.6 to 3.4.0 to mitigate multiple vulnerabilities

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -640,6 +640,7 @@ Apache-2.0
 
 ------------------------------------------------------------------------------
 BSD-2-Clause
+  jline-3.22.0.jar
   jsch-0.1.55.jar
   stax2-api-4.2.1.jar
   zstd-jni-1.5.0-4.jar
@@ -774,6 +775,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 Common Development and Distribution License Version 1.1
+  codemodel-2.6.jar
   jaxb-api-2.3.0.jar
   jaxb-impl-2.2.3-1.jar
   jersey-client-1.19.4.jar

--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -5,7 +5,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 ------------------------------------------------------------------------------
 Apache-2.0
   FastInfoset-1.2.16.jar
-  HikariCP-java7-2.4.12.jar
+  HikariCP-4.0.3.jar
   RoaringBitmap-0.7.17.jar
   WMI4Java-1.6.3.jar
   accessors-smart-2.5.0.jar
@@ -16,8 +16,8 @@ Apache-2.0
   arrow-memory-netty-12.0.1.jar
   arrow-vector-12.0.1.jar
   assertj-core-3.18.1.jar
-  audience-annotations-0.5.0.jar
-  avro-1.7.7.jar
+  audience-annotations-0.12.0.jar
+  avro-1.9.2.jar
   awaitility-4.1.0.jar
   aws-java-sdk-core-1.12.646.jar
   aws-java-sdk-kms-1.12.646.jar
@@ -27,7 +27,7 @@ Apache-2.0
   caffeine-3.0.3.jar
   cassandra-driver-core-3.10.0.jar
   commons-beanutils-1.9.4.jar
-  commons-cli-1.2.jar
+  commons-cli-1.5.0.jar
   commons-codec-1.16.1.jar
   commons-collections-3.2.2.jar
   commons-collections4-4.4.jar
@@ -38,9 +38,9 @@ Apache-2.0
   commons-daemon-1.0.13.jar
   commons-io-2.15.1.jar
   commons-io-2.9.0.jar
+  commons-lang-2.6.jar
   commons-lang3-3.14.0.jar
   commons-logging-1.2.jar
-  commons-math3-3.1.1.jar
   commons-math3-3.6.1.jar
   commons-net-3.9.0.jar
   commons-text-1.10.0.jar
@@ -58,36 +58,36 @@ Apache-2.0
   geronimo-jcache_1.0_spec-1.0-alpha-1.jar
   gson-2.9.0.jar
   guava-32.0.1-jre.jar
-  guice-4.0.jar
-  guice-servlet-4.0.jar
-  hadoop-annotations-3.3.6.jar
-  hadoop-auth-3.3.6.jar
-  hadoop-common-3.3.6-tests.jar
-  hadoop-common-3.3.6.jar
-  hadoop-hdfs-3.3.6-tests.jar
-  hadoop-hdfs-3.3.6.jar
-  hadoop-hdfs-client-3.3.6.jar
-  hadoop-mapreduce-client-app-3.3.6.jar
-  hadoop-mapreduce-client-common-3.3.6.jar
-  hadoop-mapreduce-client-core-3.3.6.jar
-  hadoop-mapreduce-client-hs-3.3.6.jar
-  hadoop-mapreduce-client-jobclient-3.3.6-tests.jar
-  hadoop-mapreduce-client-jobclient-3.3.6.jar
-  hadoop-mapreduce-client-shuffle-3.3.6.jar
-  hadoop-minicluster-3.3.6.jar
-  hadoop-registry-3.3.6.jar
-  hadoop-shaded-guava-1.1.1.jar
-  hadoop-shaded-protobuf_3_7-1.1.1.jar
-  hadoop-yarn-api-3.3.6.jar
-  hadoop-yarn-client-3.3.6.jar
-  hadoop-yarn-common-3.3.6.jar
-  hadoop-yarn-server-applicationhistoryservice-3.3.6.jar
-  hadoop-yarn-server-common-3.3.6.jar
-  hadoop-yarn-server-nodemanager-3.3.6.jar
-  hadoop-yarn-server-resourcemanager-3.3.6.jar
-  hadoop-yarn-server-tests-3.3.6-tests.jar
-  hadoop-yarn-server-timelineservice-3.3.6.jar
-  hadoop-yarn-server-web-proxy-3.3.6.jar
+  guice-4.2.3.jar
+  guice-servlet-4.2.3.jar
+  hadoop-annotations-3.4.0.jar
+  hadoop-auth-3.4.0.jar
+  hadoop-common-3.4.0-tests.jar
+  hadoop-common-3.4.0.jar
+  hadoop-hdfs-3.4.0-tests.jar
+  hadoop-hdfs-3.4.0.jar
+  hadoop-hdfs-client-3.4.0.jar
+  hadoop-mapreduce-client-app-3.4.0.jar
+  hadoop-mapreduce-client-common-3.4.0.jar
+  hadoop-mapreduce-client-core-3.4.0.jar
+  hadoop-mapreduce-client-hs-3.4.0.jar
+  hadoop-mapreduce-client-jobclient-3.4.0-tests.jar
+  hadoop-mapreduce-client-jobclient-3.4.0.jar
+  hadoop-mapreduce-client-shuffle-3.4.0.jar
+  hadoop-minicluster-3.4.0.jar
+  hadoop-registry-3.4.0.jar
+  hadoop-shaded-guava-1.2.0.jar
+  hadoop-shaded-protobuf_3_21-1.2.0.jar
+  hadoop-yarn-api-3.4.0.jar
+  hadoop-yarn-client-3.4.0.jar
+  hadoop-yarn-common-3.4.0.jar
+  hadoop-yarn-server-applicationhistoryservice-3.4.0.jar
+  hadoop-yarn-server-common-3.4.0.jar
+  hadoop-yarn-server-nodemanager-3.4.0.jar
+  hadoop-yarn-server-resourcemanager-3.4.0.jar
+  hadoop-yarn-server-tests-3.4.0-tests.jar
+  hadoop-yarn-server-timelineservice-3.4.0.jar
+  hadoop-yarn-server-web-proxy-3.4.0.jar
   httpclient-4.5.13.jar
   httpcore-4.4.13.jar
   ipaddress-5.3.3.jar
@@ -96,7 +96,6 @@ Apache-2.0
   jProcesses-1.6.5.jar
   jackson-annotations-2.15.2.jar
   jackson-core-2.15.2.jar
-  jackson-core-asl-1.9.13.jar
   jackson-databind-2.15.2.jar
   jackson-dataformat-cbor-2.15.2.jar
   jackson-dataformat-csv-2.15.2.jar
@@ -104,15 +103,13 @@ Apache-2.0
   jackson-datatype-jsr310-2.15.2.jar
   jackson-jaxrs-base-2.15.2.jar
   jackson-jaxrs-json-provider-2.15.2.jar
-  jackson-mapper-asl-1.9.13.jar
   jackson-module-jaxb-annotations-2.15.2.jar
   jakarta.validation-api-2.0.2.jar
   jamm-0.3.3.jar
-  java-util-1.9.0.jar
   javapoet-1.13.0.jar
   javassist-3.25.0-GA.jar
-  javax-websocket-client-impl-9.4.51.v20230217.jar
-  javax-websocket-server-impl-9.4.51.v20230217.jar
+  javax-websocket-client-impl-9.4.53.v20231009.jar
+  javax-websocket-server-impl-9.4.53.v20231009.jar
   javax.inject-1.jar
   jcip-annotations-1.0-1.jar
   jctools-core-3.3.0.jar
@@ -133,28 +130,25 @@ Apache-2.0
   jnr-constants-0.9.9.jar
   jnr-ffi-2.1.7.jar
   joda-time-2.8.1.jar
-  json-io-2.5.1.jar
   json-path-2.9.0.jar
   json-smart-2.5.0.jar
+  jsonschema2pojo-core-1.0.2.jar
   jsr305-3.0.2.jar
-  kerb-admin-1.0.1.jar
-  kerb-client-1.0.1.jar
-  kerb-common-1.0.1.jar
-  kerb-core-1.0.1.jar
-  kerb-crypto-1.0.1.jar
-  kerb-identity-1.0.1.jar
-  kerb-server-1.0.1.jar
-  kerb-simplekdc-1.0.1.jar
-  kerb-util-1.0.1.jar
-  kerby-asn1-1.0.1.jar
-  kerby-config-1.0.1.jar
-  kerby-pkix-1.0.1.jar
-  kerby-util-1.0.1.jar
-  kerby-xdr-1.0.1.jar
-  kotlin-stdlib-1.4.10.jar
-  kotlin-stdlib-common-1.4.10.jar
+  kerb-admin-2.0.3.jar
+  kerb-client-2.0.3.jar
+  kerb-common-2.0.3.jar
+  kerb-core-2.0.3.jar
+  kerb-crypto-2.0.3.jar
+  kerb-identity-2.0.3.jar
+  kerb-server-2.0.3.jar
+  kerb-simplekdc-2.0.3.jar
+  kerb-util-2.0.3.jar
+  kerby-asn1-2.0.3.jar
+  kerby-config-2.0.3.jar
+  kerby-pkix-2.0.3.jar
+  kerby-util-2.0.3.jar
+  kerby-xdr-2.0.3.jar
   listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-  log4j-1.2.17.jar
   log4j-api-2.17.1.jar
   log4j-core-2.17.1.jar
   lucene-analyzers-common-8.11.2.jar
@@ -164,46 +158,43 @@ Apache-2.0
   magnolia_2.12-0.17.0.jar
   mercator_2.12-0.2.1.jar
   metrics-core-3.2.4.jar
-  netty-3.10.6.Final.jar
-  netty-all-4.1.89.Final.jar
+  netty-all-4.1.100.Final.jar
   netty-buffer-4.1.100.Final.jar
   netty-codec-4.1.100.Final.jar
-  netty-codec-dns-4.1.89.Final.jar
-  netty-codec-haproxy-4.1.89.Final.jar
+  netty-codec-dns-4.1.100.Final.jar
+  netty-codec-haproxy-4.1.100.Final.jar
   netty-codec-http-4.1.100.Final.jar
-  netty-codec-http2-4.1.89.Final.jar
-  netty-codec-memcache-4.1.89.Final.jar
-  netty-codec-mqtt-4.1.89.Final.jar
-  netty-codec-redis-4.1.89.Final.jar
-  netty-codec-smtp-4.1.89.Final.jar
-  netty-codec-socks-4.1.89.Final.jar
-  netty-codec-stomp-4.1.89.Final.jar
-  netty-codec-xml-4.1.89.Final.jar
+  netty-codec-http2-4.1.100.Final.jar
+  netty-codec-memcache-4.1.100.Final.jar
+  netty-codec-mqtt-4.1.100.Final.jar
+  netty-codec-redis-4.1.100.Final.jar
+  netty-codec-smtp-4.1.100.Final.jar
+  netty-codec-socks-4.1.100.Final.jar
+  netty-codec-stomp-4.1.100.Final.jar
+  netty-codec-xml-4.1.100.Final.jar
   netty-common-4.1.100.Final.jar
   netty-handler-4.1.100.Final.jar
-  netty-handler-proxy-4.1.89.Final.jar
-  netty-handler-ssl-ocsp-4.1.89.Final.jar
+  netty-handler-proxy-4.1.100.Final.jar
+  netty-handler-ssl-ocsp-4.1.100.Final.jar
   netty-resolver-4.1.100.Final.jar
-  netty-resolver-dns-4.1.89.Final.jar
-  netty-resolver-dns-classes-macos-4.1.89.Final.jar
-  netty-resolver-dns-native-macos-4.1.89.Final-osx-aarch_64.jar
-  netty-resolver-dns-native-macos-4.1.89.Final-osx-x86_64.jar
+  netty-resolver-dns-4.1.100.Final.jar
+  netty-resolver-dns-classes-macos-4.1.100.Final.jar
+  netty-resolver-dns-native-macos-4.1.100.Final-osx-aarch_64.jar
+  netty-resolver-dns-native-macos-4.1.100.Final-osx-x86_64.jar
   netty-transport-4.1.100.Final.jar
   netty-transport-classes-epoll-4.1.100.Final.jar
-  netty-transport-classes-kqueue-4.1.89.Final.jar
+  netty-transport-classes-kqueue-4.1.100.Final.jar
   netty-transport-native-epoll-4.1.100.Final-linux-aarch_64.jar
   netty-transport-native-epoll-4.1.100.Final-linux-x86_64.jar
   netty-transport-native-epoll-4.1.100.Final.jar
-  netty-transport-native-kqueue-4.1.89.Final-osx-aarch_64.jar
-  netty-transport-native-kqueue-4.1.89.Final-osx-x86_64.jar
+  netty-transport-native-kqueue-4.1.100.Final-osx-aarch_64.jar
+  netty-transport-native-kqueue-4.1.100.Final-osx-x86_64.jar
   netty-transport-native-unix-common-4.1.100.Final.jar
-  netty-transport-rxtx-4.1.89.Final.jar
-  netty-transport-sctp-4.1.89.Final.jar
-  netty-transport-udt-4.1.89.Final.jar
-  nimbus-jose-jwt-9.8.1.jar
+  netty-transport-rxtx-4.1.100.Final.jar
+  netty-transport-sctp-4.1.100.Final.jar
+  netty-transport-udt-4.1.100.Final.jar
+  nimbus-jose-jwt-9.31.jar
   objenesis-3.2.jar
-  okhttp-4.9.3.jar
-  okio-jvm-2.8.0.jar
   opencsv-5.7.1.jar
   opentest4j-1.2.0.jar
   parboiled-core-1.2.0.jar
@@ -222,18 +213,18 @@ Apache-2.0
   shiro-crypto-hash-1.13.0.jar
   shiro-event-1.13.0.jar
   shiro-lang-1.13.0.jar
-  snappy-java-1.1.8.2.jar
-  token-provider-1.0.1.jar
-  websocket-api-9.4.51.v20230217.jar
-  websocket-client-9.4.51.v20230217.jar
-  websocket-common-9.4.51.v20230217.jar
-  websocket-server-9.4.51.v20230217.jar
-  websocket-servlet-9.4.51.v20230217.jar
+  snappy-java-1.1.10.4.jar
+  token-provider-2.0.3.jar
+  websocket-api-9.4.53.v20231009.jar
+  websocket-client-9.4.53.v20231009.jar
+  websocket-common-9.4.53.v20231009.jar
+  websocket-server-9.4.53.v20231009.jar
+  websocket-servlet-9.4.53.v20231009.jar
   woodstox-core-5.4.0.jar
   xercesImpl-2.12.2.jar
   xml-apis-1.4.01.jar
-  zookeeper-3.6.3.jar
-  zookeeper-jute-3.6.3.jar
+  zookeeper-3.8.3.jar
+  zookeeper-jute-3.8.3.jar
 ------------------------------------------------------------------------------
 
                                  Apache License
@@ -649,11 +640,38 @@ Apache-2.0
 
 ------------------------------------------------------------------------------
 BSD-2-Clause
-  dnsjava-2.1.7.jar
-  jline-3.9.0.jar
   jsch-0.1.55.jar
   stax2-api-4.2.1.jar
   zstd-jni-1.5.0-4.jar
+------------------------------------------------------------------------------
+
+Copyright <year> <copyright holder>
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+	 this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+------------------------------------------------------------------------------
+BSD-2-Clause
+  dnsjava-3.4.0.jar
 ------------------------------------------------------------------------------
 
 Copyright <year> <copyright holder>
@@ -725,7 +743,6 @@ BSD-3-Clause
   hamcrest-2.2.jar
   hamcrest-core-1.3.jar
   leveldbjni-all-1.8.jar
-  paranamer-2.3.jar
   protobuf-java-2.5.0.jar
 ------------------------------------------------------------------------------
 
@@ -2100,6 +2117,217 @@ after the cause of action arose. Each party waives its rights to a jury trial
 in any resulting litigation.
 
 ------------------------------------------------------------------------------
+Eclipse Public License - v 1.0
+  logback-classic-1.2.10.jar
+  logback-core-1.2.10.jar
+------------------------------------------------------------------------------
+
+Eclipse Public License - v 1.0
+
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
+LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+     a) in the case of the initial Contributor, the initial code and
+     documentation distributed under this Agreement, and
+     b) in the case of each subsequent Contributor:
+          i) changes to the Program, and
+          ii) additions to the Program;
+
+where such changes and/or additions to the Program originate from and are
+distributed by that particular Contributor. A Contribution 'originates' from a
+Contributor if it was added to the Program by such Contributor itself or
+anyone acting on such Contributor's behalf. Contributions do not include
+additions to the Program which: (i) are separate modules of software
+distributed in conjunction with the Program under their own license agreement,
+and (ii) are not derivative works of the Program.
+"Contributor" means any person or entity that distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which are
+necessarily infringed by the use or sale of its Contribution alone or when
+combined with the Program.
+
+"Program" means the Contributions distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement,
+including all Contributors.
+
+2. GRANT OF RIGHTS
+
+     a) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free copyright license to
+     reproduce, prepare derivative works of, publicly display, publicly
+     perform, distribute and sublicense the Contribution of such Contributor,
+     if any, and such derivative works, in source code and object code form.
+
+     b) Subject to the terms of this Agreement, each Contributor hereby grants
+     Recipient a non-exclusive, worldwide, royalty-free patent license under
+     Licensed Patents to make, use, sell, offer to sell, import and otherwise
+     transfer the Contribution of such Contributor, if any, in source code and
+     object code form. This patent license shall apply to the combination of
+     the Contribution and the Program if, at the time the Contribution is
+     added by the Contributor, such addition of the Contribution causes such
+     combination to be covered by the Licensed Patents. The patent license
+     shall not apply to any other combinations which include the Contribution.
+     No hardware per se is licensed hereunder.
+
+     c) Recipient understands that although each Contributor grants the
+     licenses to its Contributions set forth herein, no assurances are
+     provided by any Contributor that the Program does not infringe the patent
+     or other intellectual property rights of any other entity. Each
+     Contributor disclaims any liability to Recipient for claims brought by
+     any other entity based on infringement of intellectual property rights or
+     otherwise. As a condition to exercising the rights and licenses granted
+     hereunder, each Recipient hereby assumes sole responsibility to secure
+     any other intellectual property rights needed, if any. For example, if a
+     third party patent license is required to allow Recipient to distribute
+     the Program, it is Recipient's responsibility to acquire that license
+     before distributing the Program.
+
+     d) Each Contributor represents that to its knowledge it has sufficient
+     copyright rights in its Contribution, if any, to grant the copyright
+     license set forth in this Agreement.
+
+3. REQUIREMENTS
+A Contributor may choose to distribute the Program in object code form under
+its own license agreement, provided that:
+
+     a) it complies with the terms and conditions of this Agreement; and
+
+     b) its license agreement:
+          i) effectively disclaims on behalf of all Contributors all
+          warranties and conditions, express and implied, including warranties
+          or conditions of title and non-infringement, and implied warranties
+          or conditions of merchantability and fitness for a particular
+          purpose;
+          ii) effectively excludes on behalf of all Contributors all liability
+          for damages, including direct, indirect, special, incidental and
+          consequential damages, such as lost profits;
+          iii) states that any provisions which differ from this Agreement are
+          offered by that Contributor alone and not by any other party; and
+          iv) states that source code for the Program is available from such
+          Contributor, and informs licensees how to obtain it in a reasonable
+          manner on or through a medium customarily used for software
+          exchange.
+
+When the Program is made available in source code form:
+
+     a) it must be made available under this Agreement; and
+
+     b) a copy of this Agreement must be included with each copy of the
+     Program.
+Contributors may not remove or alter any copyright notices contained within
+the Program.
+
+Each Contributor must identify itself as the originator of its Contribution,
+if any, in a manner that reasonably allows subsequent Recipients to identify
+the originator of the Contribution.
+
+4. COMMERCIAL DISTRIBUTION
+Commercial distributors of software may accept certain responsibilities with
+respect to end users, business partners and the like. While this license is
+intended to facilitate the commercial use of the Program, the Contributor who
+includes the Program in a commercial product offering should do so in a manner
+which does not create potential liability for other Contributors. Therefore,
+if a Contributor includes the Program in a commercial product offering, such
+Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+every other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits and
+other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such Commercial
+Contributor in connection with its distribution of the Program in a commercial
+product offering. The obligations in this section do not apply to any claims
+or Losses relating to any actual or alleged intellectual property
+infringement. In order to qualify, an Indemnified Contributor must: a)
+promptly notify the Commercial Contributor in writing of such claim, and b)
+allow the Commercial Contributor to control, and cooperate with the Commercial
+Contributor in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own expense.
+
+For example, a Contributor might include the Program in a commercial product
+offering, Product X. That Contributor is then a Commercial Contributor. If
+that Commercial Contributor then makes performance claims, or offers
+warranties related to Product X, those performance claims and warranties are
+such Commercial Contributor's responsibility alone. Under this section, the
+Commercial Contributor would have to defend claims against the other
+Contributors related to those performance claims and warranties, and if a
+court requires any other Contributor to pay any damages as a result, the
+Commercial Contributor must pay those damages.
+
+5. NO WARRANTY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+Recipient is solely responsible for determining the appropriateness of using
+and distributing the Program and assumes all risks associated with its
+exercise of rights under this Agreement , including but not limited to the
+risks and costs of program errors, compliance with applicable laws, damage to
+or loss of data, programs or equipment, and unavailability or interruption of
+operations.
+
+6. DISCLAIMER OF LIABILITY
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
+LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of the
+remainder of the terms of this Agreement, and without further action by the
+parties hereto, such provision shall be reformed to the minimum extent
+necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Program itself
+(excluding combinations of the Program with other software or hardware)
+infringes such Recipient's patent(s), then such Recipient's rights granted
+under Section 2(b) shall terminate as of the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it fails to
+comply with any of the material terms or conditions of this Agreement and does
+not cure such failure in a reasonable period of time after becoming aware of
+such noncompliance. If all Recipient's rights under this Agreement terminate,
+Recipient agrees to cease use and distribution of the Program as soon as
+reasonably practicable. However, Recipient's obligations under this Agreement
+and any licenses granted by Recipient relating to the Program shall continue
+and survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement, but in
+order to avoid inconsistency the Agreement is copyrighted and may only be
+modified in the following manner. The Agreement Steward reserves the right to
+publish new versions (including revisions) of this Agreement from time to
+time. No one other than the Agreement Steward has the right to modify this
+Agreement. The Eclipse Foundation is the initial Agreement Steward. The
+Eclipse Foundation may assign the responsibility to serve as the Agreement
+Steward to a suitable separate entity. Each new version of the Agreement will
+be given a distinguishing version number. The Program (including
+Contributions) may always be distributed subject to the version of the
+Agreement under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to distribute the Program
+(including its Contributions) under the new version. Except as expressly
+stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
+licenses to the intellectual property of any Contributor under this Agreement,
+whether expressly, by implication, estoppel or otherwise. All rights in the
+Program not expressly granted under this Agreement are reserved.
+
+This Agreement is governed by the laws of the State of New York and the
+intellectual property laws of the United States of America. No party to this
+Agreement will bring a legal action under this Agreement more than one year
+after the cause of action arose. Each party waives its rights to a jury trial
+in any resulting litigation.
+
+------------------------------------------------------------------------------
 Eclipse Public License - v 2.0
   hk2-api-2.6.1.jar
   hk2-locator-2.6.1.jar
@@ -2800,10 +3028,11 @@ and/or involve the use of third party software.
 
 ------------------------------------------------------------------------------
 MIT
-  bcpkix-jdk15on-1.68.jar
+  bcpkix-jdk15on-1.70.jar
   bcpkix-jdk18on-1.75.jar
-  bcprov-jdk15on-1.68.jar
+  bcprov-jdk15on-1.70.jar
   bcprov-jdk18on-1.75.jar
+  bcutil-jdk15on-1.70.jar
   bcutil-jdk18on-1.75.jar
   cassandra-1.17.6.jar
   checker-qual-3.33.0.jar
@@ -2827,7 +3056,6 @@ MIT
   reactive-streams-1.0.4.jar
   slf4j-api-1.7.36.jar
   slf4j-api-2.0.11.jar
-  slf4j-log4j12-1.7.25.jar
   slf4j-nop-1.7.30.jar
   slf4j-reload4j-1.7.36.jar
   testcontainers-1.17.6.jar

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -35,7 +35,7 @@ Apache License, 2.0
 
 Apache-2.0
   FastInfoset-1.2.16.jar
-  HikariCP-java7-2.4.12.jar
+  HikariCP-4.0.3.jar
   RoaringBitmap-0.7.17.jar
   WMI4Java-1.6.3.jar
   accessors-smart-2.5.0.jar
@@ -46,8 +46,8 @@ Apache-2.0
   arrow-memory-netty-12.0.1.jar
   arrow-vector-12.0.1.jar
   assertj-core-3.18.1.jar
-  audience-annotations-0.5.0.jar
-  avro-1.7.7.jar
+  audience-annotations-0.12.0.jar
+  avro-1.9.2.jar
   awaitility-4.1.0.jar
   aws-java-sdk-core-1.12.646.jar
   aws-java-sdk-kms-1.12.646.jar
@@ -57,7 +57,7 @@ Apache-2.0
   caffeine-3.0.3.jar
   cassandra-driver-core-3.10.0.jar
   commons-beanutils-1.9.4.jar
-  commons-cli-1.2.jar
+  commons-cli-1.5.0.jar
   commons-codec-1.16.1.jar
   commons-collections-3.2.2.jar
   commons-collections4-4.4.jar
@@ -68,9 +68,9 @@ Apache-2.0
   commons-daemon-1.0.13.jar
   commons-io-2.15.1.jar
   commons-io-2.9.0.jar
+  commons-lang-2.6.jar
   commons-lang3-3.14.0.jar
   commons-logging-1.2.jar
-  commons-math3-3.1.1.jar
   commons-math3-3.6.1.jar
   commons-net-3.9.0.jar
   commons-text-1.10.0.jar
@@ -88,36 +88,36 @@ Apache-2.0
   geronimo-jcache_1.0_spec-1.0-alpha-1.jar
   gson-2.9.0.jar
   guava-32.0.1-jre.jar
-  guice-4.0.jar
-  guice-servlet-4.0.jar
-  hadoop-annotations-3.3.6.jar
-  hadoop-auth-3.3.6.jar
-  hadoop-common-3.3.6-tests.jar
-  hadoop-common-3.3.6.jar
-  hadoop-hdfs-3.3.6-tests.jar
-  hadoop-hdfs-3.3.6.jar
-  hadoop-hdfs-client-3.3.6.jar
-  hadoop-mapreduce-client-app-3.3.6.jar
-  hadoop-mapreduce-client-common-3.3.6.jar
-  hadoop-mapreduce-client-core-3.3.6.jar
-  hadoop-mapreduce-client-hs-3.3.6.jar
-  hadoop-mapreduce-client-jobclient-3.3.6-tests.jar
-  hadoop-mapreduce-client-jobclient-3.3.6.jar
-  hadoop-mapreduce-client-shuffle-3.3.6.jar
-  hadoop-minicluster-3.3.6.jar
-  hadoop-registry-3.3.6.jar
-  hadoop-shaded-guava-1.1.1.jar
-  hadoop-shaded-protobuf_3_7-1.1.1.jar
-  hadoop-yarn-api-3.3.6.jar
-  hadoop-yarn-client-3.3.6.jar
-  hadoop-yarn-common-3.3.6.jar
-  hadoop-yarn-server-applicationhistoryservice-3.3.6.jar
-  hadoop-yarn-server-common-3.3.6.jar
-  hadoop-yarn-server-nodemanager-3.3.6.jar
-  hadoop-yarn-server-resourcemanager-3.3.6.jar
-  hadoop-yarn-server-tests-3.3.6-tests.jar
-  hadoop-yarn-server-timelineservice-3.3.6.jar
-  hadoop-yarn-server-web-proxy-3.3.6.jar
+  guice-4.2.3.jar
+  guice-servlet-4.2.3.jar
+  hadoop-annotations-3.4.0.jar
+  hadoop-auth-3.4.0.jar
+  hadoop-common-3.4.0-tests.jar
+  hadoop-common-3.4.0.jar
+  hadoop-hdfs-3.4.0-tests.jar
+  hadoop-hdfs-3.4.0.jar
+  hadoop-hdfs-client-3.4.0.jar
+  hadoop-mapreduce-client-app-3.4.0.jar
+  hadoop-mapreduce-client-common-3.4.0.jar
+  hadoop-mapreduce-client-core-3.4.0.jar
+  hadoop-mapreduce-client-hs-3.4.0.jar
+  hadoop-mapreduce-client-jobclient-3.4.0-tests.jar
+  hadoop-mapreduce-client-jobclient-3.4.0.jar
+  hadoop-mapreduce-client-shuffle-3.4.0.jar
+  hadoop-minicluster-3.4.0.jar
+  hadoop-registry-3.4.0.jar
+  hadoop-shaded-guava-1.2.0.jar
+  hadoop-shaded-protobuf_3_21-1.2.0.jar
+  hadoop-yarn-api-3.4.0.jar
+  hadoop-yarn-client-3.4.0.jar
+  hadoop-yarn-common-3.4.0.jar
+  hadoop-yarn-server-applicationhistoryservice-3.4.0.jar
+  hadoop-yarn-server-common-3.4.0.jar
+  hadoop-yarn-server-nodemanager-3.4.0.jar
+  hadoop-yarn-server-resourcemanager-3.4.0.jar
+  hadoop-yarn-server-tests-3.4.0-tests.jar
+  hadoop-yarn-server-timelineservice-3.4.0.jar
+  hadoop-yarn-server-web-proxy-3.4.0.jar
   httpclient-4.5.13.jar
   httpcore-4.4.13.jar
   ipaddress-5.3.3.jar
@@ -126,7 +126,6 @@ Apache-2.0
   jProcesses-1.6.5.jar
   jackson-annotations-2.15.2.jar
   jackson-core-2.15.2.jar
-  jackson-core-asl-1.9.13.jar
   jackson-databind-2.15.2.jar
   jackson-dataformat-cbor-2.15.2.jar
   jackson-dataformat-csv-2.15.2.jar
@@ -134,15 +133,13 @@ Apache-2.0
   jackson-datatype-jsr310-2.15.2.jar
   jackson-jaxrs-base-2.15.2.jar
   jackson-jaxrs-json-provider-2.15.2.jar
-  jackson-mapper-asl-1.9.13.jar
   jackson-module-jaxb-annotations-2.15.2.jar
   jakarta.validation-api-2.0.2.jar
   jamm-0.3.3.jar
-  java-util-1.9.0.jar
   javapoet-1.13.0.jar
   javassist-3.25.0-GA.jar
-  javax-websocket-client-impl-9.4.51.v20230217.jar
-  javax-websocket-server-impl-9.4.51.v20230217.jar
+  javax-websocket-client-impl-9.4.53.v20231009.jar
+  javax-websocket-server-impl-9.4.53.v20231009.jar
   javax.inject-1.jar
   jcip-annotations-1.0-1.jar
   jctools-core-3.3.0.jar
@@ -163,28 +160,25 @@ Apache-2.0
   jnr-constants-0.9.9.jar
   jnr-ffi-2.1.7.jar
   joda-time-2.8.1.jar
-  json-io-2.5.1.jar
   json-path-2.9.0.jar
   json-smart-2.5.0.jar
+  jsonschema2pojo-core-1.0.2.jar
   jsr305-3.0.2.jar
-  kerb-admin-1.0.1.jar
-  kerb-client-1.0.1.jar
-  kerb-common-1.0.1.jar
-  kerb-core-1.0.1.jar
-  kerb-crypto-1.0.1.jar
-  kerb-identity-1.0.1.jar
-  kerb-server-1.0.1.jar
-  kerb-simplekdc-1.0.1.jar
-  kerb-util-1.0.1.jar
-  kerby-asn1-1.0.1.jar
-  kerby-config-1.0.1.jar
-  kerby-pkix-1.0.1.jar
-  kerby-util-1.0.1.jar
-  kerby-xdr-1.0.1.jar
-  kotlin-stdlib-1.4.10.jar
-  kotlin-stdlib-common-1.4.10.jar
+  kerb-admin-2.0.3.jar
+  kerb-client-2.0.3.jar
+  kerb-common-2.0.3.jar
+  kerb-core-2.0.3.jar
+  kerb-crypto-2.0.3.jar
+  kerb-identity-2.0.3.jar
+  kerb-server-2.0.3.jar
+  kerb-simplekdc-2.0.3.jar
+  kerb-util-2.0.3.jar
+  kerby-asn1-2.0.3.jar
+  kerby-config-2.0.3.jar
+  kerby-pkix-2.0.3.jar
+  kerby-util-2.0.3.jar
+  kerby-xdr-2.0.3.jar
   listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar
-  log4j-1.2.17.jar
   log4j-api-2.17.1.jar
   log4j-core-2.17.1.jar
   lucene-analyzers-common-8.11.2.jar
@@ -194,46 +188,43 @@ Apache-2.0
   magnolia_2.12-0.17.0.jar
   mercator_2.12-0.2.1.jar
   metrics-core-3.2.4.jar
-  netty-3.10.6.Final.jar
-  netty-all-4.1.89.Final.jar
+  netty-all-4.1.100.Final.jar
   netty-buffer-4.1.100.Final.jar
   netty-codec-4.1.100.Final.jar
-  netty-codec-dns-4.1.89.Final.jar
-  netty-codec-haproxy-4.1.89.Final.jar
+  netty-codec-dns-4.1.100.Final.jar
+  netty-codec-haproxy-4.1.100.Final.jar
   netty-codec-http-4.1.100.Final.jar
-  netty-codec-http2-4.1.89.Final.jar
-  netty-codec-memcache-4.1.89.Final.jar
-  netty-codec-mqtt-4.1.89.Final.jar
-  netty-codec-redis-4.1.89.Final.jar
-  netty-codec-smtp-4.1.89.Final.jar
-  netty-codec-socks-4.1.89.Final.jar
-  netty-codec-stomp-4.1.89.Final.jar
-  netty-codec-xml-4.1.89.Final.jar
+  netty-codec-http2-4.1.100.Final.jar
+  netty-codec-memcache-4.1.100.Final.jar
+  netty-codec-mqtt-4.1.100.Final.jar
+  netty-codec-redis-4.1.100.Final.jar
+  netty-codec-smtp-4.1.100.Final.jar
+  netty-codec-socks-4.1.100.Final.jar
+  netty-codec-stomp-4.1.100.Final.jar
+  netty-codec-xml-4.1.100.Final.jar
   netty-common-4.1.100.Final.jar
   netty-handler-4.1.100.Final.jar
-  netty-handler-proxy-4.1.89.Final.jar
-  netty-handler-ssl-ocsp-4.1.89.Final.jar
+  netty-handler-proxy-4.1.100.Final.jar
+  netty-handler-ssl-ocsp-4.1.100.Final.jar
   netty-resolver-4.1.100.Final.jar
-  netty-resolver-dns-4.1.89.Final.jar
-  netty-resolver-dns-classes-macos-4.1.89.Final.jar
-  netty-resolver-dns-native-macos-4.1.89.Final-osx-aarch_64.jar
-  netty-resolver-dns-native-macos-4.1.89.Final-osx-x86_64.jar
+  netty-resolver-dns-4.1.100.Final.jar
+  netty-resolver-dns-classes-macos-4.1.100.Final.jar
+  netty-resolver-dns-native-macos-4.1.100.Final-osx-aarch_64.jar
+  netty-resolver-dns-native-macos-4.1.100.Final-osx-x86_64.jar
   netty-transport-4.1.100.Final.jar
   netty-transport-classes-epoll-4.1.100.Final.jar
-  netty-transport-classes-kqueue-4.1.89.Final.jar
+  netty-transport-classes-kqueue-4.1.100.Final.jar
   netty-transport-native-epoll-4.1.100.Final-linux-aarch_64.jar
   netty-transport-native-epoll-4.1.100.Final-linux-x86_64.jar
   netty-transport-native-epoll-4.1.100.Final.jar
-  netty-transport-native-kqueue-4.1.89.Final-osx-aarch_64.jar
-  netty-transport-native-kqueue-4.1.89.Final-osx-x86_64.jar
+  netty-transport-native-kqueue-4.1.100.Final-osx-aarch_64.jar
+  netty-transport-native-kqueue-4.1.100.Final-osx-x86_64.jar
   netty-transport-native-unix-common-4.1.100.Final.jar
-  netty-transport-rxtx-4.1.89.Final.jar
-  netty-transport-sctp-4.1.89.Final.jar
-  netty-transport-udt-4.1.89.Final.jar
-  nimbus-jose-jwt-9.8.1.jar
+  netty-transport-rxtx-4.1.100.Final.jar
+  netty-transport-sctp-4.1.100.Final.jar
+  netty-transport-udt-4.1.100.Final.jar
+  nimbus-jose-jwt-9.31.jar
   objenesis-3.2.jar
-  okhttp-4.9.3.jar
-  okio-jvm-2.8.0.jar
   opencsv-5.7.1.jar
   opentest4j-1.2.0.jar
   parboiled-core-1.2.0.jar
@@ -252,18 +243,18 @@ Apache-2.0
   shiro-crypto-hash-1.13.0.jar
   shiro-event-1.13.0.jar
   shiro-lang-1.13.0.jar
-  snappy-java-1.1.8.2.jar
-  token-provider-1.0.1.jar
-  websocket-api-9.4.51.v20230217.jar
-  websocket-client-9.4.51.v20230217.jar
-  websocket-common-9.4.51.v20230217.jar
-  websocket-server-9.4.51.v20230217.jar
-  websocket-servlet-9.4.51.v20230217.jar
+  snappy-java-1.1.10.4.jar
+  token-provider-2.0.3.jar
+  websocket-api-9.4.53.v20231009.jar
+  websocket-client-9.4.53.v20231009.jar
+  websocket-common-9.4.53.v20231009.jar
+  websocket-server-9.4.53.v20231009.jar
+  websocket-servlet-9.4.53.v20231009.jar
   woodstox-core-5.4.0.jar
   xercesImpl-2.12.2.jar
   xml-apis-1.4.01.jar
-  zookeeper-3.6.3.jar
-  zookeeper-jute-3.6.3.jar
+  zookeeper-3.8.3.jar
+  zookeeper-jute-3.8.3.jar
 
 Apache-2.0
   gradle-tooling-api-6.1.1.jar
@@ -275,11 +266,12 @@ BSD 2-Clause
   jersey-hk2-2.34.jar
 
 BSD-2-Clause
-  dnsjava-2.1.7.jar
-  jline-3.9.0.jar
   jsch-0.1.55.jar
   stax2-api-4.2.1.jar
   zstd-jni-1.5.0-4.jar
+
+BSD-2-Clause
+  dnsjava-3.4.0.jar
 
 BSD-3-Clause
   ST4-4.1.jar
@@ -297,7 +289,6 @@ BSD-3-Clause
   hamcrest-2.2.jar
   hamcrest-core-1.3.jar
   leveldbjni-all-1.8.jar
-  paranamer-2.3.jar
   protobuf-java-2.5.0.jar
 
 Common Development and Distribution License Version 1.1
@@ -337,8 +328,8 @@ Eclipse Distribution License - v 1.0
   txw2-2.3.2.jar
 
 Eclipse Public License - Version 1.0
-  javax-websocket-client-impl-9.4.51.v20230217.jar
-  javax-websocket-server-impl-9.4.51.v20230217.jar
+  javax-websocket-client-impl-9.4.53.v20231009.jar
+  javax-websocket-server-impl-9.4.53.v20231009.jar
   jetty-http-9.4.53.v20231009.jar
   jetty-io-9.4.53.v20231009.jar
   jetty-security-9.4.53.v20231009.jar
@@ -348,17 +339,21 @@ Eclipse Public License - Version 1.0
   jetty-util-ajax-9.4.53.v20231009.jar
   jetty-webapp-9.4.53.v20231009.jar
   jetty-xml-9.4.53.v20231009.jar
-  websocket-api-9.4.51.v20230217.jar
-  websocket-client-9.4.51.v20230217.jar
-  websocket-common-9.4.51.v20230217.jar
-  websocket-server-9.4.51.v20230217.jar
-  websocket-servlet-9.4.51.v20230217.jar
+  websocket-api-9.4.53.v20231009.jar
+  websocket-client-9.4.53.v20231009.jar
+  websocket-common-9.4.53.v20231009.jar
+  websocket-server-9.4.53.v20231009.jar
+  websocket-servlet-9.4.53.v20231009.jar
 
 Eclipse Public License - v 1.0
   eclipse-collections-10.4.0.jar
   eclipse-collections-api-10.4.0.jar
   junit-4.13.2.jar
   schemacrawler-15.04.01.jar
+
+Eclipse Public License - v 1.0
+  logback-classic-1.2.10.jar
+  logback-core-1.2.10.jar
 
 Eclipse Public License - v 2.0
   hk2-api-2.6.1.jar
@@ -390,6 +385,10 @@ GNU General Public License (GPL), version 2, with the Classpath exception
 
 GNU Lesser General Public License
   schemacrawler-15.04.01.jar
+
+GNU Lesser General Public License
+  logback-classic-1.2.10.jar
+  logback-core-1.2.10.jar
 
 GNU Lesser General Public License Version 2.1
   jnr-posix-3.0.44.jar
@@ -429,10 +428,11 @@ LGPL-2.1-or-later
   jna-5.9.0.jar
 
 MIT
-  bcpkix-jdk15on-1.68.jar
+  bcpkix-jdk15on-1.70.jar
   bcpkix-jdk18on-1.75.jar
-  bcprov-jdk15on-1.68.jar
+  bcprov-jdk15on-1.70.jar
   bcprov-jdk18on-1.75.jar
+  bcutil-jdk15on-1.70.jar
   bcutil-jdk18on-1.75.jar
   cassandra-1.17.6.jar
   checker-qual-3.33.0.jar
@@ -456,7 +456,6 @@ MIT
   reactive-streams-1.0.4.jar
   slf4j-api-1.7.36.jar
   slf4j-api-2.0.11.jar
-  slf4j-log4j12-1.7.25.jar
   slf4j-nop-1.7.30.jar
   slf4j-reload4j-1.7.36.jar
   testcontainers-1.17.6.jar

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -266,6 +266,7 @@ BSD 2-Clause
   jersey-hk2-2.34.jar
 
 BSD-2-Clause
+  jline-3.22.0.jar
   jsch-0.1.55.jar
   stax2-api-4.2.1.jar
   zstd-jni-1.5.0-4.jar
@@ -292,6 +293,7 @@ BSD-3-Clause
   protobuf-java-2.5.0.jar
 
 Common Development and Distribution License Version 1.1
+  codemodel-2.6.jar
   jaxb-api-2.3.0.jar
   jaxb-impl-2.2.3-1.jar
   jersey-client-1.19.4.jar

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -93,6 +93,12 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
     }
 
+    // The following dependencies needs to be excluded because they do not have licenses which we are allowed to include
+    def withoutLicenseViolations = {
+        exclude group: 'com.sun.codemodel'
+        exclude group: 'org.jline'
+    }
+
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
 
     testImplementation 'org.mock-server:mockserver-netty:5.15.0'
@@ -107,10 +113,10 @@ dependencies {
 
     testImplementation group: 'org.apache.hive', name: 'hive-jdbc', version: '1.2.2', withoutServers
 
-    compileOnly group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.6', withoutServers
+    compileOnly group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.4.0', withoutServers
     // If updated check if the transitive dependency to javax.servlet.jsp:jsp-api:2.1 has also updated
     // and remove the manual licensing check for it in licenses-3rdparties.gradle
-    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.6', withoutServers
+    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.0', withoutServers.andThen(withoutLicenseViolations)
 
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     // explicit update comomns.io version

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -93,12 +93,6 @@ dependencies {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
     }
 
-    // The following dependencies needs to be excluded because they do not have licenses which we are allowed to include
-    def withoutLicenseViolations = {
-        exclude group: 'com.sun.codemodel'
-        exclude group: 'org.jline'
-    }
-
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
 
     testImplementation 'org.mock-server:mockserver-netty:5.15.0'
@@ -116,7 +110,7 @@ dependencies {
     compileOnly group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.4.0', withoutServers
     // If updated check if the transitive dependency to javax.servlet.jsp:jsp-api:2.1 has also updated
     // and remove the manual licensing check for it in licenses-3rdparties.gradle
-    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.0', withoutServers.andThen(withoutLicenseViolations)
+    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.0', withoutServers
 
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
     // explicit update comomns.io version

--- a/extra-dependencies/hadoop/build.gradle
+++ b/extra-dependencies/hadoop/build.gradle
@@ -37,17 +37,11 @@ def commonExclusions = {
     exclude group: 'com.google.guava', module: 'guava'
 }
 
-// The following dependencies needs to be excluded because they do not have licenses which we are allowed to include
-def withoutLicenseViolations = {
-    exclude group: 'com.sun.codemodel'
-    exclude group: 'org.jline'
-}
-
 dependencies {
     implementation group: 'org.apache.hadoop', name: 'hadoop-hdfs-client', version: '3.4.0', commonExclusions
     // If updated check if the transitive dependency to javax.servlet.jsp:jsp-api:2.1 has also updated
     // and remove the manual licensing check for it in licenses-3rdparties.gradle
-    implementation group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.0', commonExclusions.andThen(withoutLicenseViolations)
+    implementation group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.0', commonExclusions
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.23.1', commonExclusions
 }
 

--- a/extra-dependencies/hadoop/build.gradle
+++ b/extra-dependencies/hadoop/build.gradle
@@ -37,11 +37,17 @@ def commonExclusions = {
     exclude group: 'com.google.guava', module: 'guava'
 }
 
+// The following dependencies needs to be excluded because they do not have licenses which we are allowed to include
+def withoutLicenseViolations = {
+    exclude group: 'com.sun.codemodel'
+    exclude group: 'org.jline'
+}
+
 dependencies {
-    implementation group: 'org.apache.hadoop', name: 'hadoop-hdfs-client', version: '3.3.6', commonExclusions
+    implementation group: 'org.apache.hadoop', name: 'hadoop-hdfs-client', version: '3.4.0', commonExclusions
     // If updated check if the transitive dependency to javax.servlet.jsp:jsp-api:2.1 has also updated
     // and remove the manual licensing check for it in licenses-3rdparties.gradle
-    implementation group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.6', commonExclusions
+    implementation group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.0', commonExclusions.andThen(withoutLicenseViolations)
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.23.1', commonExclusions
 }
 

--- a/licenses-3rdparties.gradle
+++ b/licenses-3rdparties.gradle
@@ -118,6 +118,8 @@ downloadLicenses {
                     'javax.servlet.jsp:jsp-api:2.1' : license('Common Development and Distribution License Version 1.1', null),
                     'org.antlr:ST4:4.1' : license('BSD-3-Clause', null),
                     'org.gradle:gradle-tooling-api:6.1.1' : license('Apache-2.0', null),
+                    'org.jline:jline:3.22.0' : license('BSD-2-Clause', 'http://opensource.org/licenses/BSD-2-Clause'),
+                    'com.sun.codemodel:codemodel:2.6' : license('Common Development and Distribution License Version 1.1', null),
     ]
     aliases = allowList.collectEntries { lic ->
         def actual = license(lic.name, lic.url)

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -21,17 +21,11 @@ dependencies {
         exclude group: 'org.apache.hive', module: 'hive-service'
     }
 
-    // The following dependencies needs to be excluded because they do not have licenses which we are allowed to include
-    def withoutLicenseViolations = {
-        exclude group: 'com.sun.codemodel'
-        exclude group: 'org.jline'
-    }
-
     api group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.4.0', withoutServers
     // If updated check if the transitive dependency to javax.servlet.jsp:jsp-api:2.1 has also updated
     // and remove the manual licensing check for it in licenses-3rdparties.gradle
-    api group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.0', withoutServers.andThen(withoutLicenseViolations)
-    api group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.4.0', withoutServers.andThen(withoutLicenseViolations)
+    api group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.0', withoutServers
+    api group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.4.0', withoutServers
 
     api group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.4.14'
     api group: 'org.jetbrains', name: 'annotations', version: "17.0.0"

--- a/test-utils/build.gradle
+++ b/test-utils/build.gradle
@@ -21,11 +21,17 @@ dependencies {
         exclude group: 'org.apache.hive', module: 'hive-service'
     }
 
-    api group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.3.6', withoutServers
+    // The following dependencies needs to be excluded because they do not have licenses which we are allowed to include
+    def withoutLicenseViolations = {
+        exclude group: 'com.sun.codemodel'
+        exclude group: 'org.jline'
+    }
+
+    api group: 'org.apache.hadoop', name: 'hadoop-hdfs', version: '3.4.0', withoutServers
     // If updated check if the transitive dependency to javax.servlet.jsp:jsp-api:2.1 has also updated
     // and remove the manual licensing check for it in licenses-3rdparties.gradle
-    api group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.6', withoutServers
-    api group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.3.6', withoutServers
+    api group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.0', withoutServers.andThen(withoutLicenseViolations)
+    api group: 'org.apache.hadoop', name: 'hadoop-minicluster', version: '3.4.0', withoutServers.andThen(withoutLicenseViolations)
 
     api group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '4.4.14'
     api group: 'org.jetbrains', name: 'annotations', version: "17.0.0"


### PR DESCRIPTION
This PR will mitigate the following vulnerabilities:

CVE 2019-10172 (high)
CVE-2019-10202 (critical)
CVE-2019-16869 (medium)
CVE-2019-17571 (critical)
CVE-2020-9488 (low)
CVE-2020-29582 (low)
CVE-2021-4104 (medium)
CVE-2022-23302 (high)
CVE-2022-23305 (high)
CVE-2022-23307 (high)
CVE-2022-24329 (medium)
CVE-2023-3635 (medium)
CVE-2023-26464 (medium)
CVE-2023-34453 (medium)
CVE-2023-34454 (medium)
CVE-2023-34455 (high)
CVE-2023-34462 (medium)
CVE-2023-36478 (high)
CVE-2023-40167 (medium)
CVE-2023-43642 (high)
CVE-2023-44487 (high)
CVE-2023-44981 (high)
CVE-2024-23944 (medium)

CWE-310 (medium)
CWE-611 (low)


4.4 version of https://github.com/neo4j/apoc/pull/612