### PR TITLE
[uRFsgcuC] Backport of 5.x ifNeeded quote fix

### DIFF
--- a/core-it/src/test/java/apoc/core/it/ExportCsvS3Test.java
+++ b/core-it/src/test/java/apoc/core/it/ExportCsvS3Test.java
@@ -95,7 +95,7 @@ public class ExportCsvS3Test extends S3BaseTest {
                     + ",,,,,,,,3,4,NEXT_DELIVERY%n");
     private static final String EXPECTED_NEEDED_QUOTES =
             String.format("_id,_labels,age,city,kids,male,name,street,_start,_end,_type%n"
-                    + "0,:User:User1,42,,\"[\"a\",\"b\",\"c\"]\",true,foo,,,,%n"
+                    + "0,:User:User1,42,,\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",true,foo,,,,%n"
                     + "1,:User,42,,,,bar,,,,%n"
                     + "2,:User,12,,,,,,,,%n"
                     + "3,:Address:Address1,,Milano,,,Andrea,\"Via Garibaldi, 7\",,,%n"

--- a/core/src/main/java/apoc/export/csv/CsvFormat.java
+++ b/core/src/main/java/apoc/export/csv/CsvFormat.java
@@ -101,7 +101,7 @@ public class CsvFormat implements Format {
     private CSVWriter getCsvWriter(Writer writer, ExportConfig config) {
         CSVWriter out;
         switch (config.isQuotes()) {
-            case ExportConfig.NONE_QUOTES:
+            case ExportConfig.NO_QUOTES:
                 out = new CSVWriter(
                         writer,
                         config.getDelimChar(),
@@ -110,12 +110,12 @@ public class CsvFormat implements Format {
                         CSVWriter.DEFAULT_LINE_END);
                 applyQuotesToAll = false;
                 break;
-            case ExportConfig.IF_NEEDED_QUUOTES:
+            case ExportConfig.IF_NEEDED_QUOTES:
                 out = new CSVWriter(
                         writer,
                         config.getDelimChar(),
                         ExportConfig.QUOTECHAR,
-                        '\0', // escape char
+                        CSVWriter.DEFAULT_ESCAPE_CHARACTER,
                         CSVWriter.DEFAULT_LINE_END);
                 applyQuotesToAll = false;
                 break;

--- a/core/src/main/java/apoc/export/util/ExportConfig.java
+++ b/core/src/main/java/apoc/export/util/ExportConfig.java
@@ -46,9 +46,9 @@ public class ExportConfig extends CompressionConfig {
     }
 
     public static final char QUOTECHAR = '"';
-    public static final String NONE_QUOTES = "none";
+    public static final String NO_QUOTES = "none";
     public static final String ALWAYS_QUOTES = "always";
-    public static final String IF_NEEDED_QUUOTES = "ifNeeded";
+    public static final String IF_NEEDED_QUOTES = "ifNeeded";
 
     public static final int DEFAULT_BATCH_SIZE = 20000;
     private static final int DEFAULT_UNWIND_BATCH_SIZE = 20;
@@ -196,12 +196,12 @@ public class ExportConfig extends CompressionConfig {
         try {
             this.quotes = (String) config.getOrDefault("quotes", DEFAULT_QUOTES);
 
-            if (!quotes.equals(ALWAYS_QUOTES) && !quotes.equals(NONE_QUOTES) && !quotes.equals(IF_NEEDED_QUUOTES)) {
+            if (!quotes.equals(ALWAYS_QUOTES) && !quotes.equals(NO_QUOTES) && !quotes.equals(IF_NEEDED_QUOTES)) {
                 throw new RuntimeException("The string value of the field quote is not valid");
             }
 
         } catch (ClassCastException e) { // backward compatibility
-            this.quotes = toBoolean(config.get("quotes")) ? ALWAYS_QUOTES : NONE_QUOTES;
+            this.quotes = toBoolean(config.get("quotes")) ? ALWAYS_QUOTES : NO_QUOTES;
         }
     }
 

--- a/core/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/core/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -92,9 +92,9 @@ public class ExportCsvTest {
                     + "\"Bar Sport\",\"\",\"\",\"[\"\"Address\"\"]\"%n"
                     + "\"\",\"\",\"via Benni\",\"[\"\"Address\"\"]\"%n");
     private static final String EXPECTED_QUERY_QUOTES_NEEDED = String.format(
-            "a.name,a.city,a.street,labels(a)%n" + "Andrea,Milano,\"Via Garibaldi, 7\",\"[\"Address1\",\"Address\"]\"%n"
-                    + "Bar Sport,,,\"[\"Address\"]\"%n"
-                    + ",,via Benni,\"[\"Address\"]\"%n");
+            "a.name,a.city,a.street,labels(a)%n" + "Andrea,Milano,\"Via Garibaldi, 7\",\"[\"\"Address1\"\",\"\"Address\"\"]\"%n"
+                    + "Bar Sport,,,\"[\"\"Address\"\"]\"%n"
+                    + ",,via Benni,\"[\"\"Address\"\"]\"%n");
     private static final String EXPECTED = String.format(
             "\"_id\",\"_labels\",\"age\",\"city\",\"kids\",\"male\",\"name\",\"street\",\"_start\",\"_end\",\"_type\"%n"
                     + "\"0\",\":User:User1\",\"42\",\"\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"true\",\"foo\",\"\",,,%n"
@@ -134,7 +134,7 @@ public class ExportCsvTest {
                     + ",,,,,,,,3,4,NEXT_DELIVERY%n");
     private static final String EXPECTED_NEEDED_QUOTES =
             String.format("_id,_labels,age,city,kids,male,name,street,_start,_end,_type%n"
-                    + "0,:User:User1,42,,\"[\"a\",\"b\",\"c\"]\",true,foo,,,,%n"
+                    + "0,:User:User1,42,,\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",true,foo,,,,%n"
                     + "1,:User,42,,,,bar,,,,%n"
                     + "2,:User,12,,,,,,,,%n"
                     + "3,:Address:Address1,,Milano,,,Andrea,\"Via Garibaldi, 7\",,,%n"
@@ -142,6 +142,16 @@ public class ExportCsvTest {
                     + "5,:Address,,,,,,via Benni,,,%n"
                     + ",,,,,,,,0,1,KNOWS%n"
                     + ",,,,,,,,3,4,NEXT_DELIVERY%n");
+    private static final String EXPECTED_QUOTES_ALWAYS =
+            "\"_id\",\"_labels\",\"age\",\"city\",\"kids\",\"male\",\"name\",\"street\",\"_start\",\"_end\",\"_type\"\n"
+                    + "\"0\",\":User:User1\",\"42\",\"\",\"[\"\"a\"\",\"\"b\"\",\"\"c\"\"]\",\"true\",\"foo\",\"\",,,\n"
+                    + "\"1\",\":User\",\"42\",\"\",\"\",\"\",\"bar\",\"\",,,\n"
+                    + "\"2\",\":User\",\"12\",\"\",\"\",\"\",\"\",\"\",,,\n"
+                    + "\"3\",\":Address:Address1\",\"\",\"Milano\",\"\",\"\",\"Andrea\",\"Via Garibaldi, 7\",,,\n"
+                    + "\"4\",\":Address\",\"\",\"\",\"\",\"\",\"Bar Sport\",\"\",,,\n"
+                    + "\"5\",\":Address\",\"\",\"\",\"\",\"\",\"\",\"via Benni\",,,\n"
+                    + ",,,,,,,,\"0\",\"1\",\"KNOWS\"\n"
+                    + ",,,,,,,,\"3\",\"4\",\"NEXT_DELIVERY\"\n";
 
     private static final File directory = new File("target/import");
 
@@ -365,6 +375,17 @@ public class ExportCsvTest {
                 map("file", fileName),
                 (r) -> assertResults(fileName, r, "database"));
         assertEquals(EXPECTED_NEEDED_QUOTES, readFile(fileName));
+    }
+
+    @Test
+    public void testExportAllCsvAlwaysQuotes() {
+        String fileName = "all.csv";
+        TestUtil.testCall(
+                db,
+                "CALL apoc.export.csv.all($file,{quotes: 'always'})",
+                map("file", fileName),
+                (r) -> assertResults(fileName, r, "database"));
+        assertEquals(EXPECTED_QUOTES_ALWAYS, readFile(fileName));
     }
 
     @Test


### PR DESCRIPTION
[uRFsgcuC] Backports fix from 5.x so that quotes are correctly applied when the `ifNeeded` flag is used. Inspired by [fix](https://github.com/neo4j/apoc/pull/645).