### PR TITLE
Fixes #4058: Add support for mixedbread.ai Embedding API

### DIFF
--- a/docs/asciidoc/modules/ROOT/nav.adoc
+++ b/docs/asciidoc/modules/ROOT/nav.adoc
@@ -65,6 +65,8 @@ include::partial$generated-documentation/nav.adoc[]
     ** xref:ml/vertexai.adoc[]
     ** xref:ml/openai.adoc[]
     ** xref:ml/bedrock.adoc[]
+    ** xref:ml/watsonai.adoc[]
+    ** xref:ml/mixedbread.adoc[]
 
 * xref:background-operations/index.adoc[]
     ** xref::background-operations/apoc-load-directory-async.adoc[]

--- a/docs/asciidoc/modules/ROOT/pages/ml/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/index.adoc
@@ -11,3 +11,4 @@ This section includes:
 * xref::ml/openai.adoc[]
 * xref::ml/bedrock.adoc[]
 * xref::ml/watsonai.adoc[]
+* xref::ml/mixedbread.adoc[]

--- a/docs/asciidoc/modules/ROOT/pages/ml/mixedbread.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/mixedbread.adoc
@@ -1,0 +1,182 @@
+[[Mixedbread-api]]
+= Mixedbread API Access
+:description: This section describes procedures that can be used to access the Mixedbread API.
+
+
+Here is a list of all available Mixedbread API procedures:
+
+
+[opts=header, cols="1, 4", separator="|"]
+|===
+|name| description
+|apoc.ml.mixedbread.custom(body, $config)| To create a customizable Mixedbread API call
+|apoc.ml.mixedbread.embedding(texts, $config)| To create a Mixedbread API call to generate embeddings
+|===
+
+The `$config` parameter coincides with the payload to be passed to the http request,
+and additionally the following configuration keys.
+
+
+.Common configuration parameter
+
+|===
+| key | description
+| apiType | analogous to `apoc.ml.openai.type` APOC config
+| endpoint | analogous to `apoc.ml.openai.url` APOC config
+| apiVersion | analogous to `apoc.ml.azure.api.version` APOC config
+| path | To customize the url portion added to the base url (defined by the `endpoint` config).
+By default, is `/embeddings`, `/completions` and `/chat/completions` for respectively the `apoc.ml.openai.embedding`, `apoc.ml.openai.completion` and `apoc.ml.openai.chat` procedures.
+| jsonPath | To customize https://github.com/json-path/JsonPath[JSONPath] of the response.
+The default is `$` for the `apoc.ml.openai.chat` and `apoc.ml.openai.completion` procedures, and `$.data` for the `apoc.ml.openai.embedding` procedure.
+|===
+
+Since embeddings are a super set of the Openai ones,
+under-the-hood they leverage the apoc.ml.openai.* procedures,
+so we can also create an APOC config `apoc.ml.openai.url` instead of the `endpoint` config.
+
+
+== Generate Embeddings API
+
+This procedure `apoc.ml.mixedbread.embedding` can take a list of text strings, and will return one row per string, with the embedding data as a 1536 element vector.
+It uses the `/embeddings/create` API which is https://www.mixedbread.ai/api-reference/endpoints/embeddings#create-embeddings[documented here^].
+
+Additional configuration is passed to the API, the default model used is `mxbai-embed-large-v1`.
+
+
+.Parameters
+[%autowidth, opts=header]
+|===
+|name | description
+| texts | List of text strings
+| apiKey | OpenAI API key
+| configuration | optional map. See `Configuration` table above
+|===
+
+.Results
+[%autowidth, opts=header]
+|===
+|name | description
+| index | index entry in original list
+| text  | line of text from original list
+| embedding | embedding list of floatings/binary,
+    or map of embedding lists of floatings / binaries, in case of multiple encoding_format
+|===
+
+
+.Generate Embeddings Call
+[source,cypher]
+----
+CALL apoc.ml.mixedbread.embedding(['Some Text'], $apiKey, {}) yield index, text, embedding;
+----
+
+.Generate Embeddings Response
+[%autowidth, opts=header]
+|===
+|index | text | embedding
+|0 | "Some Text" | [-0.0065358975, -7.9563365E-4, .... -0.010693862, -0.005087272]
+|===
+
+
+.Generate Embeddings Call with custom embedding dimension and model
+[source,cypher]
+----
+CALL apoc.ml.mixedbread.embedding(['Some Text', 'Other Text'], 
+    $apiKey, 
+    {model: 'mxbai-embed-2d-large-v1', dimensions: 4}
+)
+----
+
+.Generate Embeddings Example Response
+[%autowidth, opts=header]
+|===
+|index | text | embedding
+|0 | "Some Text" | [0.019943237, -0.08843994, 0.068603516, 0.034942627]
+|1 | "Other Text" | [0.011482239, -0.09069824, 0.05331421, 0.034088135]
+|===
+
+
+.Generate Embeddings Call with custom embedding dimension, model and encoding_format
+[source,cypher]
+----
+CALL apoc.ml.mixedbread.embedding(['Some Text', 'garpez'], 
+    $apiKey, 
+    {encoding_format: ["float", "binary", "ubinary", "int8", "uint8", "base64"]}
+)
+----
+
+.Generate Embeddings Example Response
+[%autowidth, opts=header]
+|===
+| index | text | embedding
+| 0 | "Some Text" | {binary: <binaryResult>, ubinary: <ubinaryResult>, int8: <int8Result>, uint8: <uint8Result>, base64: <base64Result>, float: <floatResult>}
+| 0 | "garpez" | {binary: <binaryResult>, ubinary: <ubinaryResult>, int8: <int8Result>, uint8: <uint8Result>, base64: <base64Result>, float: <floatResult>}
+|===
+
+
+
+
+== Custom API
+
+Via the `apoc.ml.mixedbread.custom` we can create a customizable Mixedbread API Request, 
+returning a generic stream of objects.
+
+For example, we can use the https://www.mixedbread.ai/api-reference/endpoints/reranking[Reranking API].
+
+
+.Reranking API Call
+[source,cypher]
+----
+CALL apoc.ml.mixedbread.custom($apiKey, 
+    { 
+        endpoint: "https://api.mixedbread.ai/v1/reranking",
+        model: "mixedbread-ai/mxbai-rerank-large-v1",
+        query: "Who is the author of To Kill a Mockingbird?",
+        top_k: 3,
+        input: [
+            "To Kill a Mockingbird is a novel by Harper Lee published in 1960. It was immediately successful, winning the Pulitzer Prize, and has become a classic of modern American literature.",
+                    "The novel Moby-Dick was written by Herman Melville and first published in 1851. It is considered a masterpiece of American literature and deals with complex themes of obsession, revenge, and the conflict between good and evil.",
+                    "Harper Lee, an American novelist widely known for her novel To Kill a Mockingbird, was born in 1926 in Monroeville, Alabama. She received the Pulitzer Prize for Fiction in 1961.",
+                    "Jane Austen was an English novelist known primarily for her six major novels, which interpret, critique and comment upon the British landed gentry at the end of the 18th century.",
+                    "The Harry Potter series, which consists of seven fantasy novels written by British author J.K. Rowling, is among the most popular and critically acclaimed books of the modern era.",
+                    "The Great Gatsby, a novel written by American author F. Scott Fitzgerald, was published in 1925. The story is set in the Jazz Age and follows the life of millionaire Jay Gatsby and his pursuit of Daisy Buchanan."
+        ]
+    }
+)
+----
+
+.Generate Embeddings Example Response
+[%autowidth, opts=header]
+|===
+| value
+a|
+[source,json]
+----
+{
+  "model": "mixedbread-ai/mxbai-rerank-large-v1",
+  "return_input": false,
+  "data": [
+    {
+      "index": 0,
+      "score": 0.9980469,
+      "object": "text_document"
+    },
+    {
+      "index": 2,
+      "score": 0.9980469,
+      "object": "text_document"
+    },
+    {
+      "index": 3,
+      "score": 0.06915283,
+      "object": "text_document"
+    }
+  ],
+  "usage": {
+    "total_tokens": 302,
+    "prompt_tokens": 302
+  },
+  "object": "list",
+  "top_k": 3
+}
+----
+|===

--- a/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
@@ -251,6 +251,7 @@ CALL apoc.ml.openai.chat([{"role": "user", "content": "Explain the importance of
 ----
 
 
+
 == Query with natural language
 
 This procedure `apoc.ml.query` takes a question in natural language and returns the results of that query.

--- a/extended/src/main/java/apoc/ml/MixedbreadAI.java
+++ b/extended/src/main/java/apoc/ml/MixedbreadAI.java
@@ -1,0 +1,80 @@
+package apoc.ml;
+
+import apoc.ApocConfig;
+import apoc.result.ObjectResult;
+import org.neo4j.graphdb.security.URLAccessChecker;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static apoc.ml.OpenAI.API_TYPE_CONF_KEY;
+import static apoc.ml.OpenAI.APOC_ML_OPENAI_URL;
+import static apoc.ml.OpenAI.MODEL_CONF_KEY;
+
+public class MixedbreadAI {
+    
+    public static final String ENDPOINT_CONF_KEY = "endpoint";
+    public static final String DEFAULT_MODEL_ID = "mxbai-embed-large-v1";
+    public static final String MIXEDBREAD_BASE_URL = "https://api.mixedbread.ai/v1";
+    public static final String ERROR_MSG_MISSING_ENDPOINT = "The endpoint must be defined via config `%s` or via apoc.conf `%s`"
+            .formatted(ENDPOINT_CONF_KEY, APOC_ML_OPENAI_URL);
+    
+    public static final String ERROR_MSG_MISSING_MODELID = "The model must be defined via config `%s`"
+            .formatted(MODEL_CONF_KEY);
+
+
+    /**
+         * embedding is an Object instead of List<Double>, as with a Mixedbread request having `"encoding_format": [<multipleFormat>]`,
+         * the result can be e.g. {... "embedding": { "float": [<floatEmbedding>], "base": <base64Embedding>,   } ...}
+         * instead of e.g. {... "embedding": [<floatEmbedding>] ...}
+         */
+    public record EmbeddingResult(long index, String text, Object embedding) { }
+    
+    @Context
+    public URLAccessChecker urlAccessChecker;
+    
+    @Context
+    public ApocConfig apocConfig;
+
+
+    @Procedure("apoc.ml.mixedbread.custom")
+    @Description("apoc.mixedbread.custom(, configuration) - returns the embeddings for a given text")
+    public Stream<ObjectResult> custom(@Name("api_key") String apiKey, @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
+        if (!configuration.containsKey(MODEL_CONF_KEY)) {
+            throw new RuntimeException(ERROR_MSG_MISSING_MODELID);
+        }
+        
+        configuration.put(API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.MIXEDBREAD_CUSTOM.name());
+        
+        return OpenAI.executeRequest(apiKey, configuration, 
+                        null, null, null, null, null, 
+                        apocConfig, 
+                        urlAccessChecker)
+                .map(ObjectResult::new);
+    }
+    
+
+    @Procedure("apoc.ml.mixedbread.embedding")
+    @Description("apoc.mixedbread.mixedbread([texts], api_key, configuration) - returns the embeddings for a given text")
+    public Stream<EmbeddingResult> getEmbedding(@Name("texts") List<String> texts,
+                                                       @Name("api_key") String apiKey,
+                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
+        configuration.putIfAbsent(MODEL_CONF_KEY, DEFAULT_MODEL_ID);
+
+        configuration.put(API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.MIXEDBREAD_EMBEDDING.name());
+        return OpenAI.getEmbeddingResult(texts, apiKey, configuration, apocConfig, urlAccessChecker,
+                (map, text) -> {
+                    Long index = (Long) map.get("index");
+                    return new EmbeddingResult(index, text, map.get("embedding"));
+                },
+                m -> new EmbeddingResult(-1, m, List.of())
+        );
+
+    }
+
+}

--- a/extended/src/main/java/apoc/ml/MixedbreadAI.java
+++ b/extended/src/main/java/apoc/ml/MixedbreadAI.java
@@ -12,9 +12,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static apoc.ml.MLUtil.MODEL_CONF_KEY;
 import static apoc.ml.OpenAI.API_TYPE_CONF_KEY;
 import static apoc.ml.OpenAI.APOC_ML_OPENAI_URL;
-import static apoc.ml.OpenAI.MODEL_CONF_KEY;
 
 public class MixedbreadAI {
     

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -137,10 +137,6 @@ public class OpenAI {
         List<String> nonNullTexts = collect.get(true);
 
         Stream<Object> resultStream = executeRequest(apiKey, configuration, "embeddings", "text-embedding-ada-002", "input", nonNullTexts, "$.data", apocConfig, urlAccessChecker);
-//        Function<Map<String, Object>, R> mapRFunction = m -> {
-//            Long index = (Long) m.get("index");
-//            return new EmbeddingResult(index, nonNullTexts.get(index.intValue()), m.get("embedding"));
-//        };
         Stream<T> embeddingResultStream = resultStream
                 .flatMap(v -> ((List<Map<String, Object>>) v).stream())
                 .map(m -> {
@@ -150,10 +146,6 @@ public class OpenAI {
                 });
 
         List<String> nullTexts = collect.getOrDefault(false, List.of());
-//        Function<String, R> stringRFunction = i -> {
-//            // null text return index -1 to indicate that are not coming from `/embeddings` RestAPI
-//            return new EmbeddingResult(-1, i, List.of());
-//        };
         Stream<T> nullResultStream = nullTexts.stream()
                 .map(nullMapping);
         return Stream.concat(embeddingResultStream, nullResultStream);

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -5,7 +5,6 @@ import apoc.Extended;
 import apoc.result.MapResult;
 import apoc.util.JsonUtil;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.jetbrains.annotations.NotNull;
 import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;

--- a/extended/src/main/resources/extended.txt
+++ b/extended/src/main/resources/extended.txt
@@ -114,6 +114,8 @@ apoc.ml.fromCypher
 apoc.ml.fromQueries
 apoc.ml.query
 apoc.ml.schema
+apoc.ml.mixedbread.custom
+apoc.ml.mixedbread.embedding
 apoc.ml.openai.chat
 apoc.ml.openai.completion
 apoc.ml.openai.embedding

--- a/extended/src/test/java/apoc/ml/MixedbreadAIIT.java
+++ b/extended/src/test/java/apoc/ml/MixedbreadAIIT.java
@@ -1,0 +1,259 @@
+package apoc.ml;
+
+import apoc.util.TestUtil;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static apoc.ml.MixedbreadAI.*;
+import static apoc.ml.OpenAI.MODEL_CONF_KEY;
+import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testResult;
+import static apoc.util.Util.map;
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class MixedbreadAIIT {
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule();
+
+    private static String apiKey;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        String keyIdEnv = "MIXEDBREAD_API_KEY";
+        apiKey = System.getenv(keyIdEnv);
+
+        Assume.assumeNotNull("No MIXEDBREAD_API_KEY environment configured", apiKey);
+
+        TestUtil.registerProcedure(db, MixedbreadAI.class);
+    }
+
+    @Test
+    public void getEmbedding() {
+        testResult(db, "CALL apoc.ml.mixedbread.embedding(['Some Text', 'Other Text'], $apiKey, $conf)", 
+                map("apiKey", apiKey, "conf", emptyMap()),
+                r -> {
+                    Map<String, Object> row = r.next();
+                    assertEmbedding(row, 0L, "Some Text", 1024);
+
+                    row = r.next();
+                    assertEmbedding(row, 1L, "Other Text", 1024);
+                    
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    @Test
+    public void getEmbeddingWithNulls() {
+        testResult(db, "CALL apoc.ml.mixedbread.embedding([null, 'Some Text', null, 'Another Text'], $apiKey, $conf)", 
+                Map.of("apiKey", apiKey, "conf", emptyMap()),
+                (r) -> {
+
+                    Map<String, Object> row = r.next();
+                    assertEquals(1024, ((List) row.get("embedding")).size());
+                    assertEquals("Some Text", row.get("text"));
+
+                    row = r.next();
+                    assertEquals(1024, ((List) row.get("embedding")).size());
+                    assertEquals("Another Text", row.get("text"));
+
+                    row = r.next();
+                    assertNullEmbedding(row);
+                    
+                    row = r.next();
+                    assertNullEmbedding(row);
+
+                    assertFalse(r.hasNext());
+                });
+    }
+    
+    @Test
+    public void getEmbeddingWithCustomMultipleEncodingFormats() {
+        Set<String> formats = Set.of("float", "binary", "ubinary", "int8", "uint8", "base64");
+        Map<String, Object> conf = map("encoding_format", formats);
+        testResult(db, "CALL apoc.ml.mixedbread.embedding(['Some Text', 'Other Text'], $apiKey, $conf)", 
+                map("apiKey", apiKey, "conf", conf),
+                r -> {
+                    Map<String, Object> row = r.next();
+                    assertEquals(0L, row.get("index"));
+                    assertEquals("Some Text", row.get("text"));
+                    var embedding = (Map) row.get("embedding");
+                    assertEquals(formats, embedding.keySet());
+                    assertTrue(embedding.get("float") instanceof List);
+                    assertTrue(embedding.get("binary") instanceof List);
+                    assertTrue(embedding.get("ubinary") instanceof List);
+                    assertTrue(embedding.get("int8") instanceof List);
+                    assertTrue(embedding.get("uint8") instanceof List);
+                    assertTrue(embedding.get("base64") instanceof String);
+
+                    row = r.next();
+                    assertEquals(1L, row.get("index"));
+                    assertEquals("Other Text", row.get("text"));
+                    embedding = (Map) row.get("embedding");
+                    assertEquals(formats, embedding.keySet());
+                    assertTrue(embedding.get("float") instanceof List);
+                    assertTrue(embedding.get("binary") instanceof List);
+                    assertTrue(embedding.get("ubinary") instanceof List);
+                    assertTrue(embedding.get("int8") instanceof List);
+                    assertTrue(embedding.get("uint8") instanceof List);
+                    assertTrue(embedding.get("base64") instanceof String);
+
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    @Test
+    public void getEmbeddingWithCustomEmbeddingSize() {
+        testResult(db, "CALL apoc.ml.mixedbread.embedding(['Some Text', 'Other Text'], $apiKey, $conf)",
+                map("apiKey", apiKey, "conf", map("dimensions", 256)),
+                r -> {
+                    Map<String, Object> row = r.next();
+                    assertEmbedding(row, 0L, "Some Text", 256);
+
+                    row = r.next();
+                    assertEmbedding(row, 1L, "Other Text", 256);
+
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    @Test
+    public void getEmbeddingWithOtherModel() {
+        testResult(db, "CALL apoc.ml.mixedbread.embedding(['Some Text', 'Other Text'], $apiKey, $conf)",
+                map("apiKey", apiKey, "conf", map(MODEL_CONF_KEY, "mxbai-embed-2d-large-v1")),
+                r -> {
+                    Map<String, Object> row = r.next();
+                    assertEmbedding(row, 0L, "Some Text", 1024);
+
+                    row = r.next();
+                    assertEmbedding(row, 1L, "Other Text", 1024);
+
+                    assertFalse(r.hasNext());
+                });
+    }
+
+    @Test
+    public void getEmbeddingWithWrongModel() {
+        try {
+            testCall(db, "CALL apoc.ml.mixedbread.embedding(['Some Text', 'Other Text'], $apiKey, $conf)",
+                    map("apiKey", apiKey, 
+                            "conf", map(MODEL_CONF_KEY, "wrong-id")
+                    ),
+                    r -> fail("Should fail due to wrong model id"));
+        } catch (Exception e) {
+            String errMsg = e.getMessage();
+            assertTrue("Actual error message is: " + errMsg,
+                    errMsg.contains("Server returned HTTP response code: 422 for URL: https://api.mixedbread.ai/v1/embeddings")
+            );
+            
+        }
+    }
+
+    /**
+     * Example taken from here: https://www.mixedbread.ai/api-reference/endpoints/reranking 
+     */
+    @Test
+    public void customWithReranking() {
+        List<String> input = List.of("To Kill a Mockingbird is a novel by Harper Lee published in 1960. It was immediately successful, winning the Pulitzer Prize, and has become a classic of modern American literature.",
+                "The novel Moby-Dick was written by Herman Melville and first published in 1851. It is considered a masterpiece of American literature and deals with complex themes of obsession, revenge, and the conflict between good and evil.",
+                "Harper Lee, an American novelist widely known for her novel To Kill a Mockingbird, was born in 1926 in Monroeville, Alabama. She received the Pulitzer Prize for Fiction in 1961.",
+                "Jane Austen was an English novelist known primarily for her six major novels, which interpret, critique and comment upon the British landed gentry at the end of the 18th century.",
+                "The Harry Potter series, which consists of seven fantasy novels written by British author J.K. Rowling, is among the most popular and critically acclaimed books of the modern era.",
+                "The Great Gatsby, a novel written by American author F. Scott Fitzgerald, was published in 1925. The story is set in the Jazz Age and follows the life of millionaire Jay Gatsby and his pursuit of Daisy Buchanan."
+        );
+        Map<String, Object> conf = map(ENDPOINT_CONF_KEY, MIXEDBREAD_BASE_URL + "/reranking",
+                MODEL_CONF_KEY, "mixedbread-ai/mxbai-rerank-large-v1", 
+                "query", "Who is the author of To Kill a Mockingbird?",
+                "top_k", 3,
+                "input", input
+        );
+        testCall(db, "CALL apoc.ml.mixedbread.custom($apiKey, $conf)",
+                Map.of("apiKey", apiKey, "conf", conf),
+                row -> {
+                    Map value = (Map) row.get("value");
+                    
+                    List<Map> data = (List<Map>) value.get("data");
+                    assertEquals(3, data.size());
+                    
+                    Map<String, Object> firstData = map("index", 0L, 
+                            "score", 0.9980469, 
+                            "object", "text_document");
+                    assertEquals(firstData, data.get(0));
+
+
+                    Map<String, Object> secondData = map(
+                            "index", 2L,
+                            "score", 0.9980469,
+                            "object", "text_document");
+                    assertEquals(secondData, data.get(1));
+
+                    Map<String, Object> thirdData = map(
+                            "index", 3L,
+                            "score", 0.06915283,
+                            "object", "text_document");
+                    assertEquals(thirdData, data.get(2));
+                    
+                    assertEquals("list", value.get("object"));
+                });
+    }
+
+    @Test
+    public void customWithMissingEndpoint() {
+        try {
+            testCall(db, "CALL apoc.ml.mixedbread.custom($apiKey, $conf)",
+                    map("apiKey", apiKey,
+                            "conf", map(MODEL_CONF_KEY, "aModelId")
+                    ),
+                    r -> fail("Should fail due to missing endpoint"));
+        } catch (Exception e) {
+            String errMsg = e.getMessage();
+            assertTrue("Actual error message is: " + errMsg, 
+                    errMsg.contains(ERROR_MSG_MISSING_ENDPOINT)
+            );
+        }
+    }
+
+    @Test
+    public void customWithMissingModel() {
+        try {
+            testCall(db, "CALL apoc.ml.mixedbread.custom($apiKey, $conf)",
+                    map("apiKey", apiKey,
+                            "conf", map(ENDPOINT_CONF_KEY, MIXEDBREAD_BASE_URL + "/reranking",
+                                    "foo", "bar")
+                    ),
+                    r -> fail("Should fail due to missing model"));
+        } catch (Exception e) {
+            String errMsg = e.getMessage();
+            assertTrue("Actual error message is: " + errMsg,
+                    errMsg.contains(ERROR_MSG_MISSING_MODELID)
+            );
+        }
+    }
+
+    private static void assertEmbedding(Map<String, Object> row,
+                                        long expectedIdx,
+                                        String expectedText,
+                                        Integer expectedSize) {
+        assertEquals(expectedIdx, row.get("index"));
+        assertEquals(expectedText, row.get("text"));
+        var embedding = (List<Double>) row.get("embedding");
+        assertEquals(expectedSize, embedding.size());
+    }
+
+    private static void assertNullEmbedding(Map<String, Object> row) {
+        assertEmbedding(row, -1, null, 0);
+    }
+                
+}

--- a/extended/src/test/java/apoc/ml/MixedbreadAIIT.java
+++ b/extended/src/test/java/apoc/ml/MixedbreadAIIT.java
@@ -12,8 +12,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static apoc.ml.MLUtil.MODEL_CONF_KEY;
 import static apoc.ml.MixedbreadAI.*;
-import static apoc.ml.OpenAI.MODEL_CONF_KEY;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
 import static apoc.util.Util.map;


### PR DESCRIPTION
Fixes #4058

- New procedures instead of apoc.ml.openai since it behaves a bit different, and we can use other APIs, like reranking
  - They leverage the openAI ones