### PR TITLE
Solve dev 5.21 compile errors

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "apoc-core"]
 	path = apoc-core
 	url = https://github.com/neo4j/apoc
-	branch = 5.20
+	branch = dev

--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -243,7 +243,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
     public boolean registerProcedure(ProcedureSignature signature, String statement) {
         QualifiedName name = signature.name();
         try {
-            boolean exists = globalProceduresRegistry.getCurrentView().getAllProcedures().stream()
+            boolean exists = globalProceduresRegistry.getCurrentView().getAllProcedures()
                     .anyMatch(s -> s.name().equals(name));
             if (exists) {
                 // we deregister and remove possible homonyms signatures overridden/overloaded

--- a/extended/src/main/java/apoc/cypher/CypherExtended.java
+++ b/extended/src/main/java/apoc/cypher/CypherExtended.java
@@ -25,7 +25,6 @@ import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.TerminationGuard;
 
-import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -352,8 +351,8 @@ public class CypherExtended {
     private Reader readerForFile(@Name("file") String fileName) {
         try {
             return FileUtils.readerFor(fileName, CompressionAlgo.NONE.name(), urlAccessChecker);
-        } catch (IOException ioe) {
-            throw new RuntimeException("Error accessing file "+fileName,ioe);
+        } catch (Exception e) {
+            throw new RuntimeException("Error accessing file "+fileName,e);
         }
     }
 

--- a/extended/src/main/java/apoc/export/arrow/ImportArrow.java
+++ b/extended/src/main/java/apoc/export/arrow/ImportArrow.java
@@ -21,6 +21,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.security.URLAccessChecker;
+import org.neo4j.graphdb.security.URLAccessValidationError;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Mode;
@@ -29,6 +30,7 @@ import org.neo4j.procedure.Procedure;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.channels.SeekableByteChannel;
 import java.util.Arrays;
 import java.util.Collection;
@@ -152,7 +154,7 @@ public class ImportArrow {
     }
 
     
-    private ArrowReader getReader(Object input) throws IOException {
+    private ArrowReader getReader(Object input) throws IOException, URISyntaxException, URLAccessValidationError {
         RootAllocator allocator = new RootAllocator();
         if (input instanceof String) {
             final SeekableByteChannel channel = FileUtils.inputStreamFor(input, null, null, null, urlAccessChecker)

--- a/extended/src/main/java/apoc/export/parquet/ParquetReadUtil.java
+++ b/extended/src/main/java/apoc/export/parquet/ParquetReadUtil.java
@@ -8,9 +8,11 @@ import org.apache.parquet.io.InputFile;
 import org.apache.parquet.io.SeekableInputStream;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.neo4j.graphdb.security.URLAccessChecker;
+import org.neo4j.graphdb.security.URLAccessValidationError;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -30,14 +32,14 @@ public class ParquetReadUtil {
         };
     }
 
-    public static InputFile getInputFile(Object source, URLAccessChecker urlAccessChecker) throws IOException {
+    public static InputFile getInputFile(Object source, URLAccessChecker urlAccessChecker) throws IOException, URISyntaxException, URLAccessValidationError {
         return new ParquetStream(FileUtils.inputStreamFor(source, null, null, CompressionAlgo.NONE.name(), urlAccessChecker).readAllBytes());
     }
 
     public static ApocParquetReader getReader(Object source, ParquetConfig conf, URLAccessChecker urlAccessChecker) {
         try {
             return new ApocParquetReader(getInputFile(source, urlAccessChecker), conf);
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/extended/src/main/java/apoc/load/LoadCsv.java
+++ b/extended/src/main/java/apoc/load/LoadCsv.java
@@ -57,7 +57,7 @@ public class LoadCsv {
             }
             reader = FileUtils.readerFor(urlOrBinary, httpHeaders, payload, config.getCompressionAlgo(), urlAccessChecker);
             return streamCsv(url, config, reader);
-        } catch (IOException e) {
+        } catch (Exception e) {
             closeReaderSafely(reader);
             if(!config.isFailOnError())
                 return Stream.of(new CSVResult(new String[0], new String[0], 0, true, Collections.emptyMap(), emptyList(), EnumSet.noneOf(Results.class)));

--- a/extended/src/main/java/apoc/load/LoadHtml.java
+++ b/extended/src/main/java/apoc/load/LoadHtml.java
@@ -4,6 +4,8 @@ import apoc.Extended;
 import apoc.result.MapResult;
 import apoc.util.MissingDependencyException;
 import apoc.util.FileUtils;
+
+import java.net.URISyntaxException;
 import java.nio.charset.UnsupportedCharsetException;
 
 import org.apache.commons.lang3.StringUtils;
@@ -14,6 +16,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.security.URLAccessChecker;
+import org.neo4j.graphdb.security.URLAccessValidationError;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
@@ -97,7 +100,7 @@ public class LoadHtml {
         }
     }
 
-    private InputStream getHtmlInputStream(String url, Map<String, String> query, LoadHtmlConfig config) throws IOException {
+    private InputStream getHtmlInputStream(String url, Map<String, String> query, LoadHtmlConfig config) throws IOException, URISyntaxException, URLAccessValidationError {
 
         final boolean isHeadless = config.isHeadless();
         final boolean isAcceptInsecureCerts = config.isAcceptInsecureCerts();

--- a/extended/src/test/java/apoc/export/parquet/ParquetTest.java
+++ b/extended/src/test/java/apoc/export/parquet/ParquetTest.java
@@ -110,7 +110,7 @@ public class ParquetTest {
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, false);
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, false);
 
-        assertFails("CALL apoc.export.parquet.all('ignore.parquet')", EXPORT_TO_FILE_PARQUET_ERROR);
+        assertFails("CALL apoc.export.parquet.all('ignore.parquet')", LOAD_FROM_FILE_ERROR);
     }
 
     @Test

--- a/extended/src/test/java/apoc/load/LoadCsvTest.java
+++ b/extended/src/test/java/apoc/load/LoadCsvTest.java
@@ -331,7 +331,7 @@ RETURN m.col_1,m.col_2,m.col_3
     }
 
     @Test public void testWithSpacesInFileName() throws Exception {
-        String url = "test pipe column with spaces in filename.csv";
+        String url = "file:///test%20pipe%20column%20with%20spaces%20in%20filename.csv";
         testResult(db, "CALL apoc.load.csv($url,{results:['map','list','stringMap','strings'],mapping:{name:{type:'string'},beverage:{array:true,arraySep:'|',type:'string'}}})", map("url",url), // 'file:test.csv'
                 (r) -> {
                     assertEquals(asList("Selma", asList("Soda")), r.next().get("list"));

--- a/extended/src/test/java/apoc/util/ExtendedTestUtil.java
+++ b/extended/src/test/java/apoc/util/ExtendedTestUtil.java
@@ -3,6 +3,7 @@ package apoc.util;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.ResultTransformer;
+import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.test.assertion.Assert;
 
 import java.util.Collections;
@@ -16,6 +17,13 @@ import static org.junit.Assert.assertNull;
 import static org.neo4j.test.assertion.Assert.assertEventually;
 
 public class ExtendedTestUtil {
+
+    /**
+     * Mock URLAccessChecker instance with checkURL(URL url) {return url}
+     */
+    public static class MockURLAccessChecker {
+        public static final URLAccessChecker INSTANCE = url -> url;
+    }
 
     public static void assertMapEquals(Map<String, Object> expected, Map<String, Object> actual) {
         assertMapEquals(null, expected, actual);

--- a/extended/src/test/java/apoc/util/FileUtilsTest.java
+++ b/extended/src/test/java/apoc/util/FileUtilsTest.java
@@ -15,8 +15,10 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 
+import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
 import static org.junit.Assert.assertEquals;
+import static apoc.util.ExtendedTestUtil.MockURLAccessChecker;
 
 public class FileUtilsTest {
 
@@ -54,6 +56,7 @@ public class FileUtilsTest {
         if (testName.getMethodName().endsWith(TEST_WITH_DIRECTORY_IMPORT)) {
             apocConfig().setProperty("server.directories.import", importFolder);
         }
+        apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         TestUtil.registerProcedure(db, Config.class);
     }
 
@@ -64,50 +67,49 @@ public class FileUtilsTest {
 
     @Test
     public void notChangeFileUrlWithDirectoryImportConstrainedURI() throws Exception {
-        assertEquals(TEST_FILE_ABSOLUTE, FileUtils.changeFileUrlIfImportDirectoryConstrained(TEST_FILE));
+        assertEquals(TEST_FILE_ABSOLUTE, FileUtils.changeFileUrlIfImportDirectoryConstrained(TEST_FILE, MockURLAccessChecker.INSTANCE));
     }
 
     @Test
     public void notChangeFileUrlWithDirectoryAndProtocolImportConstrainedURI() throws Exception {
-        assertEquals(TEST_FILE_ABSOLUTE, FileUtils.changeFileUrlIfImportDirectoryConstrained("file://" + TEST_FILE));
+        assertEquals(TEST_FILE_ABSOLUTE, FileUtils.changeFileUrlIfImportDirectoryConstrained("file://" + TEST_FILE, MockURLAccessChecker.INSTANCE));
     }
 
     @Test
     public void changeNoSlashesUrlWithDirectoryImportConstrainedURIWithDirectoryImport() throws Exception {
-        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("test.csv"));
+        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("test.csv", MockURLAccessChecker.INSTANCE));
     }
 
     @Test
     public void changeSlashUrlWithDirectoryImportConstrainedURIWithDirectoryImport() throws Exception {
-        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("/test.csv"));
+        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("/test.csv", MockURLAccessChecker.INSTANCE));
     }
 
     @Test
     public void changeFileSlashUrlWithDirectoryImportConstrainedURIWithDirectoryImport() throws Exception {
-        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("file:/test.csv"));
+        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("file:/test.csv", MockURLAccessChecker.INSTANCE));
     }
 
     @Test
     public void changeFileDoubleSlashesUrlWithDirectoryImportConstrainedURIWithDirectoryImport() throws Exception {
-        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("file://test.csv"));
+        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("file://test.csv", MockURLAccessChecker.INSTANCE));
     }
 
     @Test
     public void changeFileTripleSlashesUrlWithDirectoryImportConstrainedURIWithDirectoryImport() throws Exception {
-        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("file:///test.csv"));
+        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("file:///test.csv", MockURLAccessChecker.INSTANCE));
     }
 
     @Test
     public void importDirectoryWithRelativePathWithDirectoryImport() throws Exception {
-        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("test.csv"));
+        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("test.csv", MockURLAccessChecker.INSTANCE));
     }
-
 
     @Test
     public void importDirectoryWithRelativeArchivePathWithDirectoryImport() throws Exception {
         String localPath = "test.zip!sub/test.csv";
         String expected = importFolder + "/" + localPath;
-        assertEquals(Paths.get(expected).toUri().toString(), FileUtils.changeFileUrlIfImportDirectoryConstrained(localPath));
+        assertEquals(Paths.get(expected).toUri().toString(), FileUtils.changeFileUrlIfImportDirectoryConstrained(localPath, MockURLAccessChecker.INSTANCE));
     }
 
 }


### PR DESCRIPTION
- [Fixed various 5.21 compile errors after restoring submodule version](https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/ccaa5615eb089add531fc3ae52fa151fa448afc0)
See [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/9226836558/job/25387484476)

- [Solved error: cannot find symbol, due to `org.neo4j.kernel.api.procedure.ProcedureView` 5.21 changes](https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/39dc06071354e176504876a8651ce9d01115103a)
See [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/9364741459/job/25778380117#step:7:224)

- [Changed ParquetTest.testStreamRoundtripParquetAllWithImportExportConfsDisabled](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4100/commits/ceb2380aa420e51df6def8bed6d5599c4f7fcdea)
since FileUtils now has a method [apocConfig().checkReadAllowed(url, urlAccessChecker);](https://github.com/neo4j/apoc/blob/dev/common/src/main/java/apoc/util/FileUtils.java#L200)

- [Changed LoadCsvTest.testWithSpacesInFileName](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4100/commits/67f4b5c4fa733462eb30f29cba803aa220ce1904)
since FileUtils.changeFileUrlIfImportDirectoryConstrained now has a method [getLoadFileUrl(...)](https://github.com/neo4j/apoc/blob/dev/common/src/main/java/apoc/util/FileUtils.java#L205), 
which makes the procedure fail if we have a file name like `name with spaces` instead of `file:///name%20with%20spaces`, 
and on which we cannot change the code, as it's in Core