### PR TITLE
Fixes #4134: The apoc.vectordb.weaviate.query and the apoc.vectordb.milvus.query/get should populate the fields config with the metadataKey if present

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/index.adoc
@@ -39,6 +39,11 @@ Besides the above config, the `apoc.vectordb.<type>.get` and the `apoc.vectordb.
     To let the procedure know which key in the restAPI (if present) corresponds to the one that should be populated as respectively the vector/metadata/score/text result.
     Defaults are "vector", "metadata", "score", "text".
     See examples below.
+| fields | a list of field to be returned, it has to be specified in the case of `apoc.vectordb.weaviate.query`, `apoc.vectordb.milvus.get` and `apoc.vectordb.milvus.query`.
+    To this list will be added under-the-hood, the key present in the `metadataKey`, defined in the `mapping` config.
+    If absent, it just returns the field specified in the `metadataKey` defined in the `mapping` config.
+
+    If the `fields` is empty and we're executing the procedures just mentioned, it returns an error.
 |===
 
 

--- a/extended/src/main/java/apoc/vectordb/MilvusHandler.java
+++ b/extended/src/main/java/apoc/vectordb/MilvusHandler.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 
 import static apoc.util.MapUtil.map;
-import static apoc.vectordb.VectorEmbeddingConfig.FIELDS_KEY;
+import static apoc.vectordb.VectorDbUtil.getFieldList;
 import static apoc.vectordb.VectorEmbeddingConfig.META_AS_SUBKEY_KEY;
 import static apoc.vectordb.VectorEmbeddingConfig.SCORE_KEY;
 
@@ -57,10 +57,7 @@ public class MilvusHandler implements VectorDbHandler {
         private VectorEmbeddingConfig getVectorEmbeddingConfig(Map<String, Object> config, List<String> procFields, String collection, Map<String, Object> additionalBodies) {
             config.putIfAbsent(META_AS_SUBKEY_KEY, false);
 
-            List listFields = (List) config.get(FIELDS_KEY);
-            if (listFields == null) {
-                throw new RuntimeException("You have to define `field` list of parameter to be returned");
-            }
+            List listFields = getFieldList(config);
             if (procFields.contains("vector") && !listFields.contains("vector")) {
                 listFields.add("vector");
             }

--- a/extended/src/main/java/apoc/vectordb/WeaviateHandler.java
+++ b/extended/src/main/java/apoc/vectordb/WeaviateHandler.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import static apoc.ml.RestAPIConfig.BODY_KEY;
 import static apoc.ml.RestAPIConfig.METHOD_KEY;
 import static apoc.util.MapUtil.map;
-import static apoc.vectordb.VectorEmbeddingConfig.FIELDS_KEY;
+import static apoc.vectordb.VectorDbUtil.getFieldList;
 import static apoc.vectordb.VectorEmbeddingConfig.METADATA_KEY;
 import static apoc.vectordb.VectorEmbeddingConfig.VECTOR_KEY;
 
@@ -47,10 +47,7 @@ public class WeaviateHandler implements VectorDbHandler {
             config.putIfAbsent(METHOD_KEY, "POST");
             VectorEmbeddingConfig vectorEmbeddingConfig = getVectorEmbeddingConfig(config);
 
-            List list = (List) config.get(FIELDS_KEY);
-            if (list == null) {
-                throw new RuntimeException("You have to define `field` list of parameter to be returned");
-            }
+            List list = getFieldList(config);
             Object fieldList = String.join("\n", list);
 
             filter = filter == null

--- a/extended/src/test/java/apoc/vectordb/VectorDbTestUtil.java
+++ b/extended/src/test/java/apoc/vectordb/VectorDbTestUtil.java
@@ -90,17 +90,28 @@ public class VectorDbTestUtil {
     }
     
     public static void assertReadOnlyProcWithMappingResults(Result r, String node) {
+        assertReadOnlyProcWithMappingResults(r, node,
+                Map.of("city", "Berlin", "foo", "one"),
+                Map.of("city", "London", "foo", "two")
+        );
+    }
+    
+    public static void assertReadOnlyProcWithMappingResults(Result r, String node,
+                                                            Map<String, Object> metadataRowOne,
+                                                            Map<String, Object> metadataRowTwo) {
         Map<String, Object> row = r.next();
         Map<String, Object> props = ((Entity) row.get(node)).getAllProperties();
         assertEquals(MapUtil.map("readID", "one"), props);
         assertNotNull(row.get("vector"));
         assertNotNull(row.get("id"));
+        assertEquals(metadataRowOne, row.get("metadata"));
 
         row = r.next();
         props = ((Entity) row.get(node)).getAllProperties();
         assertEquals(MapUtil.map("readID", "two"), props);
         assertNotNull(row.get("vector"));
         assertNotNull(row.get("id"));
+        assertEquals(metadataRowTwo, row.get("metadata"));
 
         assertFalse(r.hasNext());
     }


### PR DESCRIPTION
Fixes #4134

Now the `fields` config is added with the `metadataKey` value, if present.
So, in case `mapping` config is defined, the `fields` key is no longer needed.