### PR TITLE
Fixes #4101: Add Vector Db performance tests

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/chroma.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/chroma.adoc
@@ -237,3 +237,18 @@ RETURN value
 CALL apoc.vectordb.chroma.delete($host, '<collection_id>', [1,2], {<optional config>})
 ----
 
+=== Performance
+
+The table below shows the time spent on all operations on a sample of 41.666 records.
+
+.Performance results
+[opts="header"]
+|===
+| Operation | Time (ms)
+| apoc.vectordb.chroma.createCollection | 158
+| apoc.vectordb.chroma.upsert | 10650
+| apoc.vectordb.chroma.get | 2357
+| apoc.vectordb.chroma.query | 1068
+| apoc.vectordb.chroma.delete | 9827
+| apoc.vectordb.chroma.deleteCollection | 141
+|===

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/chroma.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/chroma.adoc
@@ -239,7 +239,9 @@ CALL apoc.vectordb.chroma.delete($host, '<collection_id>', [1,2], {<optional con
 
 === Performance
 
-The table below shows the time spent on all operations on a sample of 41.666 records.
+The table below shows the time spent on all operations on a sample of 41.666 records,
+tested with a MacBook Pro M3 Pro 18GB Ram using a Docker with 8 CPU, Memory limit 10GB and Swap 1.5GB.
+
 
 .Performance results
 [opts="header"]

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/milvus.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/milvus.adoc
@@ -242,7 +242,8 @@ CALL apoc.vectordb.milvus.delete('http://localhost:19531', 'test_collection', [1
 
 === Performance
 
-The table below shows the time spent on all operations on a sample of 16.384 records.
+The table below shows the time spent on all operations on a sample of 16.384 records,
+tested with a MacBook Pro M3 Pro 18GB Ram using a Docker with 8 CPU, Memory limit 10GB and Swap 1.5GB.
 
 .Performance results
 [opts="header"]

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/milvus.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/milvus.adoc
@@ -239,3 +239,19 @@ RETURN value
 ----
 CALL apoc.vectordb.milvus.delete('http://localhost:19531', 'test_collection', [1,2], {<optional config>})
 ----
+
+=== Performance
+
+The table below shows the time spent on all operations on a sample of 16.384 records.
+
+.Performance results
+[opts="header"]
+|===
+| Operation | Time (ms)
+| apoc.vectordb.milvus.createCollection | 69
+| apoc.vectordb.milvus.upsert | 567
+| apoc.vectordb.milvus.get | 3508
+| apoc.vectordb.milvus.query | 459
+| apoc.vectordb.milvus.delete | 411
+| apoc.vectordb.milvus.deleteCollection | 62
+|===

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/qdrant.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/qdrant.adoc
@@ -242,7 +242,8 @@ CALL apoc.vectordb.qdrant.delete($hostOrKey, 'test_collection', [1,2], {<optiona
 
 === Performance
 
-The table below shows the time spent on all operations on a sample of 230.000 records.
+The table below shows the time spent on all operations on a sample of 230.000 records,
+tested with a MacBook Pro M3 Pro 18GB Ram using a Docker with 8 CPU, Memory limit 10GB and Swap 1.5GB.
 
 .Performance results
 [opts="header"]

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/qdrant.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/qdrant.adoc
@@ -239,3 +239,19 @@ RETURN value
 ----
 CALL apoc.vectordb.qdrant.delete($hostOrKey, 'test_collection', [1,2], {<optional config>})
 ----
+
+=== Performance
+
+The table below shows the time spent on all operations on a sample of 230.000 records.
+
+.Performance results
+[opts="header"]
+|===
+| Operation | Time (ms)
+| apoc.vectordb.qdrant.createCollection | 129
+| apoc.vectordb.qdrant.upsert | 1962
+| apoc.vectordb.qdrant.get | 4567
+| apoc.vectordb.qdrant.query | 81
+| apoc.vectordb.qdrant.delete | 21
+| apoc.vectordb.qdrant.deleteCollection | 37
+|===

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/weaviate.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/weaviate.adoc
@@ -258,7 +258,8 @@ CALL apoc.vectordb.weaviate.delete($host, 'test_collection', [1,2], {<optional c
 
 === Performance
 
-The table below shows the time spent on all operations on a sample of 100.000 records.
+The table below shows the time spent on all operations on a sample of 100.000 records,
+tested with a MacBook Pro M3 Pro 18GB Ram using a Docker with 8 CPU, Memory limit 10GB and Swap 1.5GB.
 
 .Performance results
 [opts="header"]

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/weaviate.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/weaviate.adoc
@@ -255,3 +255,19 @@ RETURN value
 ----
 CALL apoc.vectordb.weaviate.delete($host, 'test_collection', [1,2], {<optional config>})
 ----
+
+=== Performance
+
+The table below shows the time spent on all operations on a sample of 100.000 records.
+
+.Performance results
+[opts="header"]
+|===
+| Operation | Time (ms)
+| apoc.vectordb.weaviate.createCollection | 59
+| apoc.vectordb.weaviate.upsert | 319766
+| apoc.vectordb.weaviate.get | 41431
+| apoc.vectordb.weaviate.query | 1887
+| apoc.vectordb.weaviate.delete | 53218
+| apoc.vectordb.weaviate.deleteCollection | 201
+|===

--- a/extended-it/src/test/java/apoc/vectordb/WeaviateTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/WeaviateTest.java
@@ -3,17 +3,20 @@ package apoc.vectordb;
 import apoc.ml.Prompt;
 import apoc.util.MapUtil;
 import apoc.util.TestUtil;
+import org.apache.commons.lang3.time.StopWatch;
 import org.junit.AfterClass;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Result;
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 import org.testcontainers.weaviate.WeaviateContainer;
 
@@ -22,11 +25,25 @@ import java.util.Map;
 
 import static apoc.ml.Prompt.API_KEY_CONF;
 import static apoc.ml.RestAPIConfig.HEADERS_KEY;
+import static apoc.util.ExtendedTestUtil.stopWatchLog;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testCallEmpty;
 import static apoc.util.TestUtil.testResult;
 import static apoc.util.Util.map;
 import static apoc.vectordb.VectorDbHandler.Type.WEAVIATE;
+import static apoc.vectordb.VectorDbTestUtil.EntityType.FALSE;
+import static apoc.vectordb.VectorDbTestUtil.EntityType.NODE;
+import static apoc.vectordb.VectorDbTestUtil.EntityType.REL;
+import static apoc.vectordb.VectorDbTestUtil.assertBerlinResult;
+import static apoc.vectordb.VectorDbTestUtil.assertLondonResult;
+import static apoc.vectordb.VectorDbTestUtil.assertNodesCreated;
+import static apoc.vectordb.VectorDbTestUtil.assertReadOnlyProcWithMappingResults;
+import static apoc.vectordb.VectorDbTestUtil.assertRelsCreated;
+import static apoc.vectordb.VectorDbTestUtil.dropAndDeleteAll;
+import static apoc.vectordb.VectorDbTestUtil.generateFakeData;
+import static apoc.vectordb.VectorDbTestUtil.getAuthHeader;
+import static apoc.vectordb.VectorDbTestUtil.getFakeIds;
+import static apoc.vectordb.VectorDbTestUtil.getSizePerformanceVectors;
 import static apoc.vectordb.VectorDbTestUtil.EntityType.FALSE;
 import static apoc.vectordb.VectorDbTestUtil.EntityType.NODE;
 import static apoc.vectordb.VectorDbTestUtil.EntityType.REL;
@@ -61,6 +78,8 @@ public class WeaviateTest {
             .withEnv("AUTHENTICATION_APIKEY_ENABLED", "true")
             .withEnv("AUTHENTICATION_APIKEY_ALLOWED_KEYS", ADMIN_KEY + "," + READONLY_KEY)
             .withEnv("AUTHENTICATION_APIKEY_USERS", "jane@doe.com,ian-smith")
+            
+            .withEnv("QUERY_MAXIMUM_RESULTS", "100000")
             
             .withEnv("AUTHORIZATION_ADMINLIST_ENABLED", "true")
             .withEnv("AUTHORIZATION_ADMINLIST_USERS", "jane@doe.com,john@doe.com")
@@ -538,5 +557,68 @@ public class WeaviateTest {
                         "attributes", List.of("city", "foo")
                 ),
                 VectorDbTestUtil::assertRagWithVectors);
+    }
+
+    @Ignore("This test measures procedures performances, we ignore it since it's slow and just log the times spent")
+    @Test
+    public void performanceTest() {
+        StopWatch watch = new StopWatch();
+        watch.start();
+
+        String collection = "PerformanceCol";
+        testCall(db, "CALL apoc.vectordb.weaviate.createCollection($host, $collection, 'cosine', 4, $conf)",
+                map("host", HOST, "collection", collection, "conf", ADMIN_HEADER_CONF),
+                r -> {
+                    Map value = (Map) r.get("value");
+                    assertEquals(collection, value.get("class"));
+                });
+        stopWatchLog(watch, "apoc.vectordb.weaviate.createCollection");
+
+        List<Map<String, Object>> data = generateFakeData(VectorDbHandler.Type.WEAVIATE.name());
+
+        watch.start();
+        testResult(db, """
+                        CALL apoc.vectordb.weaviate.upsert($host, $collection, $data, $conf)
+                        """,
+                MapUtil.map("host", HOST,  "collection", collection, "conf", ADMIN_HEADER_CONF, "data", data),
+                Result::resultAsString);
+        stopWatchLog(watch, "apoc.vectordb.weaviate.upsert");
+
+        watch.start();
+        testResult(db, "CALL apoc.vectordb.weaviate.get($host, $collection, $ids, $conf) ",
+                MapUtil.map(
+                        "host", HOST,
+                        "collection", collection,
+                        "conf", map(ALL_RESULTS_KEY, true, HEADERS_KEY, READONLY_AUTHORIZATION),
+                        "ids", getFakeIds(data)
+                ),
+                Result::resultAsString);
+        stopWatchLog(watch, "apoc.vectordb.weaviate.get");
+
+        watch.start();
+        testResult(db,
+                """
+                CALL apoc.vectordb.weaviate.query($host, $collection, [0.2, 0.1, 0.9, 0.7], null, $limit, $conf) YIELD metadata, id, score, vector""",
+                map("host", HOST,
+                        "collection", collection,
+                        "conf", map(ALL_RESULTS_KEY, true, FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION),
+                        "limit", getSizePerformanceVectors(VectorDbHandler.Type.WEAVIATE.name())
+                ),
+                Result::resultAsString);
+        stopWatchLog(watch, "apoc.vectordb.weaviate.query");
+
+        watch.start();
+        testResult(db,
+                "CALL apoc.vectordb.weaviate.delete($host, $collection, $ids, $conf)",
+                map("host", HOST, "collection", collection,  "conf", ADMIN_HEADER_CONF, "ids", getFakeIds(data)),
+                Result::resultAsString);
+        stopWatchLog(watch, "apoc.vectordb.weaviate.delete");
+
+        watch.start();
+        testResult(db,
+                "CALL apoc.vectordb.weaviate.deleteCollection($host, $collection, $conf)",
+                map("host", HOST, "collection", collection, "conf", ADMIN_HEADER_CONF),
+                Result::resultAsString);
+        stopWatchLog(watch, "apoc.vectordb.weaviate.deleteCollection");
     }
 }

--- a/extended/src/test/java/apoc/util/ExtendedTestUtil.java
+++ b/extended/src/test/java/apoc/util/ExtendedTestUtil.java
@@ -1,5 +1,6 @@
 package apoc.util;
 
+import org.apache.commons.lang3.time.StopWatch;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.ResultTransformer;
@@ -82,5 +83,11 @@ public class ExtendedTestUtil {
                 return false;
             }
         }, (v) -> v, timeout, TimeUnit.SECONDS);
+    }
+
+    public static void stopWatchLog(StopWatch watch, String operation) {
+        watch.stop();
+        System.out.println("Operation: " + operation  + " | Time spent: " + watch.getTime() + "ms");
+        watch.reset();
     }
 }


### PR DESCRIPTION
Fixes #4101

Added performance tests with different vector sizes, since each vector db has a different infrastructural limit,
for example, ChromaDb's upsert API is limited to 41666