### PR TITLE
Fixes #4000: Add self-explanation to the model, include the verbal schema description to the flow

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/ml/genai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/genai.adoc
@@ -91,6 +91,7 @@ RETURN m.title
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
 | model | The Open AI model | no, default `gpt-4o`
 | sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number
+| additionalPrompts | To specify other prompts to be passed to improve the request
 |===
 
 .Results
@@ -100,6 +101,107 @@ RETURN m.title
 | value | the result of the query
 | cypher | the query used to compute the result
 |===
+
+
+We can use the `additionalPrompts` config to improve the request, e.g. adding the natural language description of the schema (like the output of the `apoc.ml.schema` for instance).
+Since OpenAI is mainly trained to elaborate natural language questions asked in, rather than Cypher queries, by using this configuration it is possible to achieve better results.
+For example, given the https://neo4j.com/docs/getting-started/appendix/tutorials/guide-import-relational-and-etl/[Northwind dataset] we can execute:
+
+.Query call
+[source,cypher]
+----
+CALL apoc.ml.schema({apiKey: $apiKey}) YIELD value
+WITH value
+CALL apoc.ml.query("Which 5 employees had sold the product 'Chocolade' and has the highest selling count of another product?
+  Please returns the employee identificator, the other product name and the count orders of another product",
+{
+    retries: 8,
+    retryWithError: true,
+    apiKey: $apiKey,
+    additionalPrompts: [
+        {role: "system", content: "The human description of the schema is the following:\n" + value}
+    ]
+})
+YIELD query, value RETURN query, value
+----
+
+with a result similar to the following.
+
+NOTE: the results are not deterministic and will potentially change each time the query is re-executed
+
+.Results
+[%autowidth, opts=header]
+|===
+| query | value
+| "cypher
+MATCH (p:Product {productName: 'Chocolade'})<-[:CONTAINS]-(:Order)<-[:SOLD]-(e:Employee)
+MATCH (e)-[:SOLD]->(o:Order)-[:CONTAINS]->(p2:Product)
+WITH e, p2, COUNT(DISTINCT o) AS orderCount
+ORDER BY orderCount DESC
+RETURN e.employeeID AS employeeID, p2.productName AS otherProduct, orderCount
+LIMIT 5
+" 
+| {
+"otherProduct": "Gnocchi di nonna Alice",
+"employeeID": "4",
+"orderCount": 14
+}
+| "cypher
+MATCH (p:Product {productName: 'Chocolade'})<-[:CONTAINS]-(:Order)<-[:SOLD]-(e:Employee)
+MATCH (e)-[:SOLD]->(o:Order)-[:CONTAINS]->(p2:Product)
+WITH e, p2, COUNT(DISTINCT o) AS orderCount
+ORDER BY orderCount DESC
+RETURN e.employeeID AS employeeID, p2.productName AS otherProduct, orderCount
+LIMIT 5
+"
+| {
+"otherProduct": "Pâté chinois",
+"employeeID": "4",
+"orderCount": 12
+}
+| "cypher
+MATCH (p:Product {productName: 'Chocolade'})<-[:CONTAINS]-(:Order)<-[:SOLD]-(e:Employee)
+MATCH (e)-[:SOLD]->(o:Order)-[:CONTAINS]->(p2:Product)
+WITH e, p2, COUNT(DISTINCT o) AS orderCount
+ORDER BY orderCount DESC
+RETURN e.employeeID AS employeeID, p2.productName AS otherProduct, orderCount
+LIMIT 5
+"
+| {
+"otherProduct": "Gumbär Gummibärchen",
+"employeeID": "3",
+"orderCount": 12
+}
+| "cypher
+MATCH (p:Product {productName: 'Chocolade'})<-[:CONTAINS]-(:Order)<-[:SOLD]-(e:Employee)
+MATCH (e)-[:SOLD]->(o:Order)-[:CONTAINS]->(p2:Product)
+WITH e, p2, COUNT(DISTINCT o) AS orderCount
+ORDER BY orderCount DESC
+RETURN e.employeeID AS employeeID, p2.productName AS otherProduct, orderCount
+LIMIT 5
+"
+| {
+"otherProduct": "Flotemysost",
+"employeeID": "1",
+"orderCount": 12
+}
+| "cypher
+MATCH (p:Product {productName: 'Chocolade'})<-[:CONTAINS]-(:Order)<-[:SOLD]-(e:Employee)
+MATCH (e)-[:SOLD]->(o:Order)-[:CONTAINS]->(p2:Product)
+WITH e, p2, COUNT(DISTINCT o) AS orderCount
+ORDER BY orderCount DESC
+RETURN e.employeeID AS employeeID, p2.productName AS otherProduct, orderCount
+LIMIT 5
+"
+| {
+"otherProduct": "Pavlova",
+"employeeID": "1",
+"orderCount": 11
+}
+|===
+
+Respect to using the procedure without the natural language schema description, the output has fewer hallucinations, 
+like properties hold by different labels and relationships linked to other entities.
 
 
 == Describe the graph model with natural language
@@ -125,6 +227,7 @@ RETURN *
 +---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 1 row
 ----
+
 
 .Input Parameters
 [%autowidth, opts=header]
@@ -205,6 +308,7 @@ RETURN DISTINCT a.name
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
 | model | The Open AI model | no, default `gpt-4o`
 | sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number
+| additionalPrompts | To specify other prompts to be passed to improve the request
 |===
 
 .Results
@@ -213,6 +317,47 @@ RETURN DISTINCT a.name
 | name | description
 | value | the description of the dataset
 |===
+
+
+We can use the `additionalPrompts` config to improve the request, e.g. adding the natural language description of the schema (like the output of the `apoc.ml.schema` for instance).
+Since OpenAI is mainly trained to elaborate natural language questions asked in, rather than Cypher queries, by using this configuration it is possible to achieve better results.
+For example, given the https://neo4j.com/docs/getting-started/appendix/tutorials/guide-import-relational-and-etl/[Northwind dataset] we can execute:
+
+.Query call
+[source,cypher]
+----
+CALL apoc.ml.schema({apiKey: $apiKey}) YIELD value
+WITH value
+CALL apoc.ml.cypher("Which 5 employees had sold the product 'Chocolade' and has the highest selling count of another product? 
+  Please returns the employee identificator, the other product name and the count orders of another product",
+{
+  count: 1,
+  apiKey: $apiKey,
+  additionalPrompts: [
+    {role: "system", content: "The human description of the schema is the following:\n" + value}
+  ]
+})
+YIELD value RETURN value
+----
+
+with a result similar to the following.
+
+NOTE: the results are not deterministic and will potentially change each time the query is re-executed
+
+.Results
+[%autowidth, opts=header]
+|===
+| value
+| MATCH (p:Product {productName: 'Chocolade'})<-[:CONTAINS]-(o:Order)<-[:SOLD]-(e:Employee)
+MATCH (e)-[:SOLD]->(o2:Order)-[:CONTAINS]->(p2:Product)
+WITH e, p2, COUNT(DISTINCT o2) AS ordersCnt
+ORDER BY ordersCnt DESC
+RETURN e.employeeID AS employeeID, p2.productName AS otherProduct, ordersCnt
+LIMIT 5
+|===
+
+Respect to using the procedure without the natural language schema description, the output has fewer hallucinations,
+like properties hold by different labels and relationships linked to other entities.
 
 == Create a natural language query explanation from a cypher query
 

--- a/extended/src/main/java/apoc/util/ExtendedUtil.java
+++ b/extended/src/main/java/apoc/util/ExtendedUtil.java
@@ -183,7 +183,6 @@ public class ExtendedUtil
             case "node", "relationship":
                 return JsonUtil.parse(value, null, Map.class);
             case "no_value":
-            case "NO_VALUE":
                 return null;
             case "listboolean":
                 value = StringUtils.removeStart(value, "[");
@@ -353,6 +352,12 @@ public class ExtendedUtil
         return CollectionUtils.isNotEmpty(labels) ?
                 ":" + labels.stream().map(Util::quote).collect(Collectors.joining(":")) :
                 "";
+    }
+
+    public static List<String> splitSemicolonAndRemoveBlanks(String value) {
+        return Arrays.stream(value.split(";\n"))
+                .filter(i -> !i.isBlank())
+                .toList();
     }
             
 

--- a/extended/src/test/resources/northwind_dataset.cypher
+++ b/extended/src/test/resources/northwind_dataset.cypher
@@ -1,0 +1,61 @@
+// Create orders
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/orders.csv' AS row
+MERGE (order:Order {orderID: row.OrderID})
+  ON CREATE SET order.shipName = row.ShipName;
+
+// Create products
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/products.csv' AS row
+MERGE (product:Product {productID: row.ProductID})
+  ON CREATE SET product.productName = row.ProductName, product.unitPrice = toFloat(row.UnitPrice);
+
+// Create suppliers
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/suppliers.csv' AS row
+MERGE (supplier:Supplier {supplierID: row.SupplierID})
+  ON CREATE SET supplier.companyName = row.CompanyName;
+
+
+// Create employees
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/employees.csv' AS row
+MERGE (e:Employee {employeeID:row.EmployeeID})
+  ON CREATE SET e.firstName = row.FirstName, e.lastName = row.LastName, e.title = row.Title;
+
+
+// Create categories
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/categories.csv' AS row
+MERGE (c:Category {categoryID: row.CategoryID})
+  ON CREATE SET c.categoryName = row.CategoryName, c.description = row.Description;
+
+
+// Create relationships between orders and products
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/orders.csv' AS row
+MATCH (order:Order {orderID: row.OrderID})
+MATCH (product:Product {productID: row.ProductID})
+MERGE (order)-[op:CONTAINS]->(product)
+  ON CREATE SET op.unitPrice = toFloat(row.UnitPrice), op.quantity = toFloat(row.Quantity);
+
+
+// Create relationships between orders and employees
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/orders.csv' AS row
+MATCH (order:Order {orderID: row.OrderID})
+MATCH (employee:Employee {employeeID: row.EmployeeID})
+MERGE (employee)-[:SOLD]->(order);
+
+
+// Create relationships between products and suppliers
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/products.csv' AS row
+MATCH (product:Product {productID: row.ProductID})
+MATCH (supplier:Supplier {supplierID: row.SupplierID})
+MERGE (supplier)-[:SUPPLIES]->(product);
+
+// Create relationships between products and categories
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/products.csv' AS row
+MATCH (product:Product {productID: row.ProductID})
+MATCH (category:Category {categoryID: row.CategoryID})
+MERGE (product)-[:PART_OF]->(category);
+
+
+// Create relationships between employees (reporting hierarchy)
+LOAD CSV WITH HEADERS FROM 'https://gist.githubusercontent.com/jexp/054bc6baf36604061bf407aa8cd08608/raw/8bdd36dfc88381995e6823ff3f419b5a0cb8ac4f/employees.csv' AS row
+MATCH (employee:Employee {employeeID: row.EmployeeID})
+MATCH (manager:Employee {employeeID: row.ReportsTo})
+MERGE (employee)-[:REPORTS_TO]->(manager);

--- a/extended/src/test/resources/northwind_schema.cypher
+++ b/extended/src/test/resources/northwind_schema.cypher
@@ -1,0 +1,6 @@
+CREATE INDEX product_id FOR (p:Product) ON (p.productID);
+CREATE INDEX product_name FOR (p:Product) ON (p.productName);
+CREATE INDEX supplier_id FOR (s:Supplier) ON (s.supplierID);
+CREATE INDEX employee_id FOR (e:Employee) ON (e.employeeID);
+CREATE INDEX category_id FOR (c:Category) ON (c.categoryID);
+CREATE CONSTRAINT order_id FOR (o:Order) REQUIRE o.orderID IS UNIQUE;


### PR DESCRIPTION
Fixes #4000

- Improved schema prompt to retrieve slightly better results
- Added `additionalPrompts` config which can accept list of maps with other request messages
 - we can use it together with apoc.ml.schema to improve the results
 - added examples with Northwind database: https://neo4j.com/docs/getting-started/appendix/tutorials/guide-import-relational-and-etl/