### PR TITLE
Fixes #4054: Broken Dependencies with apoc.mongo

### DIFF
--- a/extra-dependencies/mongodb/build.gradle
+++ b/extra-dependencies/mongodb/build.gradle
@@ -17,7 +17,7 @@ jar {
 }
 
 dependencies {
-    implementation 'org.mongodb:mongodb-driver:3.2.2', commonExclusions
+    implementation 'org.mongodb:mongodb-driver-sync:4.11.1', commonExclusions
 }
 
 


### PR DESCRIPTION
Fixes #4054

- upgraded driver version
- tested in Neo4j Desktop with mongo:4 and mongo:7.0.4 images (the ones present in the integration tests)