### PR TITLE
Fixes #3360: Add support for newer Elasticsearch search api

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/database-integration/elasticsearch.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/elasticsearch.adoc
@@ -23,6 +23,13 @@ include::example$generated-documentation/apoc.es.delete.adoc[]
 |===
 // end::elasticsearch[]
 
+[NOTE]
+====
+It is currently not possible to query Elastic 8 via certificate, 
+but only disabling ssl with the configuration `"xpack.security.http.ssl.enabled=false"`, using the basic authentication via the header config (see `config parameter` below)
+or (not recommended) disabling security via `xpack.security.enabled=false`
+====
+
 
 == Example
 
@@ -197,6 +204,8 @@ Config can be an optional *map*, which can have the following entries:
 | headers | `Map` | {`content-type`: "application/json", `method`, "<httpMethod>"} | Contains a header map to add (or replace) the default one.
     The `method: <httpMethod>` is needed by APOC to figure out under the hood, which http request method to pass. 
     That is, by default, it is `PUT` with the `apoc.es.put`, POST with the `apoc.es.post` and `apoc.es.postRaw`, and GET in other cases.
+| version | `String` | `DEFAULT` | Can be `DEFAULT` and `EIGHT`, in order to change the RestAPI endpoint based on Elastic version. 
+    See `Endpoint` table below.
 |===
 
 
@@ -213,6 +222,48 @@ Authorization: Basic <Base64Token>
 method: GET
 Content-Type: application/json
 ```
+
+
+Some APIs in Elastic 8 can be called by the procedures without needing configuration `{version: 'EIGHT'}`,
+for example the `apoc.es.stats`,
+but for several APIs, it is necessary to set it, to handle the endpoint properly,
+for example the `apoc.es.query`.
+
+.Endpoint
+[opts=header]
+|===
+| procedure(s) | with version: `DEFAULT` | with version: `EIGHT` 
+| `apoc.es.stats(host)` |  <host>/_stats | same as `DEFAULT`
+| `apoc.es.query(host, index, type, query, payload, $conf)` |  <host>/<index param>/<type param>/_stats?<query param> | <host>/<index param>/_stats?<query param>
+| `apoc.es.getRaw/apoc.es.postRaw(host, path, payload, $conf)` | `<host>/<path param>` | same as `DEFAULT`
+| the others `apoc.es.<name>(host, index, type, id, query, payload, $conf)` procedures |  `<host>/<index param>/<type param>/<id param>_stats?<query param>`
+By default, the `<index param>` and `<id param>` will be populated as `_all`, while the `<id param>`, if not present, will be removed from the endpoint 
+|  `<host>/<index param>/<type param>/<id param>_stats?<query param>`. Note that you only need to enter one of three values between `<index param>`,`<id param>` and `<type param>`, the others will eventually be excluded from the endpoint.
+
+The type param is usually an underscore string indicating the type of the API, e.g. `_doc` or `_update` (while previously indicated https://www.elastic.co/guide/en/elasticsearch/reference/6.1/removal-of-types.html[the mapping types]).
+This is to allow you to call, for example, https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html[this API]
+|===
+
+
+For example, by using the `apoc.es.query`, we can execute a Search API:
+[source, cypher]
+----
+CALL apoc.es.query(<$host>, <$index>, <$type>, 'q=name:Neo4j', null, { version: 'EIGHT' })
+----
+
+Updates a document in Elastic 8 via https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update.html#docs-update[Update API]:
+
+[source, cypher]
+----
+CALL apoc.es.put($host,'<indexName>','_doc','<idName>','refresh=true',{name: 'foo'}, {version: 'EIGHT'})
+----
+
+Call a https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#indices-create-index[Create Index API] in elastic 8:
+
+[source, cypher]
+----
+CALL apoc.es.put($host,'<indexName>', null, null, null, null, { version: 'EIGHT' })
+----
 
 
 === Results

--- a/extended-it/src/test/java/apoc/es/ElasticVersionEightTest.java
+++ b/extended-it/src/test/java/apoc/es/ElasticVersionEightTest.java
@@ -1,0 +1,84 @@
+package apoc.es;
+
+import apoc.util.TestUtil;
+import apoc.util.Util;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static apoc.es.ElasticSearchConfig.VERSION_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ElasticVersionEightTest extends ElasticSearchTest {
+    public static final String ES_TYPE = "_doc";
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        Map<String, Object> config = Map.of("headers", basicAuthHeader, VERSION_KEY, ElasticSearchHandler.Version.EIGHT.name());
+        Map<String, Object> params = Util.map("index", ES_INDEX,
+                "id", ES_ID, "type", ES_TYPE, "config", config);
+        
+        String tag = "8.12.1";
+        Map<String, String> envMap = Map.of(
+                "xpack.security.http.ssl.enabled", "false",
+                "cluster.routing.allocation.disk.threshold_enabled","false"
+        );
+
+        getElasticContainer(tag, envMap, params);
+    }
+
+    @Override
+    String getEsType() {
+        return ES_TYPE;
+    }
+    
+    @Test
+    public void testCreateIndexAPI() {
+        TestUtil.testCall(db, "CALL apoc.es.put($host,'my-index-000001',null,null,null,null,$config)",
+                paramsWithBasicAuth,
+                r -> {
+            Object actual = ((Map) r.get("value")).get("index");
+            assertEquals("my-index-000001", actual);
+        });
+    }
+    
+    @Test
+    public void testGetIndexAPI() {
+        TestUtil.testCall(db, "CALL apoc.es.get($host,$index,null,null,null,null,$config) yield value",
+                paramsWithBasicAuth,
+                r -> {
+            Set valueKeys = ((Map) r.get("value")).keySet();
+            assertEquals(Set.of(ES_INDEX), valueKeys);
+        });
+    }
+
+    @Test
+    public void testSearchWithQueryAsPayload() {
+        TestUtil.testCall(db, "CALL apoc.es.query($host, $index, null, 'pretty', {`_source`: {includes: ['name']}}, $config) yield value", paramsWithBasicAuth,
+                this::searchQueryPayloadAssertions);
+    }
+
+    @Test
+    public void testSearchWithQueryAsPayloadAndWithoutIndex() {
+        TestUtil.testCall(db, "CALL apoc.es.query($host, null, null, 'pretty', {`_source`: {includes: ['name']}}, $config) yield value", paramsWithBasicAuth,
+                this::searchQueryPayloadAssertions);
+    }
+
+    private void searchQueryPayloadAssertions(Map<String, Object> r) {
+        List<Map> values = (List<Map>) extractValueFromResponse(r, "$.hits.hits");
+        assertEquals(3, values.size());
+
+        values.forEach(item -> {
+            Map source = (Map) item.get("_source");
+
+            assertTrue("Actual _source is: " + source,
+                    source.equals(Map.of()) || source.equals(Map.of("name", "Neo4j"))
+            );
+        });
+    }
+
+}

--- a/extended-it/src/test/java/apoc/es/ElasticVersionSevenTest.java
+++ b/extended-it/src/test/java/apoc/es/ElasticVersionSevenTest.java
@@ -1,0 +1,189 @@
+package apoc.es;
+
+import apoc.util.TestUtil;
+import apoc.util.Util;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static apoc.ApocConfig.apocConfig;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ElasticVersionSevenTest extends ElasticSearchTest {
+
+    public static final String ES_TYPE = UUID.randomUUID().toString();
+    private final static String HOST = "localhost";
+    public static final ElasticSearchHandler DEFAULT_HANDLER = ElasticSearchHandler.Version.DEFAULT.get();
+
+    private static final Map<String, Object> defaultParams = Util.map("index", ES_INDEX, "type", ES_TYPE, "id", ES_ID);
+    
+    @BeforeClass
+    public static void setUp() throws Exception {
+        
+        Map<String, Object> config = Map.of("headers", basicAuthHeader);
+        Map<String, Object> params = new HashMap<>(defaultParams);
+        params.put("config", config);
+
+
+        String tag = "7.9.2";
+        getElasticContainer(tag, Map.of(), params);
+        
+        String httpHostAddress = elastic.getHttpHostAddress();
+        HTTP_HOST_ADDRESS = String.format("elastic:%s@%s",
+                password,
+                httpHostAddress);
+
+        HTTP_URL_ADDRESS = "http://" + HTTP_HOST_ADDRESS;
+
+        defaultParams.put("host", HTTP_HOST_ADDRESS);
+        defaultParams.put("url", HTTP_URL_ADDRESS);
+    }
+
+    @Override
+    String getEsType() {
+        return ES_TYPE;
+    }
+    
+    
+    /*
+    Tests without basic auth header
+    */
+
+    @Test
+    public void testGetRowProcedure() {
+        Map<String, Object> params = Map.of("url", HTTP_URL_ADDRESS, "suffix", getRawProcedureUrl(ES_ID, ES_TYPE));
+
+        TestUtil.testCall(db, "CALL apoc.es.getRaw($url,$suffix, null)", params,
+                commonEsGetConsumer());
+    }
+
+    @Test
+    public void testStats() throws Exception {
+        TestUtil.testCall(db, "CALL apoc.es.stats($host)", defaultParams, 
+                commonEsStatsConsumer());
+
+    }
+
+    @Test
+    public void testProceduresWithUrl() {
+        TestUtil.testCall(db, "CALL apoc.es.stats($url)", defaultParams, 
+                commonEsStatsConsumer());
+
+        TestUtil.testCall(db, "CALL apoc.es.get($url,$index,$type,$id,null,null) yield value", defaultParams, 
+                commonEsGetConsumer());
+    }
+
+    @Test
+    public void testProceduresWithUrlKeyConf() {
+        apocConfig().setProperty("apoc.es.myUrlKey.url", HTTP_URL_ADDRESS);
+
+        TestUtil.testCall(db, "CALL apoc.es.stats('myUrlKey')", 
+                commonEsStatsConsumer());
+
+        TestUtil.testCall(db, "CALL apoc.es.get('myUrlKey',$index,$type,$id,null,null, $config) yield value", paramsWithBasicAuth, 
+                commonEsGetConsumer());
+    }
+
+    @Test
+    public void testProceduresWithHostKeyConf() {
+        apocConfig().setProperty("apoc.es.myHostKey.host", HTTP_HOST_ADDRESS);
+
+        TestUtil.testCall(db, "CALL apoc.es.stats('myHostKey')",
+                commonEsStatsConsumer());
+
+        TestUtil.testCall(db, "CALL apoc.es.get('myHostKey',$index,$type,$id,null,null, $config) yield value", paramsWithBasicAuth,
+                commonEsGetConsumer());
+    }
+    
+    @Test
+    public void testGetWithQueryAsStringSingleParam() {
+        TestUtil.testCall(db, "CALL apoc.es.get($host,$index,$type,$id,'_source_includes=name',null, {}) yield value", defaultParams,
+                commonEsGetConsumer());
+    }
+
+    /**
+     * We want to search our document by name --> /test-index/test-type/_search?q=name:Neo4j
+     * This test uses a plain string to query ES
+     */
+    @Test
+    public void testSearchWithQueryAsAString() {
+        TestUtil.testCall(db, "CALL apoc.es.query($host,$index,$type,'q=name:Neo4j',null) yield value", defaultParams, r -> {
+            Object name = extractValueFromResponse(r, "$.hits.hits[0]._source.name");
+            assertEquals("Neo4j", name);
+        });
+    }
+
+    @Test
+    public void testGetQueryUrlShouldBeTheSameAsOldFormatting() {
+        String index = ES_INDEX;
+        String type = ES_TYPE;
+        String id = ES_ID;
+        Map<String, String> query = new HashMap<>();
+        query.put("name", "get");
+
+        String host = HOST;
+        String hostUrl = DEFAULT_HANDLER.getElasticSearchUrl(host);
+
+        String queryUrl = hostUrl + String.format("/%s/%s/%s?%s", index == null ? "_all" : index,
+                type == null ? "_all" : type,
+                id == null ? "" : id,
+                DEFAULT_HANDLER.toQueryParams(query));
+
+        assertEquals(queryUrl, DEFAULT_HANDLER.getQueryUrl(host, index, type, id, query));
+    }
+
+    @Test
+    public void testGetQueryUrlShouldNotHaveTrailingQuestionMarkIfQueryIsNull() {
+        String index = ES_INDEX;
+        String type = ES_TYPE;
+        String id = ES_TYPE;
+
+        String host = HOST;
+        String hostUrl = DEFAULT_HANDLER.getElasticSearchUrl(host);
+        String queryUrl = hostUrl + String.format("/%s/%s/%s?%s", index,
+                type == null ? "_all" : type,
+                id == null ? "" : id,
+                DEFAULT_HANDLER.toQueryParams(null));
+
+        // First we test the older version against the newest one
+        assertNotEquals(queryUrl, DEFAULT_HANDLER.getQueryUrl(host, index, type, id, null));
+        assertFalse(DEFAULT_HANDLER.getQueryUrl(host, index, type, id, null).endsWith("?"));
+    }
+
+    @Test
+    public void testGetQueryUrlShouldNotHaveTrailingQuestionMarkIfQueryIsEmpty() {
+        String index = ES_INDEX;
+        String type = ES_TYPE;
+        String id = ES_ID;
+
+        String host = HOST;
+        String hostUrl = DEFAULT_HANDLER.getElasticSearchUrl(host);
+        String queryUrl = hostUrl + String.format("/%s/%s/%s?%s", index == null ? "_all" : index,
+                type == null ? "_all" : type,
+                id == null ? "" : id,
+                DEFAULT_HANDLER.toQueryParams(new HashMap<String, String>()));
+
+        // First we test the older version against the newest one
+        assertNotEquals(queryUrl, DEFAULT_HANDLER.getQueryUrl(host, index, type, id, new HashMap<String, String>()));
+        assertTrue(!DEFAULT_HANDLER.getQueryUrl(host, index, type, id, new HashMap<String, String>()).endsWith("?"));
+    }
+
+    /**
+     * Simple get request for document retrieval but we also send multiple commands (as a Map) to ES
+     * http://localhost:9200/test-index/test-type/4fa40c40-db89-4761-b6a3-75f0015db059?_source_includes=name&_source_excludes=description
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testGetWithQueryAsMapMultipleParams() throws Exception {
+        TestUtil.testCall(db, "CALL apoc.es.get($host,$index,$type,$id,{_source_includes:'name',_source_excludes:'description'},null) yield value", defaultParams,
+                commonEsGetConsumer());
+    }
+
+}

--- a/extended/src/main/java/apoc/es/ElasticSearch.java
+++ b/extended/src/main/java/apoc/es/ElasticSearch.java
@@ -3,7 +3,6 @@ package apoc.es;
 import apoc.Extended;
 import apoc.load.LoadJsonUtils;
 import apoc.result.MapResult;
-import apoc.util.UrlResolver;
 import apoc.util.Util;
 import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.procedure.Context;
@@ -13,9 +12,6 @@ import org.neo4j.procedure.Procedure;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**

--- a/extended/src/main/java/apoc/es/ElasticSearch.java
+++ b/extended/src/main/java/apoc/es/ElasticSearch.java
@@ -28,80 +28,6 @@ public class ElasticSearch {
     @Context
     public URLAccessChecker urlAccessChecker;
     
-    private final static String fullQueryTemplate = "/%s/%s/%s?%s";
-
-    // /{index}/{type}/_search?{query}
-    private final static String fullQuerySearchTemplate = "/%s/%s/_search?%s";
-
-    /**
-     * With this pattern we can match both key:value params and key=value params
-     */
-    private final static Pattern KEY_VALUE = Pattern.compile("(.*)(:|=)(.*)");
-
-    protected String getElasticSearchUrl(String hostOrKey) {
-        return new UrlResolver("http", "localhost", 9200).getUrl("es", hostOrKey);
-    }
-
-    /**
-     * Get the full Elasticsearch url
-     *
-     * @param hostOrKey
-     * @param index
-     * @param type
-     * @param id
-     * @param query
-     * @return
-     */
-    public String getQueryUrl(String hostOrKey, String index, String type, String id, Object query) {
-        return getElasticSearchUrl(hostOrKey) + formatQueryUrl(index, type, id, query);
-    }
-
-    /**
-     * @param hostOrKey
-     * @param index
-     * @param type
-     * @param query
-     * @return
-     */
-    protected String getSearchQueryUrl(String hostOrKey, String index, String type, Object query) {
-        return getElasticSearchUrl(hostOrKey) + formatSearchQueryUrl(index, type, query);
-    }
-
-    /**
-     * @param index
-     * @param type
-     * @param query
-     * @return
-     */
-    private String formatSearchQueryUrl(String index, String type, Object query) {
-        String queryUrl = String.format(fullQuerySearchTemplate,
-                index == null ? "_all" : index,
-                type == null ? "_all" : type,
-                toQueryParams(query));
-
-        return queryUrl.endsWith("?") ? queryUrl.substring(0, queryUrl.length() - 1) : queryUrl;
-    }
-
-    /**
-     * Format the query url template according to the parameters.
-     * The format will be /{index}/{type}/{id}?{query} if query is not empty (or null) otherwise the format will be /{index}/{type}/{id}
-     *
-     * @param index
-     * @param type
-     * @param id
-     * @param query
-     * @return
-     */
-    private String formatQueryUrl(String index, String type, String id, Object query) {
-        String queryUrl = String.format(fullQueryTemplate,
-                index == null ? "_all" : index,
-                type == null ? "_all" : type,
-                id == null ? "" : id,
-                toQueryParams(query));
-
-        return queryUrl.endsWith("?") ? queryUrl.substring(0, queryUrl.length() - 1) : queryUrl;
-    }
-
     /**
      * @param payload
      * @return
@@ -112,61 +38,48 @@ public class ElasticSearch {
         return payload.toString();
     }
 
-
-    /**
-     * @param query
-     * @return
-     */
-    protected String toQueryParams(Object query) {
-        if (query == null) return "";
-        if (query instanceof Map) {
-            Map<String, Object> map = (Map<String, Object>) query;
-            if (map.isEmpty()) return "";
-            return map.entrySet().stream().map(e -> e.getKey() + "=" + Util.encodeUrlComponent(e.getValue().toString())).collect(Collectors.joining("&"));
-        } else {
-            // We have to encode only the values not the keys
-            return Pattern.compile("&").splitAsStream(query.toString())
-                    .map(KEY_VALUE::matcher)
-                    .filter(Matcher::matches)
-                    .map(matcher -> matcher.group(1) + matcher.group(2) + Util.encodeUrlComponent(matcher.group(3)))
-                    .collect(Collectors.joining("&"));
-        }
-    }
-
     @Procedure
     @Description("apoc.es.stats(host-or-key,$config) - elastic search statistics")
-    public Stream<MapResult> stats(@Name("hostOrKey") String hostOrKey, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
-        String url = getElasticSearchUrl(hostOrKey);
-        return loadJsonStream(url + "/_stats", new ElasticSearchConfig(config), null);
+    public Stream<MapResult> stats(@Name("host") String hostOrKey, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
+        ElasticSearchConfig conf = new ElasticSearchConfig(config);
+        String url = conf.getVersion().getElasticSearchUrl(hostOrKey);
+        return loadJsonStream(url + "/_stats", conf, null);
     }
 
     @Procedure
     @Description("apoc.es.get(host-or-key,index-or-null,type-or-null,id-or-null,query-or-null,payload-or-null,$config) yield value - perform a GET operation on elastic search")
     public Stream<MapResult> get(@Name("hostOrKey") String hostOrKey, @Name("index") String index, @Name("type") String type, @Name("id") String id, @Name("query") Object query, @Name("payload") Object payload,
                                  @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
-        return loadJsonStream(getQueryUrl(hostOrKey, index, type, id, query), new ElasticSearchConfig(config), toPayload(payload));
+        ElasticSearchConfig conf = new ElasticSearchConfig(config);
+        String queryUrl = conf.getVersion().getQueryUrl(hostOrKey, index, type, id, query);//.replace("mytype/", "");
+        return loadJsonStream(queryUrl, conf, toPayload(payload));
     }
 
     @Procedure
     @Description("apoc.es.query(host-or-key,index-or-null,type-or-null,query-or-null,payload-or-null,$config) yield value - perform a SEARCH operation on elastic search")
     public Stream<MapResult> query(@Name("hostOrKey") String hostOrKey, @Name("index") String index, @Name("type") String type, @Name("query") Object query, @Name("payload") Object payload,
                                    @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
-        return loadJsonStream(getSearchQueryUrl(hostOrKey, index, type, query), new ElasticSearchConfig(config), toPayload(payload));
+        ElasticSearchConfig conf = new ElasticSearchConfig(config);
+        String searchQueryUrl = conf.getVersion().getSearchQueryUrl(hostOrKey, index, type, query);//.replace("mytype/", "");
+
+        return loadJsonStream(searchQueryUrl, conf, toPayload(payload));
     }
 
     @Procedure
     @Description("apoc.es.getRaw(host-or-key,path,payload-or-null,$config) yield value - perform a raw GET operation on elastic search")
     public Stream<MapResult> getRaw(@Name("hostOrKey") String hostOrKey, @Name("path") String suffix, @Name("payload") Object payload,
                                     @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
-        String url = getElasticSearchUrl(hostOrKey);
-        return loadJsonStream(url + "/" + suffix, new ElasticSearchConfig(config), toPayload(payload));
+        ElasticSearchConfig conf = new ElasticSearchConfig(config);
+        String url = conf.getVersion().getElasticSearchUrl(hostOrKey);
+        return loadJsonStream(url + "/" + suffix, conf, toPayload(payload));
     }
 
     @Procedure
     @Description("apoc.es.postRaw(host-or-key,path,payload-or-null,$config) yield value - perform a raw POST operation on elastic search")
     public Stream<MapResult> postRaw(@Name("hostOrKey") String hostOrKey, @Name("path") String suffix, @Name("payload") Object payload, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
-        String url = getElasticSearchUrl(hostOrKey);
-        return loadJsonStream(url + "/" + suffix, new ElasticSearchConfig(config, "POST"), toPayload(payload));
+        ElasticSearchConfig conf = new ElasticSearchConfig(config, "POST");
+        String url = conf.getVersion().getElasticSearchUrl(hostOrKey);
+        return loadJsonStream(url + "/" + suffix, conf, toPayload(payload));
     }
 
     @Procedure
@@ -178,7 +91,9 @@ public class ElasticSearch {
         {
             payload = Collections.emptyMap();
         }
-        return loadJsonStream(getQueryUrl(hostOrKey, index, type, null, query), new ElasticSearchConfig(config, "POST"), toPayload(payload));
+        ElasticSearchConfig conf = new ElasticSearchConfig(config, "POST");
+        String queryUrl = conf.getVersion().getQueryUrl(hostOrKey, index, type, null, query);
+        return loadJsonStream(queryUrl, conf, toPayload(payload));
     }
 
     @Procedure
@@ -190,24 +105,29 @@ public class ElasticSearch {
         {
             payload = Collections.emptyMap();
         }
-        return loadJsonStream(getQueryUrl(hostOrKey, index, type, id, query), new ElasticSearchConfig(config, "PUT"), toPayload(payload));
+
+        ElasticSearchConfig conf = new ElasticSearchConfig(config, "PUT");
+        String queryUrl = conf.getVersion().getQueryUrl(hostOrKey, index, type, id, query);
+        return loadJsonStream(queryUrl, conf, toPayload(payload));
     }
 
     @Procedure
     @Description("apoc.es.delete(host-or-key,index-or-null,type-or-null,id-or-null,query-or-null,$config) yield value - perform a DELETE operation on elastic search")
     public Stream<MapResult> delete(@Name("hostOrKey") String hostOrKey,
-                                 @Name("index") String index,
-                                 @Name("type") String type,
-                                 @Name("id") String id,
-                                 @Name(value = "query", defaultValue = "null") Object query,
-                                 @Name(value = "config", defaultValue = "{}") Map<String,Object> config) {
+                                    @Name("index") String index,
+                                    @Name("type") String type,
+                                    @Name("id") String id,
+                                    @Name(value = "query", defaultValue = "null") Object query,
+                                    @Name(value = "config", defaultValue = "{}") Map<String,Object> config) {
         /* Conceptually payload should be null, but we have to put "" instead,
            as the `apoc.util.Util.writePayload` method has an `if (payload == null) return;`
            but we need to add the `con.setDoOutput(true);`, placed right after that condition.
            Otherwise, an error `Cannot write to a URLConnection if doOutput=false - call setDoOutput(true)` will be thrown
         */
         String payload = "";
-        return loadJsonStream(getQueryUrl(hostOrKey, index, type, id, query), new ElasticSearchConfig(config, "DELETE"), payload);
+        ElasticSearchConfig conf = new ElasticSearchConfig(config, "DELETE");
+        String queryUrl = conf.getVersion().getQueryUrl(hostOrKey, index, type, id, query);
+        return loadJsonStream(queryUrl, conf, payload);
     }
 
     private Stream<MapResult> loadJsonStream(@Name("url") Object url, ElasticSearchConfig conf, @Name("payload") String payload) {

--- a/extended/src/main/java/apoc/es/ElasticSearchConfig.java
+++ b/extended/src/main/java/apoc/es/ElasticSearchConfig.java
@@ -4,10 +4,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import static apoc.es.ElasticSearchHandler.Version;
+
 public class ElasticSearchConfig {
     public static final String HEADERS_KEY = "headers";
+    public static final String VERSION_KEY = "version";
 
     private final Map<String, Object> headers;
+    private final ElasticSearchHandler version;
 
     public ElasticSearchConfig(Map<String, Object> config) {
         this(config, null);
@@ -24,9 +28,16 @@ public class ElasticSearchConfig {
             headerConf.putIfAbsent("method", httpMethod);
         }
         this.headers = headerConf;
+        
+        String versionConf = (String) config.getOrDefault(VERSION_KEY, Version.DEFAULT.name());
+        this.version = Version.valueOf(versionConf).get();
     }
 
     public Map<String, Object> getHeaders() {
         return headers;
+    }
+
+    public ElasticSearchHandler getVersion() {
+        return version;
     }
 }

--- a/extended/src/main/java/apoc/es/ElasticSearchHandler.java
+++ b/extended/src/main/java/apoc/es/ElasticSearchHandler.java
@@ -1,0 +1,145 @@
+package apoc.es;
+
+
+import apoc.util.UrlResolver;
+import apoc.util.Util;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public abstract class ElasticSearchHandler {
+
+    /**
+     * With this pattern we can match both key:value params and key=value params
+     */
+    private final static Pattern KEY_VALUE = Pattern.compile("(.*)(:|=)(.*)");
+
+    protected String getElasticSearchUrl(String hostOrKey) {
+        return new UrlResolver("http", "localhost", 9200).getUrl("es", hostOrKey);
+    }
+    
+    /**
+     * @param query
+     * @return
+     */
+    protected String toQueryParams(Object query) {
+        if (query == null) return "";
+        if (query instanceof Map) {
+            Map<String, Object> map = (Map<String, Object>) query;
+            if (map.isEmpty()) return "";
+            return map.entrySet().stream().map(e -> e.getKey() + "=" + Util.encodeUrlComponent(e.getValue().toString())).collect(Collectors.joining("&"));
+        } else {
+            // We have to encode only the values not the keys
+            return Pattern.compile("&").splitAsStream(query.toString())
+                    .map(KEY_VALUE::matcher)
+                    .filter(Matcher::matches)
+                    .map(matcher -> matcher.group(1) + matcher.group(2) + Util.encodeUrlComponent(matcher.group(3)))
+                    .collect(Collectors.joining("&"));
+        }
+    }
+
+    /**
+     * Get the full Elasticsearch url
+     */
+    protected String getQueryUrl(String hostOrKey, String index, String type, String id, Object query) {
+        return getElasticSearchUrl(hostOrKey) + formatQueryUrl(index, type, id, query);
+    }
+
+    /**
+     * Get the full Elasticsearch search url
+     */
+    protected String getSearchQueryUrl(String hostOrKey, String index, String type, Object query) {
+        return getElasticSearchUrl(hostOrKey) + formatSearchQueryUrl(index, type, query);
+    }
+
+    /**
+     * Format the Search API url template according to the parameters.
+     */
+    protected abstract String formatSearchQueryUrl(String index, String type, Object query);
+
+    /**
+     * Format the query url template according to the parameters.
+     * The format will be /{index}/{type}/{id}?{query} if query is not empty (or null) otherwise the format will be /{index}/{type}/{id}
+     */
+    protected abstract String formatQueryUrl(String index, String type, String id, Object query);
+    
+    enum Version {
+        EIGHT(new Eight()),
+        DEFAULT(new Default());
+
+        private final ElasticSearchHandler handler;
+        Version(ElasticSearchHandler handler) {
+            this.handler = handler;
+        }
+
+        public ElasticSearchHandler get() {
+            return handler;
+        }
+    }
+
+    static class Eight extends ElasticSearchHandler {
+
+        @Override
+        protected String formatSearchQueryUrl(String index, String type, Object query) {
+            
+            String queryUrl = String.format( "/%s/_search?%s",
+                    index == null ? "_all" : index,
+                    toQueryParams(query));
+            
+            return removeTerminalQuote(queryUrl);
+        }
+
+        @Override
+        protected String formatQueryUrl(String index, String type, String id, Object query) {
+
+            String queryUrl = Arrays.asList(index, type, id)
+                    .stream()
+                    .filter(StringUtils::isNotBlank)
+                    .collect(Collectors.joining("/"));
+
+            String queryParams = toQueryParams(query);
+            queryParams = "".equals(queryParams)
+                    ? ""
+                    : ("?" + queryParams);
+
+            return "/" + queryUrl + queryParams;
+        }
+    }
+
+    static class Default extends ElasticSearchHandler {
+
+        private final String fullQueryTemplate = "/%s/%s/%s?%s";
+        private final String fullQuerySearchTemplate = "/%s/%s/_search?%s";
+        
+        @Override
+        protected String formatSearchQueryUrl(String index, String type, Object query) {
+            String queryUrl = String.format(fullQuerySearchTemplate,
+                    index == null ? "_all" : index,
+                    type == null ? "_all" : type,
+                    toQueryParams(query));
+
+            return removeTerminalQuote(queryUrl);
+        }
+
+        @Override
+        protected String formatQueryUrl(String index, String type, String id, Object query) {
+            String queryUrl = String.format(fullQueryTemplate,
+                    index == null ? "_all" : index,
+                    type == null ? "_all" : type,
+                    id == null ? "" : id,
+                    toQueryParams(query));
+
+            return removeTerminalQuote(queryUrl);
+        }
+    }
+
+    @NotNull
+    private static String removeTerminalQuote(String queryUrl) {
+        return queryUrl.endsWith("?") ? queryUrl.substring(0, queryUrl.length() - 1) : queryUrl;
+    }
+}


### PR DESCRIPTION
Fixes #3360

Created a trello card (id: uHLecigr), to add the certificate handling [here](https://github.com/neo4j/apoc/blob/dev/common/src/main/java/apoc/util/Util.java#L334).  

Since we cannot use certificates, see below, I created tests using basic authentication with the `xpack.security.http.ssl.enabled: false` configuration

- Create factory ElasticSearchHandler
- Split test to test both Elastic 7.9.2 (default tag) and Elastic 8.12.1, where the ElasticSearchTest.java is now the Base Test
- Tried several Elastic 8 APIs
- Some refactoring / code cleaning