### PR TITLE
Fixes #4090: The apoc.vectordb.*.get/query procedures should search for nodes/relationships with mapping config

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/chroma.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/chroma.adoc
@@ -146,7 +146,7 @@ which will be returned in the `entity` column result.
 
 
 
-Or else, we can create a node if not exists, via `create: true`:
+We can also set the mapping configuration `mode` to `CREATE_IF_MISSING` (which creates nodes if not exist), `READ_ONLY` (to search for nodes/rels, without making updates) or `UPDATE_EXISTING` (default behavior):
 
 [source,cypher]
 ----
@@ -155,7 +155,7 @@ CALL apoc.vectordb.chroma.queryAndUpdate($host, '<collection_id>',
     {},
     5, 
     { mapping: {
-            create: true,
+            mode: "CREATE_IF_MISSING",
             embeddingKey: "vect", 
             nodeLabel: "Test", 
             entityKey: "myId", 
@@ -187,6 +187,27 @@ CALL apoc.vectordb.chroma.queryAndUpdate($host, '<collection_id>',
 which populates the two relationships as: `()-[:TEST {myId: 'one', city: 'Berlin', vect: [vector1]}]-()`
 and `()-[:TEST {myId: 'two', city: 'London', vect: [vector2]}]-()`,
 which will be returned in the `entity` column result.
+
+
+We can also use mapping for `apoc.vectordb.chroma.query` procedure, to search for nodes/rels fitting label/type and metadataKey, without making updates
+(i.e. equivalent to `*.queryOrUpdate` procedure with mapping config having `mode: "READ_ONLY"`).
+
+For example, with the previous relationships, we can execute the following procedure, which just return the relationships in the column `rel`:
+
+[source,cypher]
+----
+CALL apoc.vectordb.weaviate.query($host, 'test_collection',
+    [0.2, 0.1, 0.9, 0.7],
+    {},
+    5, 
+    { fields: ["city", "foo"],
+      mapping: {
+        relType: "TEST", 
+        entityKey: "myId", 
+        metadataKey: "foo" 
+      }
+    })
+----
 
 [NOTE]
 ====

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/chroma.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/chroma.adoc
@@ -119,17 +119,6 @@ CALL apoc.vectordb.chroma.queryAndUpdate($host,
 | ...
 |===
 
-[NOTE]
-====
-We can use mapping with `apoc.vectordb.chroma.getAndUpdate` procedure as well
-====
-
-[NOTE]
-====
-To optimize performances, we can choose what to `YIELD` with the apoc.vectordb.chroma.query and the `apoc.vectordb.chroma.get` procedures.
-For example, by executing a `CALL apoc.vectordb.chroma.query(...) YIELD metadata, score, id`, the RestAPI request will have an {"include": ["metadatas", "documents", "distances"]},
-so that we do not return the other values that we do not need.
-====
 
 We can define a mapping, to fetch the associated nodes and relationships and optionally create them, by leveraging the vector metadata.
 
@@ -199,6 +188,17 @@ which populates the two relationships as: `()-[:TEST {myId: 'one', city: 'Berlin
 and `()-[:TEST {myId: 'two', city: 'London', vect: [vector2]}]-()`,
 which will be returned in the `entity` column result.
 
+[NOTE]
+====
+We can use mapping with `apoc.vectordb.chroma.get*` procedures as well
+====
+
+[NOTE]
+====
+To optimize performances, we can choose what to `YIELD` with the apoc.vectordb.chroma.query and the `apoc.vectordb.chroma.get` procedures.
+For example, by executing a `CALL apoc.vectordb.chroma.query(...) YIELD metadata, score, id`, the RestAPI request will have an {"include": ["metadatas", "documents", "distances"]},
+so that we do not return the other values that we do not need.
+====
 
 .Delete vectors (it leverages https://docs.trychroma.com/usage-guide#deleting-data-from-a-collection[this API])
 [source,cypher]

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/milvus.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/milvus.adoc
@@ -189,9 +189,28 @@ which populates the two relationships as: `()-[:TEST {myId: 'one', city: 'Berlin
 and `()-[:TEST {myId: 'two', city: 'London', vect: [vector2]}]-()`,
 which will be returned in the `entity` column result.
 
+
+We can also use mapping for `apoc.vectordb.milvus.query` procedure, to search for nodes/rels fitting label/type and metadataKey, without making updates.
+For example, with the previous relationships, we can execute the following procedure, which just return the relationships in the column `rel`:
+
+[source,cypher]
+----
+CALL apoc.vectordb.milvus.query('http://localhost:19531', 'test_collection',
+    [0.2, 0.1, 0.9, 0.7],
+    {},
+    5, 
+    { mapping: {
+            embeddingKey: "vect", 
+            relType: "TEST", 
+            entityKey: "myId", 
+            metadataKey: "foo" 
+        }
+    })
+----
+
 [NOTE]
 ====
-We can use mapping with `apoc.vectordb.milvus.getAndUpdate` procedure as well
+We can use mapping with `apoc.vectordb.milvus.get*` procedures as well
 ====
 
 [NOTE]

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/milvus.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/milvus.adoc
@@ -147,7 +147,7 @@ which populates the two nodes as: `(:Test {myId: 'one', city: 'Berlin', vect: [v
 which will be returned in the `entity` column result.
 
 
-Or else, we can create a node if not exists, via `create: true`:
+We can also set the mapping configuration `mode` to `CREATE_IF_MISSING` (which creates nodes if not exist), `READ_ONLY` (to search for nodes/rels, without making updates) or `UPDATE_EXISTING` (default behavior):
 
 [source,cypher]
 ----
@@ -156,7 +156,7 @@ CALL apoc.vectordb.milvus.queryAndUpdate('http://localhost:19531', 'test_collect
     {},
     5, 
     { mapping: {
-            create: true,
+            mode: "CREATE_IF_MISSING",
             embeddingKey: "vect", 
             nodeLabel: "Test", 
             entityKey: "myId", 
@@ -190,7 +190,9 @@ and `()-[:TEST {myId: 'two', city: 'London', vect: [vector2]}]-()`,
 which will be returned in the `entity` column result.
 
 
-We can also use mapping for `apoc.vectordb.milvus.query` procedure, to search for nodes/rels fitting label/type and metadataKey, without making updates.
+We can also use mapping for `apoc.vectordb.milvus.query` procedure, to search for nodes/rels fitting label/type and metadataKey, without making updates
+(i.e. equivalent to `*.queryOrUpdate` procedure with mapping config having `mode: "READ_ONLY"`).
+
 For example, with the previous relationships, we can execute the following procedure, which just return the relationships in the column `rel`:
 
 [source,cypher]

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/pinecone.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/pinecone.adoc
@@ -203,9 +203,28 @@ which populates the two relationships as: `()-[:TEST {myId: 'one', city: 'Berlin
 and `()-[:TEST {myId: 'two', city: 'London', vect: [vector2]}]-()`,
 which will be returned in the `entity` column result.
 
+
+We can also use mapping for `apoc.vectordb.pinecone.query` procedure, to search for nodes/rels fitting label/type and metadataKey, without making updates.
+For example, with the previous relationships, we can execute the following procedure, which just return the relationships in the column `rel`:
+
+[source,cypher]
+----
+CALL apoc.vectordb.pinecone.query($host, 'test-index',
+    [0.2, 0.1, 0.9, 0.7],
+    {},
+    5, 
+    { mapping: {
+            embeddingKey: "vect", 
+            relType: "TEST", 
+            entityKey: "myId", 
+            metadataKey: "foo" 
+        }
+    })
+----
+
 [NOTE]
 ====
-We can use mapping with `apoc.vectordb.pinecone.getAndUpdate` procedure as well
+We can use mapping with `apoc.vectordb.pinecone.get*` procedures as well
 ====
 
 [NOTE]

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/pinecone.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/pinecone.adoc
@@ -161,7 +161,7 @@ which populates the two nodes as: `(:Test {myId: 'one', city: 'Berlin', vect: [v
 which will be returned in the `entity` column result.
 
 
-Or else, we can create a node if not exists, via `create: true`:
+We can also set the mapping configuration `mode` to `CREATE_IF_MISSING` (which creates nodes if not exist), `READ_ONLY` (to search for nodes/rels, without making updates) or `UPDATE_EXISTING` (default behavior):
 
 [source,cypher]
 ----
@@ -170,7 +170,7 @@ CALL apoc.vectordb.pinecone.queryAndUpdate($host, 'test-index',
     {},
     5, 
     { mapping: {
-            create: true,
+            mode: "CREATE_IF_MISSING",
             embeddingKey: "vect", 
             nodeLabel: "Test", 
             entityKey: "myId", 
@@ -204,7 +204,9 @@ and `()-[:TEST {myId: 'two', city: 'London', vect: [vector2]}]-()`,
 which will be returned in the `entity` column result.
 
 
-We can also use mapping for `apoc.vectordb.pinecone.query` procedure, to search for nodes/rels fitting label/type and metadataKey, without making updates.
+We can also use mapping for `apoc.vectordb.pinecone.query` procedure, to search for nodes/rels fitting label/type and metadataKey, without making updates
+(i.e. equivalent to `*.queryOrUpdate` procedure with mapping config having `mode: "READ_ONLY"`).
+
 For example, with the previous relationships, we can execute the following procedure, which just return the relationships in the column `rel`:
 
 [source,cypher]

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/qdrant.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/qdrant.adoc
@@ -191,9 +191,27 @@ which populates the two relationships as: `()-[:TEST {myId: 'one', city: 'Berlin
 and `()-[:TEST {myId: 'two', city: 'London', vect: [vector2]}]-()`,
 which will be returned in the `entity` column result.
 
+
+We can also use mapping for `apoc.vectordb.qdrant.query` procedure, to search for nodes/rels fitting label/type and metadataKey, without making updates.
+For example, with the previous relationships, we can execute the following procedure, which just return the relationships in the column `rel`:
+
+[source,cypher]
+----
+CALL apoc.vectordb.qdrant.queryAndUpdate($hostOrKey, 'test_collection',
+    [0.2, 0.1, 0.9, 0.7],
+    {},
+    5, 
+    { mapping: {
+            relType: "TEST", 
+            entityKey: "myId", 
+            metadataKey: "foo" 
+        }
+    })
+----
+
 [NOTE]
 ====
-We can use mapping with `apoc.vectordb.qdrant.getAndUpdate` procedure as well
+We can use mapping with `apoc.vectordb.qdrant.get*` procedures as well
 ====
 
 [NOTE]

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/qdrant.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/qdrant.adoc
@@ -149,7 +149,7 @@ which populates the two nodes as: `(:Test {myId: 'one', city: 'Berlin', vect: [v
 which will be returned in the `entity` column result.
 
 
-Or else, we can create a node if not exists, via `create: true`:
+We can also set the mapping configuration `mode` to `CREATE_IF_MISSING` (which creates nodes if not exist), `READ_ONLY` (to search for nodes/rels, without making updates) or `UPDATE_EXISTING` (default behavior):
 
 [source,cypher]
 ----
@@ -158,7 +158,7 @@ CALL apoc.vectordb.qdrant.queryAndUpdate($hostOrKey, 'test_collection',
     {},
     5, 
     { mapping: {
-            create: true,
+            mode: "CREATE_IF_MISSING",
             embeddingKey: "vect", 
             nodeLabel: "Test", 
             entityKey: "myId", 
@@ -192,12 +192,14 @@ and `()-[:TEST {myId: 'two', city: 'London', vect: [vector2]}]-()`,
 which will be returned in the `entity` column result.
 
 
-We can also use mapping for `apoc.vectordb.qdrant.query` procedure, to search for nodes/rels fitting label/type and metadataKey, without making updates.
+We can also use mapping for `apoc.vectordb.qdrant.query` procedure, to search for nodes/rels fitting label/type and metadataKey, without making updates
+(i.e. equivalent to `*.queryOrUpdate` procedure with mapping config having `mode: "READ_ONLY"`).
+
 For example, with the previous relationships, we can execute the following procedure, which just return the relationships in the column `rel`:
 
 [source,cypher]
 ----
-CALL apoc.vectordb.qdrant.queryAndUpdate($hostOrKey, 'test_collection',
+CALL apoc.vectordb.qdrant.query($hostOrKey, 'test_collection',
     [0.2, 0.1, 0.9, 0.7],
     {},
     5, 

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/weaviate.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/weaviate.adoc
@@ -205,9 +205,29 @@ and `()-[:TEST {myId: 'two', city: 'London', vect: [vector2]}]-()`,
 which will be returned in the `entity` column result.
 
 
+We can also use mapping for `apoc.vectordb.weaviate.query` procedure, to search for nodes/rels fitting label/type and metadataKey, without making updates.
+For example, with the previous relationships, we can execute the following procedure, which just return the relationships in the column `rel`:
+
+[source,cypher]
+----
+CALL apoc.vectordb.weaviate.query($host, 'test_collection',
+    [0.2, 0.1, 0.9, 0.7],
+    {},
+    5, 
+    { fields: ["city", "foo"],
+      mapping: {
+        relType: "TEST", 
+        entityKey: "myId", 
+        metadataKey: "foo" 
+      }
+    })
+----
+
+
+
 [NOTE]
 ====
-We can use mapping with `apoc.vectordb.weaviate.getAndUpdate` procedure as well
+We can use mapping with `apoc.vectordb.weaviate.get*` procedures as well
 ====
 
 [NOTE]

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/weaviate.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/weaviate.adoc
@@ -160,7 +160,7 @@ and `(:Test {myId: 'two', city: 'London', vect: [vector2]})`,
 which will be returned in the `entity` column result.
 
 
-Or else, we can create a node if not exists, via `create: true`:
+We can also set the mapping configuration `mode` to `CREATE_IF_MISSING` (which creates nodes if not exist), `READ_ONLY` (to search for nodes/rels, without making updates) or `UPDATE_EXISTING` (default behavior):
 
 [source,cypher]
 ----
@@ -170,7 +170,7 @@ CALL apoc.vectordb.weaviate.queryAndUpdate($host, 'test_collection',
     5, 
     { fields: ["city", "foo"],
       mapping: {
-        create: true,
+        mode: "CREATE_IF_MISSING",
         embeddingKey: "vect", 
         nodeLabel: "Test", 
         entityKey: "myId", 
@@ -205,7 +205,9 @@ and `()-[:TEST {myId: 'two', city: 'London', vect: [vector2]}]-()`,
 which will be returned in the `entity` column result.
 
 
-We can also use mapping for `apoc.vectordb.weaviate.query` procedure, to search for nodes/rels fitting label/type and metadataKey, without making updates.
+We can also use mapping for `apoc.vectordb.weaviate.query` procedure, to search for nodes/rels fitting label/type and metadataKey, without making updates
+(i.e. equivalent to `*.queryOrUpdate` procedure with mapping config having `mode: "READ_ONLY"`).
+
 For example, with the previous relationships, we can execute the following procedure, which just return the relationships in the column `rel`:
 
 [source,cypher]

--- a/extended-it/src/test/java/apoc/vectordb/ChromaDbTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/ChromaDbTest.java
@@ -1,8 +1,6 @@
 package apoc.vectordb;
 
 import apoc.util.TestUtil;
-import apoc.util.Util;
-import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -18,7 +16,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static apoc.ml.RestAPIConfig.HEADERS_KEY;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
@@ -30,7 +27,6 @@ import static apoc.vectordb.VectorDbTestUtil.assertReadOnlyProcWithMappingResult
 import static apoc.vectordb.VectorDbTestUtil.assertRelsCreated;
 import static apoc.vectordb.VectorDbTestUtil.dropAndDeleteAll;
 import static apoc.vectordb.VectorDbTestUtil.EntityType.*;
-import static apoc.vectordb.VectorDbUtil.ERROR_READONLY_MAPPING;
 import static apoc.vectordb.VectorEmbeddingConfig.ALL_RESULTS_KEY;
 import static apoc.vectordb.VectorEmbeddingConfig.MAPPING_KEY;
 import static apoc.vectordb.VectorMappingConfig.*;
@@ -233,7 +229,8 @@ public class ChromaDbTest {
                     NODE_LABEL, "Test",
                     ENTITY_KEY, "myId",
                     METADATA_KEY, "foo",
-                    CREATE_KEY, true)
+                    MODE_KEY, MappingMode.CREATE_IF_MISSING.toString()
+                )
         );
         
         testResult(db, "CALL apoc.vectordb.chroma.queryAndUpdate($host, $collection, [0.2, 0.1, 0.9, 0.7], {}, 5, $conf)",

--- a/extended-it/src/test/java/apoc/vectordb/MilvusTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/MilvusTest.java
@@ -32,16 +32,16 @@ import static apoc.vectordb.VectorDbTestUtil.dropAndDeleteAll;
 import static apoc.vectordb.VectorEmbeddingConfig.ALL_RESULTS_KEY;
 import static apoc.vectordb.VectorEmbeddingConfig.FIELDS_KEY;
 import static apoc.vectordb.VectorEmbeddingConfig.MAPPING_KEY;
-import static apoc.vectordb.VectorMappingConfig.CREATE_KEY;
+import static apoc.vectordb.VectorMappingConfig.MODE_KEY;
 import static apoc.vectordb.VectorMappingConfig.EMBEDDING_KEY;
 import static apoc.vectordb.VectorMappingConfig.ENTITY_KEY;
 import static apoc.vectordb.VectorMappingConfig.METADATA_KEY;
 import static apoc.vectordb.VectorMappingConfig.NODE_LABEL;
 import static apoc.vectordb.VectorMappingConfig.REL_TYPE;
+import static apoc.vectordb.VectorMappingConfig.MappingMode;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 import static org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAME;
 import static org.neo4j.configuration.GraphDatabaseSettings.SYSTEM_DATABASE_NAME;
 
@@ -230,7 +230,8 @@ public class MilvusTest {
                         NODE_LABEL, "Test",
                         ENTITY_KEY, "myId",
                         METADATA_KEY, "foo",
-                        CREATE_KEY, true)
+                        MODE_KEY, MappingMode.CREATE_IF_MISSING.toString()
+                )
         );
         testResult(db, "CALL apoc.vectordb.milvus.queryAndUpdate($host, 'test_collection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf)",
                 map("host", HOST, "conf", conf),

--- a/extended-it/src/test/java/apoc/vectordb/MilvusTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/MilvusTest.java
@@ -2,7 +2,6 @@ package apoc.vectordb;
 
 import apoc.util.TestUtil;
 import apoc.util.Util;
-import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -27,9 +26,9 @@ import static apoc.vectordb.VectorDbTestUtil.EntityType.REL;
 import static apoc.vectordb.VectorDbTestUtil.assertBerlinResult;
 import static apoc.vectordb.VectorDbTestUtil.assertLondonResult;
 import static apoc.vectordb.VectorDbTestUtil.assertNodesCreated;
+import static apoc.vectordb.VectorDbTestUtil.assertReadOnlyProcWithMappingResults;
 import static apoc.vectordb.VectorDbTestUtil.assertRelsCreated;
 import static apoc.vectordb.VectorDbTestUtil.dropAndDeleteAll;
-import static apoc.vectordb.VectorDbUtil.ERROR_READONLY_MAPPING;
 import static apoc.vectordb.VectorEmbeddingConfig.ALL_RESULTS_KEY;
 import static apoc.vectordb.VectorEmbeddingConfig.FIELDS_KEY;
 import static apoc.vectordb.VectorEmbeddingConfig.MAPPING_KEY;
@@ -298,6 +297,24 @@ public class MilvusTest {
     }
 
     @Test
+    public void getReadOnlyVectorsWithMapping() {
+        db.executeTransactionally("CREATE (:Test {readID: 'one'}), (:Test {readID: 'two'})");
+
+        Map<String, Object> conf = map(ALL_RESULTS_KEY, true,
+                FIELDS_KEY, FIELDS,
+                MAPPING_KEY, map(EMBEDDING_KEY, "vect",
+                        NODE_LABEL, "Test",
+                        ENTITY_KEY, "readID",
+                        METADATA_KEY, "foo"));
+
+        testResult(db, "CALL apoc.vectordb.milvus.get($host, 'test_collection', [1, 2], $conf) " +
+                       "YIELD vector, id, metadata, node RETURN * ORDER BY id",
+                map("host", HOST, "conf", conf),
+                r -> assertReadOnlyProcWithMappingResults(r, "node")
+        );
+    }
+
+    @Test
     public void queryVectorsWithCreateNodeUsingExistingNode() {
 
         db.executeTransactionally("CREATE (:Test {myId: 'one'}), (:Test {myId: 'two'})");
@@ -336,7 +353,8 @@ public class MilvusTest {
                 MAPPING_KEY, map(EMBEDDING_KEY, "vect",
                 REL_TYPE, "TEST",
                 ENTITY_KEY, "myId",
-                METADATA_KEY, "foo"));
+                METADATA_KEY, "foo")
+        );
         testResult(db, "CALL apoc.vectordb.milvus.queryAndUpdate($host, 'test_collection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf)",
                 map("host", HOST, "conf", conf),
                 r -> {
@@ -356,17 +374,20 @@ public class MilvusTest {
 
     @Test
     public void queryReadOnlyVectorsWithMapping() {
-        Map<String, Object> conf = map(ALL_RESULTS_KEY, true,
-                MAPPING_KEY, map(EMBEDDING_KEY, "vect"));
+        db.executeTransactionally("CREATE (:Start)-[:TEST {readID: 'one'}]->(:End), (:Start)-[:TEST {readID: 'two'}]->(:End)");
 
-        try {
-            testCall(db, "CALL apoc.vectordb.milvus.query($host, 'test_collection', [0.2, 0.1, 0.9, 0.7], {}, 5, $conf)",
-                    map("host", HOST, "conf", conf),
-                    r -> fail()
-            );
-        } catch (RuntimeException e) {
-            Assertions.assertThat(e.getMessage()).contains(ERROR_READONLY_MAPPING);
-        }
+        Map<String, Object> conf = map(ALL_RESULTS_KEY, true,
+                FIELDS_KEY, FIELDS,
+                MAPPING_KEY, map(
+                        REL_TYPE, "TEST",
+                        ENTITY_KEY, "readID",
+                        METADATA_KEY, "foo")
+        );
+
+        testResult(db, "CALL apoc.vectordb.milvus.query($host, 'test_collection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf)",
+                map("host", HOST, "conf", conf),
+                r -> assertReadOnlyProcWithMappingResults(r, "rel")
+        );
     }
 
     @Test

--- a/extended-it/src/test/java/apoc/vectordb/QdrantTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/QdrantTest.java
@@ -9,9 +9,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.neo4j.dbms.api.DatabaseManagementService;
-import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Result;
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 import org.testcontainers.qdrant.QdrantContainer;
 
@@ -265,7 +263,8 @@ public class QdrantTest {
                         NODE_LABEL, "Test",
                         ENTITY_KEY, "myId",
                         METADATA_KEY, "foo",
-                        CREATE_KEY, true)
+                        MODE_KEY, MappingMode.CREATE_IF_MISSING.toString()
+                )
         );
         testResult(db, "CALL apoc.vectordb.qdrant.queryAndUpdate($host, 'test_collection', [0.2, 0.1, 0.9, 0.7], {}, 5, $conf)",
                 map("host", HOST, "conf", conf),

--- a/extended-it/src/test/java/apoc/vectordb/WeaviateTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/WeaviateTest.java
@@ -2,7 +2,6 @@ package apoc.vectordb;
 
 import apoc.util.MapUtil;
 import apoc.util.TestUtil;
-import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -27,7 +26,6 @@ import static apoc.util.Util.map;
 import static apoc.vectordb.VectorDbHandler.Type.WEAVIATE;
 import static apoc.vectordb.VectorDbTestUtil.*;
 import static apoc.vectordb.VectorDbTestUtil.EntityType.*;
-import static apoc.vectordb.VectorDbUtil.ERROR_READONLY_MAPPING;
 import static apoc.vectordb.VectorEmbeddingConfig.ALL_RESULTS_KEY;
 import static apoc.vectordb.VectorEmbeddingConfig.FIELDS_KEY;
 import static apoc.vectordb.VectorEmbeddingConfig.MAPPING_KEY;
@@ -255,8 +253,9 @@ public class WeaviateTest {
                 MAPPING_KEY, map(EMBEDDING_KEY, "vect",
                     NODE_LABEL, "Test",
                     ENTITY_KEY, "myId",
-                    METADATA_KEY, "foo",
-                    CREATE_KEY, true)
+                    METADATA_KEY, "foo", 
+                    MODE_KEY, MappingMode.CREATE_IF_MISSING.toString()
+                )
         );
         testResult(db, "CALL apoc.vectordb.weaviate.queryAndUpdate($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf) " +
                        "YIELD score, vector, id, metadata, node RETURN * ORDER BY id",

--- a/extended/src/main/java/apoc/vectordb/ChromaDb.java
+++ b/extended/src/main/java/apoc/vectordb/ChromaDb.java
@@ -129,7 +129,8 @@ public class ChromaDb {
                                                       @Name("collection") String collection,
                                                       @Name("ids") List<Object> ids,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return getCommon(hostOrKey, collection, ids, configuration, false);
+        setReadOnlyMappingMode(configuration);
+        return getCommon(hostOrKey, collection, ids, configuration);
     }
 
     @Procedure(value = "apoc.vectordb.chroma.getAndUpdate", mode = Mode.WRITE)
@@ -138,15 +139,14 @@ public class ChromaDb {
                                                       @Name("collection") String collection,
                                                       @Name("ids") List<Object> ids,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return getCommon(hostOrKey, collection, ids, configuration, true);
+        return getCommon(hostOrKey, collection, ids, configuration);
     }
 
-    private Stream<EmbeddingResult> getCommon(String hostOrKey, String collection, List<Object> ids, Map<String, Object> configuration, boolean updateMode) throws Exception {
+    private Stream<EmbeddingResult> getCommon(String hostOrKey, String collection, List<Object> ids, Map<String, Object> configuration) throws Exception {
         String url = "%s/api/v1/collections/%s/get";
         Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
 
         VectorEmbeddingConfig apiConfig = DB_HANDLER.getEmbedding().fromGet(config, procedureCallContext, ids, collection);
-        apiConfig.getMapping().setUpdateMode(updateMode);
         
         return getEmbeddingResultStream(apiConfig, procedureCallContext, urlAccessChecker, tx,
                 v -> listToMap((Map) v).stream());
@@ -160,7 +160,8 @@ public class ChromaDb {
                                          @Name(value = "filter", defaultValue = "{}") Map<String, Object> filter,
                                          @Name(value = "limit", defaultValue = "10") long limit,
                                          @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration, false);
+        setReadOnlyMappingMode(configuration);
+        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration);
     }
 
     @Procedure(value = "apoc.vectordb.chroma.queryAndUpdate", mode = Mode.WRITE)
@@ -171,15 +172,14 @@ public class ChromaDb {
                                                       @Name(value = "filter", defaultValue = "{}") Map<String, Object> filter,
                                                       @Name(value = "limit", defaultValue = "10") long limit,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration, true);
+        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration);
     }
 
-    private Stream<EmbeddingResult> queryCommon(String hostOrKey, String collection, List<Double> vector, Map<String, Object> filter, long limit, Map<String, Object> configuration, boolean updateMode) throws Exception {
+    private Stream<EmbeddingResult> queryCommon(String hostOrKey, String collection, List<Double> vector, Map<String, Object> filter, long limit, Map<String, Object> configuration) throws Exception {
         String url = "%s/api/v1/collections/%s/query";
         Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
 
         VectorEmbeddingConfig conf = DB_HANDLER.getEmbedding().fromQuery(config, procedureCallContext, vector, filter, limit, collection);
-        conf.getMapping().setUpdateMode(updateMode);
         return getEmbeddingResultStream(conf, procedureCallContext, urlAccessChecker, tx,
                 v -> listOfListsToMap((Map) v).stream());
     }

--- a/extended/src/main/java/apoc/vectordb/Pinecone.java
+++ b/extended/src/main/java/apoc/vectordb/Pinecone.java
@@ -23,6 +23,7 @@ import static apoc.vectordb.VectorDb.executeRequest;
 import static apoc.vectordb.VectorDb.getEmbeddingResultStream;
 import static apoc.vectordb.VectorDbHandler.Type.PINECONE;
 import static apoc.vectordb.VectorDbUtil.getCommonVectorDbInfo;
+import static apoc.vectordb.VectorDbUtil.setReadOnlyMappingMode;
 
 @Extended
 public class Pinecone {
@@ -132,7 +133,8 @@ public class Pinecone {
                                                       @Name("collection") String collection,
                                                       @Name("ids") List<Object> ids,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return getCommon(hostOrKey, collection, ids, configuration, false);
+        setReadOnlyMappingMode(configuration);
+        return getCommon(hostOrKey, collection, ids, configuration);
     }
 
     @Procedure(value = "apoc.vectordb.pinecone.getAndUpdate", mode = Mode.WRITE)
@@ -141,15 +143,14 @@ public class Pinecone {
                                                       @Name("collection") String collection,
                                                       @Name("ids") List<Object> ids,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return getCommon(hostOrKey, collection, ids, configuration, true);
+        return getCommon(hostOrKey, collection, ids, configuration);
     }
 
-    private Stream<VectorDbUtil.EmbeddingResult> getCommon(String hostOrKey, String collection, List<Object> ids, Map<String, Object> configuration, boolean updateMode) throws Exception {
+    private Stream<VectorDbUtil.EmbeddingResult> getCommon(String hostOrKey, String collection, List<Object> ids, Map<String, Object> configuration) throws Exception {
         String url = "%s/vectors/fetch";
         Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
         
         VectorEmbeddingConfig conf = DB_HANDLER.getEmbedding().fromGet(config, procedureCallContext, ids, collection);
-        conf.getMapping().setUpdateMode(updateMode);
         
         return getEmbeddingResultStream(conf, procedureCallContext, urlAccessChecker, tx,
                 v -> {
@@ -167,7 +168,8 @@ public class Pinecone {
                                                       @Name(value = "filter", defaultValue = "{}") Map<String, Object> filter,
                                                       @Name(value = "limit", defaultValue = "10") long limit,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration, false);
+        setReadOnlyMappingMode(configuration);
+        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration);
     }
 
     @Procedure(value = "apoc.vectordb.pinecone.queryAndUpdate", mode = Mode.WRITE)
@@ -178,15 +180,14 @@ public class Pinecone {
                                                       @Name(value = "filter", defaultValue = "{}") Map<String, Object> filter,
                                                       @Name(value = "limit", defaultValue = "10") long limit,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration, true);
+        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration);
     }
 
-    private Stream<VectorDbUtil.EmbeddingResult> queryCommon(String hostOrKey, String collection, List<Double> vector, Map<String, Object> filter, long limit, Map<String, Object> configuration, boolean updateMode) throws Exception {
+    private Stream<VectorDbUtil.EmbeddingResult> queryCommon(String hostOrKey, String collection, List<Double> vector, Map<String, Object> filter, long limit, Map<String, Object> configuration) throws Exception {
         String url = "%s/query";
         Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
 
         VectorEmbeddingConfig conf = DB_HANDLER.getEmbedding().fromQuery(config, procedureCallContext, vector, filter, limit, collection);
-        conf.getMapping().setUpdateMode(updateMode);
         
         return getEmbeddingResultStream(conf, procedureCallContext, urlAccessChecker, tx,
                 v -> {

--- a/extended/src/main/java/apoc/vectordb/Pinecone.java
+++ b/extended/src/main/java/apoc/vectordb/Pinecone.java
@@ -22,7 +22,6 @@ import static apoc.ml.RestAPIConfig.METHOD_KEY;
 import static apoc.vectordb.VectorDb.executeRequest;
 import static apoc.vectordb.VectorDb.getEmbeddingResultStream;
 import static apoc.vectordb.VectorDbHandler.Type.PINECONE;
-import static apoc.vectordb.VectorDbUtil.checkMappingConf;
 import static apoc.vectordb.VectorDbUtil.getCommonVectorDbInfo;
 
 @Extended
@@ -133,7 +132,7 @@ public class Pinecone {
                                                       @Name("collection") String collection,
                                                       @Name("ids") List<Object> ids,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return getCommon(hostOrKey, collection, ids, configuration, true);
+        return getCommon(hostOrKey, collection, ids, configuration, false);
     }
 
     @Procedure(value = "apoc.vectordb.pinecone.getAndUpdate", mode = Mode.WRITE)
@@ -142,18 +141,16 @@ public class Pinecone {
                                                       @Name("collection") String collection,
                                                       @Name("ids") List<Object> ids,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return getCommon(hostOrKey, collection, ids, configuration, false);
+        return getCommon(hostOrKey, collection, ids, configuration, true);
     }
 
-    private Stream<VectorDbUtil.EmbeddingResult> getCommon(String hostOrKey, String collection, List<Object> ids, Map<String, Object> configuration, boolean readOnly) throws Exception {
+    private Stream<VectorDbUtil.EmbeddingResult> getCommon(String hostOrKey, String collection, List<Object> ids, Map<String, Object> configuration, boolean updateMode) throws Exception {
         String url = "%s/vectors/fetch";
         Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
-
-        if (readOnly) {
-            checkMappingConf(configuration, "apoc.vectordb.pinecone.getAndUpdate");
-        }
         
         VectorEmbeddingConfig conf = DB_HANDLER.getEmbedding().fromGet(config, procedureCallContext, ids, collection);
+        conf.getMapping().setUpdateMode(updateMode);
+        
         return getEmbeddingResultStream(conf, procedureCallContext, urlAccessChecker, tx,
                 v -> {
                     Object vectors = ((Map) v).get("vectors");
@@ -170,7 +167,7 @@ public class Pinecone {
                                                       @Name(value = "filter", defaultValue = "{}") Map<String, Object> filter,
                                                       @Name(value = "limit", defaultValue = "10") long limit,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration, true);
+        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration, false);
     }
 
     @Procedure(value = "apoc.vectordb.pinecone.queryAndUpdate", mode = Mode.WRITE)
@@ -181,18 +178,16 @@ public class Pinecone {
                                                       @Name(value = "filter", defaultValue = "{}") Map<String, Object> filter,
                                                       @Name(value = "limit", defaultValue = "10") long limit,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration, false);
+        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration, true);
     }
 
-    private Stream<VectorDbUtil.EmbeddingResult> queryCommon(String hostOrKey, String collection, List<Double> vector, Map<String, Object> filter, long limit, Map<String, Object> configuration, boolean readOnly) throws Exception {
+    private Stream<VectorDbUtil.EmbeddingResult> queryCommon(String hostOrKey, String collection, List<Double> vector, Map<String, Object> filter, long limit, Map<String, Object> configuration, boolean updateMode) throws Exception {
         String url = "%s/query";
         Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
 
-        if (readOnly) {
-            checkMappingConf(configuration, "apoc.vectordb.pinecone.queryAndUpdate");
-        }
-
         VectorEmbeddingConfig conf = DB_HANDLER.getEmbedding().fromQuery(config, procedureCallContext, vector, filter, limit, collection);
+        conf.getMapping().setUpdateMode(updateMode);
+        
         return getEmbeddingResultStream(conf, procedureCallContext, urlAccessChecker, tx,
                 v -> {
                     Map map = (Map) v;

--- a/extended/src/main/java/apoc/vectordb/Qdrant.java
+++ b/extended/src/main/java/apoc/vectordb/Qdrant.java
@@ -131,7 +131,8 @@ public class Qdrant {
                                                       @Name("collection") String collection,
                                                       @Name("ids") List<Object> ids,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return getCommon(hostOrKey, collection, ids, configuration, false);
+        setReadOnlyMappingMode(configuration);
+        return getCommon(hostOrKey, collection, ids, configuration);
     }
 
     @Procedure(value = "apoc.vectordb.qdrant.getAndUpdate", mode = Mode.WRITE)
@@ -140,15 +141,14 @@ public class Qdrant {
                                                       @Name("collection") String collection,
                                                       @Name("ids") List<Object> ids,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return getCommon(hostOrKey, collection, ids, configuration, true);
+        return getCommon(hostOrKey, collection, ids, configuration);
     }
 
-    private Stream<EmbeddingResult> getCommon(String hostOrKey, String collection, List<Object> ids, Map<String, Object> configuration, boolean updateMode) throws Exception {
+    private Stream<EmbeddingResult> getCommon(String hostOrKey, String collection, List<Object> ids, Map<String, Object> configuration) throws Exception {
         String url = "%s/collections/%s/points";
         Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
 
         VectorEmbeddingConfig conf = DB_HANDLER.getEmbedding().fromGet(config, procedureCallContext, ids, collection);
-        conf.getMapping().setUpdateMode(updateMode);
         
         return getEmbeddingResultStream(conf, procedureCallContext, urlAccessChecker, tx);
     }
@@ -161,7 +161,8 @@ public class Qdrant {
                                                       @Name(value = "filter", defaultValue = "{}") Map<String, Object> filter,
                                                       @Name(value = "limit", defaultValue = "10") long limit,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration, false);
+        setReadOnlyMappingMode(configuration);
+        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration);
     }
 
     @Procedure(value = "apoc.vectordb.qdrant.queryAndUpdate", mode = Mode.WRITE)
@@ -172,15 +173,14 @@ public class Qdrant {
                                                   @Name(value = "filter", defaultValue = "{}") Map<String, Object> filter,
                                                   @Name(value = "limit", defaultValue = "10") long limit,
                                                   @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration, true);
+        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration);
     }
 
-    private Stream<EmbeddingResult> queryCommon(String hostOrKey, String collection, List<Double> vector, Map<String, Object> filter, long limit, Map<String, Object> configuration, boolean updateMode) throws Exception {
+    private Stream<EmbeddingResult> queryCommon(String hostOrKey, String collection, List<Double> vector, Map<String, Object> filter, long limit, Map<String, Object> configuration) throws Exception {
         String url = "%s/collections/%s/points/search";
         Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
         
         VectorEmbeddingConfig conf = DB_HANDLER.getEmbedding().fromQuery(config, procedureCallContext, vector, filter, limit, collection);
-        conf.getMapping().setUpdateMode(updateMode);
         
         return getEmbeddingResultStream(conf, procedureCallContext, urlAccessChecker, tx);
     }

--- a/extended/src/main/java/apoc/vectordb/Qdrant.java
+++ b/extended/src/main/java/apoc/vectordb/Qdrant.java
@@ -131,7 +131,7 @@ public class Qdrant {
                                                       @Name("collection") String collection,
                                                       @Name("ids") List<Object> ids,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return getCommon(hostOrKey, collection, ids, configuration, true);
+        return getCommon(hostOrKey, collection, ids, configuration, false);
     }
 
     @Procedure(value = "apoc.vectordb.qdrant.getAndUpdate", mode = Mode.WRITE)
@@ -140,18 +140,16 @@ public class Qdrant {
                                                       @Name("collection") String collection,
                                                       @Name("ids") List<Object> ids,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return getCommon(hostOrKey, collection, ids, configuration, false);
+        return getCommon(hostOrKey, collection, ids, configuration, true);
     }
 
-    private Stream<EmbeddingResult> getCommon(String hostOrKey, String collection, List<Object> ids, Map<String, Object> configuration, boolean readOnly) throws Exception {
+    private Stream<EmbeddingResult> getCommon(String hostOrKey, String collection, List<Object> ids, Map<String, Object> configuration, boolean updateMode) throws Exception {
         String url = "%s/collections/%s/points";
         Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
 
-        if (readOnly) {
-            checkMappingConf(configuration, "apoc.vectordb.qdrant.getAndUpdate");
-        }
-        
         VectorEmbeddingConfig conf = DB_HANDLER.getEmbedding().fromGet(config, procedureCallContext, ids, collection);
+        conf.getMapping().setUpdateMode(updateMode);
+        
         return getEmbeddingResultStream(conf, procedureCallContext, urlAccessChecker, tx);
     }
 
@@ -163,7 +161,7 @@ public class Qdrant {
                                                       @Name(value = "filter", defaultValue = "{}") Map<String, Object> filter,
                                                       @Name(value = "limit", defaultValue = "10") long limit,
                                                       @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration, true);
+        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration, false);
     }
 
     @Procedure(value = "apoc.vectordb.qdrant.queryAndUpdate", mode = Mode.WRITE)
@@ -174,18 +172,16 @@ public class Qdrant {
                                                   @Name(value = "filter", defaultValue = "{}") Map<String, Object> filter,
                                                   @Name(value = "limit", defaultValue = "10") long limit,
                                                   @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
-        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration, false);
+        return queryCommon(hostOrKey, collection, vector, filter, limit, configuration, true);
     }
 
-    private Stream<EmbeddingResult> queryCommon(String hostOrKey, String collection, List<Double> vector, Map<String, Object> filter, long limit, Map<String, Object> configuration, boolean readOnly) throws Exception {
+    private Stream<EmbeddingResult> queryCommon(String hostOrKey, String collection, List<Double> vector, Map<String, Object> filter, long limit, Map<String, Object> configuration, boolean updateMode) throws Exception {
         String url = "%s/collections/%s/points/search";
         Map<String, Object> config = getVectorDbInfo(hostOrKey, collection, configuration, url);
-
-        if (readOnly) {
-            checkMappingConf(configuration, "apoc.vectordb.qdrant.queryAndUpdate");
-        }
         
         VectorEmbeddingConfig conf = DB_HANDLER.getEmbedding().fromQuery(config, procedureCallContext, vector, filter, limit, collection);
+        conf.getMapping().setUpdateMode(updateMode);
+        
         return getEmbeddingResultStream(conf, procedureCallContext, urlAccessChecker, tx);
     }
 

--- a/extended/src/main/java/apoc/vectordb/VectorDb.java
+++ b/extended/src/main/java/apoc/vectordb/VectorDb.java
@@ -152,14 +152,19 @@ public class VectorDb {
             Node node;
             Object propValue = metaProps.get(mapping.getMetadataKey());
             node = transaction.findNode(Label.label(mapping.getNodeLabel()), mapping.getEntityKey(), propValue);
-            if (mapping.isUpdateMode()) {
-                if (node == null && mapping.isCreate()) {
-                    node = transaction.createNode(Label.label(mapping.getNodeLabel()));
-                    node.setProperty(mapping.getEntityKey(), propValue);
+            switch (mapping.getMode()) {
+                case READ_ONLY -> {
+                    // do nothing, just return the entity
                 }
-                if (node != null) {
-                    setProperties(node, metaProps);
-                    setVectorProp(mapping, embedding, node);
+                case UPDATE_EXISTING -> {
+                    setPropsIfEntityExists(mapping, metaProps, embedding, node);
+                }
+                case CREATE_IF_MISSING -> {
+                    if (node == null) {
+                        node = transaction.createNode(Label.label(mapping.getNodeLabel()));
+                        node.setProperty(mapping.getEntityKey(), propValue);
+                    }
+                    setPropsIfEntityExists(mapping, metaProps, embedding, node);
                 }
             }
             return node;
@@ -174,14 +179,25 @@ public class VectorDb {
             Relationship rel;
             Object propValue = metaProps.get(mapping.getMetadataKey());
             rel = transaction.findRelationship(RelationshipType.withName(mapping.getRelType()), mapping.getEntityKey(), propValue);
-            if (mapping.isUpdateMode() && rel != null) {
-                setProperties(rel, metaProps);
-                setVectorProp(mapping, embedding, rel);
+            switch (mapping.getMode()) {
+                case READ_ONLY -> {
+                    // do nothing, just return the entity
+                }
+                case UPDATE_EXISTING, CREATE_IF_MISSING -> {
+                    setPropsIfEntityExists(mapping, metaProps, embedding, rel);
+                }
             }
 
             return rel;
         } catch (MultipleFoundException e) {
             throw new RuntimeException("Multiple relationships found");
+        }
+    }
+
+    private static void setPropsIfEntityExists(VectorMappingConfig mapping, Map<String, Object> metaProps, List<Double> embedding, Entity entity) {
+        if (entity != null) {
+            setProperties(entity, metaProps);
+            setVectorProp(mapping, embedding, entity);
         }
     }
 

--- a/extended/src/main/java/apoc/vectordb/VectorDb.java
+++ b/extended/src/main/java/apoc/vectordb/VectorDb.java
@@ -152,15 +152,16 @@ public class VectorDb {
             Node node;
             Object propValue = metaProps.get(mapping.getMetadataKey());
             node = transaction.findNode(Label.label(mapping.getNodeLabel()), mapping.getEntityKey(), propValue);
-            if (node == null && mapping.isCreate()) {
-                node = transaction.createNode(Label.label(mapping.getNodeLabel()));
-                node.setProperty(mapping.getEntityKey(), propValue);
+            if (mapping.isUpdateMode()) {
+                if (node == null && mapping.isCreate()) {
+                    node = transaction.createNode(Label.label(mapping.getNodeLabel()));
+                    node.setProperty(mapping.getEntityKey(), propValue);
+                }
+                if (node != null) {
+                    setProperties(node, metaProps);
+                    setVectorProp(mapping, embedding, node);
+                }
             }
-            if (node != null) {
-                setProperties(node, metaProps);
-                setVectorProp(mapping, embedding, node);
-            }
-
             return node;
         } catch (MultipleFoundException e) {
             throw new RuntimeException("Multiple nodes found");
@@ -173,7 +174,7 @@ public class VectorDb {
             Relationship rel;
             Object propValue = metaProps.get(mapping.getMetadataKey());
             rel = transaction.findRelationship(RelationshipType.withName(mapping.getRelType()), mapping.getEntityKey(), propValue);
-            if (rel != null) {
+            if (mapping.isUpdateMode() && rel != null) {
                 setProperties(rel, metaProps);
                 setVectorProp(mapping, embedding, rel);
             }

--- a/extended/src/main/java/apoc/vectordb/VectorDbUtil.java
+++ b/extended/src/main/java/apoc/vectordb/VectorDbUtil.java
@@ -17,6 +17,8 @@ import static apoc.ml.RestAPIConfig.BASE_URL_KEY;
 import static apoc.ml.RestAPIConfig.ENDPOINT_KEY;
 import static apoc.util.SystemDbUtil.withSystemDb;
 import static apoc.vectordb.VectorEmbeddingConfig.MAPPING_KEY;
+import static apoc.vectordb.VectorMappingConfig.MODE_KEY;
+import static apoc.vectordb.VectorMappingConfig.MappingMode.READ_ONLY;
 
 public class VectorDbUtil {
 
@@ -80,4 +82,8 @@ public class VectorDbUtil {
         return (String) props.get(ExtendedSystemPropertyKeys.host.name());
     }
 
+    public static void setReadOnlyMappingMode(Map<String, Object> configuration) {
+        Map<String, Object> mappingConf = (Map<String, Object>) configuration.getOrDefault(MAPPING_KEY, new HashMap<>());
+        mappingConf.put(MODE_KEY, READ_ONLY.toString());
+    }
 }

--- a/extended/src/main/java/apoc/vectordb/VectorDbUtil.java
+++ b/extended/src/main/java/apoc/vectordb/VectorDbUtil.java
@@ -80,11 +80,4 @@ public class VectorDbUtil {
         return (String) props.get(ExtendedSystemPropertyKeys.host.name());
     }
 
-    public static void checkMappingConf(Map<String, Object> configuration, String procName) {
-        if (configuration.containsKey(MAPPING_KEY)) {
-            throw new RuntimeException(ERROR_READONLY_MAPPING + "\n" +
-                                       "Try the equivalent procedure, which is the " + procName);
-        }
-    }
-
 }

--- a/extended/src/main/java/apoc/vectordb/VectorMappingConfig.java
+++ b/extended/src/main/java/apoc/vectordb/VectorMappingConfig.java
@@ -23,6 +23,7 @@ public class VectorMappingConfig {
     private final String similarity;
 
     private final boolean create;
+    private boolean updateMode = false;
 
     public VectorMappingConfig(Map<String, Object> mapping) {
         if (mapping == null) {
@@ -66,5 +67,13 @@ public class VectorMappingConfig {
 
     public String getSimilarity() {
         return similarity;
+    }
+
+    public boolean isUpdateMode() {
+        return updateMode;
+    }
+
+    public void setUpdateMode(boolean updateMode) {
+        this.updateMode = updateMode;
     }
 }

--- a/extended/src/main/java/apoc/vectordb/VectorMappingConfig.java
+++ b/extended/src/main/java/apoc/vectordb/VectorMappingConfig.java
@@ -1,18 +1,20 @@
 package apoc.vectordb;
 
-import apoc.util.Util;
-
 import java.util.Collections;
 import java.util.Map;
 
 public class VectorMappingConfig {
+    enum MappingMode {
+        READ_ONLY, UPDATE_EXISTING, CREATE_IF_MISSING
+    }
+    
     public static final String METADATA_KEY = "metadataKey";
     public static final String ENTITY_KEY = "entityKey";
     public static final String NODE_LABEL = "nodeLabel";
     public static final String REL_TYPE = "relType";
     public static final String EMBEDDING_KEY = "embeddingKey";
     public static final String SIMILARITY_KEY = "similarity";
-    public static final String CREATE_KEY = "create";
+    public static final String MODE_KEY = "mode";
 
     private final String metadataKey;
     private final String entityKey;
@@ -22,8 +24,7 @@ public class VectorMappingConfig {
     private final String embeddingKey;
     private final String similarity;
 
-    private final boolean create;
-    private boolean updateMode = false;
+    private MappingMode mode;
 
     public VectorMappingConfig(Map<String, Object> mapping) {
         if (mapping == null) {
@@ -38,7 +39,8 @@ public class VectorMappingConfig {
 
         this.similarity = (String) mapping.getOrDefault(SIMILARITY_KEY, "cosine");
 
-        this.create = Util.toBoolean(mapping.get(CREATE_KEY));
+        String modeValue = (String) mapping.getOrDefault(MODE_KEY, MappingMode.UPDATE_EXISTING.toString() );
+        this.mode = MappingMode.valueOf( modeValue.toUpperCase() );
     }
 
     public String getMetadataKey() {
@@ -61,19 +63,11 @@ public class VectorMappingConfig {
         return embeddingKey;
     }
 
-    public boolean isCreate() {
-        return create;
-    }
-
     public String getSimilarity() {
         return similarity;
     }
 
-    public boolean isUpdateMode() {
-        return updateMode;
-    }
-
-    public void setUpdateMode(boolean updateMode) {
-        this.updateMode = updateMode;
+    public MappingMode getMode() {
+        return mode;
     }
 }

--- a/extended/src/test/java/apoc/vectordb/PineconeTest.java
+++ b/extended/src/test/java/apoc/vectordb/PineconeTest.java
@@ -3,7 +3,6 @@ package apoc.vectordb;
 import apoc.util.MapUtil;
 import apoc.util.TestUtil;
 import apoc.util.Util;
-import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -29,9 +28,9 @@ import static apoc.vectordb.VectorDbTestUtil.EntityType.REL;
 import static apoc.vectordb.VectorDbTestUtil.assertBerlinResult;
 import static apoc.vectordb.VectorDbTestUtil.assertLondonResult;
 import static apoc.vectordb.VectorDbTestUtil.assertNodesCreated;
+import static apoc.vectordb.VectorDbTestUtil.assertReadOnlyProcWithMappingResults;
 import static apoc.vectordb.VectorDbTestUtil.assertRelsCreated;
 import static apoc.vectordb.VectorDbTestUtil.dropAndDeleteAll;
-import static apoc.vectordb.VectorDbUtil.ERROR_READONLY_MAPPING;
 import static apoc.vectordb.VectorEmbeddingConfig.ALL_RESULTS_KEY;
 import static apoc.vectordb.VectorEmbeddingConfig.MAPPING_KEY;
 import static apoc.vectordb.VectorMappingConfig.*;
@@ -39,7 +38,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 import static org.neo4j.configuration.GraphDatabaseSettings.DEFAULT_DATABASE_NAME;
 import static org.neo4j.configuration.GraphDatabaseSettings.SYSTEM_DATABASE_NAME;
 
@@ -363,20 +361,23 @@ public class PineconeTest {
 
         assertNodesCreated(db);
     }
-
+    
     @Test
     public void getReadOnlyVectorsWithMapping() {
-        Map<String, Object> conf = MapUtil.map(ALL_RESULTS_KEY, true,
-                MAPPING_KEY, MapUtil.map(EMBEDDING_KEY, "vect"));
+        db.executeTransactionally("CREATE (:Test {readID: 'one'}), (:Test {readID: 'two'})");
 
-        try {
-            testCall(db, "CALL apoc.vectordb.pinecone.get($host, 'TestCollection', [1, 2], $conf)",
-                    Util.map("host", HOST, "conf", conf),
-                    r -> fail()
-            );
-        } catch (RuntimeException e) {
-            Assertions.assertThat(e.getMessage()).contains(ERROR_READONLY_MAPPING);
-        }
+        Map<String, Object> conf = map(ALL_RESULTS_KEY, true,
+                HEADERS_KEY, ADMIN_AUTHORIZATION,
+                MAPPING_KEY, map(
+                        NODE_LABEL, "Test",
+                        ENTITY_KEY, "readID",
+                        METADATA_KEY, "foo"));
+
+        testResult(db, "CALL apoc.vectordb.pinecone.get($host, 'TestCollection', [1, 2], $conf) " +
+                       "YIELD vector, id, metadata, node RETURN * ORDER BY id",
+                Util.map("host", HOST, "coll", collName, "conf", conf),
+                r -> assertReadOnlyProcWithMappingResults(r, "node")
+        );
     }
 
     @Test
@@ -405,6 +406,24 @@ public class PineconeTest {
                 });
 
         assertRelsCreated(db);
+    }
+
+    @Test
+    public void queryReadOnlyVectorsWithMapping() {
+        db.executeTransactionally("CREATE (:Start)-[:TEST {readID: 'one'}]->(:End), (:Start)-[:TEST {readID: 'two'}]->(:End)");
+
+        Map<String, Object> conf = map(ALL_RESULTS_KEY, true,
+                HEADERS_KEY, ADMIN_AUTHORIZATION,
+                MAPPING_KEY, map(
+                        REL_TYPE, "TEST",
+                        ENTITY_KEY, "readID",
+                        METADATA_KEY, "foo")
+        );
+
+        testResult(db, "CALL apoc.vectordb.pinecone.query($host, $coll, [0.2, 0.1, 0.9, 0.7], {}, 5, $conf)",
+                map("host", HOST, "coll", collName, "conf", conf),
+                r -> assertReadOnlyProcWithMappingResults(r, "rel")
+        );
     }
 
     @Test

--- a/extended/src/test/java/apoc/vectordb/PineconeTest.java
+++ b/extended/src/test/java/apoc/vectordb/PineconeTest.java
@@ -268,7 +268,9 @@ public class PineconeTest {
                         NODE_LABEL, "Test",
                         ENTITY_KEY, "myId",
                         METADATA_KEY, "foo",
-                        CREATE_KEY, true));
+                        MODE_KEY, MappingMode.CREATE_IF_MISSING.toString()
+                )
+        );
         testResult(db, "CALL apoc.vectordb.pinecone.queryAndUpdate($host, $coll, [0.2, 0.1, 0.9, 0.7], {}, 5, $conf)",
                 map("host", HOST, "coll", collName, "conf", conf),
                 r -> {

--- a/extended/src/test/java/apoc/vectordb/VectorDbTestUtil.java
+++ b/extended/src/test/java/apoc/vectordb/VectorDbTestUtil.java
@@ -1,5 +1,6 @@
 package apoc.vectordb;
 
+import apoc.util.MapUtil;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.ResourceIterator;
@@ -11,6 +12,7 @@ import static apoc.util.TestUtil.testResult;
 import static apoc.util.Util.map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class VectorDbTestUtil {
@@ -81,5 +83,21 @@ public class VectorDbTestUtil {
 
     public static Map<String, String> getAuthHeader(String key) {
         return map("Authorization", "Bearer " + key);
+    }
+    
+    public static void assertReadOnlyProcWithMappingResults(Result r, String node) {
+        Map<String, Object> row = r.next();
+        Map<String, Object> props = ((Entity) row.get(node)).getAllProperties();
+        assertEquals(MapUtil.map("readID", "one"), props);
+        assertNotNull(row.get("vector"));
+        assertNotNull(row.get("id"));
+
+        row = r.next();
+        props = ((Entity) row.get(node)).getAllProperties();
+        assertEquals(MapUtil.map("readID", "two"), props);
+        assertNotNull(row.get("vector"));
+        assertNotNull(row.get("id"));
+
+        assertFalse(r.hasNext());
     }
 }


### PR DESCRIPTION
Fixes #4090

The apoc.vectordb.*.get/query procedures show nodes/rels that can be updated with mapping config
