### PR TITLE
Fixes #4086: De ignore and solve failing docker tests in 5.21

### DIFF
--- a/extended-it/src/test/java/apoc/neo4j/docker/BoltTest.java
+++ b/extended-it/src/test/java/apoc/neo4j/docker/BoltTest.java
@@ -15,7 +15,6 @@ import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.driver.Session;
 import org.neo4j.graphdb.Entity;
@@ -46,7 +45,6 @@ import static org.neo4j.driver.Values.point;
  * @author AgileLARUS
  * @since 29.08.17
  */
-@Ignore
 public class BoltTest {
 
     public static String BOLT_URL;

--- a/extended-it/src/test/java/apoc/neo4j/docker/CoreExtendedTest.java
+++ b/extended-it/src/test/java/apoc/neo4j/docker/CoreExtendedTest.java
@@ -2,7 +2,6 @@ package apoc.neo4j.docker;
 
 import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
-import org.junit.Ignore;
 import org.junit.Test;
 import apoc.util.TestContainerUtil.ApocPackage;
 import org.neo4j.driver.Record;
@@ -25,7 +24,6 @@ import static org.junit.Assert.fail;
  into a Neo4j instance without any startup issue.
  If you don't have docker installed it will fail, and you can simply ignore it.
  */
-@Ignore
 public class CoreExtendedTest {
     @Test
     public void checkForCoreAndExtended() {

--- a/extended-it/src/test/java/apoc/neo4j/docker/StartupExtendedTest.java
+++ b/extended-it/src/test/java/apoc/neo4j/docker/StartupExtendedTest.java
@@ -6,7 +6,6 @@ import apoc.util.Neo4jContainerExtension;
 import apoc.util.TestContainerUtil;
 import apoc.util.TestContainerUtil.Neo4jVersion;
 import org.apache.commons.io.FileUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.driver.Session;
 
@@ -30,7 +29,6 @@ import static org.junit.Assert.fail;
 /*
  This test is just to verify if the APOC procedures and functions are correctly deployed into a Neo4j instance without any startup issue.
  */
-@Ignore
 public class StartupExtendedTest {
     private static final String APOC_HELP_QUERY = "CALL apoc.help('') YIELD core, type, name WHERE core = $core and type = $type RETURN name";
     private static final List<String> EXPECTED_EXTENDED_NAMES;


### PR DESCRIPTION
Fixes #4086

Tried several times, but the problems no longer seem to be present, 
maybe because the neo4j present in dev at the time differed from the 5.21 publicly released.