### PR TITLE
[NOID] Fixes #3218: java.lang.NullPointerException when setting the type of a property to datetime in the mapping config of apoc.load.csv() (#3976)

### DIFF
--- a/full/src/test/java/apoc/load/LoadCsvTest.java
+++ b/full/src/test/java/apoc/load/LoadCsvTest.java
@@ -18,6 +18,7 @@
  */
 package apoc.load;
 
+import static apoc.ApocConfig.apocConfig;
 import static apoc.util.BinaryTestUtil.fileToBinary;
 import static apoc.util.CompressionConfig.COMPRESSION;
 import static apoc.util.MapUtil.map;
@@ -28,6 +29,7 @@ import static org.mockserver.integration.ClientAndServer.startClientAndServer;
 import static org.mockserver.matchers.Times.exactly;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
+import static org.neo4j.configuration.GraphDatabaseSettings.db_temporal_timezone;
 
 import apoc.ApocSettings;
 import apoc.util.CompressionAlgo;
@@ -40,6 +42,7 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.time.ZoneId;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -832,8 +835,8 @@ public class LoadCsvTest {
             assertEquals(expected.keySet(), actual.keySet());
 
             actual.forEach((key, value) -> {
-                if (value instanceof Map mapVal) {
-                    assertMapEquals((Map<String, Object>) expected.get(key), mapVal);
+                if (value instanceof Map) {
+                    assertMapEquals((Map<String, Object>) expected.get(key), (Map) value);
                 } else {
                     assertEquals(expected.get(key), value);
                 }

--- a/full/src/test/resources/test-mapping-many-types.csv
+++ b/full/src/test/resources/test-mapping-many-types.csv
@@ -1,0 +1,3 @@
+localDateTimeField,localTimeField,timeField,dateField,dateTimeField,durationField,boolField,pointField,listDatesField
+1999,10:01,10:01:00Z,2024-01-18,2024-01-18T14:22:59,P5M1.5D,true,"{x: 56.7,y: 12.78, crs: 'wgs-84'}","2000,2001,2002"
+2000,11:01,11:01:00Z,2023-01-18,2023-01-18T14:22:59,P6M1.5D,false,"{x: 57.7,y: 11.78, crs: 'wgs-84'}","2000,2001,2002"


### PR DESCRIPTION
Fixes #3218

Cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/92ed5945669eac2395d415e9277161881e4e92b1