### PR TITLE
Solve 5.21 compile errors

### DIFF
--- a/extended/src/main/java/apoc/custom/CypherProceduresUtil.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresUtil.java
@@ -32,10 +32,12 @@ public class CypherProceduresUtil {
 
     public static QualifiedName qualifiedName(@Name("name") String name) {
         String[] names = name.split("\\.");
-        List<String> namespace = new ArrayList<>(names.length);
-        namespace.add(PREFIX);
-        namespace.addAll(Arrays.asList(names));
-        return new QualifiedName(namespace.subList(0, namespace.size() - 1), names[names.length - 1]);
+        List<String> namespaceList = new ArrayList<>(names.length);
+        namespaceList.add(PREFIX);
+        namespaceList.addAll(Arrays.asList(names));
+        String[] namespace = namespaceList.subList(0, namespaceList.size() - 1)
+                .toArray(String[]::new);
+        return new QualifiedName(namespace, names[names.length - 1]);
     }
 
     public static Mode mode(String s) {

--- a/extended/src/main/java/apoc/custom/Signatures.java
+++ b/extended/src/main/java/apoc/custom/Signatures.java
@@ -94,15 +94,15 @@ public class Signatures {
         return createProcedureSignature(name, inputSignatures, outputSignature, mode, admin, deprecated, description, warning, eager, caseInsensitive, false, false, false, false);
     }
 
-    public List<String> namespace(SignatureParser.NamespaceContext namespaceContext) {
+    public String[] namespace(SignatureParser.NamespaceContext namespaceContext) {
         List<String> parsed = namespaceContext == null ? Collections.emptyList() : namespaceContext.name().stream().map(this::name).collect(Collectors.toList());
         if (prefix == null) {
-            return parsed;
+            return parsed.toArray(String[]::new);
         } else {
             ArrayList<String> namespace = new ArrayList<>();
             namespace.add(prefix);
             namespace.addAll(parsed);
-            return namespace;
+            return namespace.toArray(String[]::new);
         }
     }
 

--- a/extended/src/main/java/apoc/cypher/CypherExtended.java
+++ b/extended/src/main/java/apoc/cypher/CypherExtended.java
@@ -25,7 +25,6 @@ import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.TerminationGuard;
 
-import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -352,8 +351,8 @@ public class CypherExtended {
     private Reader readerForFile(@Name("file") String fileName) {
         try {
             return FileUtils.readerFor(fileName, CompressionAlgo.NONE.name(), urlAccessChecker);
-        } catch (IOException ioe) {
-            throw new RuntimeException("Error accessing file "+fileName,ioe);
+        } catch (Exception e) {
+            throw new RuntimeException("Error accessing file "+fileName,e);
         }
     }
 

--- a/extended/src/main/java/apoc/export/arrow/ImportArrow.java
+++ b/extended/src/main/java/apoc/export/arrow/ImportArrow.java
@@ -21,6 +21,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.security.URLAccessChecker;
+import org.neo4j.graphdb.security.URLAccessValidationError;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Mode;
@@ -29,6 +30,7 @@ import org.neo4j.procedure.Procedure;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.nio.channels.SeekableByteChannel;
 import java.util.Arrays;
 import java.util.Collection;
@@ -152,7 +154,7 @@ public class ImportArrow {
     }
 
     
-    private ArrowReader getReader(Object input) throws IOException {
+    private ArrowReader getReader(Object input) throws IOException, URISyntaxException, URLAccessValidationError {
         RootAllocator allocator = new RootAllocator();
         if (input instanceof String) {
             final SeekableByteChannel channel = FileUtils.inputStreamFor(input, null, null, null, urlAccessChecker)

--- a/extended/src/main/java/apoc/export/parquet/ParquetReadUtil.java
+++ b/extended/src/main/java/apoc/export/parquet/ParquetReadUtil.java
@@ -8,9 +8,11 @@ import org.apache.parquet.io.InputFile;
 import org.apache.parquet.io.SeekableInputStream;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.neo4j.graphdb.security.URLAccessChecker;
+import org.neo4j.graphdb.security.URLAccessValidationError;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -30,14 +32,14 @@ public class ParquetReadUtil {
         };
     }
 
-    public static InputFile getInputFile(Object source, URLAccessChecker urlAccessChecker) throws IOException {
+    public static InputFile getInputFile(Object source, URLAccessChecker urlAccessChecker) throws IOException, URISyntaxException, URLAccessValidationError {
         return new ParquetStream(FileUtils.inputStreamFor(source, null, null, CompressionAlgo.NONE.name(), urlAccessChecker).readAllBytes());
     }
 
     public static ApocParquetReader getReader(Object source, ParquetConfig conf, URLAccessChecker urlAccessChecker) {
         try {
             return new ApocParquetReader(getInputFile(source, urlAccessChecker), conf);
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/extended/src/main/java/apoc/load/LoadCsv.java
+++ b/extended/src/main/java/apoc/load/LoadCsv.java
@@ -57,7 +57,7 @@ public class LoadCsv {
             }
             reader = FileUtils.readerFor(urlOrBinary, httpHeaders, payload, config.getCompressionAlgo(), urlAccessChecker);
             return streamCsv(url, config, reader);
-        } catch (IOException e) {
+        } catch (Exception e) {
             closeReaderSafely(reader);
             if(!config.isFailOnError())
                 return Stream.of(new CSVResult(new String[0], new String[0], 0, true, Collections.emptyMap(), emptyList(), EnumSet.noneOf(Results.class)));

--- a/extended/src/main/java/apoc/load/LoadHtml.java
+++ b/extended/src/main/java/apoc/load/LoadHtml.java
@@ -4,6 +4,8 @@ import apoc.Extended;
 import apoc.result.MapResult;
 import apoc.util.MissingDependencyException;
 import apoc.util.FileUtils;
+
+import java.net.URISyntaxException;
 import java.nio.charset.UnsupportedCharsetException;
 
 import org.apache.commons.lang3.StringUtils;
@@ -14,6 +16,7 @@ import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.security.URLAccessChecker;
+import org.neo4j.graphdb.security.URLAccessValidationError;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
@@ -97,7 +100,7 @@ public class LoadHtml {
         }
     }
 
-    private InputStream getHtmlInputStream(String url, Map<String, String> query, LoadHtmlConfig config) throws IOException {
+    private InputStream getHtmlInputStream(String url, Map<String, String> query, LoadHtmlConfig config) throws IOException, URISyntaxException, URLAccessValidationError {
 
         final boolean isHeadless = config.isHeadless();
         final boolean isAcceptInsecureCerts = config.isAcceptInsecureCerts();

--- a/extended/src/test/java/apoc/export/parquet/ParquetTest.java
+++ b/extended/src/test/java/apoc/export/parquet/ParquetTest.java
@@ -110,7 +110,7 @@ public class ParquetTest {
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, false);
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, false);
 
-        assertFails("CALL apoc.export.parquet.all('ignore.parquet')", EXPORT_TO_FILE_PARQUET_ERROR);
+        assertFails("CALL apoc.export.parquet.all('ignore.parquet')", LOAD_FROM_FILE_ERROR);
     }
 
     @Test

--- a/extended/src/test/java/apoc/load/LoadCsvTest.java
+++ b/extended/src/test/java/apoc/load/LoadCsvTest.java
@@ -331,7 +331,7 @@ RETURN m.col_1,m.col_2,m.col_3
     }
 
     @Test public void testWithSpacesInFileName() throws Exception {
-        String url = "test pipe column with spaces in filename.csv";
+        String url = "file:///test%20pipe%20column%20with%20spaces%20in%20filename.csv";
         testResult(db, "CALL apoc.load.csv($url,{results:['map','list','stringMap','strings'],mapping:{name:{type:'string'},beverage:{array:true,arraySep:'|',type:'string'}}})", map("url",url), // 'file:test.csv'
                 (r) -> {
                     assertEquals(asList("Selma", asList("Soda")), r.next().get("list"));

--- a/extended/src/test/java/apoc/systemdb/SystemDbTest.java
+++ b/extended/src/test/java/apoc/systemdb/SystemDbTest.java
@@ -72,16 +72,18 @@ public class SystemDbTest {
             Map<String, Object> map = Iterators.single(result);
             List<Node> nodes = (List<Node>) map.get("nodes");
             List<Relationship> relationships = (List<Relationship>) map.get("relationships");
-            assertEquals(6, nodes.size());
+            assertEquals(7, nodes.size());
             assertEquals(2, nodes.stream().filter( node -> "Database".equals(Iterables.single(node.getLabels()).name())).count());
             assertEquals(2, nodes.stream().filter( node -> "DatabaseName".equals(Iterables.single(node.getLabels()).name())).count());
             assertEquals(1, nodes.stream().filter( node -> "User".equals(Iterables.single(node.getLabels()).name())).count());
             assertEquals(1, nodes.stream().filter( node -> "Version".equals(Iterables.single(node.getLabels()).name())).count());
+            assertEquals(1, nodes.stream().filter( node -> "Auth".equals(Iterables.single(node.getLabels()).name())).count());
             Set<String> names = nodes.stream().map(node -> (String)node.getProperty("name")).filter(Objects::nonNull).collect(Collectors.toSet());
             org.hamcrest.MatcherAssert.assertThat( names, Matchers.containsInAnyOrder("neo4j", "system"));
 
-            assertEquals( 2, relationships.size() );
+            assertEquals( 3, relationships.size() );
             assertEquals( 2, relationships.stream().filter( rel -> "TARGETS".equals( rel.getType().name() ) ).count() );
+            assertEquals( 1, relationships.stream().filter( rel -> "HAS_AUTH".equals( rel.getType().name() ) ).count() );
         });
     }
 

--- a/extended/src/test/java/apoc/util/ExtendedTestUtil.java
+++ b/extended/src/test/java/apoc/util/ExtendedTestUtil.java
@@ -3,6 +3,7 @@ package apoc.util;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.ResultTransformer;
+import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.test.assertion.Assert;
 
 import java.util.Collections;
@@ -16,6 +17,13 @@ import static org.junit.Assert.assertNull;
 import static org.neo4j.test.assertion.Assert.assertEventually;
 
 public class ExtendedTestUtil {
+
+    /**
+     * Mock URLAccessChecker instance with checkURL(URL url) {return url}
+     */
+    public static class MockURLAccessChecker {
+        public static final URLAccessChecker INSTANCE = url -> url;
+    }
 
     public static void assertMapEquals(Map<String, Object> expected, Map<String, Object> actual) {
         assertMapEquals(null, expected, actual);

--- a/extended/src/test/java/apoc/util/FileUtilsTest.java
+++ b/extended/src/test/java/apoc/util/FileUtilsTest.java
@@ -15,8 +15,10 @@ import org.neo4j.test.rule.ImpermanentDbmsRule;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 
+import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
 import static org.junit.Assert.assertEquals;
+import static apoc.util.ExtendedTestUtil.MockURLAccessChecker;
 
 public class FileUtilsTest {
 
@@ -54,6 +56,7 @@ public class FileUtilsTest {
         if (testName.getMethodName().endsWith(TEST_WITH_DIRECTORY_IMPORT)) {
             apocConfig().setProperty("server.directories.import", importFolder);
         }
+        apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         TestUtil.registerProcedure(db, Config.class);
     }
 
@@ -64,50 +67,49 @@ public class FileUtilsTest {
 
     @Test
     public void notChangeFileUrlWithDirectoryImportConstrainedURI() throws Exception {
-        assertEquals(TEST_FILE_ABSOLUTE, FileUtils.changeFileUrlIfImportDirectoryConstrained(TEST_FILE));
+        assertEquals(TEST_FILE_ABSOLUTE, FileUtils.changeFileUrlIfImportDirectoryConstrained(TEST_FILE, MockURLAccessChecker.INSTANCE));
     }
 
     @Test
     public void notChangeFileUrlWithDirectoryAndProtocolImportConstrainedURI() throws Exception {
-        assertEquals(TEST_FILE_ABSOLUTE, FileUtils.changeFileUrlIfImportDirectoryConstrained("file://" + TEST_FILE));
+        assertEquals(TEST_FILE_ABSOLUTE, FileUtils.changeFileUrlIfImportDirectoryConstrained("file://" + TEST_FILE, MockURLAccessChecker.INSTANCE));
     }
 
     @Test
     public void changeNoSlashesUrlWithDirectoryImportConstrainedURIWithDirectoryImport() throws Exception {
-        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("test.csv"));
+        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("test.csv", MockURLAccessChecker.INSTANCE));
     }
 
     @Test
     public void changeSlashUrlWithDirectoryImportConstrainedURIWithDirectoryImport() throws Exception {
-        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("/test.csv"));
+        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("/test.csv", MockURLAccessChecker.INSTANCE));
     }
 
     @Test
     public void changeFileSlashUrlWithDirectoryImportConstrainedURIWithDirectoryImport() throws Exception {
-        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("file:/test.csv"));
+        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("file:/test.csv", MockURLAccessChecker.INSTANCE));
     }
 
     @Test
     public void changeFileDoubleSlashesUrlWithDirectoryImportConstrainedURIWithDirectoryImport() throws Exception {
-        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("file://test.csv"));
+        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("file://test.csv", MockURLAccessChecker.INSTANCE));
     }
 
     @Test
     public void changeFileTripleSlashesUrlWithDirectoryImportConstrainedURIWithDirectoryImport() throws Exception {
-        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("file:///test.csv"));
+        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("file:///test.csv", MockURLAccessChecker.INSTANCE));
     }
 
     @Test
     public void importDirectoryWithRelativePathWithDirectoryImport() throws Exception {
-        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("test.csv"));
+        assertEquals(TEST_FILE_RELATIVE, FileUtils.changeFileUrlIfImportDirectoryConstrained("test.csv", MockURLAccessChecker.INSTANCE));
     }
-
 
     @Test
     public void importDirectoryWithRelativeArchivePathWithDirectoryImport() throws Exception {
         String localPath = "test.zip!sub/test.csv";
         String expected = importFolder + "/" + localPath;
-        assertEquals(Paths.get(expected).toUri().toString(), FileUtils.changeFileUrlIfImportDirectoryConstrained(localPath));
+        assertEquals(Paths.get(expected).toUri().toString(), FileUtils.changeFileUrlIfImportDirectoryConstrained(localPath, MockURLAccessChecker.INSTANCE));
     }
 
 }


### PR DESCRIPTION
Solve 5.21 compile errors

- Added CypherScope.CYPHER_5, added [here](https://github.com/neo4j/neo4j/blob/5.21/community/kernel-api/src/main/java/org/neo4j/kernel/api/CypherScope.java), which annotates procedures usable in Cypher 5.x

- Changed [namespace](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4126/files#diff-7a6794bc38939217b5b8ca0f55b06b9cfd4bfd59ebd1be9e2a4709f12c2c3304R97) from List<String> to String[], as in neo4j 5.21 the QualifiedName [no longer accept List<String>](https://github.com/neo4j/neo4j/blob/5.21/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/procs/QualifiedName.java#L34)

- Fixed various 5.21 compile errors due to APOC Core changes,
See [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/9226836558/job/25387484476)
  -  new signature Exceptions, e.g. [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4126/files#diff-8738e5dce133a2fcd283c484ef5f701b900893eee73928024f5b2276bdc0c0a0R157)
  - changeFileUrlIfImportDirectoryConstrained method changed, see [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4126/files#diff-6060a24e7b11731338fa345cf66de22077d17892df5094e2440904c9e30707aeR80)
  - checkIfUrlBlankAndGetFileUrl method changed, see [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4126/files#diff-c0023a625db24ee70451e8d06c44b1c36a0b14fe1630dd25c25d160949e418cbR67)

- Changed ParquetTest.testStreamRoundtripParquetAllWithImportExportConfsDisabled,
since FileUtils now has a method [apocConfig().checkReadAllowed(url, urlAccessChecker);](https://github.com/neo4j/apoc/blob/dev/common/src/main/java/apoc/util/FileUtils.java#L200)

- Changed `LoadCsvTest.testWithSpacesInFileName`,
since FileUtils.changeFileUrlIfImportDirectoryConstrained now has a method [getLoadFileUrl(...)](https://github.com/neo4j/apoc/blob/dev/common/src/main/java/apoc/util/FileUtils.java#L205), 
which makes the procedure fail if we have a file name like `name with spaces` instead of `file:///name%20with%20spaces`, 
and on which we cannot change the code, as it's in Core

- Changed `SystemDbTest` due to new System Label "Auth" and Rel-type "HAS_AUTH", see [here](https://github.com/neo4j/neo4j/commit/cacefd098ba7285449dc96ce0897fa2ec67d2c4f#diff-96acffd0efd6be52da1bda0a61be494cb424a4eb0f2752964559d48c98bae2a0R49) 
