### PR TITLE
Try to solve TC 5.22 errors

### DIFF
--- a/extended-it/src/test/java/apoc/s3/LoadS3Test.java
+++ b/extended-it/src/test/java/apoc/s3/LoadS3Test.java
@@ -14,13 +14,15 @@ import org.junit.Test;
 import org.junit.jupiter.api.AfterAll;
 
 import org.neo4j.driver.internal.util.Iterables;
+import org.neo4j.graphdb.Result;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.Map;
 
 import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.APOC_IMPORT_FILE_USE_NEO4J_CONFIG;
 import static apoc.ApocConfig.apocConfig;
-import static apoc.load.LoadCsvTest.assertRow;
 import static apoc.util.ExtendedITUtil.EXTENDED_PATH;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
@@ -82,6 +84,12 @@ public class LoadS3Test extends S3BaseTest {
     private String removeRegionFromUrl(String url) {
         return url.replace(s3Container.getEndpointConfiguration().getSigningRegion() + ".", "");
     }
-
+    
+    public static void assertRow(Result r, String name, String age, long lineNo) {
+        Map<String, Object> row = r.next();
+        assertEquals(map("name", name,"age", age), row.get("map"));
+        assertEquals(asList(name, age), row.get("list"));
+        assertEquals(lineNo, row.get("lineNo"));
+    }
 
 }

--- a/extended/src/test/java/apoc/ml/WatsonTest.java
+++ b/extended/src/test/java/apoc/ml/WatsonTest.java
@@ -9,6 +9,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
+import org.mockserver.socket.PortFactory;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -33,6 +34,7 @@ import static org.mockserver.model.HttpResponse.response;
 
 public class WatsonTest {
 
+    private static final int PORT = PortFactory.findFreePort();
     private static ClientAndServer mockServer;
 
     @ClassRule
@@ -45,14 +47,15 @@ public class WatsonTest {
         TestUtil.registerProcedure(db, Watson.class);
         
         String path = "/generation/text";
-        apocConfig().setProperty(APOC_ML_WATSON_URL, "http://localhost:1080" + path);
+        apocConfig().setProperty(APOC_ML_WATSON_URL, "http://localhost:" + PORT + path);
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         apocConfig().setProperty(APOC_ML_WATSON_PROJECT_ID, "fakeProjectId");
         
         File urlFileName = new File(getUrlFileName("watson.json").getFile());
         String body = FileUtils.readFileToString(urlFileName, UTF_8);
         
-        mockServer = startClientAndServer(1080);
+        
+        mockServer = startClientAndServer(PORT);
         mockServer.when(
                         request()
                                 .withMethod("POST")


### PR DESCRIPTION
Try to solve TC 5.22 errors:

- BindException: Address already in use
Changed 1080 with PortFactory.findFreePort() in WatsonTest and LoadCsvTest to avoid the error.

- queryReadOnlyVectorsWithMapping FAILED, Caused by: java.net.SocketTimeoutException: Read timed out
Tried several time but not replicated, it could be a sporadic flaky error

----

- mock server error:
See [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/10181988389/job/28163453948?pr=4163#step:6:3351).
Copied assertion to LoadS3Test, since otherwise there is the following error,
as the `org/mockserver/socket/PortFactory` module is not included in `extended-it`, that is where the LoadS3Test is located
```
apoc.s3.LoadS3Test > testLoadCsvS3 FAILED
    java.lang.NoClassDefFoundError: org/mockserver/socket/PortFactory
        at apoc.load.LoadCsvTest.<clinit>(LoadCsvTest.java:49)
        at apoc.s3.LoadS3Test.lambda$testLoadCsvS3$0(LoadS3Test.java:55)
        at apoc.util.TestUtil.testResult(TestUtil.java:189)
        at apoc.s3.LoadS3Test.testLoadCsvS3(LoadS3Test.java:54)

        Caused by:
        java.lang.ClassNotFoundException: org.mockserver.socket.PortFactory
            at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
            at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
            at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
            ... 4 more
```
