### PR TITLE
Fixes #1596: Change key/secret to optional in apoc.nlp calls for AWS

### DIFF
--- a/extended/src/main/kotlin/apoc/nlp/aws/AWSProcedures.kt
+++ b/extended/src/main/kotlin/apoc/nlp/aws/AWSProcedures.kt
@@ -5,7 +5,6 @@ import apoc.nlp.NLPHelperFunctions
 import apoc.nlp.NLPHelperFunctions.getNodeProperty
 import apoc.nlp.NLPHelperFunctions.keyPhraseRelationshipType
 import apoc.nlp.NLPHelperFunctions.partition
-import apoc.nlp.NLPHelperFunctions.verifyKey
 import apoc.nlp.NLPHelperFunctions.verifyNodeProperty
 import apoc.nlp.NLPHelperFunctions.verifySource
 import apoc.result.NodeWithMapResult
@@ -41,8 +40,6 @@ class AWSProcedures {
         verifySource(source)
         val nodeProperty = getNodeProperty(config)
         verifyNodeProperty(source, nodeProperty)
-        verifyKey(config, "key")
-        verifyKey(config, "secret")
 
         val client: AWSClient = awsClient(config)
 
@@ -60,8 +57,6 @@ class AWSProcedures {
         verifySource(source)
         val nodeProperty = getNodeProperty(config)
         verifyNodeProperty(source, nodeProperty)
-        verifyKey(config, "key")
-        verifyKey(config, "secret")
 
         val client = awsClient(config)
         val relationshipType = NLPHelperFunctions.entityRelationshipType(config)
@@ -85,8 +80,6 @@ class AWSProcedures {
         verifySource(source)
         val nodeProperty = getNodeProperty(config)
         verifyNodeProperty(source, nodeProperty)
-        verifyKey(config, "key")
-        verifyKey(config, "secret")
 
         val client: AWSClient = awsClient(config)
 
@@ -106,8 +99,6 @@ class AWSProcedures {
         verifySource(source)
         val nodeProperty = getNodeProperty(config)
         verifyNodeProperty(source, nodeProperty)
-        verifyKey(config, "key")
-        verifyKey(config, "secret")
 
         val client = awsClient(config)
         val relationshipType = keyPhraseRelationshipType(config)
@@ -131,8 +122,6 @@ class AWSProcedures {
         verifySource(source)
         val nodeProperty = getNodeProperty(config)
         verifyNodeProperty(source, nodeProperty)
-        verifyKey(config, "key")
-        verifyKey(config, "secret")
 
         val client: AWSClient = awsClient(config)
 
@@ -152,8 +141,6 @@ class AWSProcedures {
         verifySource(source)
         val nodeProperty = getNodeProperty(config)
         verifyNodeProperty(source, nodeProperty)
-        verifyKey(config, "key")
-        verifyKey(config, "secret")
 
         val client = awsClient(config)
         val storeGraph: Boolean = config.getOrDefault("write", false) as Boolean

--- a/extended/src/test/kotlin/apoc/nlp/aws/AWSProceduresAPIWithEnvVarsTest.kt
+++ b/extended/src/test/kotlin/apoc/nlp/aws/AWSProceduresAPIWithEnvVarsTest.kt
@@ -1,0 +1,171 @@
+package apoc.nlp.aws
+
+import apoc.util.TestUtil
+import com.amazonaws.SDKGlobalConfiguration.ACCESS_KEY_ENV_VAR
+import com.amazonaws.SDKGlobalConfiguration.SECRET_KEY_ENV_VAR
+import org.junit.Assert.assertTrue
+import org.junit.Assume.assumeNotNull
+import org.junit.BeforeClass
+import org.junit.ClassRule
+import org.junit.Test
+import org.neo4j.graphdb.Result
+import org.neo4j.test.rule.ImpermanentDbmsRule
+
+
+/**
+ * To execute tests, set these environment variables:
+ * AWS_ACCESS_KEY_ID=<apiKey>;AWS_SECRET_KEY=<secretKey>
+ */
+class AWSProceduresAPIWithEnvVarsTest {
+    companion object {
+        private val apiKey: String? = System.getenv(ACCESS_KEY_ENV_VAR)
+        private val apiSecret: String? = System.getenv(SECRET_KEY_ENV_VAR)
+
+        @ClassRule
+        @JvmField
+        val neo4j = ImpermanentDbmsRule()
+
+        @BeforeClass
+        @JvmStatic
+        fun beforeClass() {
+            neo4j.executeTransactionally("""
+                CREATE (:Article {
+                  uri: "https://neo4j.com/blog/pokegraph-gotta-graph-em-all/",
+                  body: "These days I’m rarely more than a few feet away from my Nintendo Switch and I play board games, card games and role playing games with friends at least once or twice a week. I’ve even organised lunch-time Mario Kart 8 tournaments between the Neo4j European offices!"
+                });""")
+            
+            neo4j.executeTransactionally("""
+                CREATE (:Article {
+                  uri: "https://en.wikipedia.org/wiki/Nintendo_Switch",
+                  body: "The Nintendo Switch is a video game console developed by Nintendo, released worldwide in most regions on March 3, 2017. It is a hybrid console that can be used as a home console and portable device. The Nintendo Switch was unveiled on October 20, 2016. Nintendo offers a Joy-Con Wheel, a small steering wheel-like unit that a Joy-Con can slot into, allowing it to be used for racing games such as Mario Kart 8."
+                });
+            """)
+            
+            assumeNotNull(apiKey, apiSecret)
+            TestUtil.registerProcedure(neo4j, AWSProcedures::class.java)
+        }
+    }
+
+    @Test
+    fun `should extract entities in stream mode`() {
+        neo4j.executeTransactionally("""
+                MATCH (a:Article {uri: "https://neo4j.com/blog/pokegraph-gotta-graph-em-all/"})
+                CALL apoc.nlp.aws.entities.stream(a, {
+                  nodeProperty: "body"
+                })
+                YIELD value
+                UNWIND value.entities AS result
+                RETURN result;
+                """, mapOf()) {
+            assertStreamWithScoreResult(it)
+        }
+    }
+
+    @Test
+    fun `should extract entities in graph mode`() {
+        neo4j.executeTransactionally("""
+                MATCH (a:Article {uri: "https://neo4j.com/blog/pokegraph-gotta-graph-em-all/"})
+                CALL apoc.nlp.aws.entities.graph(a, {
+                  nodeProperty: "body",
+                  writeRelationshipType: "ENTITY"
+                })
+                YIELD graph AS g
+                RETURN g;
+                """, mapOf()) {
+            assertGraphResult(it)
+        }
+    }
+
+    @Test
+    fun `should extract key phrases in stream mode`() {
+        neo4j.executeTransactionally("""
+                MATCH (a:Article {uri: "https://neo4j.com/blog/pokegraph-gotta-graph-em-all/"})
+                CALL apoc.nlp.aws.keyPhrases.stream(a, {
+                  nodeProperty: "body"
+                })
+                YIELD value
+                UNWIND value.keyPhrases AS result
+                RETURN result
+                """, mapOf()) {
+            assertStreamWithScoreResult(it)
+        }
+    }
+
+    @Test
+    fun `should extract key phrases in graph mode`() {
+        neo4j.executeTransactionally("""
+                MATCH (a:Article {uri: "https://neo4j.com/blog/pokegraph-gotta-graph-em-all/"})
+                CALL apoc.nlp.aws.keyPhrases.graph(a, {
+                  nodeProperty: "body",
+                  writeRelationshipType: "KEY_PHRASE",
+                  write: true
+                })
+                YIELD graph AS g
+                RETURN g;
+                """, mapOf()) {
+            assertGraphResult(it)
+        }
+    }
+
+    @Test
+    fun `should extract sentiment in stream mode`() {
+        neo4j.executeTransactionally("""
+                MATCH (a:Article {uri: "https://neo4j.com/blog/pokegraph-gotta-graph-em-all/"})
+                CALL apoc.nlp.aws.sentiment.stream(a, {
+                  nodeProperty: "body"
+                })
+                YIELD value
+                RETURN value AS result;
+                """, mapOf()) {
+            assertSentimentScoreResult(it)
+        }
+    }
+
+    @Test
+    fun `should extract sentiment in graph mode`() {
+        neo4j.executeTransactionally("""
+                MATCH (a:Article {uri: "https://neo4j.com/blog/pokegraph-gotta-graph-em-all/"})
+                CALL apoc.nlp.aws.sentiment.graph(a, {
+                  nodeProperty: "body",
+                  write: true
+                })
+                YIELD graph AS g
+                UNWIND g.nodes AS node
+                RETURN node {.uri, .sentiment, .sentimentScore} AS result;
+                """, mapOf()) {
+            assertSentimentScoreResult(it)
+        }
+    }
+
+    private fun assertStreamWithScoreResult(it: Result) {
+        val asSequence = it.asSequence().toList()
+        assertTrue(asSequence.isNotEmpty())
+
+        asSequence.forEach {
+            val entity: Map<String, Any> = it["result"] as Map<String, Any>
+            assertTrue(entity.containsKey("score"))
+        }
+    }
+
+    private fun assertGraphResult(it: Result) {
+        val asSequence = it.asSequence().toList()
+        assertTrue(asSequence.isNotEmpty())
+
+        asSequence.forEach {
+            val entity: Map<String, Any> = it["g"] as Map<String, Any>
+            assertTrue(entity.containsKey("nodes"))
+            assertTrue(entity.containsKey("relationships"))
+        }
+    }
+
+    private fun assertSentimentScoreResult(it: Result) {
+        val asSequence = it.asSequence().toList()
+        assertTrue(asSequence.isNotEmpty())
+
+        asSequence.forEach {
+            val entity: Map<String, Any> = it["result"] as Map<String, Any>
+            assertTrue(entity.containsKey("sentimentScore"))
+        }
+    }
+}
+

--- a/extended/src/test/kotlin/apoc/nlp/aws/AWSProceduresErrorsTest.kt
+++ b/extended/src/test/kotlin/apoc/nlp/aws/AWSProceduresErrorsTest.kt
@@ -1,5 +1,6 @@
 package apoc.nlp.aws
 
+import apoc.nlp.aws.RealAWSClient.Companion.missingCredentialError
 import apoc.util.TestUtil
 import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertThat
@@ -69,7 +70,7 @@ class AWSProceduresErrorsTest {
                 println(it.resultAsString())
             }
         }
-        assertThat(exception.message, containsString("java.lang.IllegalArgumentException: Missing parameter `key`"))
+        assertThat(exception.message, containsString(missingCredentialError))
     }
 
     @Test
@@ -86,6 +87,6 @@ class AWSProceduresErrorsTest {
                 println(it.resultAsString())
             }
         }
-        assertThat(exception.message, containsString("java.lang.IllegalArgumentException: Missing parameter `secret`"))
+        assertThat(exception.message, containsString(missingCredentialError))
     }
 }


### PR DESCRIPTION
Fixes #1596

Now the apoc.nlp, in case of key and secret config not defined, leverage [com.amazonaws.auth.DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html), so it look for env vars, system properties, etc..