### PR TITLE
Solve 5.20 extra-dependencies conflict errors

### DIFF
--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -113,11 +113,11 @@ dependencies {
     // testImplementation analogous is not needed since is bundled via `test-utils` submodule
     compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.0', withoutServers
 
-    compileOnly group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.16.1'
+    compileOnly group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.17.0'
     compileOnly group: 'org.apache.arrow', name: 'arrow-vector', version: '13.0.0'
     compileOnly group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '13.0.0'
 
-    testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.16.1'
+    testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.17.0'
     testImplementation group: 'org.apache.arrow', name: 'arrow-vector', version: '13.0.0'
     testImplementation group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '13.0.0'
 

--- a/extra-dependencies/aws/build.gradle
+++ b/extra-dependencies/aws/build.gradle
@@ -18,6 +18,6 @@ jar {
 }
 
 dependencies {
-    implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.425'
-    implementation group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: '1.12.425'
+    implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.425', commonExclusions
+    implementation group: 'com.amazonaws', name: 'aws-java-sdk-sts', version: '1.12.425', commonExclusions
 }

--- a/extra-dependencies/build.gradle
+++ b/extra-dependencies/build.gradle
@@ -45,6 +45,7 @@ ext {
         exclude group: 'org.slf4j', module: 'slf4j-api'
 
         // jackson
+        exclude group: 'com.fasterxml.jackson.core', module: 'jackson-core'
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
 

--- a/extra-dependencies/yaml/build.gradle
+++ b/extra-dependencies/yaml/build.gradle
@@ -17,7 +17,7 @@ jar {
 }
 
 dependencies {
-    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.16.1', commonExclusions
+    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.17.0', commonExclusions
 }
 
 


### PR DESCRIPTION
Upgraded `com.fasterxml.jackson.dataformat` version and excluded `jackson-core` from `extra-dependencies`, 
to solve the below conflict errors, 
since the `jackson-core:2.17.0` jar is already present in the `/lib` folder of the new neo4j version.

Conflict error:

<img width="1100" alt="Screenshot 2024-05-29 at 15 02 17" src="https://github.com/neo4j-contrib/neo4j-apoc-procedures/assets/25103389/cf1222b6-471e-4b55-9dd3-3cf82e244421">

----


Also verified that procedures using the `s3://` protocol still work.

