### PR TITLE
Fixes #4005: Add a procedure for RAG

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
@@ -589,3 +589,192 @@ RETURN *
 | name | description
 | value | the description of the dataset
 |===
+
+== Query with Retrieval-augmented generation (RAG) technique
+
+This procedure `apoc.ml.rag` takes a list of paths or a vector index name, relevant attributes and a natural language question 
+to create a prompt implementing a Retrieval-augmented generation (RAG) technique.
+
+See https://aws.amazon.com/what-is/retrieval-augmented-generation/[here] for more info about the RAG process.
+
+It uses the `chat/completions` API which is https://platform.openai.com/docs/api-reference/chat/create[documented here^].
+
+
+
+.Input Parameters
+[%autowidth, opts=header]
+|===
+| name | description | mandatory
+| paths | the list of paths to retrieve and augment the prompt, it can also be a matching query or a vector index name | yes
+| attributes | the relevant attributes useful to retrieve and augment the prompt | yes
+| question | the user question | yes
+| conf | An optional configuration map, please check the next section | no
+|===
+
+
+.Configuration map
+[%autowidth, opts=header]
+|===
+| name | description | mandatory
+| getLabelTypes | add the label / rel-type names to the info to augment the prompt | no, default `true`
+| embeddings | to search similar embeddings stored into a node vector index (in case of `embeddings: "NODE"`) or relationship vector index (in case of `embeddings: "REL"`) | no, default `"FALSE"`
+| topK | number of neighbors to find for each node (in case of `embeddings: "NODE"`) or relationships (in case of `embeddings: "REL"`) | no, default `40`
+| apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
+| prompt | the base prompt to be augmented with the context | no, default is: 
+
+"You are a customer service agent that helps a customer with answering questions about a service.
+Use the following context to answer the `user question` at the end.
+Make sure not to make any changes to the context if possible when prepare answers to provide accurate responses.
+If you don't know the answer, just say \`Sorry, I don't know`, don't try to make up an answer."
+|===
+
+
+Using the apoc.ml.rag procedure we can reduce AI hallucinations (i.e. false or misleading responses), 
+providing relevant and up-to-date information to our procedure via the 1st parameter.
+
+For example, by executing the following procedure (with the `gpt-3.5-turbo` model, last updated in January 2022)
+we have a hallucination
+
+.Query call
+[source,cypher]
+----
+CALL apoc.ml.openai.chat([
+    {role:"user", content: "Which athletes won the gold medal in mixed doubles's curling  at the 2022 Winter Olympics?"}
+], $apiKey)
+----
+
+.Example response
+[opts="header"]
+|===
+| value
+| The gold medal in curling at the 2022 Winter Olympics was won by the Swedish men's team and the Russian women's team.
+|===
+
+So, we can use the RAG technique to provide real results. 
+For example with the given dataset (with data taken from https://en.wikipedia.org/wiki/Curling_at_the_2022_Winter_Olympics[this wikipedia page]):
+
+.wikipedia dataset
+[source,cypher]
+----
+CREATE (mixed2022:Discipline {title:"Mixed doubles's curling", year: 2022})
+WITH mixed2022
+CREATE (:Athlete {name: 'Stefania Constantini', country: 'Italy', irrelevant: 'asdasd'})-[:HAS_MEDAL {medal: 'Gold', irrelevant2: 'asdasd'}]->(mixed2022)
+CREATE (:Athlete {name: 'Amos Mosaner', country: 'Italy', irrelevant: 'qweqwe'})-[:HAS_MEDAL {medal: 'Gold', irrelevant2: 'rwerew'}]->(mixed2022)
+CREATE (:Athlete {name: 'Kristin Skaslien', country: 'Norway', irrelevant: 'dfgdfg'})-[:HAS_MEDAL {medal: 'Silver', irrelevant2: 'gdfg'}]->(mixed2022)
+CREATE (:Athlete {name: 'Magnus Nedregotten', country: 'Norway', irrelevant: 'xcvxcv'})-[:HAS_MEDAL {medal: 'Silver', irrelevant2: 'asdasd'}]->(mixed2022)
+CREATE (:Athlete {name: 'Almida de Val', country: 'Sweden', irrelevant: 'rtyrty'})-[:HAS_MEDAL {medal: 'Bronze', irrelevant2: 'bfbfb'}]->(mixed2022)
+CREATE (:Athlete {name: 'Oskar Eriksson', country: 'Sweden', irrelevant: 'qwresdc'})-[:HAS_MEDAL {medal: 'Bronze', irrelevant2: 'juju'}]->(mixed2022)
+----
+
+we can execute:
+
+.Query call
+[source,cypher]
+----
+MATCH path=(:Athlete)-[:HAS_MEDAL]->(Discipline)
+WITH collect(path) AS paths
+CALL apoc.ml.rag(paths, 
+  ["name", "country", "medal", "title", "year"], 
+  "Which athletes won the gold medal in mixed doubles's curling  at the 2022 Winter Olympics?", 
+  {apiKey: $apiKey}
+) YIELD value
+RETURN value
+----
+
+.Example response
+[opts="header"]
+|===
+| value
+| The gold medal in curling at the 2022 Winter Olympics was won by Stefania Constantini and Amos Mosaner from Italy.
+|===
+
+or:
+
+.Query call
+[source,cypher]
+----
+MATCH path=(:Athlete)-[:HAS_MEDAL]->(Discipline)
+WITH collect(path) AS paths
+CALL apoc.ml.rag(paths, 
+  ["name", "country", "medal", "title", "year"], 
+  "Which athletes won the silver medal in mixed doubles's curling  at the 2022 Winter Olympics?", 
+  {apiKey: $apiKey}
+) YIELD value
+RETURN value
+----
+
+.Example response
+[opts="header"]
+|===
+| value
+| The gold medal in curling at the 2022 Winter Olympics was won by Kristin Skaslien and Magnus Nedregotten from Norway.
+|===
+
+We can also pass a string query returning paths/relationships/nodes, for example:
+
+[source,cypher]
+----
+CALL apoc.ml.rag("MATCH path=(:Athlete)-[:HAS_MEDAL]->(Discipline) WITH collect(path) AS paths", 
+  ["name", "country", "medal", "title", "year"], 
+  "Which athletes won the gold medal in mixed doubles's curling  at the 2022 Winter Olympics?", 
+  {apiKey: $apiKey}
+) YIELD value
+RETURN value
+----
+
+.Example response
+[opts="header"]
+|===
+| value
+| The gold medal in curling at the 2022 Winter Olympics was won by Stefania Constantini and Amos Mosaner from Italy.
+|===
+
+or we can pass a vector index name as the 1st parameter, in case we stored useful info into embedding nodes.
+For example, given this node vector index:
+
+[source,cypher]
+----
+CREATE VECTOR INDEX `rag-embeddings`
+FOR (n:RagEmbedding) ON (n.embedding)
+OPTIONS {indexConfig: {
+ `vector.dimensions`: 1536,
+ `vector.similarity_function`: 'cosine'
+}}
+----
+
+and some (:RagEmbedding) nodes with the `text` properties, we can execute:
+
+[source,cypher]
+----
+CALL apoc.ml.rag("rag-embeddings", 
+  ["text"], 
+  "Which athletes won the gold medal in mixed doubles's curling  at the 2022 Winter Olympics?", 
+  {apiKey: $apiKey, embeddings: "NODE", topK: 20}
+) YIELD value
+RETURN value
+----
+
+or, with a relationship vector index:
+
+
+[source,cypher]
+----
+CREATE VECTOR INDEX `rag-rel-embeddings`
+FOR ()-[r:RAG_EMBEDDING]-() ON (r.embedding)
+OPTIONS {indexConfig: {
+ `vector.dimensions`: 1536,
+ `vector.similarity_function`: 'cosine'
+}}
+----
+
+and some [:RagEmbedding] relationships with the `text` properties, we can execute:
+
+[source,cypher]
+----
+CALL apoc.ml.rag("rag-rel-embeddings", 
+  ["text"], 
+  "Which athletes won the gold medal in mixed doubles's curling  at the 2022 Winter Olympics?", 
+  {apiKey: $apiKey, embeddings: "REL", topK: 20}
+) YIELD value
+RETURN value
+----

--- a/extended/src/main/java/apoc/ml/RagConfig.java
+++ b/extended/src/main/java/apoc/ml/RagConfig.java
@@ -1,0 +1,130 @@
+package apoc.ml;
+
+import apoc.util.Util;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+
+import java.util.Map;
+
+import static apoc.ml.Prompt.API_KEY_CONF;
+
+public class RagConfig {
+    public static final String UNKNOWN_ANSWER = "Sorry, I don't know";
+    public static final String DEFAULT_BASE_PROMPT = """
+            You are a customer service agent that helps a customer with answering questions about a service.
+            Use the following context to answer the `user question` at the end. Make sure not to make any changes to the context if possible when prepare answers to provide accurate responses.
+            If you don't know the answer, just say `%s`, don't try to make up an answer.
+            """.formatted(UNKNOWN_ANSWER);
+    
+    public static final String EMBEDDINGS_CONF = "embeddings";
+    public static final String GET_LABEL_TYPES_CONF = "getLabelTypes";
+    public static final String TOP_K_CONF = "topK";
+    public static final String PROMPT_CONF = "prompt";
+    
+    private final boolean getLabelTypes;
+    private final EmbeddingQuery embeddings;
+    private final Integer topK;
+    private final String apiKey;
+    private final String basePrompt;
+    private final Map<String, Object> confMap;
+
+    public RagConfig(Map<String, Object> confMap) {
+        if (confMap == null) {
+            confMap = Map.of();
+        }
+
+        this.confMap = confMap;
+        this.getLabelTypes = Util.toBoolean(confMap.getOrDefault(GET_LABEL_TYPES_CONF, true));
+        String embeddingString = (String) confMap.getOrDefault(EMBEDDINGS_CONF, EmbeddingQuery.Type.FALSE.name());
+        this.embeddings = EmbeddingQuery.Type.valueOf(embeddingString).get();
+        this.topK = Util.toInteger(confMap.getOrDefault(TOP_K_CONF, 40));
+        this.apiKey = (String) confMap.get(API_KEY_CONF);
+        this.basePrompt = (String) confMap.getOrDefault(PROMPT_CONF, DEFAULT_BASE_PROMPT);
+    }
+
+    public boolean isGetLabelTypes() {
+        return getLabelTypes;
+    }
+
+    public EmbeddingQuery getEmbeddings() {
+        return embeddings;
+    }
+
+    public Integer getTopK() {
+        return topK;
+    }
+
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    public String getBasePrompt() {
+        return basePrompt;
+    }
+
+    public Map<String, Object> getConfMap() {
+        return confMap;
+    }
+    
+    public interface EmbeddingQuery {
+        Result getQuery(String queryOrIndex, String question, Transaction tx, RagConfig config);
+    
+        String BASE_EMBEDDING_QUERY = """
+                    CALL apoc.ml.openai.embedding([$question], $key , $conf)
+                    YIELD index, text, embedding
+                    WITH text, embedding
+                    """;
+    
+        default Map<String, Object> getParams(String queryOrIndex, String question, RagConfig config) {
+            return Map.of("vectorIndex", queryOrIndex,
+                    TOP_K_CONF, config.getTopK(),
+                    "question", question,
+                    "key", config.getApiKey(),
+                    "conf", config.getConfMap());
+        }
+    
+        enum Type {
+            NODE(new Node()),
+            REL(new Rel()),
+            FALSE(new False());
+    
+            private final EmbeddingQuery embedding;
+    
+            Type(EmbeddingQuery embedding) {
+                this.embedding = embedding;
+            }
+    
+            public EmbeddingQuery get() {
+                return embedding;
+            }
+        }
+    
+        class False implements EmbeddingQuery {
+            @Override
+            public Result getQuery(String queryOrIndex, String question, Transaction tx, RagConfig config) {
+                return tx.execute(queryOrIndex);
+            }
+        }
+    
+        class Node implements EmbeddingQuery {
+            @Override
+            public Result getQuery(String queryOrIndex, String question, Transaction tx, RagConfig config) {
+                return tx.execute(BASE_EMBEDDING_QUERY + """
+                            CALL db.index.vector.queryNodes($vectorIndex, $topK, embedding) YIELD node
+                            RETURN node""",
+                        getParams(queryOrIndex, question, config));
+            }
+        }
+    
+        class Rel implements EmbeddingQuery {
+            @Override
+            public Result getQuery(String queryOrIndex, String question, Transaction tx, RagConfig config) {
+                return tx.execute(BASE_EMBEDDING_QUERY + """
+                                    CALL db.index.vector.queryRelationships($vectorIndex, $topK, embedding) YIELD relationship
+                                    RETURN relationship""",
+                        getParams(queryOrIndex, question, config));
+            }
+        }
+    }
+}
+

--- a/extended/src/main/resources/extended.txt
+++ b/extended/src/main/resources/extended.txt
@@ -113,6 +113,7 @@ apoc.ml.cypher
 apoc.ml.fromCypher
 apoc.ml.fromQueries
 apoc.ml.query
+apoc.ml.rag
 apoc.ml.schema
 apoc.ml.mixedbread.custom
 apoc.ml.mixedbread.embedding

--- a/extended/src/test/java/apoc/ml/PromptIT.java
+++ b/extended/src/test/java/apoc/ml/PromptIT.java
@@ -22,15 +22,36 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
+import static apoc.ml.Prompt.API_KEY_CONF;
+import static apoc.ml.Prompt.UNKNOWN_ANSWER;
+import static apoc.ml.RagConfig.*;
+import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.Assert.fail;
 
 public class PromptIT {
 
     private static final String OPENAI_KEY = System.getenv("OPENAI_KEY");
+    private static final List<String> RAG_ATTRIBUTES = List.of("name", "country", "medal", "title", "year");
+    private static final String CREATE_EMBEDDINGS_FOR_RAG = """
+                MATCH path=(a:Athlete)-[medal:HAS_MEDAL]->(d:Discipline)
+                WITH 'Athlete name: ' + a.name + '\\ncountry: ' + a.country + '\\nmedal: ' + medal.medal + '\\nyear: ' + d.year AS text
+                WITH collect(text) AS texts
+                CALL apoc.ml.openai.embedding(texts, $apiKey)
+                yield embedding, text
+                """;
+    private static final String QUERY_RAG = """
+                MATCH path=(:Athlete)-[:HAS_MEDAL]->(Discipline)
+                WITH collect(path) AS paths
+                CALL apoc.ml.rag(paths, $attributes, $question, $conf) YIELD value
+                RETURN value
+                """;
 
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
@@ -42,12 +63,19 @@ public class PromptIT {
 
     @Before
     public void setUp() {
-        TestUtil.registerProcedure(db, Prompt.class, Meta.class, Strings.class, Coll.class);
+        TestUtil.registerProcedure(db, Prompt.class, OpenAI.class, Meta.class, Strings.class, Coll.class);
         String movies = Util.readResourceFile("movies.cypher");
         try (Transaction tx = db.beginTx()) {
             tx.execute(movies);
             tx.commit();
         }
+        
+        String rag = Util.readResourceFile("rag.cypher");
+        try (Transaction tx = db.beginTx()) {
+            tx.execute(rag);
+            tx.commit();
+        }
+
     }
 
     @Test
@@ -216,6 +244,214 @@ public class PromptIT {
                     String value = ((String) r.get("value")).toLowerCase();
                     Assertions.assertThat(value).containsAnyOf("does not contain", "empty", "undefined", "doesn't have");
                 });
+    }
+
+    @Test
+    public void ragWithRelevantAttributesComparedToIrrelevantOneAndChatProcedure() {
+        String question = "Which athletes won the gold medal in mixed doubles's curling  at the 2022 Winter Olympics?";
+        
+        // -- test with hallucinations, wrong winner names
+        testCall(db, """
+                CALL apoc.ml.openai.chat([
+                    {role:"user", content: $question}
+                ], $apiKey)""", 
+                map("apiKey", OPENAI_KEY, "question", question),
+                r -> {
+                    var result = (Map<String,Object>) r.get("value");
+
+                    Map message = ((List<Map<String,Map>>) result.get("choices")).get(0).get("message");
+                    assertEquals("assistant", message.get("role"));
+                    String value = (String) message.get("content");
+
+                    String msg = "Current value is: " + value;
+                    assertTrue(msg, value.contains("gold medal"));
+                    assertNot2022Winners(value);
+                });
+
+        // -- test RAG with irrilevant attributes
+        testCall(db, QUERY_RAG,
+                map("attributes", List.of("irrelevant", "irrelevant2"),
+                        "question", "Which athletes won the gold medal in curling at the 2022 Winter Olympics?",
+                        "conf", map(API_KEY_CONF, OPENAI_KEY)
+                ),
+                (r) -> {
+                    String value = (String) r.get("value");
+                    String message = "Current value is: " + value;
+                    assertTrue(message, value.contains(UNKNOWN_ANSWER));
+
+                    assertNot2022Winners(value);
+                });
+
+        // -- test RAG with relevant attributes
+        testCall(db, QUERY_RAG,
+                map(
+                        "attributes", RAG_ATTRIBUTES,
+                        "question", "Which athletes won the gold medal in curling at the 2022 Winter Olympics?",
+                        "conf", map("apiKey", OPENAI_KEY)
+                ),
+                (r) -> {
+                    String value = (String) r.get("value");
+                    String message = "Current value is: " + value;
+                    assertTrue(message, value.contains("Stefania Constantini"));
+                    assertTrue(message, value.contains("Amos Mosaner"));
+                    assertTrue(message, value.contains("Italy"));
+                });
+    }
+
+    @Test
+    public void ragWithIrrilevantAttributesAndCustomPrompt() {
+        String customUnknownAnswer = "Absolutely no idea :/";
+        String prompt = """
+                You are a customer service agent that helps a customer with answering questions about a service.
+                Use the following context to answer the `user question` at the end.
+                If you don't know the answer, just say `%s`, don't try to make up an answer.
+                """.formatted(customUnknownAnswer);
+        
+        testCall(db, QUERY_RAG,
+                map("attributes", List.of("irrelevant", "irrelevant2"),
+                        "question", "Which athletes won the gold medal in curling at the 2022 Winter Olympics?",
+                        "conf", map(API_KEY_CONF, OPENAI_KEY, 
+                                PROMPT_CONF, prompt
+                        )
+                ),
+                (r) -> {
+                    String value = (String) r.get("value");
+                    String message = "Current value is: " + value;
+                    assertTrue(message, value.contains(customUnknownAnswer));
+
+                    assertNot2022Winners(value);
+                });
+    }
+    
+    @Test
+    public void testRagWithVariousQuestions() {
+        testCall(db, QUERY_RAG,
+                map("attributes", RAG_ATTRIBUTES,
+                        "question", "Which athletes won the gold medal in curling at the 2018 Winter Olympics?",
+                        "conf", map(API_KEY_CONF, OPENAI_KEY)
+                ),
+                (r) -> {
+                    String value = (String) r.get("value");
+                    assertThat(value).contains("Lawes", "Morris", "USA");
+                    assertNot2022Winners(value);
+                });
+
+        testCall(db, QUERY_RAG,
+                map("attributes", RAG_ATTRIBUTES,
+                        "question", "Which athletes won the silver medal in curling at the 2022 Winter Olympics?",
+                        "conf", map(API_KEY_CONF, OPENAI_KEY)
+                ),
+                (r) -> {
+                    String value = (String) r.get("value");
+                    assertThat(value).contains("Kristin Skaslien", "Magnus Nedregotten", "Norway");
+                    assertNot2022Winners(value);
+                });
+    }
+    
+    @Test
+    public void testRagQueryString() {
+        testCall(db, QUERY_RAG,
+                map(
+                        "query", "MATCH path=(:Athlete)-[:HAS_MEDAL]->(Discipline) RETURN path",
+                        "attributes", RAG_ATTRIBUTES,
+                        "question", "Which athletes won the gold medal in curling at the 2022 Winter Olympics?",
+                        "conf", map(API_KEY_CONF, OPENAI_KEY)
+                ),
+                (r) -> {
+                    String value = (String) r.get("value");
+                    assert2022Winners(value);
+                });
+    }
+
+    @Test
+    public void testRagEmbedding() {
+        // create vector index and node embeddings
+        String indexName = "rag-embeddings";
+        db.executeTransactionally("""
+                CREATE VECTOR INDEX `%s`
+                FOR (n:RagEmbedding) ON (n.embedding)
+                OPTIONS {indexConfig: {
+                 `vector.dimensions`: 1536,
+                 `vector.similarity_function`: 'cosine'
+                }}"""
+                .formatted(indexName)
+        );
+
+        db.executeTransactionally(CREATE_EMBEDDINGS_FOR_RAG + "\nCREATE (:RagEmbedding {text: text, embedding: embedding})",
+                map("apiKey", OPENAI_KEY)
+        );
+
+        Map<String, Object> conf = map(API_KEY_CONF, OPENAI_KEY,
+                EMBEDDINGS_CONF, EmbeddingQuery.Type.NODE.name(),
+                TOP_K_CONF, 10);
+        
+        testCall(db, "CALL apoc.ml.rag($query, $attributes, $question, $conf)",
+                map(
+                        "query", indexName,
+                        "attributes", List.of("text"),
+                        "question", "Which athletes won the gold medal in curling at the 2022 Winter Olympics?",
+                        "conf", conf
+                ),
+                (r) -> {
+                    String value = (String) r.get("value");
+                    assert2022Winners(value);
+                });
+    }
+
+    @Test
+    public void testRagEmbeddingWithRels() {
+        // create vector index and rels embeddings
+        String indexName = "rag-rel-embeddings";
+        db.executeTransactionally("""
+                CREATE VECTOR INDEX `%s`
+                FOR ()-[r:RAG_EMBEDDING]-() ON (r.embedding)
+                OPTIONS {indexConfig: {
+                 `vector.dimensions`: 1536,
+                 `vector.similarity_function`: 'cosine'
+                }}"""
+                .formatted(indexName)
+        );
+        
+        db.executeTransactionally(CREATE_EMBEDDINGS_FOR_RAG + "\nCREATE (:Start)-[:RAG_EMBEDDING {text: text, embedding: embedding}]->(:End)",
+                map("apiKey", OPENAI_KEY)
+        );
+
+        Map<String, Object> conf = map(API_KEY_CONF, OPENAI_KEY,
+                EMBEDDINGS_CONF, EmbeddingQuery.Type.NODE.name(),
+                TOP_K_CONF, 10);
+        try {
+            testCall(db, "CALL apoc.ml.rag($query, $attributes, $question, $conf)",
+                    map(
+                            "query", indexName,
+                            "attributes", List.of("text"),
+                            "question", "Which athletes won the gold medal in curling at the 2022 Winter Olympics?",
+                            "conf", conf
+                    ),
+                    (r) -> fail());
+        } catch (Exception e) {
+            assertThat(e.getMessage()).contains("it cannot be queried for nodes");
+        }
+
+        conf.put(EMBEDDINGS_CONF, EmbeddingQuery.Type.REL.name());
+        testCall(db, "CALL apoc.ml.rag($query, $attributes, $question, $conf)",
+                map(
+                        "query", indexName,
+                        "attributes", List.of("text"),
+                        "question", "Which athletes won the gold medal in curling at the 2022 Winter Olympics?",
+                        "conf", conf
+                ),
+                (r) -> {
+                    String value = (String) r.get("value");
+                    assert2022Winners(value);
+                });
+    }
+
+    private static void assertNot2022Winners(String value) {
+        assertThat(value).doesNotContain("Stefania Constantini", "Amos Mosaner", "Italy");
+    }
+
+    private static void assert2022Winners(String value) {
+        assertThat(value).contains("Stefania Constantini", "Amos Mosaner", "Italy");
     }
 
 }

--- a/extended/src/test/resources/rag.cypher
+++ b/extended/src/test/resources/rag.cypher
@@ -1,0 +1,16 @@
+CREATE (mixed2022:Discipline {title:"Mixed doubles curling", year: 2022})
+WITH mixed2022
+CREATE (:Athlete {name: 'Stefania Constantini', country: 'Italy', irrelevant: 'asdasd'})-[:HAS_MEDAL {medal: 'Gold', irrelevant2: 'asdasd'}]->(mixed2022)
+CREATE (:Athlete {name: 'Amos Mosaner', country: 'Italy', irrelevant: 'qweqwe'})-[:HAS_MEDAL {medal: 'Gold', irrelevant2: 'rwerew'}]->(mixed2022)
+CREATE (:Athlete {name: 'Kristin Skaslien', country: 'Norway', irrelevant: 'dfgdfg'})-[:HAS_MEDAL {medal: 'Silver', irrelevant2: 'gdfg'}]->(mixed2022)
+CREATE (:Athlete {name: 'Magnus Nedregotten', country: 'Norway', irrelevant: 'xcvxcv'})-[:HAS_MEDAL {medal: 'Silver', irrelevant2: 'asdasd'}]->(mixed2022)
+CREATE (:Athlete {name: 'Almida de Val', country: 'Sweden', irrelevant: 'rtyrty'})-[:HAS_MEDAL {medal: 'Bronze', irrelevant2: 'bfbfb'}]->(mixed2022)
+CREATE (:Athlete {name: 'Oskar Eriksson', country: 'Sweden', irrelevant: 'qwresdc'})-[:HAS_MEDAL {medal: 'Bronze', irrelevant2: 'juju'}]->(mixed2022)
+CREATE (mixed2018:Discipline {title:"Mixed doubles's curling", year: 2018})
+WITH mixed2018
+CREATE (:Athlete {name: 'Lawes', country: 'USA', irrelevant: 'asdasd'})-[:HAS_MEDAL {medal: 'Gold', irrelevant2: 'asdasd'}]->(mixed2018)
+CREATE (:Athlete {name: 'Morris', country: 'USA', irrelevant: 'qweqwe'})-[:HAS_MEDAL {medal: 'Gold', irrelevant2: 'rwerew'}]->(mixed2018)
+CREATE (:Athlete {name: 'mock name 3', country: 'mock country 2', irrelevant: 'dfgdfg'})-[:HAS_MEDAL {medal: 'Silver', irrelevant2: 'gdfg'}]->(mixed2018)
+CREATE (:Athlete {name: 'mock name 4', country: 'mock country 2', irrelevant: 'xcvxcv'})-[:HAS_MEDAL {medal: 'Silver', irrelevant2: 'asdasd'}]->(mixed2018)
+CREATE (:Athlete {name: 'mock name 5', country: 'mock country 3', irrelevant: 'rtyrty'})-[:HAS_MEDAL {medal: 'Bronze', irrelevant2: 'bfbfb'}]->(mixed2018)
+CREATE (:Athlete {name: 'mock name 6', country: 'mock country 3', irrelevant: 'qwresdc'})-[:HAS_MEDAL {medal: 'Bronze', irrelevant2: 'juju'}]->(mixed2018)


### PR DESCRIPTION
Fixes #4005

Added a procedure for RAG you pass the user question plus a graph pattern (paths) and relevant attributes and it creates a prompt to answer the user question using the data on those paths and executes that with the llm provider and returns the answer


Retrieval-augmented generation (RAG) is a technique that reduces hallucinations and enhances the accuracy and reliability of generative AI models with facts fetched from external sources.
See here: https://aws.amazon.com/it/what-is/retrieval-augmented-generation/

# Changes

- Created `apoc.ml.rag(paths, attributes, question, conf)` procedure
- `paths` can be a list of paths to retrieve and augment the prompt, it can also be a matching query or a vector index name
- `attributes` is the list of relevant attributes useful to retrieve and augment the prompt
- `question` is the user question
- `conf` can have 
  - `getLabelTypes` (to add label/rel names to the useful info), 
  - `embeddings` to retrieve entities from vector node/rel indexes
  - `topK` to retrieve k result in case of vector index search
  - `prompt` to customize the base prompt to be augmented with the context
  - `apiKey`

