### PR TITLE
Fixes #4102: make apache commons libraries that are now part of neo4j as provided or exclude them

### DIFF
--- a/extra-dependencies/build.gradle
+++ b/extra-dependencies/build.gradle
@@ -67,6 +67,9 @@ ext {
         exclude group: 'io.netty', module: 'netty-transport-native-kqueue'
         exclude group: 'io.netty', module: 'netty-transport-native-unix-common'
         exclude group: 'io.netty', module: 'netty-tcnative-classes'
+        
+        // logging
+        exclude group: 'org.apache.logging.log4j'
     }
 }
 

--- a/extra-dependencies/xls/build.gradle
+++ b/extra-dependencies/xls/build.gradle
@@ -18,19 +18,10 @@ jar {
 }
 
 dependencies {
-    implementation group: 'org.apache.poi', name: 'poi', version: '5.1.0', {
-        exclude group: 'org.apache.logging.log4j'
-    }
-    implementation group: 'org.apache.poi', name: 'poi-ooxml-lite', version: '5.1.0', {
-        exclude group: 'org.apache.logging.log4j'
-    }
-    implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.1.0' , {
-        exclude group: 'org.apache.commons', module: 'commons-compress'
-        exclude group: 'org.apache.logging.log4j'
-    }
-    implementation group: 'org.apache.xmlbeans', name: 'xmlbeans', version: '5.0.2', {
-        exclude group: 'org.apache.logging.log4j'
-    }
-    implementation group: 'com.github.virtuald', name: 'curvesapi', version: '1.06'
-    implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
+    implementation group: 'org.apache.poi', name: 'poi', version: '5.2.5', commonExclusions
+    implementation group: 'org.apache.poi', name: 'poi-ooxml-lite', version: '5.2.5', commonExclusions
+    implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.2.5' , commonExclusions
+    implementation group: 'org.apache.xmlbeans', name: 'xmlbeans', version: '5.2.1', commonExclusions
+    implementation group: 'com.github.virtuald', name: 'curvesapi', version: '1.08', commonExclusions
+    implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4', commonExclusions
 }


### PR DESCRIPTION
Fixes #4102: Make Apache Commons libraries that are now part of neo4jas provided or exclude them

- Upgraded dependencies to solve conflict errors and fix sub-dependencies vulnerabilities
- Added `'org.apache.logging.log4j'` to `commonExclusions` and changed exclusions in `extra-dependencies/xls/build.gradle` to `commonExclusions`