### PR TITLE
Fixes #4121: Better error messaging with vectordb query/get procedures

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/chroma.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/chroma.adoc
@@ -74,9 +74,9 @@ CALL apoc.vectordb.chroma.get($host, '<collection_id>', ['1','2'], {<optional co
 .Example results
 [opts="header"]
 |===
-| score | metadata | id | vector | text | entity
-| null | {city: "Berlin", foo: "one"} | null | null | null | null
-| null | {city: "Berlin", foo: "two"} | null | null | null | null
+| score | metadata | id | vector | text | entity | errors
+| null | {city: "Berlin", foo: "one"} | null | null | null | null | null
+| null | {city: "Berlin", foo: "two"} | null | null | null | null | null
 | ...
 |===
 
@@ -91,9 +91,9 @@ CALL apoc.vectordb.chroma.get($host, '<collection_id>', ['1','2'], {<optional co
 .Example results
 [opts="header"]
 |===
-| score | metadata | id | vector | text | entity
-| null | {city: "Berlin", foo: "one"} | 1 | [...] | ajeje | null
-| null | {city: "Berlin", foo: "two"} | 2 | [...] | brazorf | null
+| score | metadata | id | vector | text | entity  | errors
+| null | {city: "Berlin", foo: "one"} | 1 | [...] | ajeje | null | null
+| null | {city: "Berlin", foo: "two"} | 2 | [...] | brazorf | null | null
 | ...
 |===
 
@@ -113,9 +113,9 @@ CALL apoc.vectordb.chroma.queryAndUpdate($host,
 .Example results
 [opts="header"]
 |===
-| score | metadata | id | vector | text
-| 1, | {city: "Berlin", foo: "one"} | 1 | [...] | ajeje
-| 0.1 | {city: "Berlin", foo: "two"} | 2 | [...] | brazorf
+| score | metadata | id | vector | text | errors
+| 1, | {city: "Berlin", foo: "one"} | 1 | [...] | ajeje | null
+| 0.1 | {city: "Berlin", foo: "two"} | 2 | [...] | brazorf | null
 | ...
 |===
 

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/custom.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/custom.adoc
@@ -63,9 +63,9 @@ CALL apoc.vectordb.custom.get('https://<INDEX-ID>.svc.gcp-starter.pinecone.io/qu
 .Example results
 [opts="header"]
 |===
-| score | metadata | id | vector | text
-| 1, | {a: 1} | 1 | [1,2,3,4]
-| 0.1 | {a: 2} | 2 | [1,2,3,4]
+| score | metadata | id | vector | text | errors
+| 1, | {a: 1} | 1 | [1,2,3,4] | null
+| 0.1 | {a: 2} | 2 | [1,2,3,4] | null
 | ...
 |===
 

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/milvus.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/milvus.adoc
@@ -76,10 +76,19 @@ CALL apoc.vectordb.milvus.get('http://localhost:19531', 'test_collection', [1,2]
 .Example results
 [opts="header"]
 |===
-| score | metadata | id | vector | text | entity
-| null | {city: "Berlin", foo: "one"} | null | null | null | null
-| null | {city: "Berlin", foo: "two"} | null | null | null | null
+| score | metadata | id | vector | text | entity | errors
+| null | {city: "Berlin", foo: "one"} | null | null | null | null | null
+| null | {city: "Berlin", foo: "two"} | null | null | null | null | null
 | ...
+|===
+
+In case of errors, e.g. due to `apoc.vectordb.milvus.query` with wrong vector size as a 3rd parameter, the error field will be populated, for example:
+
+.Example results
+[opts="header"]
+|===
+| score | metadata | id | vector | text | errors
+| null | null | null | null | null | ..please check the primary key and its' type can only in [int, string], error: unable to cast "wrong" of type string to int64..
 |===
 
 .Get vectors with `{allResults: true}`
@@ -92,9 +101,9 @@ CALL apoc.vectordb.milvus.get('http://localhost:19531', 'test_collection', [1,2]
 .Example results
 [opts="header"]
 |===
-| score | metadata | id | vector | text | entity
-| null | {city: "Berlin", foo: "one"} | 1 | [...] | null | null
-| null | {city: "Berlin", foo: "two"} | 2 | [...] | null | null
+| score | metadata | id | vector | text | entity | errors
+| null | {city: "Berlin", foo: "one"} | 1 | [...] | null | null | null
+| null | {city: "Berlin", foo: "two"} | 2 | [...] | null | null | null
 | ...
 |===
 
@@ -115,12 +124,20 @@ CALL apoc.vectordb.milvus.query('http://localhost:19531',
 .Example results
 [opts="header"]
 |===
-| score | metadata | id | vector | text | entity
-| 1, | {city: "Berlin", foo: "one"} | 1 | [...] | null | null
-| 0.1 | {city: "Berlin", foo: "two"} | 2 | [...] | null | null
+| score | metadata | id | vector | text | entity | errors
+| 1, | {city: "Berlin", foo: "one"} | 1 | [...] | null | null | null
+| 0.1 | {city: "Berlin", foo: "two"} | 2 | [...] | null | null | null
 | ...
 |===
 
+In case of errors, e.g. due to `apoc.vectordb.milvus.query` with wrong vector size as a 3rd parameter, the error field will be populated, for example:
+
+.Example results
+[opts="header"]
+|===
+| score | metadata | id | vector | text | errors
+| null | null | null | null | null | ..can only accept json format request, error: dimension: 4, but length of []float: 3: invalid parameter[expected=FloatVector][actual=[0.2,0.1,0.9]]..
+|===
 
 We can define a mapping, to auto-create one/multiple nodes and relationships, by leveraging the vector metadata.
 

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/pinecone.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/pinecone.adoc
@@ -92,9 +92,9 @@ CALL apoc.vectordb.pinecone.get($host, 'test-index', [1,2], {<optional config>})
 .Example results
 [opts="header"]
 |===
-| score | metadata | id | vector | text | entity
-| null | {city: "Berlin", foo: "one"} | null | null | null | null
-| null | {city: "Berlin", foo: "two"} | null | null | null | null
+| score | metadata | id | vector | text | entity | errors
+| null | {city: "Berlin", foo: "one"} | null | null | null | null | null
+| null | {city: "Berlin", foo: "two"} | null | null | null | null | null
 | ...
 |===
 
@@ -108,9 +108,9 @@ CALL apoc.vectordb.pinecone.get($host, 'test-index', ['1','2'], {allResults: tru
 .Example results
 [opts="header"]
 |===
-| score | metadata | id | vector | text | entity
-| null | {city: "Berlin", foo: "one"} | 1 | [...] | null | null
-| null | {city: "Berlin", foo: "two"} | 2 | [...] | null | null
+| score | metadata | id | vector | text | entity | errors
+| null | {city: "Berlin", foo: "one"} | 1 | [...] | null | null | null
+| null | {city: "Berlin", foo: "two"} | 2 | [...] | null | null | null
 | ...
 |===
 
@@ -129,9 +129,9 @@ CALL apoc.vectordb.pinecone.query($host,
 .Example results
 [opts="header"]
 |===
-| score | metadata | id | vector | text | entity
-| 1, | {city: "Berlin", foo: "one"} | 1 | [...] | null | null
-| 0.1 | {city: "Berlin", foo: "two"} | 2 | [...] | null | null
+| score | metadata | id | vector | text | entity | errors
+| 1, | {city: "Berlin", foo: "one"} | 1 | [...] | null | null | null
+| 0.1 | {city: "Berlin", foo: "two"} | 2 | [...] | null | null | null
 | ...
 |===
 

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/qdrant.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/qdrant.adoc
@@ -75,9 +75,9 @@ CALL apoc.vectordb.qdrant.get($hostOrKey, 'test_collection', [1,2], {<optional c
 .Example results
 [opts="header"]
 |===
-| score | metadata | id | vector | text | entity
-| null | {city: "Berlin", foo: "one"} | null | null | null | null
-| null | {city: "Berlin", foo: "two"} | null | null | null | null
+| score | metadata | id | vector | text | entity | errors
+| null | {city: "Berlin", foo: "one"} | null | null | null | null | null
+| null | {city: "Berlin", foo: "two"} | null | null | null | null | null
 | ...
 |===
 
@@ -91,9 +91,9 @@ CALL apoc.vectordb.qdrant.get($hostOrKey, 'test_collection', [1,2], {allResults:
 .Example results
 [opts="header"]
 |===
-| score | metadata | id | vector | text | entity
-| null | {city: "Berlin", foo: "one"} | 1 | [...] | null | null
-| null | {city: "Berlin", foo: "two"} | 2 | [...] | null | null
+| score | metadata | id | vector | text | entity | errors
+| null | {city: "Berlin", foo: "one"} | 1 | [...] | null | null | null
+| null | {city: "Berlin", foo: "two"} | 2 | [...] | null | null | null
 | ...
 |===
 
@@ -114,9 +114,9 @@ CALL apoc.vectordb.qdrant.query($hostOrKey,
 .Example results
 [opts="header"]
 |===
-| score | metadata | id | vector | text | entity
-| 1, | {city: "Berlin", foo: "one"} | 1 | [...] | null | null
-| 0.1 | {city: "Berlin", foo: "two"} | 2 | [...] | null | null
+| score | metadata | id | vector | text | entity | errors
+| 1, | {city: "Berlin", foo: "one"} | 1 | [...] | null | null | null
+| 0.1 | {city: "Berlin", foo: "two"} | 2 | [...] | null | null | null
 | ...
 |===
 

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/weaviate.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/weaviate.adoc
@@ -87,9 +87,9 @@ CALL apoc.vectordb.weaviate.get($host, 'test_collection', [1,2], {<optional conf
 .Example results
 [opts="header"]
 |===
-| score | metadata | id | vector | text | entity
-| null | {city: "Berlin", foo: "one"} | null | null | null | null
-| null | {city: "Berlin", foo: "two"} | null | null | null | null
+| score | metadata | id | vector | text | entity | errors
+| null | {city: "Berlin", foo: "one"} | null | null | null | null | null
+| null | {city: "Berlin", foo: "two"} | null | null | null | null | null
 | ...
 |===
 
@@ -104,9 +104,9 @@ CALL apoc.vectordb.weaviate.get($host, 'test_collection', [1,2], {allResults: tr
 .Example results
 [opts="header"]
 |===
-| score | metadata | id | vector | text | entity
-| null | {city: "Berlin", foo: "one"} | 1 | [...] | null | null
-| null | {city: "Berlin", foo: "two"} | 2 | [...] | null | null
+| score | metadata | id | vector | text | entity | errors
+| null | {city: "Berlin", foo: "one"} | 1 | [...] | null | null | null
+| null | {city: "Berlin", foo: "two"} | 2 | [...] | null | null | null
 | ...
 |===
 
@@ -126,12 +126,20 @@ CALL apoc.vectordb.weaviate.query($host,
 .Example results
 [opts="header"]
 |===
-| score | metadata | id | vector | text
-| 1, | {city: "Berlin", foo: "one"} | 1 | [...] | null
-| 0.1 | {city: "Berlin", foo: "two"} | 2 | [...] | null
+| score | metadata | id | vector | text | errors
+| 1, | {city: "Berlin", foo: "one"} | 1 | [...] | null | null
+| 0.1 | {city: "Berlin", foo: "two"} | 2 | [...] | null | null
 | ...
 |===
 
+In case of errors, e.g. due to `apoc.vectordb.weaviate.query` with wrong vector size as a 3rd parameter, the error field will be populated, for example:
+
+.Example results
+[opts="header"]
+|===
+| score | metadata | id | vector | text | errors
+| null | null | null | null | null | ..vector search: knn search: distance between entrypoint and query node: vector lengths don't match: 4 vs 3..
+|===
 
 We can define a mapping, to fetch the associated nodes and relationships and optionally create them, by leveraging the vector metadata.
 

--- a/extended/src/main/java/apoc/vectordb/Milvus.java
+++ b/extended/src/main/java/apoc/vectordb/Milvus.java
@@ -23,6 +23,7 @@ import static apoc.vectordb.VectorDb.executeRequest;
 import static apoc.vectordb.VectorDb.getEmbeddingResultStream;
 import static apoc.vectordb.VectorDbHandler.Type.MILVUS;
 import static apoc.vectordb.VectorDbUtil.*;
+import static apoc.vectordb.VectorEmbeddingConfig.DEFAULT_ERRORS;
 
 @Extended
 public class Milvus {
@@ -180,6 +181,9 @@ public class Milvus {
 
     private Stream<Map> getMapStream(Map v) {
         var data = v.get("data");
+        if (data == null) {
+            return Stream.of(Map.of(DEFAULT_ERRORS, v));
+        }
 
         return ((List<Map>) data).stream()
                 .map(i -> {

--- a/extended/src/main/java/apoc/vectordb/VectorDb.java
+++ b/extended/src/main/java/apoc/vectordb/VectorDb.java
@@ -114,6 +114,12 @@ public class VectorDb {
     }
 
     public static EmbeddingResult getEmbeddingResult(VectorEmbeddingConfig conf, Transaction tx, boolean hasEmbedding, boolean hasMetadata, VectorMappingConfig mapping, Map m) {
+        Object errors = m.get(conf.getErrorsKey());
+        if (errors != null) {
+            return new EmbeddingResult(null, null, null, null, null, null, null,
+                    errors);
+        }
+        
         Object id = conf.isAllResults() ? m.get(conf.getIdKey()) : null;
         List<Double> embedding = hasEmbedding ? (List<Double>) m.get(conf.getVectorKey()) : null;
         Map<String, Object> metadata = hasMetadata ? (Map<String, Object>) m.get(conf.getMetadataKey()) : null;
@@ -126,7 +132,8 @@ public class VectorDb {
         if (entity != null) entity = Util.rebind(tx, entity);
         return new EmbeddingResult(id, score, embedding, metadata, text,
                 mapping.getNodeLabel() == null ? null : (Node) entity,
-                mapping.getNodeLabel() != null ? null : (Relationship) entity
+                mapping.getNodeLabel() != null ? null : (Relationship) entity,
+                errors
         );
     }
 

--- a/extended/src/main/java/apoc/vectordb/VectorDbUtil.java
+++ b/extended/src/main/java/apoc/vectordb/VectorDbUtil.java
@@ -39,7 +39,8 @@ public class VectorDbUtil {
     public record EmbeddingResult(
             Object id, Double score, List<Double> vector, Map<String, Object> metadata, String text,
             Node node,
-            Relationship rel) {}
+            Relationship rel,
+            Object errors) {}
     
     public static Map<String, Object> getCommonVectorDbInfo(
             String hostOrKey, String collection, Map<String, Object> configuration, String templateUrl, VectorDbHandler handler) {

--- a/extended/src/main/java/apoc/vectordb/VectorEmbeddingConfig.java
+++ b/extended/src/main/java/apoc/vectordb/VectorEmbeddingConfig.java
@@ -16,6 +16,7 @@ public class VectorEmbeddingConfig {
     
     public static final String DEFAULT_ID = "id";
     public static final String DEFAULT_TEXT = "text";
+    public static final String DEFAULT_ERRORS = "errors";
     public static final String DEFAULT_VECTOR = "vector";
     public static final String DEFAULT_METADATA = "metadata";
     public static final String DEFAULT_SCORE = "score";
@@ -27,6 +28,7 @@ public class VectorEmbeddingConfig {
     private final String vectorKey;
     private final String metadataKey;
     private final String scoreKey;
+    private final String errorsKey;
 
     private final boolean allResults;
     private final boolean metaAsSubKey;
@@ -40,6 +42,7 @@ public class VectorEmbeddingConfig {
         this.scoreKey = (String) config.getOrDefault(SCORE_KEY, DEFAULT_SCORE);
         this.idKey = (String) config.getOrDefault(ID_KEY, DEFAULT_ID);
         this.textKey = (String) config.getOrDefault(TEXT_KEY, DEFAULT_TEXT);
+        this.errorsKey = (String) config.getOrDefault(TEXT_KEY, DEFAULT_ERRORS);
         this.allResults = Util.toBoolean(config.get(ALL_RESULTS_KEY));
         this.mapping = new VectorMappingConfig((Map<String, Object>) config.getOrDefault(MAPPING_KEY, Map.of()));
 
@@ -66,6 +69,10 @@ public class VectorEmbeddingConfig {
 
     public String getTextKey() {
         return textKey;
+    }
+
+    public String getErrorsKey() {
+        return errorsKey;
     }
 
     public boolean isAllResults() {


### PR DESCRIPTION
Fixes #4121

Added errors field to EmbeddingResult, 
which will be returned in case of JSON response with 200 OK having a value with key "errors", like happening with `apoc.vectordb.milvus.query` and `apoc.vectordb.weaviate.query` endpoints, and with `apoc.vectordb.milvus.get` endpoint