### PR TITLE
Try to solve 5.21 TC errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ classes
 dependency-reduced-pom.xml
 derby*
 .gradle
-gradle.properties
 build/
 *~
 \#*

--- a/extended-it/src/test/java/apoc/vectordb/ChromaDbTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/ChromaDbTest.java
@@ -77,7 +77,7 @@ public class ChromaDbTest {
         
         CHROMA_CONTAINER.start();
 
-        HOST = "localhost:" + CHROMA_CONTAINER.getMappedPort(8000);
+        HOST = CHROMA_CONTAINER.getEndpoint();
         TestUtil.registerProcedure(db, ChromaDb.class, VectorDb.class, Prompt.class);
         
         testCall(db, "CALL apoc.vectordb.chroma.createCollection($host, 'test_collection', 'cosine', 4)",
@@ -404,7 +404,7 @@ public class ChromaDbTest {
     @Test
     public void queryVectorsWithSystemDbStorage() {
         String keyConfig = "chroma-config-foo";
-        String baseUrl = "http://" + HOST;
+        String baseUrl = HOST;
         Map<String, Object> mapping = map(EMBEDDING_KEY, "vect",
                 NODE_LABEL, "Test",
                 ENTITY_KEY, "myId",

--- a/extended-it/src/test/java/apoc/vectordb/QdrantTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/QdrantTest.java
@@ -82,7 +82,7 @@ public class QdrantTest {
         
         QDRANT_CONTAINER.start();
 
-        HOST = "localhost:" + QDRANT_CONTAINER.getMappedPort(6333);
+        HOST = QDRANT_CONTAINER.getHost() + ":" +QDRANT_CONTAINER.getMappedPort(6333);
         TestUtil.registerProcedure(db, Qdrant.class, VectorDb.class, Prompt.class);
 
         testCall(db, "CALL apoc.vectordb.qdrant.createCollection($host, 'test_collection', 'Cosine', 4, $conf)",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx5G -XX:MaxMetaspaceSize=256m


### PR DESCRIPTION
- commit https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4137/commits/aaab44ed254fa7614f2df71b3ea37d527b47036a, vectordb tests:
changed `"localhost"` to `<CONTAINER>.getHost()` to solve the connection refused error in TeamCity

![Bildschirmfoto 2024-07-06 um 11 26 00](https://github.com/neo4j-contrib/neo4j-apoc-procedures/assets/25103389/a8633651-9539-4169-ba52-fce9cfc58d0a)


- commit https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4137/commits/2087e9d88fc589cd80fdb628c0bb9be2d2048561, de-ignored gradle.properties,[ to be consistent with the Core one, which has the gradle.properties explicit](https://github.com/neo4j/apoc/blob/dev/gradle.properties), and to try to solve the heap space error in TeamCity:

![Bildschirmfoto 2024-07-06 um 11 27 12](https://github.com/neo4j-contrib/neo4j-apoc-procedures/assets/25103389/0f3d4fa9-0cb9-4f71-8363-9b340442524c)
