### PR TITLE
Fixes #4055: Upgrade hadoop to 3.4.0

### DIFF
--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -111,9 +111,9 @@ dependencies {
 
     compileOnly group: 'org.apache.parquet', name: 'parquet-hadoop', version: '1.13.1', withoutServers
     // testImplementation analogous is not needed since is bundled via `test-utils` submodule
-    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.1.0', withoutServers
+    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.0', withoutServers
     
-    compileOnly group: 'org.apache.hadoop', name: 'hadoop-aws', version: '3.3.5', {
+    compileOnly group: 'org.apache.hadoop', name: 'hadoop-aws', version: '3.4.0', {
         exclude group: 'com.amazonaws'
     }
 
@@ -125,7 +125,7 @@ dependencies {
     testImplementation group: 'org.apache.arrow', name: 'arrow-vector', version: '13.0.0'
     testImplementation group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '13.0.0'
     
-    testImplementation group: 'org.apache.hadoop', name: 'hadoop-aws', version: '3.3.5', {
+    testImplementation group: 'org.apache.hadoop', name: 'hadoop-aws', version: '3.4.0', {
         exclude group: 'com.amazonaws'
     }
 

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -112,10 +112,6 @@ dependencies {
     compileOnly group: 'org.apache.parquet', name: 'parquet-hadoop', version: '1.13.1', withoutServers
     // testImplementation analogous is not needed since is bundled via `test-utils` submodule
     compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.0', withoutServers
-    
-    compileOnly group: 'org.apache.hadoop', name: 'hadoop-aws', version: '3.4.0', {
-        exclude group: 'com.amazonaws'
-    }
 
     compileOnly group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.16.1'
     compileOnly group: 'org.apache.arrow', name: 'arrow-vector', version: '13.0.0'
@@ -124,11 +120,6 @@ dependencies {
     testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.16.1'
     testImplementation group: 'org.apache.arrow', name: 'arrow-vector', version: '13.0.0'
     testImplementation group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '13.0.0'
-    
-    testImplementation group: 'org.apache.hadoop', name: 'hadoop-aws', version: '3.4.0', {
-        exclude group: 'com.amazonaws'
-    }
-
 
     // These dependencies affect the tests only, they will not be packaged in the resulting .jar
     testImplementation project(':test-utils')

--- a/extra-dependencies/hadoop/build.gradle
+++ b/extra-dependencies/hadoop/build.gradle
@@ -28,14 +28,14 @@ shadowJar {
 }
 
 dependencies {
-    implementation group: 'org.apache.hadoop', name: 'hadoop-hdfs-client', version: '3.3.5', commonExclusions
-    implementation group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.5', commonExclusions
+    implementation group: 'org.apache.hadoop', name: 'hadoop-hdfs-client', version: '3.4.0', commonExclusions
+    implementation group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.0', commonExclusions
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.23.1', commonExclusions
 
     implementation group: 'org.apache.parquet', name: 'parquet-hadoop', version: '1.13.1', commonExclusions
     implementation group: 'org.apache.parquet', name: 'parquet-column', version: '1.13.1', commonExclusions
-    implementation group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: '3.3.5', commonExclusions
-    implementation group: 'org.apache.hadoop', name: 'hadoop-aws', version: '3.3.5', commonExclusions.andThen {
+    implementation group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: '3.4.0', commonExclusions
+    implementation group: 'org.apache.hadoop', name: 'hadoop-aws', version: '3.4.0', commonExclusions.andThen {
         exclude group: 'com.amazonaws'
     }
 }

--- a/extra-dependencies/hadoop/build.gradle
+++ b/extra-dependencies/hadoop/build.gradle
@@ -35,9 +35,6 @@ dependencies {
     implementation group: 'org.apache.parquet', name: 'parquet-hadoop', version: '1.13.1', commonExclusions
     implementation group: 'org.apache.parquet', name: 'parquet-column', version: '1.13.1', commonExclusions
     implementation group: 'org.apache.hadoop', name: 'hadoop-mapreduce-client-core', version: '3.4.0', commonExclusions
-    implementation group: 'org.apache.hadoop', name: 'hadoop-aws', version: '3.4.0', commonExclusions.andThen {
-        exclude group: 'com.amazonaws'
-    }
 }
 
 


### PR DESCRIPTION
Fixes #4055

- Updated and tested hadoop new dependencies

----

- [removed unnecessary hadoop-aws package](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4063/commits/61c64def3da2ea5b5b8e7ba851a5c0ce9d8fafd5) commit: removed the hadoop-aws, since it cause a strange [heap space error](https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/9079399293/job/24995551577?pr=4063#step:7:276) with the 3.4.0 version,
but it's unnecessary anyway, as with the `hadoop-*` 3.4.0 packages, the hadoop procedures work also without that package,
e.g. `call apoc.load.parquet("s3://s3.us-east-2.amazonaws.com:443/aws-public-blockchain/v1.0/btc/transactions/date=2010-05-01/part-00000-8829a06f-164c-4e33-a24a-780316e09cc6-c000.snappy.parquet?accessKey=<accessKey>&secretKey=<secretKey>")` 