### PR TITLE
Solve dev with APOC 5.22 build errors

### DIFF
--- a/extended/src/test/java/apoc/systemdb/SystemDbTest.java
+++ b/extended/src/test/java/apoc/systemdb/SystemDbTest.java
@@ -19,8 +19,10 @@ import java.util.HashSet;
 import org.apache.commons.io.FileUtils;
 import org.hamcrest.Matchers;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.ProvideSystemProperty;
 import org.junit.jupiter.api.AfterAll;
 
 import org.neo4j.configuration.GraphDatabaseSettings;
@@ -36,14 +38,19 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static apoc.ApocConfig.APOC_TRIGGER_ENABLED;
 import static apoc.ApocConfig.apocConfig;
 import static apoc.systemdb.SystemDbConfig.FEATURES_KEY;
 import static apoc.systemdb.SystemDbConfig.FILENAME_KEY;
 import static org.junit.Assert.assertEquals;
 
 public class SystemDbTest {
-    private static File directory = new File("target/import");
+    private static final File directory = new File("target/import");
 
+    @ClassRule
+    public static final ProvideSystemProperty systemPropertyRule =
+            new ProvideSystemProperty(APOC_TRIGGER_ENABLED, String.valueOf(true));
+    
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule()
             .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath());
@@ -57,7 +64,6 @@ public class SystemDbTest {
         apocConfig().setProperty(ApocConfig.APOC_IMPORT_FILE_ENABLED, true);
         apocConfig().setProperty(ApocConfig.APOC_EXPORT_FILE_ENABLED, true);
         apocConfig().setProperty(ExtendedApocConfig.APOC_UUID_ENABLED, true);
-        apocConfig().setProperty(ApocConfig.APOC_TRIGGER_ENABLED, true);
         TestUtil.registerProcedure(db, SystemDb.class, Trigger.class, CypherProcedures.class, Uuid.class, Periodic.class, DataVirtualizationCatalog.class, CypherExtended.class);
     }
 

--- a/extended/src/test/java/apoc/trigger/TriggerExtendedTest.java
+++ b/extended/src/test/java/apoc/trigger/TriggerExtendedTest.java
@@ -22,7 +22,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static apoc.ApocConfig.APOC_TRIGGER_ENABLED;
-import static apoc.ApocConfig.apocConfig;
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.configuration.GraphDatabaseSettings.procedure_unrestricted;
 

--- a/extended/src/test/java/apoc/trigger/TriggerExtendedTest.java
+++ b/extended/src/test/java/apoc/trigger/TriggerExtendedTest.java
@@ -4,8 +4,10 @@ import apoc.create.Create;
 import apoc.nodes.Nodes;
 import apoc.util.TestUtil;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.ProvideSystemProperty;
 import org.junit.jupiter.api.AfterAll;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Label;
@@ -29,17 +31,17 @@ import static org.neo4j.configuration.GraphDatabaseSettings.procedure_unrestrict
  * @since 20.09.16
  */
 public class TriggerExtendedTest {
+    @ClassRule
+    public static final ProvideSystemProperty systemPropertyRule =
+            new ProvideSystemProperty(APOC_TRIGGER_ENABLED, String.valueOf(true));
+    
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule()
             .withSetting(procedure_unrestricted, List.of("apoc*"));
 
-    private long start;
-
     @Before
     public void setUp() throws Exception {
-        start = System.currentTimeMillis();
         TestUtil.registerProcedure(db, Trigger.class, TriggerExtended.class, Nodes.class, Create.class);
-        apocConfig().setProperty(APOC_TRIGGER_ENABLED, true);
     }
 
     @AfterAll


### PR DESCRIPTION
Added `systemPropertyRule` to the `apoc.trigger.*` related tests, to solve tests that fail [due to these changes](https://github.com/neo4j/apoc/pull/637/files).

Otherwise, we will have a NullPointer, since the `triggerHandler` variable won't be assigned.

This happens since, using the `apocConfig().setProperty(ApocConfig.APOC_TRIGGER_ENABLED, true);` currently present, this [if condition](https://github.com/neo4j/apoc/pull/637/files#diff-e9c5851b9e9eaf8bf7fc7c3873340b49e22d840d0b7caba1b9fda8562006f02cR41) is false, because the `apocConfig` will be evaluated later, unlike the `systemPropertyRule` mechanism.


#### Other changes

- removed unused start field 