### PR TITLE
Fixes #3998: Solve CypherExtendedTest and CypherEnterpriseExtendedTest

### DIFF
--- a/extended-it/src/test/java/apoc/neo4j/docker/CypherEnterpriseExtendedTest.java
+++ b/extended-it/src/test/java/apoc/neo4j/docker/CypherEnterpriseExtendedTest.java
@@ -31,7 +31,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-@Ignore
 public class CypherEnterpriseExtendedTest {
     private static final String CREATE_RETURNQUERY_NODES = "UNWIND range(0,3) as id \n" +
                                                            "CREATE (n:ReturnQuery {id:id})-[:REL {idRel: id}]->(:Other {idOther: id})";

--- a/extended/src/test/java/apoc/cypher/CypherExtendedTest.java
+++ b/extended/src/test/java/apoc/cypher/CypherExtendedTest.java
@@ -49,7 +49,6 @@ import static org.neo4j.driver.internal.util.Iterables.count;
  * @since 08.05.16
  */
 
-@Ignore
 public class CypherExtendedTest {
     public static final String IMPORT_DIR = "src/test/resources";
     @ClassRule


### PR DESCRIPTION
Fixes #3998


Solved the first 2 test errors, CypherEnterpriseExtendedTest and CypherExtendedTest.
The 3rd one depends on the Core.

- De-ignored and solved tests with neo4j 5.19+ version.
The following error is possibly due to the transaction closing, which has to be done with try-with-res, instead of via onClose(..) 
```
The transaction has been terminated. Retry your operation in a new transaction, 
and you should see a successful result. 
The transaction was marked as failed because a query failed. org.neo4j.graphdb.TransactionTerminatedException: The transaction has been terminated. 
Retry your operation in a new transaction, and you should see a successful result. 
The transaction was marked as failed because a query failed. 

```

