### PR TITLE
[aYPLiTQG] Remove isSchema check to be more performant

### DIFF
--- a/full/src/main/java/apoc/cypher/CypherExtended.java
+++ b/full/src/main/java/apoc/cypher/CypherExtended.java
@@ -272,7 +272,8 @@ public class CypherExtended {
                             return consumeResult(result, queue, addStatistics, tx, fileName);
                         } catch (Exception e) {
                             // APOC historically skips schema operations
-                            if (!e.getMessage().contains("Schema operations on database 'neo4j' are not allowed")) {
+                            if (!(e.getMessage().contains("Schema operations on database")
+                                    && e.getMessage().contains("are not allowed"))) {
                                 collectError(queue, reportError, e, fileName);
                                 return null;
                             }

--- a/full/src/test/resources/wrong_statements.cypher
+++ b/full/src/test/resources/wrong_statements.cypher
@@ -1,1 +1,3 @@
+CREATE INDEX ON :Node(id);
 CREATE (n:Person{id:1);
+CREATE (n:Person{id:1});

--- a/full/src/test/resources/wrong_statements_runtime.cypher
+++ b/full/src/test/resources/wrong_statements_runtime.cypher
@@ -1,2 +1,2 @@
 CREATE (n:Fail {foo: 1});
-
+CREATE (n:Fail {foo: 2});


### PR DESCRIPTION
RunFile is not allowed to run schema operations, in 4.4.0.9 the validation check for this was a regex that was very basic, then in 4.4.0.11 this was updated to be more accurate, what happens is that every query gets run through an explain which checks if the query is a Schema operation, and if it is, it will ignore it. 

The problem I see with this is that it will now run this potentially time consuming check for every query in the file as well as actually running the query.

This PR removes this check and instead checks the errors thrown, if a schema error is thrown then it will handle this there to keep old behaviour.