### PR TITLE
Fixes #3611: ML API procedures handle null values being passed in better

### DIFF
--- a/extended/src/main/java/apoc/ml/MLUtil.java
+++ b/extended/src/main/java/apoc/ml/MLUtil.java
@@ -1,0 +1,5 @@
+package apoc.ml;
+
+public class MLUtil {
+    public static final String ERROR_NULL_INPUT = "The input provided is null. Please specify a valid input";
+}

--- a/extended/src/main/java/apoc/ml/Watson.java
+++ b/extended/src/main/java/apoc/ml/Watson.java
@@ -39,6 +39,9 @@ public class Watson {
     @Procedure("apoc.ml.watson.chat")
     @Description("apoc.ml.watson.chat(messages, accessToken, $configuration) - prompts the completion API")
     public Stream<MapResult> chatCompletion(@Name("messages") List<Map<String, Object>> messages, @Name("accessToken") String accessToken, @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
+        if (messages == null) {
+            return Stream.of(new MapResult(null));
+        }
         String prompt = messages.stream()
                 .map(message -> {
                     Object role = message.get("role");
@@ -56,6 +59,9 @@ public class Watson {
     @Procedure("apoc.ml.watson.completion")
     @Description("apoc.ml.watson.completion(prompt, accessToken, $configuration) - prompts the completion API")
     public Stream<MapResult> completion(@Name("prompt") String prompt, @Name("accessToken") String accessToken, @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
+        if (prompt == null) {
+            return Stream.of(new MapResult(null));
+        }
         return executeRequest(prompt, accessToken, configuration);
     }
 

--- a/extended/src/main/java/apoc/ml/aws/Bedrock.java
+++ b/extended/src/main/java/apoc/ml/aws/Bedrock.java
@@ -17,6 +17,7 @@ import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 import org.apache.commons.lang3.StringUtils;
 
+import static apoc.ml.MLUtil.ERROR_NULL_INPUT;
 import static apoc.ml.aws.AWSConfig.JSON_PATH;
 import static apoc.ml.aws.BedrockInvokeConfig.MODEL;
 import static apoc.util.JsonUtil.OBJECT_MAPPER;
@@ -60,7 +61,9 @@ public class Bedrock {
     public Stream<MapResult> chatCompletion(
             @Name("messages") List<Map<String, Object>> messages,
             @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) {
-
+        if (messages == null) {
+            throw new RuntimeException(ERROR_NULL_INPUT);
+        }
         var config = new HashMap<>(configuration);
         config.putIfAbsent(MODEL, ANTHROPIC_CLAUDE_V2);
 
@@ -94,7 +97,9 @@ public class Bedrock {
     @Description("apoc.ml.bedrock.completion(prompt, $conf) - prompts the completion API")
     public Stream<MapResult> completion(@Name("prompt") String prompt,
                                        @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) {
-
+        if (prompt == null) {
+            throw new RuntimeException(ERROR_NULL_INPUT);
+        }
         var config = new HashMap<>(configuration);
         config.putIfAbsent(MODEL, JURASSIC_2_ULTRA);
         
@@ -109,6 +114,9 @@ public class Bedrock {
     @Description("apoc.ml.bedrock.embedding([texts], $configuration) - returns the embeddings for a given text")
     public Stream<Embedding> embedding(@Name(value = "texts") List<String> texts,
                                        @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) {
+        if (texts == null) {
+            throw new RuntimeException(ERROR_NULL_INPUT);
+        }
         var config = new HashMap<>(configuration);
         config.putIfAbsent(MODEL, TITAN_EMBED_TEXT);
 
@@ -127,6 +135,9 @@ public class Bedrock {
     @Procedure("apoc.ml.bedrock.image")
     public Stream<Image> image(@Name(value = "body") Map<String, Object> body,
                                @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) {
+        if (body == null) {
+            throw new RuntimeException(ERROR_NULL_INPUT);
+        }
         configuration.putIfAbsent(MODEL, STABILITY_STABLE_DIFFUSION_XL);
         configuration.putIfAbsent(JSON_PATH, "$.artifacts[0]");
         

--- a/extended/src/test/java/apoc/ml/MLTestUtil.java
+++ b/extended/src/test/java/apoc/ml/MLTestUtil.java
@@ -1,0 +1,25 @@
+package apoc.ml;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+
+import java.util.Map;
+
+import static apoc.ml.MLUtil.ERROR_NULL_INPUT;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class MLTestUtil {
+    public static void assertNullInputFails(GraphDatabaseService db, String query, Map<String, Object> params) {
+        try {
+            testCall(db, query, params,
+                    (row) -> fail("Should fail due to null input")
+            );
+        } catch (RuntimeException e) {
+            String message = e.getMessage();
+            assertTrue("Current error message is: " + message, 
+                    message.contains(ERROR_NULL_INPUT)
+            );
+        }
+    }
+}

--- a/extended/src/test/java/apoc/ml/OpenAIIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIIT.java
@@ -1,6 +1,7 @@
 package apoc.ml;
 
 import apoc.util.TestUtil;
+import apoc.util.collection.Iterators;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
@@ -8,12 +9,17 @@ import org.junit.Test;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
+import static apoc.ml.MLTestUtil.assertNullInputFails;
 import static apoc.ml.OpenAI.MODEL_CONF_KEY;
 import static apoc.ml.OpenAITestResultUtils.*;
 import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testResult;
 import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertEquals;
 
 public class OpenAIIT {
 
@@ -69,6 +75,19 @@ public class OpenAIIT {
     }
 
     @Test
+    public void getEmbeddingNull() {
+        testResult(db, "CALL apoc.ml.openai.embedding([null, 'Some Text', null, 'Other Text'], $apiKey, $conf)", Map.of("apiKey",openaiKey, "conf", emptyMap()),
+                r -> {
+                    Set<String> actual = Iterators.asSet(r.columnAs("text"));
+
+                    Set<String> expected = new HashSet<>() {{
+                        add(null); add(null); add("Some Text"); add("Other Text");
+                    }};
+                    assertEquals(expected, actual);
+                });
+    }
+
+    @Test
     public void completion() {
         testCall(db, COMPLETION_QUERY,
                 Map.of("apiKey", openaiKey, "conf", emptyMap()),
@@ -103,5 +122,26 @@ public class OpenAIIT {
   ]
 }
          */
+    }
+
+    @Test
+    public void embeddingsNull() {
+        assertNullInputFails(db, "CALL apoc.ml.openai.embedding(null, $apiKey, $conf)",
+                Map.of("apiKey", openaiKey, "conf", emptyMap())
+        );
+    }
+
+    @Test
+    public void completionNull() {
+        assertNullInputFails(db, "CALL apoc.ml.openai.completion(null, $apiKey, $conf)",
+                Map.of("apiKey", openaiKey, "conf", emptyMap())
+        );
+    }
+    
+    @Test
+    public void chatCompletionNull() {
+        assertNullInputFails(db, "CALL apoc.ml.openai.chat(null, $apiKey, $conf)",
+                Map.of("apiKey", openaiKey, "conf", emptyMap())
+        );
     }
 }

--- a/extended/src/test/java/apoc/ml/VertexAIIT.java
+++ b/extended/src/test/java/apoc/ml/VertexAIIT.java
@@ -27,8 +27,6 @@ import static apoc.ml.VertexAIHandler.RESOURCE_CONF_KEY;
 import static apoc.ml.VertexAIHandler.STREAM_RESOURCE;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
-import static java.util.Collections.emptyMap;
-import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;

--- a/extended/src/test/java/apoc/ml/VertexAIIT.java
+++ b/extended/src/test/java/apoc/ml/VertexAIIT.java
@@ -1,6 +1,7 @@
 package apoc.ml;
 
 import apoc.util.TestUtil;
+import apoc.util.collection.Iterators;
 import org.apache.commons.io.FileUtils;
 import org.junit.Assume;
 import org.junit.Before;
@@ -13,15 +14,21 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import static apoc.ml.MLTestUtil.assertNullInputFails;
 import static apoc.ml.VertexAIHandler.ENDPOINT_CONF_KEY;
 import static apoc.ml.VertexAIHandler.MODEL_CONF_KEY;
 import static apoc.ml.VertexAIHandler.PREDICT_RESOURCE;
 import static apoc.ml.VertexAIHandler.RESOURCE_CONF_KEY;
 import static apoc.ml.VertexAIHandler.STREAM_RESOURCE;
 import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testResult;
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -64,6 +71,20 @@ public class VertexAIIT {
             assertEquals(768, embedding.size());
             assertEquals(true, embedding.stream().allMatch(d -> d instanceof Double));
         });
+    }
+
+    @Test
+    public void getEmbeddingNull() {
+        testResult(db, "CALL apoc.ml.vertexai.embedding([null, 'Some Text', null, 'Other Text'], $apiKey, $project)",
+                parameters,
+                r -> {
+                    Set<String> actual = Iterators.asSet(r.columnAs("text"));
+
+                    Set<String> expected = new HashSet<>() {{
+                        add(null); add(null); add("Some Text"); add("Other Text");
+                    }};
+                    assertEquals(expected, actual);
+                });
     }
 
     @Test
@@ -208,5 +229,26 @@ public class VertexAIIT {
         String stringRow = row.toString();
         assertTrue(stringRow.toLowerCase().contains(expected),
                 "Actual result is: " + stringRow);
+    }
+
+    @Test
+    public void embeddingsNull() {
+        assertNullInputFails(db, "CALL apoc.ml.vertexai.embedding(null, $apiKey, $project)",
+                parameters
+        );
+    }
+    
+    @Test
+    public void completionNull() {
+        assertNullInputFails(db, "CALL apoc.ml.vertexai.completion(null, $apiKey, $project)",
+                parameters
+        );
+    }
+
+    @Test
+    public void chatCompletionNull() {
+        assertNullInputFails(db, "CALL apoc.ml.vertexai.chat(null, $apiKey, $project)",
+                parameters
+        );
     }
 }

--- a/extended/src/test/java/apoc/ml/WatsonIT.java
+++ b/extended/src/test/java/apoc/ml/WatsonIT.java
@@ -13,7 +13,9 @@ import java.util.Map;
 
 import static apoc.ExtendedApocConfig.APOC_ML_WATSON_URL;
 import static apoc.ExtendedApocConfig.APOC_ML_WATSON_PROJECT_ID;
+import static apoc.ml.MLTestUtil.assertNullInputFails;
 import static apoc.util.TestUtil.testCall;
+import static java.util.Collections.emptyMap;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -129,5 +131,19 @@ public class WatsonIT {
         assertTrue(generatedText.toLowerCase().contains(text));
         assertEquals(inputTokenCount, result.get("input_token_count"));
         assertEquals(stopReason, result.get("stop_reason"));
+    }
+
+    @Test
+    public void completionNull() {
+        assertNullInputFails(db, "CALL apoc.ml.watson.completion(null, $apiKey, $conf)",
+                Map.of("apiKey", accessToken, "conf", emptyMap())
+        );
+    }
+
+    @Test
+    public void chatCompletionNull() {
+        assertNullInputFails(db, "CALL apoc.ml.watson.chat(null, $apiKey, $conf)",
+                Map.of("apiKey", accessToken, "conf", emptyMap())
+        );
     }
 }

--- a/extended/src/test/java/apoc/ml/aws/BedrockIT.java
+++ b/extended/src/test/java/apoc/ml/aws/BedrockIT.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import static apoc.ApocConfig.apocConfig;
 import static apoc.ExtendedApocConfig.APOC_AWS_KEY_ID;
 import static apoc.ExtendedApocConfig.APOC_AWS_SECRET_KEY;
+import static apoc.ml.MLTestUtil.assertNullInputFails;
 import static apoc.ml.aws.AWSConfig.KEY_ID;
 import static apoc.ml.aws.AWSConfig.METHOD_KEY;
 import static apoc.ml.aws.AWSConfig.SECRET_KEY;
@@ -27,8 +28,10 @@ import static apoc.ml.aws.BedrockTestUtil.*;
 import static apoc.ml.aws.BedrockUtil.*;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
+import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeNotNull;
@@ -290,5 +293,33 @@ public class BedrockIT {
     private static void assertionsTitanEmbed(Map value) {
         assertNotNull(value.get("inputTextTokenCount"));
         assertNotNull(value.get("embedding"));
+    }
+
+    @Test
+    public void embeddingNull() {
+        assertNullInputFails(db, "CALL apoc.ml.bedrock.embedding(null)",
+                emptyMap()
+        );
+    }
+
+    @Test
+    public void completionNull() {
+        assertNullInputFails(db, "CALL apoc.ml.bedrock.completion(null)",
+                emptyMap()
+        );
+    }
+
+    @Test
+    public void chatCompletionNull() {
+        assertNullInputFails(db, "CALL apoc.ml.bedrock.chat(null)",
+                emptyMap()
+        );
+    }
+
+    @Test
+    public void imageNull() {
+        assertNullInputFails(db, "CALL apoc.ml.bedrock.image(null)",
+                emptyMap()
+        );
     }
 }

--- a/extended/src/test/java/apoc/ml/aws/BedrockIT.java
+++ b/extended/src/test/java/apoc/ml/aws/BedrockIT.java
@@ -31,7 +31,6 @@ import static apoc.util.TestUtil.testResult;
 import static java.util.Collections.emptyMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeNotNull;

--- a/extended/src/test/java/apoc/ml/sagemaker/SageMakerIT.java
+++ b/extended/src/test/java/apoc/ml/sagemaker/SageMakerIT.java
@@ -22,8 +22,11 @@ import static apoc.ExtendedApocConfig.APOC_AWS_SECRET_KEY;
 import static apoc.ml.aws.AWSConfig.HEADERS_KEY;
 import static apoc.ml.aws.AWSConfig.REGION_KEY;
 import static apoc.ml.aws.SageMakerConfig.ENDPOINT_NAME_KEY;
+import static apoc.util.TestUtil.testCall;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeNotNull;
 
@@ -158,6 +161,23 @@ public class SageMakerIT {
 
     private void assertEventually(Callable<Boolean> booleanCallable) {
         Assert.assertEventually(booleanCallable, val -> val, 30, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void completionNull() {
+        testCall(db, "CALL apoc.ml.sagemaker.completion(null, $conf)",
+                Map.of("conf", emptyMap()),
+                (row) -> assertNull(row.get("value"))
+        );
+    }
+
+    @Test
+    public void chatCompletionNull() {
+        testCall(db,
+                "CALL apoc.ml.sagemaker.chat(null, $conf)",
+                Map.of("conf", emptyMap()),
+                (row) -> assertNull(row.get("value"))
+        );
     }
 
 }


### PR DESCRIPTION
Fixes #3611 

- vertexai and openai embeddings return null rows with null list values
- embeddings, chat completion, completion and image procedures return null if the input parameter is null
- not implemented null check in apoc.ml.<type>.custom procedures, since we can potentially pass a null parameter (e.g. to call [this RestAPI](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_GetModelInvocationLoggingConfiguration.html))



### Additional notes

- Added trello card (id: G2oExgfb) for the above issue.

Would be great to handle errors like these, but we cannot implement it since is part of APOC Core:

`CALL apoc.ml.openai.chat([ {role:"user", content:null}], $apiKey, $conf)`

We should do something like this:

```
        @Override
        public InputStream getInputStream() throws IOException {
            if (con instanceof HttpURLConnection httpConn && httpConn.getResponseCode() >= 400) 
            {
                // return ErrorStream as a RuntimeException 
                String errMsg = new String(httpConn.getErrorStream().readAllBytes());
                throw new RuntimeException("Error during HTTP call:\n" + errMsg);
            }
            
            return toLimitedIStream(con.getInputStream(), getLength());
        }
```