### PR TITLE
Fixed several CI errors and bump version 5.20.0 (#3456) (#3536) (#3726)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ downloadLicenses {
 
 allprojects {
     group = 'org.neo4j.procedure'
-    version = '5.19.0'
+    version = '5.20.0'
     archivesBaseName = 'apoc'
     description = """neo4j-apoc-procedures"""
 }
@@ -71,8 +71,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise-debian' : 'neo4j:5.19.0-enterprise-debian',
-                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-debian' : 'neo4j:5.19.0-debian',
+                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise-debian' : 'neo4j:5.20.0-enterprise-debian',
+                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-debian' : 'neo4j:5.20.0-debian',
                 'coreDir': 'apoc-core/core',
                 'testDockerBundle': false
 
@@ -131,7 +131,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.19.0"
+    neo4jVersion = "5.20.0"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.18.3'

--- a/docs/asciidoc/antora.yml
+++ b/docs/asciidoc/antora.yml
@@ -8,4 +8,4 @@ asciidoc:
     docs-version: "5.0"
     branch: "5.0"
     apoc-release-absolute: "5.0"
-    apoc-release: "5.19.0"
+    apoc-release: "5.20.0"

--- a/docs/asciidoc/modules/ROOT/partials/neo4j-server.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/neo4j-server.adoc
@@ -24,6 +24,7 @@ The version compatibility matrix explains the mapping between Neo4j and APOC ver
 [opts=header]
 |===
 |apoc version | neo4j version
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.20.0[5.20.0^] | 5.20.0 (5.20.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.19.0[5.19.0^] | 5.19.0 (5.19.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.18.0[5.18.0^] | 5.18.0 (5.18.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.17.1[5.17.1^] | 5.17.0 (5.17.x)

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -29,7 +29,7 @@ plugins {
     id 'org.neo4j.doc.build.docbook' version '1.0-alpha12'
 }
 
-if (!project.hasProperty('apocVersion')) { ext.apocVersion = '5.19.0' }
+if (!project.hasProperty('apocVersion')) { ext.apocVersion = '5.20.0' }
 
 ext {
     versionParts = apocVersion.split('-')

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     apt project(':processor')
     apt group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective   // mandatory to run @ServiceProvider based META-INF code generation
 
-    antlr "org.antlr:antlr4:4.7.2", {
+    antlr "org.antlr:antlr4:4.13.1", {
         exclude group: 'org.glassfish'
         exclude group: 'com.ibm.icu'
         exclude group: 'org.abego.treelayout'

--- a/extended/src/test/java/apoc/ml/VertexAITest.java
+++ b/extended/src/test/java/apoc/ml/VertexAITest.java
@@ -9,6 +9,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
+import org.mockserver.socket.PortFactory;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -50,7 +51,7 @@ public class VertexAITest {
         TestUtil.registerProcedure(db, VertexAI.class);
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
 
-        mockServer = startClientAndServer(1080);
+        mockServer = startClientAndServer(PortFactory.findFreePort());
 
         var path = Paths.get(getUrlFileName(VERTEX_MOCK_FOLDER + EMBEDDINGS).toURI()).getParent().toUri();
         // {project} will be substituted by project parameter, 

--- a/extended/src/test/java/apoc/ml/aws/BedrockTest.java
+++ b/extended/src/test/java/apoc/ml/aws/BedrockTest.java
@@ -10,6 +10,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
+import org.mockserver.socket.PortFactory;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -45,6 +46,7 @@ public class BedrockTest {
     private static final String STABLE_DIFFUSION_JSON = "/stable-diffusion.json";
     private static final String TITAN_EMBED_JSON = "/titan-embed.json";
     private static final Pair<String, String> AUTH_HEADER = Pair.of("Authorization", "AWS V4 mocked");
+    private static final int PORT = PortFactory.findFreePort();
 
     private static ClientAndServer mockServer;
 
@@ -56,7 +58,7 @@ public class BedrockTest {
         TestUtil.registerProcedure(db, Bedrock.class);
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
 
-        mockServer = startClientAndServer(1080);
+        mockServer = startClientAndServer(PORT);
 
         Stream.of(
                 LIST_MODELS_JSON,
@@ -135,7 +137,7 @@ public class BedrockTest {
     private static Map<String, Object> getParams(Map<String, Object> body, String path) {
         Map authHeader = Map.of(AUTH_HEADER.getKey(), AUTH_HEADER.getValue());
         return Map.of("body", body,
-                "conf", Map.of(ENDPOINT_KEY, "http://localhost:1080" + path,
+                "conf", Map.of(ENDPOINT_KEY, "http://localhost:" + PORT + path,
                         HEADERS_KEY, authHeader)
         );
     }

--- a/extended/src/test/java/apoc/ml/sagemaker/SageMakerTest.java
+++ b/extended/src/test/java/apoc/ml/sagemaker/SageMakerTest.java
@@ -10,6 +10,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
+import org.mockserver.socket.PortFactory;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -38,6 +39,7 @@ public class SageMakerTest {
     private static final String COMPLETIONS = "completions";
     private static final String CHAT_COMPLETIONS = "chat/completions";
     private static final Pair<String, String> AUTH_HEADER = Pair.of("Authorization", "AWS V4 mocked");
+    private static final int PORT = PortFactory.findFreePort();
 
     private static ClientAndServer mockServer;
 
@@ -49,7 +51,7 @@ public class SageMakerTest {
         TestUtil.registerProcedure(db, SageMaker.class);
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
 
-        mockServer = startClientAndServer(1080);
+        mockServer = startClientAndServer(PORT);
 
         Stream.of(EMBEDDINGS, COMPLETIONS, CHAT_COMPLETIONS)
                 .forEach(SageMakerTest::setRequestResponse);
@@ -135,7 +137,7 @@ public class SageMakerTest {
 
     private static Map<String, Object> getParams(String path) {
         Map authHeader = Map.of(AUTH_HEADER.getKey(), AUTH_HEADER.getValue());
-        return Map.of("conf", Map.of(ENDPOINT_KEY, "http://localhost:1080/" + path,
+        return Map.of("conf", Map.of(ENDPOINT_KEY, "http://localhost:%s/%s".formatted( PORT, path),
                         HEADERS_KEY, authHeader)
         );
     }

--- a/extra-dependencies/build.gradle
+++ b/extra-dependencies/build.gradle
@@ -71,7 +71,7 @@ ext {
 
 
 subprojects {
-    version = '5.19.0'
+    version = '5.20.0'
     group = 'org.neo4j.contrib'
 }
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,8 +1,8 @@
 :readme:
 :branch: 5.4
 :docs: https://neo4j.com/labs/apoc/5
-:apoc-release: 5.19.0
-:neo4j-version: 5.19.0
+:apoc-release: 5.20.0
+:neo4j-version: 5.20.0
 :img: https://raw.githubusercontent.com/neo4j-contrib/neo4j-apoc-procedures/{branch}/docs/images
 
 https://community.neo4j.com[image:https://img.shields.io/discourse/users?logo=discourse&server=https%3A%2F%2Fcommunity.neo4j.com[Discourse users]]


### PR DESCRIPTION
- Cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/11c94f34b339cbe475bb92a9f122e06456342de4 (bump version)

---

- Fixed [several CI errors](https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/8685106098/job/23816840835), like this:
```
apoc.custom.CypherProceduresStorageTest > testMultipleOverrideWithFunctionAndProcedures FAILED
    org.neo4j.graphdb.QueryExecutionException: Failed to invoke procedure `apoc.custom.declareProcedure`: Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.UnsupportedOperationException: java.io.InvalidClassException: org.antlr.v4.runtime.atn.ATN; Could not deserialize ATN with version 3 (expected 4). [in thread "Test worker"]
        at app//org.neo4j.kernel.impl.query.QueryExecutionKernelException.asUserException(QueryExecutionKernelException.java:32)
        at app//org.neo4j.cypher.internal.javacompat.ResultSubscriber.converted(ResultSubscriber.java:370)
        at app//org.neo4j.cypher.internal.javacompat.ResultSubscriber.assertNoErrors(ResultSubscriber.java:357)
        at app//org.neo4j.cypher.internal.javacompat.ResultSubscriber.init(ResultSubscriber.java:81)
        at app//org.neo4j.cypher.internal.javacompat.ExecutionEngine.executeQuery(ExecutionEngine.java:112)
        at app//org.neo4j.kernel.impl.coreapi.TransactionImpl.execute(TransactionImpl.java:236)
        at app//org.neo4j.kernel.impl.coreapi.TransactionImpl.execute(TransactionImpl.java:226)
```
They are caused by a subdependency of neo4j 5.19.0+, that use another version of antlr, as we can see by executing `./gradlew :core:dependencies`:
```
  +--- org.neo4j:neo4j-cypher-cst-factory:5.19.0
  |    +--- org.neo4j:neo4j-util:5.19.0 (*)
  |    +--- org.neo4j:neo4j-ast:5.19.0 (*)
  |    +--- org.neo4j:neo4j-cypher-antlr-parser:5.19.0
  |    |    \--- org.antlr:antlr4-runtime:4.13.1
...
```

---

- Fixed [MockServer error](https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/8692379736/job/23843818293), by changing 1080 to `PortFactory.findFreePort()`, since the tests are executing in parallel, sometimes a `Connection refused` as below is thrown, as the port may be occupied by another MockServer test.:
```
apoc.ml.sagemaker.SageMakerTest > getEmbedding FAILED
    org.neo4j.graphdb.QueryExecutionException: Failed to invoke procedure `apoc.ml.sagemaker.embedding`: Caused by: java.net.ConnectException: Connection refused
        at app//org.neo4j.kernel.impl.query.QueryExecutionKernelException.asUserException(QueryExecutionKernelException.java:32)
        at app//org.neo4j.cypher.internal.javacompat.ResultSubscriber.converted(ResultSubscriber.java:370)
```