### PR TITLE
Fixes #4133: switch default model for cypher/schema interactions to gpt-4o

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/ml/genai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/genai.adoc
@@ -89,7 +89,7 @@ RETURN m.title
 | retryWithError | If true, in case of error retry the api adding the following messages to the body request:
 {`"role":"user", "content": "The previous Cypher Statement throws the following error, consider it to return the correct statement: `<errorMessage>`"}, {"role":"assistant", "content":"Cypher Statement (in backticks):"}` | no, default `false`
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
-| model | The Open AI model | no, default `gpt-3.5-turbo`
+| model | The Open AI model | no, default `gpt-4o`
 | sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number
 |===
 
@@ -138,7 +138,7 @@ RETURN *
 |===
 | name | description | mandatory
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
-| model | The Open AI model | no, default `gpt-3.5-turbo`
+| model | The Open AI model | no, default `gpt-4o`
 | sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number
 |===
 
@@ -203,7 +203,7 @@ RETURN DISTINCT a.name
 | name | description | mandatory
 | count | The number of queries to retrieve | no, default `1`
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
-| model | The Open AI model | no, default `gpt-3.5-turbo`
+| model | The Open AI model | no, default `gpt-4o`
 | sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number
 |===
 
@@ -250,7 +250,7 @@ overall, this graph database schema provides a simple yet powerful representatio
 | name | description | mandatory
 | retries | The number of retries in case of API call failures | no, default `3`
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
-| model | The Open AI model | no, default `gpt-3.5-turbo`
+| model | The Open AI model | no, default `gpt-4o`
 | sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number
 |===
 
@@ -329,7 +329,7 @@ RETURN *
 |===
 | name | description | mandatory
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
-| model | The Open AI model | no, default `gpt-3.5-turbo`
+| model | The Open AI model | no, default `gpt-4o`
 | sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number
 |===
 

--- a/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
@@ -178,7 +178,7 @@ This procedure `apoc.ml.openai.chat` takes a list of maps of chat exchanges betw
 
 It uses the `/chat/create` API which is https://platform.openai.com/docs/api-reference/chat/create[documented here^].
 
-Additional configuration is passed to the API, the default model used is `gpt-3.5-turbo`.
+Additional configuration is passed to the API, the default model used is `gpt-4o`.
 
 .Chat Completion Call
 [source,cypher]

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -176,7 +176,8 @@ public class OpenAI {
         if (messages == null) {
             throw new RuntimeException(ERROR_NULL_INPUT);
         }
-        return executeRequest(apiKey, configuration, "chat/completions", "gpt-3.5-turbo", "messages", messages, "$", apocConfig, urlAccessChecker)
+        configuration.putIfAbsent("model", "gpt-4o");
+        return executeRequest(apiKey, configuration, "chat/completions", (String) configuration.get("model"), "messages", messages, "$", apocConfig, urlAccessChecker)
                 .map(v -> (Map<String,Object>)v).map(MapResult::new);
         // https://platform.openai.com/docs/api-reference/chat/create
     /*

--- a/extended/src/main/java/apoc/ml/Prompt.java
+++ b/extended/src/main/java/apoc/ml/Prompt.java
@@ -312,7 +312,7 @@ public class Prompt {
         prompt.addAll(otherPrompts);
         
         String apiKey = (String) conf.get(API_KEY_CONF);
-        String model = (String) conf.getOrDefault("model", "gpt-3.5-turbo");
+        String model = (String) conf.getOrDefault("model", "gpt-4o");
         String result = OpenAI.executeRequest(apiKey, Map.of(), "chat/completions",
                         model, "messages", prompt, "$", apocConfig, urlAccessChecker)
                 .map(v -> (Map<String, Object>) v)


### PR DESCRIPTION
Fixes #4133

- Changed default model
- Added test with old model, to make sure they continue to work afterwards