### PR TITLE
Try to solve 5.20 TC errors

### DIFF
--- a/extended-it/src/test/java/apoc/vectordb/ChromaDbTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/ChromaDbTest.java
@@ -59,7 +59,7 @@ public class ChromaDbTest {
         
         CHROMA_CONTAINER.start();
 
-        HOST = "localhost:" + CHROMA_CONTAINER.getMappedPort(8000);
+        HOST =  CHROMA_CONTAINER.getEndpoint();
         TestUtil.registerProcedure(db, ChromaDb.class, VectorDb.class);
         
         testCall(db, "CALL apoc.vectordb.chroma.createCollection($host, 'test_collection', 'cosine', 4)",
@@ -386,7 +386,7 @@ public class ChromaDbTest {
     @Test
     public void queryVectorsWithSystemDbStorage() {
         String keyConfig = "chroma-config-foo";
-        String baseUrl = "http://" + HOST;
+        String baseUrl = HOST;
         Map<String, Object> mapping = map(EMBEDDING_KEY, "vect",
                 NODE_LABEL, "Test",
                 ENTITY_KEY, "myId",

--- a/extended-it/src/test/java/apoc/vectordb/QdrantTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/QdrantTest.java
@@ -71,7 +71,7 @@ public class QdrantTest {
         
         QDRANT_CONTAINER.start();
 
-        HOST = "localhost:" + QDRANT_CONTAINER.getMappedPort(6333);
+        HOST = QDRANT_CONTAINER.getHost() + ":" + QDRANT_CONTAINER.getMappedPort(6333);
         TestUtil.registerProcedure(db, Qdrant.class, VectorDb.class);
 
         testCall(db, "CALL apoc.vectordb.qdrant.createCollection($host, 'test_collection', 'Cosine', 4, $conf)",

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -111,13 +111,13 @@ dependencies {
 
     compileOnly group: 'org.apache.parquet', name: 'parquet-hadoop', version: '1.13.1', withoutServers
     // testImplementation analogous is not needed since is bundled via `test-utils` submodule
-    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.0', withoutServers
+    compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.3.6', withoutServers
 
-    compileOnly group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.17.0'
+    compileOnly group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.16.1'
     compileOnly group: 'org.apache.arrow', name: 'arrow-vector', version: '13.0.0'
     compileOnly group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '13.0.0'
 
-    testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.17.0'
+    testImplementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.16.1'
     testImplementation group: 'org.apache.arrow', name: 'arrow-vector', version: '13.0.0'
     testImplementation group: 'org.apache.arrow', name: 'arrow-memory-netty', version: '13.0.0'
 


### PR DESCRIPTION
- vectordb tests:
changed `"localhost"` to `<CONTAINER>.getHost()`

- hadoop tests:
restored hadoop dependencies to those present in version 5.19.0, that has been changed [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4063) and [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4094)