### PR TITLE
Fixes #4138: Add support for loading Gephi GEXF file format

### DIFF
--- a/docs/asciidoc/modules/ROOT/nav.adoc
+++ b/docs/asciidoc/modules/ROOT/nav.adoc
@@ -26,6 +26,8 @@ include::partial$generated-documentation/nav.adoc[]
     ** xref::import/load-csv.adoc[]
     ** xref::import/xls.adoc[]
     ** xref::import/html.adoc[]
+    ** xref::import/parquet.adoc[]
+    ** xref::import/gexf.adoc[]
 
 * xref:export/index.adoc[]
     ** xref::export/xls.adoc[]

--- a/docs/asciidoc/modules/ROOT/pages/import/gexf.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/gexf.adoc
@@ -1,0 +1,222 @@
+[[gexf]]
+= Load GEXF (Graph Exchange XML Format)
+:description: This section describes procedures that can be used to import data from GEXF files.
+
+
+
+Many existing applications and data integrations use GEXF to describes a graph with nodes and edges.
+For further information, you should visit the https://gexf.net/[official documentation].
+
+It is possible to load or import nodes and relationship from a GEXF file with the procedures
+ `apoc.load.gexf` and `apoc.import.gexf`. You need to:
+
+* provide a path to a GEXF file
+* provide configuration (optional)
+
+The `apoc.import.gexf` read as the `apoc.load.gexf` but also create nodes and relationships in Neo4j.
+
+For reading from files you'll have to enable the config option:
+
+----
+apoc.import.file.enabled=true
+----
+
+By default file paths are global, for paths relative to the `import` directory set:
+
+----
+apoc.import.file.use_neo4j_config=true
+----
+
+== Examples for apoc.load.gexf
+
+.load.gexf
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<gexf version="1.2">
+  <graph defaultedgetype="directed">
+    <nodes>
+      <node foo="bar">
+        <attvalues>
+          <attvalue for="0" value="http://gephi.org"/>
+        </attvalues>
+      </node>
+    </nodes>
+  </graph>
+</gexf>
+----
+
+[source, cypher]
+----
+CALL apoc.load.gexf('load.gexf')
+----
+
+.Results
+[opts="header"]
+|===
+| value
+| {_type: gexf, _children: [{_type: graph, defaultedgetype: directed, _children: [{_type: nodes, _children: [{_type: node, _children: [{_type: attvalues, _children: [{_type: attvalue, for: 0, value: http://gephi.org}]}], foo: bar}]}]}], version: 1.2}
+|===
+
+== Examples for apoc.import.gexf
+
+Besides the file you can pass in a config map:
+
+.Config parameters
+[opts=header]
+|===
+| name | type | default | description
+| readLabels | Boolean | false | Creates node labels based on the value in the `labels` property of `node` elements
+| defaultRelationshipType | String | RELATED | The default relationship type to use if none is specified in the GraphML file
+| storeNodeIds | Boolean | false | store the `id` property of `node` elements
+| batchSize | Integer | 20000 | The number of elements to process per transaction
+| compression | `Enum[NONE, BYTES, GZIP, BZIP2, DEFLATE, BLOCK_LZ4, FRAMED_SNAPPY]` | `null` | Allow taking binary data, either not compressed (value: `NONE`) or compressed (other values)
+| source | Map<String,String> | Empty map | See `source / target config` parameter below
+| target | Map<String,String> | Empty map | See `source / target config` parameter below
+See the xref::overview/apoc.load/apoc.load.csv.adoc#_binary_file[Binary file example]
+|===
+
+
+With the following file will be created:
+
+* 1 node with label Gephi
+* 2 nodes with label Webatlas
+* 1 node with label RTGI
+* 1 node with label BarabasiLab
+* 6 relationships of kind KNOWS
+* 1 relationship of kind HAS_TICKET
+* 1 relationship of kind BAZ
+
+.data.gexf
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<gexf xmlns="http://gexf.net/1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://gexf.net/1.3 http://gexf.net/1.3/gexf.xsd" version="1.2">
+  <meta lastmodifieddate="2009-03-20">
+    <creator>Gephi.org</creator>
+    <description>A Web network</description>
+  </meta>
+  <graph defaultedgetype="directed">
+    <attributes class="node">
+      <attribute id="0" title="url" type="string"/>
+      <attribute id="room" title="room" type="integer"/>
+      <attribute id="projects" title="projects" type="long"/>
+      <attribute id="price" title="price" type="double"/>
+      <attribute id="1" title="indegree" type="float"/>
+      <attribute id="members" title="members" type="liststring"/>
+      <attribute id="pins" title="pins" type="listboolean"/>
+      <attribute id="2" title="frog" type="boolean">
+        <default>true</default>
+      </attribute>
+    </attributes>
+    <attributes class="edge">
+      <attribute id="score" title="score" type="float"/>
+    </attributes>
+    <nodes>
+      <node id="0" label="Gephi">
+        <attvalues>
+          <attvalue for="0" value="http://gephi.org"/>
+          <attvalue for="1" value="1"/>
+          <attvalue for="room" value="10"/>
+          <attvalue for="price" value="10.02"/>
+          <attvalue for="projects" value="300"/>
+          <attvalue for="members" value="[Altomare, Sterpeto, Lino]"/>
+          <attvalue for="pins" value="[true, false, true, false]"/>
+        </attvalues>
+      </node>
+       <node id="5" label="Gephi">
+          <attvalues>
+            <attvalue for="0" value="http://test.gephi.org"/>
+            <attvalue for="1" value="2"/>
+          </attvalues>
+        </node>
+      <node id="1" label="Webatlas">
+        <attvalues>
+          <attvalue for="0" value="http://webatlas.fr"/>
+          <attvalue for="1" value="2"/>
+        </attvalues>
+      </node>
+      <node id="2" label="RTGI">
+        <attvalues>
+          <attvalue for="0" value="http://rtgi.fr"/>
+          <attvalue for="1" value="1"/>
+        </attvalues>
+      </node>
+      <node id="3" label=":BarabasiLab:Webatlas">
+        <attvalues>
+          <attvalue for="0" value="http://barabasilab.com"/>
+          <attvalue for="1" value="1"/>
+          <attvalue for="2" value="false"/>
+        </attvalues>
+      </node>
+    </nodes>
+    <edges>
+      <edge source="0" target="1" kind="KNOWS">
+          <attvalues>
+            <attvalue for="score" value="1.5"/>
+          </attvalues>
+      </edge>
+      <edge source="0" target="0" kind="BAZ">
+          <attvalues>
+            <attvalue for="foo" value="bar"/>
+            <attvalue for="score" value="2"/>
+          </attvalues>
+      </edge>
+      <edge source="0" target="2" kind="HAS_TICKET">
+          <attvalues>
+            <attvalue for="ajeje" value="brazorf"/>
+            <attvalue for="score" value="3"/>
+          </attvalues>
+      </edge>
+      <edge source="0" target="2" kind="KNOWS" />
+      <edge source="1" target="0" kind="KNOWS" />
+      <edge source="2" target="1" kind="KNOWS" />
+      <edge source="0" target="3" kind="KNOWS" />
+      <edge source="5" target="3" kind="KNOWS" />
+    </edges>
+  </graph>
+</gexf>
+----
+
+[source, cypher]
+----
+CALL apoc.import.gexf('data.gexf', {readLabels:true})
+----
+
+.Results
+[opts="header"]
+|===
+| value
+| {
+"relationships" : 8,
+"batches" : 0,
+"file" : "file:/../data.gexf",
+"nodes" : 5,
+"format" : "gexf",
+"source" : "file",
+"time" : 9736,
+"rows" : 0,
+"batchSize" : -1,
+"done" : true,
+"properties" : 21
+}
+|===
+
+We can also store the node IDs by executing:
+[source, cypher]
+----
+CALL apoc.import.gexf('data.gexf', {readLabels:true, storeNodeIds: true})
+----
+
+=== source / target config
+
+Allows the import of relations in case the source and / or target nodes are not present in the file, searching for nodes via a custom label and property.
+To do this, we can insert into the config map `source: {label: '<MY_SOURCE_LABEL>', id: `'<MY_SOURCE_ID>'`}` and/or `source: {label: '<MY_TARGET_LABEL>', id: `'<MY_TARGET_ID>'`}`
+In this way, we can search start and end nodes via the source and end attribute of `edge` tag.
+
+For example, with a config map `{source: {id: 'myId', label: 'Foo'}, target: {id: 'other', label: 'Bar'}}`
+with a edge row like `<edge id="e0" source="n0" target="n1" label="KNOWS"><data key="label">KNOWS</data></edge>`
+we search a source node `(:Foo {myId: 'n0'})` and an end node `(:Bar {other: 'n1'})`.
+The id key is optional (the default is `'id'`).
+
+
+
+

--- a/docs/asciidoc/modules/ROOT/pages/import/gexf.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/gexf.adoc
@@ -4,7 +4,7 @@
 
 
 
-Many existing applications and data integrations use GEXF to describes a graph with nodes and edges.
+Many existing applications and data integrations use GEXF to describes a graph with nodes and relationships.
 For further information, you should visit the https://gexf.net/[official documentation].
 
 It is possible to load or import nodes and relationship from a GEXF file with the procedures
@@ -56,6 +56,33 @@ CALL apoc.load.gexf('load.gexf')
 | value
 | {_type: gexf, _children: [{_type: graph, defaultedgetype: directed, _children: [{_type: nodes, _children: [{_type: node, _children: [{_type: attvalues, _children: [{_type: attvalue, for: 0, value: http://gephi.org}]}], foo: bar}]}]}], version: 1.2}
 |===
+
+
+With a malformed GEXF file, like the following one:
+
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<gexf xmlns="http://gexf.net/1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://gexf.net/1.3 http://gexf.net/1.3/gexf.xsd" version="1.2">
+  <meta lastmodifieddate="2009-03-20">
+    <creator>Gephi.org</creator>
+    <description>A Web network</description>
+  </meta>
+  <graph defaultedgetype="directed">
+    <attributes class="node">
+      </attribute>
+    <nodes>
+      <nodea id="0" label="Gephi">
+        <attvalues>
+      </node>
+    </edges>
+  </graph>
+</gexf>
+----
+
+we get the following error:
+```
+[Fatal Error] :9:9: The element type "attributes" must be terminated by the matching end-tag "</attributes>".
+```
 
 == Examples for apoc.import.gexf
 
@@ -205,6 +232,51 @@ We can also store the node IDs by executing:
 ----
 CALL apoc.import.gexf('data.gexf', {readLabels:true, storeNodeIds: true})
 ----
+
+
+With a malformed GEXF file, like the following one:
+
+----
+<?xml version="1.0" encoding="UTF-8"?>
+<gexf xmlns="http://gexf.net/1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://gexf.net/1.3 http://gexf.net/1.3/gexf.xsd" version="1.2">
+  <meta lastmodifieddate="2009-03-20">
+    <creator>Gephi.org</creator>
+    <description>A Web network</description>
+  </meta>
+  <graph defaultedgetype="directed">
+    <attributes class="node">
+      </attribute>
+    <nodes>
+      <nodea id="0" label="Gephi">
+        <attvalues>
+      </node>
+    </edges>
+  </graph>
+</gexf>
+----
+
+we get the following result, without nodes, relationships and properties imported:
+
+.Results
+[opts="header"]
+|===
+| value
+| {
+"relationships" : 8,
+"batches" : 0,
+"file" : "file:/../malformed.gexf",
+"nodes" : 0,
+"format" : "gexf",
+"source" : "file",
+"time" : 9736,
+"rows" : 0,
+"batchSize" : -1,
+"done" : true,
+"properties" : 0
+}
+|===
+
+
 
 === source / target config
 

--- a/docs/asciidoc/modules/ROOT/pages/import/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/index.adoc
@@ -13,3 +13,4 @@ For more information on these procedures, see:
 * xref::import/xls.adoc[]
 * xref::import/html.adoc[]
 * xref::import/parquet.adoc[]
+* xref::import/gexf.adoc[]

--- a/extended/src/main/java/apoc/load/Gexf.java
+++ b/extended/src/main/java/apoc/load/Gexf.java
@@ -1,0 +1,83 @@
+package apoc.load;
+
+import apoc.Extended;
+import apoc.Pools;
+import apoc.export.util.CountingReader;
+import apoc.export.util.ExportConfig;
+import apoc.export.util.ProgressReporter;
+import apoc.load.util.XmlReadUtil.Import;
+import apoc.result.MapResult;
+import apoc.result.ProgressInfo;
+import apoc.util.FileUtils;
+import apoc.util.Util;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.security.URLAccessChecker;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Mode;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+import org.neo4j.procedure.TerminationGuard;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static apoc.load.util.XmlReadUtil.Load.xmlXpathToMapResult;
+
+@Extended
+public class Gexf {
+
+    @Context
+    public GraphDatabaseService db;
+
+    @Context
+    public URLAccessChecker urlAccessChecker;
+
+    @Context
+    public TerminationGuard terminationGuard;
+
+    @Context
+    public Pools pools;
+
+    @Procedure("apoc.load.gexf")
+    @Description("apoc.load.gexf(urlOrBinary, path, $config) - load Gexf file from URL or binary source")
+    public Stream<MapResult> gexf(
+            @Name("urlOrBinary") Object urlOrBinary,
+            @Name(value = "config", defaultValue = "{}") Map<String, Object> config
+    ) throws Exception {
+        return xmlXpathToMapResult(urlOrBinary, urlAccessChecker, terminationGuard, config);
+    }
+
+    @Procedure(name = "apoc.import.gexf", mode = Mode.WRITE)
+    @Description("Imports a graph from the provided GraphML file.")
+    public Stream<ProgressInfo> importGexf(
+            @Name("urlOrBinaryFile") Object urlOrBinaryFile, @Name("config") Map<String, Object> config) {
+        ProgressInfo result = Util.inThread(pools, () -> {
+            ExportConfig exportConfig = new ExportConfig(config);
+            String file = null;
+            String source = "binary";
+            if (urlOrBinaryFile instanceof String) {
+                file = (String) urlOrBinaryFile;
+                source = "file";
+            }
+            ProgressReporter reporter = new ProgressReporter(null, null, new ProgressInfo(file, source, "gexf"));
+            Import graphReader = new Import(db)
+                    .reporter(reporter)
+                    .batchSize(exportConfig.getBatchSize())
+                    .relType(exportConfig.defaultRelationshipType())
+                    .source(exportConfig.getSource())
+                    .target(exportConfig.getTarget())
+                    .nodeLabels(exportConfig.readLabels());
+
+            if (exportConfig.storeNodeIds()) graphReader.storeNodeIds();
+
+            try (CountingReader reader =
+                         FileUtils.readerFor(urlOrBinaryFile, exportConfig.getCompressionAlgo(), urlAccessChecker)) {
+                graphReader.parseXML(reader, terminationGuard);
+            }
+
+            return reporter.getTotal();
+        });
+        return Stream.of(result);
+    }
+}

--- a/extended/src/main/java/apoc/load/Gexf.java
+++ b/extended/src/main/java/apoc/load/Gexf.java
@@ -51,7 +51,7 @@ public class Gexf {
     @Procedure(name = "apoc.import.gexf", mode = Mode.WRITE)
     @Description("Imports a graph from the provided GraphML file.")
     public Stream<ProgressInfo> importGexf(
-            @Name("urlOrBinaryFile") Object urlOrBinaryFile, @Name("config") Map<String, Object> config) {
+            @Name("urlOrBinaryFile") Object urlOrBinaryFile, @Name(value = "config", defaultValue = "{}") Map<String, Object> config) {
         ProgressInfo result = Util.inThread(pools, () -> {
             ExportConfig exportConfig = new ExportConfig(config);
             String file = null;

--- a/extended/src/main/java/apoc/load/util/XmlReadUtil.java
+++ b/extended/src/main/java/apoc/load/util/XmlReadUtil.java
@@ -1,0 +1,726 @@
+package apoc.load.util;
+
+import apoc.export.util.BatchTransaction;
+import apoc.export.util.CountingInputStream;
+import apoc.export.util.ExportConfig;
+import apoc.export.util.Reporter;
+import apoc.result.MapResult;
+import apoc.util.CompressionAlgo;
+import apoc.util.FileUtils;
+import apoc.util.JsonUtil;
+import apoc.util.Util;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.WordUtils;
+import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.security.URLAccessChecker;
+import org.neo4j.procedure.TerminationGuard;
+import org.w3c.dom.CharacterData;
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXParseException;
+
+import javax.xml.namespace.QName;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathFactory;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.lang.reflect.Array;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static apoc.load.util.XmlReadUtil.Load.generateXmlDoctypeException;
+import static apoc.util.CompressionConfig.COMPRESSION;
+import static apoc.util.ExtendedUtil.toValidValue;
+
+/**
+ * Taken from <a href="https://github.com/neo4j/apoc/blob/dev/core/src/main/java/apoc/load/Xml.java">Xml</a>
+ * placed in APOC Core
+ */
+public class XmlReadUtil {
+
+    public static class Load {
+        public static Stream<MapResult> xmlXpathToMapResult(
+                Object urlOrBinary, URLAccessChecker urlAccessChecker, TerminationGuard terminationGuard, Map<String, Object> config) throws Exception {
+            if (config == null) config = Collections.emptyMap();
+            boolean failOnError = (boolean) config.getOrDefault("failOnError", true);
+            String path = (String) config.getOrDefault("path", "/");
+            boolean simpleMode = Util.toBoolean(config.getOrDefault("simpleMode", false));
+            try {
+                Map<String, Object> headers = (Map) config.getOrDefault("headers", Collections.emptyMap());
+                CountingInputStream is = FileUtils.inputStreamFor(
+                        urlOrBinary,
+                        headers,
+                        null,
+                        (String) config.getOrDefault(COMPRESSION, CompressionAlgo.NONE.name()),
+                        urlAccessChecker);
+                return parse(is, simpleMode, path, failOnError, terminationGuard);
+            } catch (Exception e) {
+                if (!failOnError) return Stream.of(new MapResult(Collections.emptyMap()));
+                else throw e;
+            }
+        }
+
+        private static Stream<MapResult> parse(InputStream data, boolean simpleMode, String path, boolean failOnError, TerminationGuard terminationGuard)
+                throws Exception {
+            List<MapResult> result = new ArrayList<>();
+            try {
+                DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
+                documentBuilderFactory.setNamespaceAware(true);
+                documentBuilderFactory.setIgnoringElementContentWhitespace(true);
+                documentBuilderFactory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+                DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
+                documentBuilder.setEntityResolver((publicId, systemId) -> new InputSource(new StringReader("")));
+
+                Document doc = documentBuilder.parse(data);
+                XPathFactory xPathFactory = XPathFactory.newInstance();
+
+                XPath xPath = xPathFactory.newXPath();
+
+                path = StringUtils.isEmpty(path) ? "/" : path;
+                XPathExpression xPathExpression = xPath.compile(path);
+                NodeList nodeList = (NodeList) xPathExpression.evaluate(doc, XPathConstants.NODESET);
+
+                for (int i = 0; i < nodeList.getLength(); i++) {
+                    final Deque<Map<String, Object>> stack = new LinkedList<>();
+                    handleNode(stack, nodeList.item(i), simpleMode, terminationGuard);
+                    for (int index = 0; index < stack.size(); index++) {
+                        result.add(new MapResult(stack.pollFirst()));
+                    }
+                }
+            } catch (FileNotFoundException e) {
+                if (!failOnError) return Stream.of(new MapResult(Collections.emptyMap()));
+                else throw e;
+            } catch (Exception e) {
+                if (!failOnError) return Stream.of(new MapResult(Collections.emptyMap()));
+                else if (e instanceof SAXParseException && e.getMessage().contains("DOCTYPE is disallowed"))
+                    throw generateXmlDoctypeException();
+                else throw e;
+            }
+            return result.stream();
+        }
+
+        /**
+         * Collects type and attributes for the node
+         *
+         * @param node
+         * @param elementMap
+         */
+        private static void handleTypeAndAttributes(org.w3c.dom.Node node, Map<String, Object> elementMap) {
+            // Set type
+            if (node.getLocalName() != null) {
+                elementMap.put("_type", node.getLocalName());
+            }
+
+            // Set the attributes
+            if (node.getAttributes() != null) {
+                NamedNodeMap attributeMap = node.getAttributes();
+                for (int i = 0; i < attributeMap.getLength(); i++) {
+                    org.w3c.dom.Node attribute = attributeMap.item(i);
+                    elementMap.put(attribute.getNodeName(), attribute.getNodeValue());
+                }
+            }
+        }
+
+        private static void handleNode(Deque<Map<String, Object>> stack, org.w3c.dom.Node node, boolean simpleMode, TerminationGuard terminationGuard) {
+            terminationGuard.check();
+
+            // Handle document node
+            if (node.getNodeType() == org.w3c.dom.Node.DOCUMENT_NODE) {
+                NodeList children = node.getChildNodes();
+                for (int i = 0; i < children.getLength(); i++) {
+                    if (children.item(i).getLocalName() != null) {
+                        handleNode(stack, children.item(i), simpleMode, terminationGuard);
+                        return;
+                    }
+                }
+            }
+
+            Map<String, Object> elementMap = new LinkedHashMap<>();
+            handleTypeAndAttributes(node, elementMap);
+
+            // Set children
+            NodeList children = node.getChildNodes();
+            int count = 0;
+            for (int i = 0; i < children.getLength(); i++) {
+                org.w3c.dom.Node child = children.item(i);
+
+                // This is to deal with text between xml tags for example new line characters
+                if (child.getNodeType() != org.w3c.dom.Node.TEXT_NODE && child.getNodeType() != org.w3c.dom.Node.CDATA_SECTION_NODE) {
+                    handleNode(stack, child, simpleMode, terminationGuard);
+                    count++;
+                } else {
+                    // Deal with text nodes
+                    handleTextNode(child, elementMap);
+                }
+            }
+
+            if (children.getLength() > 0) {
+                if (!stack.isEmpty()) {
+                    List<Object> nodeChildren = new ArrayList<>();
+                    for (int i = 0; i < count; i++) {
+                        nodeChildren.add(stack.pollLast());
+                    }
+                    String key = simpleMode ? "_" + node.getLocalName() : "_children";
+                    Collections.reverse(nodeChildren);
+                    if (nodeChildren.size() > 0) {
+                        // Before adding the children we need to handle mixed text
+                        Object text = elementMap.get("_text");
+                        if (text instanceof List) {
+                            for (Object element : (List) text) {
+                                nodeChildren.add(element);
+                            }
+                            elementMap.remove("_text");
+                        }
+
+                        elementMap.put(key, nodeChildren);
+                    }
+                }
+            }
+
+            if (!elementMap.isEmpty()) {
+                stack.addLast(elementMap);
+            }
+        }
+
+        /**
+         * Handle TEXT nodes and CDATA nodes
+         *
+         * @param node
+         * @param elementMap
+         */
+        private static void handleTextNode(org.w3c.dom.Node node, Map<String, Object> elementMap) {
+            Object text = "";
+            int nodeType = node.getNodeType();
+            switch (nodeType) {
+                case org.w3c.dom.Node.TEXT_NODE:
+                    text = normalizeText(node.getNodeValue());
+                    break;
+                case org.w3c.dom.Node.CDATA_SECTION_NODE:
+                    text = normalizeText(((CharacterData) node).getData());
+                    break;
+                default:
+                    break;
+            }
+
+            // If the text is valid ...
+            if (!StringUtils.isEmpty(text.toString())) {
+                // We check if we have already collected some text previously
+                Object previousText = elementMap.get("_text");
+                if (previousText != null) {
+                    // If we just have a "_text" key than we need to collect to a List
+                    text = Arrays.asList(previousText.toString(), text);
+                }
+                elementMap.put("_text", text);
+            }
+        }
+
+        /**
+         * Remove trailing whitespaces and new line characters
+         *
+         * @param text
+         * @return
+         */
+        private static String normalizeText(String text) {
+            String[] tokens = StringUtils.split(text, "\n");
+            for (int i = 0; i < tokens.length; i++) {
+                tokens[i] = tokens[i].trim();
+            }
+
+            return StringUtils.join(tokens, " ").trim();
+        }
+
+        public static RuntimeException generateXmlDoctypeException() {
+            throw new RuntimeException("XML documents with a DOCTYPE are not allowed.");
+        }
+    }
+
+
+    /**
+     * Taken from <a href="https://github.com/neo4j/apoc/blob/dev/core/src/main/java/apoc/export/graphml/GraphMLReader.java">GraphMLReader</a>
+     * placed in APOC Core
+     */
+    public static class Import {
+
+        public static final String LABEL_SPLIT = " *: *";
+        private final GraphDatabaseService db;
+        private boolean storeNodeIds;
+        private RelationshipType defaultRelType = RelationshipType.withName("UNKNOWN");
+        private ExportConfig.NodeConfig source;
+        private ExportConfig.NodeConfig target;
+        private int batchSize = 40000;
+        private Reporter reporter;
+        private boolean labels;
+
+        public Import storeNodeIds() {
+            this.storeNodeIds = true;
+            return this;
+        }
+
+        public Import relType(String name) {
+            this.defaultRelType = RelationshipType.withName(name);
+            return this;
+        }
+
+        public Import batchSize(int batchSize) {
+            this.batchSize = batchSize;
+            return this;
+        }
+
+        public Import nodeLabels(boolean readLabels) {
+            this.labels = readLabels;
+            return this;
+        }
+
+        public Import source(ExportConfig.NodeConfig sourceConfig) {
+            this.source = sourceConfig;
+            return this;
+        }
+
+        public Import target(ExportConfig.NodeConfig targetConfig) {
+            this.target = targetConfig;
+            return this;
+        }
+
+        public Import reporter(Reporter reporter) {
+            this.reporter = reporter;
+            return this;
+        }
+
+        public ExportConfig.NodeConfig getSource() {
+            return source;
+        }
+
+        public ExportConfig.NodeConfig getTarget() {
+            return target;
+        }
+
+        enum Type {
+            BOOLEAN() {
+                Object parse(String value) {
+                    return Boolean.valueOf(value);
+                }
+
+                Object parseList(String value) {
+                    return Type.parseList(value, Boolean.class, (i) -> (Boolean) i);
+                }
+            },
+            INT() {
+                Object parse(String value) {
+                    return Integer.parseInt(value);
+                }
+
+                Object parseList(String value) {
+                    return Type.parseList(value, Integer.class, (n) -> ((Number) n).intValue());
+                }
+            },
+            LONG() {
+                Object parse(String value) {
+                    return Long.parseLong(value);
+                }
+
+                Object parseList(String value) {
+                    return Type.parseList(value, Long.class, (i) -> ((Number) i).longValue());
+                }
+            },
+            FLOAT() {
+                Object parse(String value) {
+                    return Float.parseFloat(value);
+                }
+
+                Object parseList(String value) {
+                    return Type.parseList(value, Float.class, (i) -> ((Number) i).floatValue());
+                }
+            },
+            DOUBLE() {
+                Object parse(String value) {
+                    return Double.parseDouble(value);
+                }
+
+                Object parseList(String value) {
+                    return Type.parseList(value, Double.class, (i) -> ((Number) i).doubleValue());
+                }
+            },
+            STRING() {
+                Object parse(String value) {
+                    return value;
+                }
+
+                Object parseList(String value) {
+                    return Type.parseList(value, String.class, (i) -> (String) i);
+                }
+            };
+
+            abstract Object parse(String value);
+
+            abstract Object parseList(String value);
+
+            public static <T> T[] parseList(String value, Class<T> asClass, Function<Object, T> convert) {
+                List parsed = JsonUtil.parse(value, null, List.class);
+                T[] converted = (T[]) Array.newInstance(asClass, parsed.size());
+
+                for (int i = 0; i < parsed.size(); i++) converted[i] = convert.apply(parsed.get(i));
+                return converted;
+            }
+
+            public static Type forType(String type) {
+                if (type == null) return STRING;
+                return valueOf(type.trim().toUpperCase());
+            }
+        }
+
+        static class Key {
+            String nameOrId;
+            boolean forNode;
+            Type listType;
+            Type type;
+            Object defaultValue;
+
+            public Key(String nameOrId, String type, String listType, String forNode) {
+                this.nameOrId = nameOrId;
+                this.type = Type.forType(type);
+                if (listType != null) {
+                    this.listType = Type.forType(listType);
+                }
+                this.forNode = forNode == null || forNode.equalsIgnoreCase("node");
+            }
+
+            private static Key defaultKey(String id, boolean forNode) {
+                return new Key(id, "string", null, forNode ? "node" : "edge");
+            }
+
+            public void setDefault(String data) {
+                this.defaultValue = type.parse(data);
+            }
+
+            public Object parseValue(String input) {
+                if (input == null || input.trim().isEmpty()) return defaultValue;
+                if (listType != null) return listType.parseList(input);
+                return type.parse(input);
+            }
+        }
+
+        public static final QName ID = QName.valueOf("id");
+        public static final QName LABELS = QName.valueOf("labels");
+        public static final QName LABEL = QName.valueOf("label");
+        public static final QName VALUE = QName.valueOf("value");
+        public static final QName FOR = QName.valueOf("for");
+        public static final QName NAME = QName.valueOf("attr.name");
+        public static final QName TYPE = QName.valueOf("attr.type");
+        public static final QName DATA_TYPE = QName.valueOf("type");
+        public static final QName LIST = QName.valueOf("attr.list");
+        public static final QName KEY = QName.valueOf("key");
+        public static final QName KIND = QName.valueOf("kind");
+
+        public Import(GraphDatabaseService db) {
+            this.db = db;
+        }
+
+        public long parseXML(Reader input, TerminationGuard terminationGuard) throws XMLStreamException {
+            Map<String, Object> dataMap = new HashMap<>();
+            Map<String, String> cache = new HashMap<>(1024 * 32);
+            XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+            inputFactory.setProperty("javax.xml.stream.isCoalescing", true);
+            inputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
+            inputFactory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+            inputFactory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+            XMLEventReader reader = inputFactory.createXMLEventReader(input);
+            Entity last = null;
+            Map<String, Key> nodeKeys = new HashMap<>();
+            Map<String, Key> relKeys = new HashMap<>();
+            int count = 0;
+            BatchTransaction tx = new BatchTransaction(db, batchSize * 10, reporter);
+            try {
+
+                while (reader.hasNext()) {
+                    terminationGuard.check();
+                    XMLEvent event;
+                    try {
+                        event = (XMLEvent) reader.next();
+                        if (event.getEventType() == XMLStreamConstants.DTD) {
+                            generateXmlDoctypeException();
+                        }
+                    } catch (Exception e) {
+                        // in case of unicode invalid chars we skip the event, or we exit in case of EOF
+                        if (e.getMessage().contains("Unexpected EOF")) {
+                            break;
+                        } else if (e.getMessage().contains("DOCTYPE")) {
+                            throw e;
+                        }
+                        continue;
+                    }
+                    if (event.isStartElement()) {
+
+                        StartElement element = event.asStartElement();
+                        String name = element.getName().getLocalPart();
+
+                        if (name.equals("graphml") || name.equals("graph") || name.equals("gexf")) continue;
+                        if (name.equals("attribute")) {
+                            String id = getAttribute(element, ID);
+                            String type = getAttribute(element, DATA_TYPE);
+                            dataMap.put(id, type);
+                        }
+                        if (name.equals("key")) {
+                            String id = getAttribute(element, ID);
+                            Key key = new Key(
+                                    getAttribute(element, NAME),
+                                    getAttribute(element, TYPE),
+                                    getAttribute(element, LIST),
+                                    getAttribute(element, FOR));
+
+                            XMLEvent next = peek(reader);
+                            if (next.isStartElement()
+                                    && next.asStartElement()
+                                    .getName()
+                                    .getLocalPart()
+                                    .equals("default")) {
+                                reader.nextEvent().asStartElement();
+                                key.setDefault(reader.nextEvent().asCharacters().getData());
+                            }
+                            if (key.forNode) nodeKeys.put(id, key);
+                            else relKeys.put(id, key);
+                            continue;
+                        }
+                        if (name.equals("attvalue")) { // Changed from data to attvalue for node properties in gexf
+                            if (last == null) continue;
+                            String id = getAttribute(element, FOR);
+                            boolean isNode = last instanceof Node;
+                            Key key = isNode ? nodeKeys.get(id) : relKeys.get(id);
+                            if (key == null) key = Key.defaultKey(id, isNode);
+                            final Map.Entry<XMLEvent, Object> eventEntry = getDataEventEntry(reader, key);
+                            final XMLEvent next = eventEntry.getKey();
+                            final Object value = getAttribute(element, VALUE);
+                            if (value != null) {
+                                if (this.labels && isNode && id.equals("labels")) {
+                                    addLabels((Node) last, value.toString());
+                                } else if (!this.labels || isNode || !id.equals("label")) {
+                                    Object convertedValue = toValidValue(value, key.nameOrId, dataMap);
+                                    last.setProperty(key.nameOrId, convertedValue);
+                                    if (reporter != null) reporter.update(0, 0, 1);
+                                }
+                            } else if (next.getEventType() == XMLStreamConstants.END_ELEMENT) {
+                                last.setProperty(key.nameOrId, StringUtils.EMPTY);
+                                reporter.update(0, 0, 1);
+                            }
+                            continue;
+                        }
+                        if (name.equals("node")) {
+                            tx.increment();
+                            String id = getAttribute(element, ID);
+                            Node node = tx.getTransaction().createNode();
+                            if (this.labels) {
+                                String labels = getAttribute(element, LABEL); // Changed from labels to label to fit gexf property format
+                                addLabels(node, labels);
+                            }
+                            if (storeNodeIds) node.setProperty("id", id);
+                            setDefaults(nodeKeys, node);
+                            last = node;
+                            cache.put(id, node.getElementId());
+                            if (reporter != null) reporter.update(1, 0, 0);
+                            count++;
+                            continue;
+                        }
+                        if (name.equals("edge")) {
+                            tx.increment();
+                            String label = getAttribute(element, KIND); // changed from label to kind for gexf
+                            Node from = getByNodeId(cache, tx.getTransaction(), element, NodeExport.NodeType.SOURCE);
+                            Node to = getByNodeId(cache, tx.getTransaction(), element, NodeExport.NodeType.TARGET);
+
+                            RelationshipType relationshipType =
+                                    label == null ? getRelationshipType(reader) : RelationshipType.withName(label);
+                            Relationship relationship = from.createRelationshipTo(to, relationshipType);
+                            setDefaults(relKeys, relationship);
+                            last = relationship;
+                            if (reporter != null) reporter.update(0, 1, 0);
+                            count++;
+                        }
+                    }
+                }
+                tx.doCommit();
+            } catch (Exception e) {
+                tx.rollback();
+                throw e;
+            } finally {
+                tx.close();
+                reader.close();
+            }
+            return count;
+        }
+
+        private Map.Entry<XMLEvent, Object> getDataEventEntry(XMLEventReader reader, Key key) {
+            Object value = key.defaultValue;
+
+            final Map.Entry<XMLEvent, String> peekEntry = peekRecursively(reader, null);
+            if (peekEntry.getValue() != null) {
+                value = key.parseValue(peekEntry.getValue());
+            }
+            return new AbstractMap.SimpleEntry<>(peekEntry.getKey(), value);
+        }
+
+        private Map.Entry<XMLEvent, String> peekRecursively(XMLEventReader reader, String data) {
+            try {
+                final XMLEvent peek = peek(reader);
+                // in case of char, we concat the result to the current value and redo the peek
+                //  in order to obtain e.g. from a string "ab<invalid_char>cd<invalid_char>ef" --> "abcdef"
+                if (peek.isCharacters()) {
+                    data = StringUtils.join(data, reader.nextEvent().asCharacters().getData());
+                    return peekRecursively(reader, data);
+                }
+                // in case the event is not a char we continue setting labels/properties
+                return new AbstractMap.SimpleEntry<>(peek, data);
+            } catch (Exception e) {
+                // in case of unicode invalid chars we continue until we get a valid event
+                return peekRecursively(reader, data);
+            }
+        }
+
+        private Node getByNodeId(
+                Map<String, String> cache, Transaction tx, StartElement element, NodeExport.NodeType nodeType) {
+            final NodeExport xmlNodeInterface = nodeType.get();
+            final ExportConfig.NodeConfig nodeConfig = xmlNodeInterface.getNodeConfigReader(this);
+
+            final String sourceTargetValue = getAttribute(element, QName.valueOf(nodeType.getName()));
+
+            final String id = cache.get(sourceTargetValue);
+            // without source/target config, we look for the internal id
+            if (StringUtils.isBlank(nodeConfig.label)) {
+                return tx.getNodeByElementId(id);
+            }
+            // with source/target configured, we search a node with a specified label
+            // and with a type specified in sourceType, if present, or string by default
+            final String attribute = getAttribute(element, QName.valueOf(nodeType.getNameType()));
+            final Object value =
+                    attribute == null ? sourceTargetValue : Type.forType(attribute).parse(sourceTargetValue);
+
+            return tx.findNode(
+                    Label.label(nodeConfig.label),
+                    Optional.ofNullable(nodeConfig.id).orElse("id"),
+                    value);
+        }
+
+        private RelationshipType getRelationshipType(XMLEventReader reader) throws XMLStreamException {
+            if (this.labels) {
+                XMLEvent peek = reader.peek();
+                boolean isChar = peek.isCharacters();
+                if (isChar && !(peek.asCharacters().isWhiteSpace())) {
+                    String value = peek.asCharacters().getData();
+                    String el = ":";
+                    String typeRel = value.contains(el) ? value.replace(el, StringUtils.EMPTY) : value;
+                    return RelationshipType.withName(typeRel.trim());
+                }
+
+                boolean notStartElementOrContainsKeyLabel = isChar || !peek.isStartElement() || containsLabelKey(peek);
+
+                if (!peek.isEndDocument() && notStartElementOrContainsKeyLabel) {
+                    reader.nextEvent();
+                    return getRelationshipType(reader);
+                }
+            }
+            reader.nextEvent(); // to prevent eventual wrong reader (f.e. self-closing tag)
+            return defaultRelType;
+        }
+
+        private boolean containsLabelKey(XMLEvent peek) {
+            final Attribute keyAttribute = peek.asStartElement().getAttributeByName(new QName("key"));
+            return keyAttribute != null && keyAttribute.getValue().equals("label");
+        }
+
+        private void addLabels(Node node, String labels) {
+            if (labels == null) return;
+            labels = labels.trim();
+            if (labels.isEmpty()) return;
+            String[] parts = labels.split(LABEL_SPLIT);
+            for (String part : parts) {
+                if (part.trim().isEmpty()) continue;
+                node.addLabel(Label.label(part.trim()));
+            }
+        }
+
+        private XMLEvent peek(XMLEventReader reader) throws XMLStreamException {
+            XMLEvent peek = reader.peek();
+            if (peek.isCharacters() && (peek.asCharacters().isWhiteSpace())) {
+                reader.nextEvent();
+                return peek(reader);
+            }
+            return peek;
+        }
+
+        private void setDefaults(Map<String, Key> keys, Entity pc) {
+            if (keys.isEmpty()) return;
+            for (Key key : keys.values()) {
+                if (key.defaultValue != null) pc.setProperty(key.nameOrId, key.defaultValue);
+            }
+        }
+
+        private String getAttribute(StartElement element, QName qname) {
+            Attribute attribute = element.getAttributeByName(qname);
+            return attribute != null ? attribute.getValue() : null;
+        }
+    }
+
+    /**
+     * Taken from <a href="https://github.com/neo4j/apoc/blob/dev/core/src/main/java/apoc/export/graphml/NodeExport.java">NodeExport</a>
+     * placed in APOC Core
+     */
+    interface NodeExport {
+
+        ExportConfig.NodeConfig getNodeConfigReader(Import reader);
+
+        enum NodeType {
+            SOURCE("source", Import::getSource),
+
+            TARGET("target", Import::getTarget);
+
+            private final String name;
+            private final NodeExport exportNode;
+
+            NodeType(String name, NodeExport exportNode) {
+                this.name = name;
+                this.exportNode = exportNode;
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            public String getNameType() {
+                return name + "Type";
+            }
+
+            NodeExport get() {
+                return exportNode;
+            }
+        }
+    }
+}

--- a/extended/src/main/java/apoc/load/util/XmlReadUtil.java
+++ b/extended/src/main/java/apoc/load/util/XmlReadUtil.java
@@ -10,7 +10,6 @@ import apoc.util.FileUtils;
 import apoc.util.JsonUtil;
 import apoc.util.Util;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.text.WordUtils;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;

--- a/extended/src/main/java/apoc/util/ExtendedUtil.java
+++ b/extended/src/main/java/apoc/util/ExtendedUtil.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.text.WordUtils;
 import org.neo4j.exceptions.Neo4jException;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.ExecutionPlanDescription;

--- a/extended/src/main/resources/extended.txt
+++ b/extended/src/main/resources/extended.txt
@@ -81,6 +81,8 @@ apoc.graph.filterProperties
 apoc.import.arrow
 apoc.import.parquet
 apoc.load.csv
+apoc.load.gexf
+apoc.import.gexf
 apoc.load.csvParams
 apoc.load.directory
 apoc.load.directory.async.add

--- a/extended/src/test/java/apoc/load/GexfTest.java
+++ b/extended/src/test/java/apoc/load/GexfTest.java
@@ -1,0 +1,215 @@
+package apoc.load;
+
+import apoc.util.TestUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.List;
+import java.util.Map;
+
+import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
+import static apoc.ApocConfig.APOC_IMPORT_FILE_USE_NEO4J_CONFIG;
+import static apoc.ApocConfig.apocConfig;
+import static apoc.util.ExtendedTestUtil.assertRelationship;
+import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GexfTest {
+    
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
+
+    @Before
+    public void setup() {
+        apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
+        apocConfig().setProperty(APOC_IMPORT_FILE_USE_NEO4J_CONFIG, false);
+        TestUtil.registerProcedure(db, Gexf.class);
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
+    }
+
+    @Test
+    public void testLoadGexf() {
+        final String file = ClassLoader.getSystemResource("gexf/single-node.gexf").toString();
+        testCall(
+                db,
+                "CALL apoc.load.gexf($file)",
+                Map.of("file", file),
+                (row) -> {
+                    Map<String, Object> value = (Map) row.get("value");
+                    String expected = "{_type=gexf, _children=[{_type=graph, defaultedgetype=directed, _children=[{_type=nodes, _children=[{_type=node, _children=[{_type=attvalues, _children=[{_type=attvalue, for=0, value=http://gephi.org}]}], id=0, label=bar}]}]}], version=1.2}";
+                    assertEquals(expected, value.toString());
+                });
+    }
+
+    @Test
+    public void testImportGexf() {
+        final String file = ClassLoader.getSystemResource("gexf/data.gexf").toString();
+        TestUtil.testCall(
+                db,
+                "CALL apoc.import.gexf($file, {readLabels:true})",
+                map("file", file),
+                (r) -> {
+                    assertEquals("gexf", r.get("format"));
+                    assertEquals(5L, r.get("nodes"));
+                    assertEquals(8L, r.get("relationships"));
+                });
+
+        TestUtil.testCallCount(db, "MATCH (n) RETURN n",5);
+
+        TestUtil.testResult(db, "MATCH (n:Gephi) RETURN properties(n) as props", r -> {
+            ResourceIterator<Map> propsIterator = r.columnAs("props");
+            Map props = propsIterator.next();
+            assertEquals("http://gephi.org", props.get("0"));
+            assertEquals(1.0f, props.get("1"));
+
+            props = propsIterator.next();
+            assertEquals("http://test.gephi.org", props.get("0"));
+        });
+
+        TestUtil.testResult(db, "MATCH (n:BarabasiLab) RETURN properties(n) as props", r -> {
+            ResourceIterator<Map> propsIterator = r.columnAs("props");
+            Map props = propsIterator.next();
+            assertEquals("http://barabasilab.com", props.get("0"));
+            assertEquals(1.0f, props.get("1"));
+        });
+
+        Map<String, Object> multiDataTypeNodeProps = Map.of(
+                "0", "http://gephi.org",
+                "1", 1.0f,
+                "room", 10,
+                "price", Double.parseDouble("10.02"),
+                "projects", 300L,
+                "members", new String[] {"Altomare", "Sterpeto", "Lino"},
+                "pins", new boolean[]{true, false, true, false}
+        );
+
+        TestUtil.testResult(
+                db,
+                "MATCH ()-[rel]->() RETURN rel ORDER BY rel.score",
+                r -> {
+                    final ResourceIterator<Relationship> rels = r.columnAs("rel");
+
+                    assertRelationship(rels.next(), "KNOWS", Map.of("score", 1.5f),
+                            List.of("Gephi"), multiDataTypeNodeProps,
+                            List.of("Webatlas"), Map.of("0", "http://webatlas.fr", "1", 2.0f)
+                    );
+
+                    assertRelationship(rels.next(), "BAZ", 
+                            Map.of("score", 2.0f, "foo", "bar"),
+                            List.of("Gephi"), multiDataTypeNodeProps,
+                            List.of("Gephi"), multiDataTypeNodeProps
+                    );
+                    
+                    assertRelationship(rels.next(), "HAS_TICKET", Map.of("score", 3f, "ajeje", "brazorf"),
+                            List.of("Gephi"), 
+                            multiDataTypeNodeProps,
+                            List.of("RTGI"),
+                            Map.of("0", "http://rtgi.fr", "1", 1.0f)
+                    );
+                    
+                    assertRelationship(rels.next(), "KNOWS",
+                            Map.of(),
+                            List.of("Gephi"),
+                            multiDataTypeNodeProps,
+                            List.of("RTGI"),
+                            Map.of("0", "http://rtgi.fr", "1", 1.0f)
+                    );
+                    
+                    assertRelationship(rels.next(), "KNOWS",
+                            Map.of(),
+                            List.of("Webatlas"),
+                            Map.of("0", "http://webatlas.fr", "1", 2.0f),
+                            List.of("Gephi"),
+                            multiDataTypeNodeProps
+                    );
+                    
+                    assertRelationship(rels.next(), "KNOWS",
+                            Map.of(),
+                            List.of("RTGI"), Map.of("0", "http://rtgi.fr", "1", 1.0f),
+                            List.of("Webatlas"), Map.of("0", "http://webatlas.fr", "1", 2.0f)
+                    );
+
+                    assertRelationship(rels.next(), "KNOWS",
+                            Map.of(),
+                            List.of("Gephi"),
+                            multiDataTypeNodeProps,
+                            List.of("Webatlas", "BarabasiLab"),
+                            Map.of("0", "http://barabasilab.com", "1", 1.0f, "2", false)
+                    );
+
+                    assertRelationship(rels.next(), "KNOWS",
+                            Map.of(),
+                            List.of("Gephi"),
+                            Map.of("0", "http://test.gephi.org", "1", 2.0f),
+                            List.of("Webatlas", "BarabasiLab"), 
+                            Map.of("0", "http://barabasilab.com", "1", 1.0f, "2", false)
+                    );
+
+                    assertFalse(rels.hasNext());
+                }
+        );
+    }
+
+    @Test
+    public void testImportGexfWithStoreNodeIds() {
+        final String file = ClassLoader.getSystemResource("gexf/single-node.gexf").toString();
+        TestUtil.testCall(
+                db,
+                "CALL apoc.import.gexf($file, {storeNodeIds: true})",
+                map("file", file),
+                (r) -> {
+                    assertEquals("gexf", r.get("format"));
+                    assertEquals(1L, r.get("nodes"));
+                });
+
+        Map props = TestUtil.singleResultFirstColumn(db, "MATCH (n) RETURN properties(n) AS props");
+        assertEquals("http://gephi.org", props.get("0"));
+        assertTrue( props.containsKey("id") );
+    }
+    
+    @Test
+    public void testImportGexfWithDefaultRelationshipTypeSourceAndTargetConfigs() {
+        String defaultRelType = "TEST_DEFAULT";
+        final String file = ClassLoader.getSystemResource("gexf/single-rel.gexf").toString();
+        
+        db.executeTransactionally("CREATE (:Foo {startId: 'start'})");
+        db.executeTransactionally("CREATE (:Bar {endId: 'end'})");
+        
+        TestUtil.testCall(
+                db,
+                "CALL apoc.import.gexf($file, {defaultRelationshipType: $defaultRelType, source: $source, target: $target})",
+                map("file", file, 
+                        "defaultRelType", defaultRelType, 
+                        "source", map("label", "Foo", "id", "startId"), 
+                        "target", map("label", "Bar", "id", "endId")
+                ),
+                (r) -> {
+                    assertEquals("gexf", r.get("format"));
+                    assertEquals(1L, r.get("relationships"));
+                });
+
+        TestUtil.testCall(db, "MATCH ()-[rel]->() RETURN rel", r -> {
+            Relationship rel = (Relationship) r.get("rel");
+            assertRelationship(rel, defaultRelType,
+                    Map.of(),
+                    List.of("Foo"),
+                    Map.of("startId", "start"),
+                    List.of("Bar"),
+                    Map.of("endId", "end")
+            );
+        });
+    }
+}

--- a/extended/src/test/java/apoc/load/GexfTest.java
+++ b/extended/src/test/java/apoc/load/GexfTest.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.APOC_IMPORT_FILE_USE_NEO4J_CONFIG;
 import static apoc.ApocConfig.apocConfig;
+import static apoc.util.ExtendedTestUtil.assertFails;
 import static apoc.util.ExtendedTestUtil.assertRelationship;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
@@ -178,6 +179,33 @@ public class GexfTest {
         Map props = TestUtil.singleResultFirstColumn(db, "MATCH (n) RETURN properties(n) AS props");
         assertEquals("http://gephi.org", props.get("0"));
         assertTrue( props.containsKey("id") );
+    }
+
+    @Test
+    public void testImportGexfWithMalformedFile() {
+        final String file = ClassLoader.getSystemResource("gexf/malformed.gexf").toString();
+        
+        TestUtil.testCall(
+                db,
+                "CALL apoc.import.gexf($file)",
+                map("file", file),
+                (r) -> {
+                    assertEquals("gexf", r.get("format"));
+                    assertEquals(0L, r.get("nodes"));
+                    assertEquals(0L, r.get("relationships"));
+                    assertEquals(0L, r.get("properties"));
+                    assertEquals(true, r.get("done"));
+                });
+    }
+
+    @Test
+    public void testLoadGexfWithMalformedFile() {
+        final String file = ClassLoader.getSystemResource("gexf/malformed.gexf").toString();
+
+        assertFails(db, "CALL apoc.load.gexf($file)",
+                Map.of("file", file),
+                "The element type \"attributes\" must be terminated by the matching end-tag \"</attributes>"
+        );
     }
     
     @Test

--- a/extended/src/test/java/apoc/util/ExtendedTestUtil.java
+++ b/extended/src/test/java/apoc/util/ExtendedTestUtil.java
@@ -76,14 +76,17 @@ public class ExtendedTestUtil {
             assertEquals(errMsg, expected.keySet(), actual.keySet());
 
             actual.forEach((key, value) -> {
+                Object expectedKey = expected.get(key);
+                boolean areBothArrays = value != null && value.getClass().isArray() 
+                                        && expectedKey != null && expectedKey.getClass().isArray();
                 if (value instanceof Map mapVal) {
-                    assertMapEquals(errMsg, (Map<String, Object>) expected.get(key), mapVal);
-                } else if (value.getClass().isArray() && expected.get(key).getClass().isArray()) {
-                    Object[] expectedArray = Iterators.array(expected.get(key));
+                    assertMapEquals(errMsg, (Map<String, Object>) expectedKey, mapVal);
+                } else if (areBothArrays) {
+                    Object[] expectedArray = Iterators.array(expectedKey);
                     Object[] actualArray = Iterators.array(value);
                     assertArrayEquals(expectedArray, actualArray);
                 } else {
-                    assertEquals(errMsg, expected.get(key), value);
+                    assertEquals(errMsg, expectedKey, value);
                 }
             });
         }

--- a/extended/src/test/resources/gexf/data.gexf
+++ b/extended/src/test/resources/gexf/data.gexf
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gexf xmlns="http://gexf.net/1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://gexf.net/1.3 http://gexf.net/1.3/gexf.xsd" version="1.2">
+  <meta lastmodifieddate="2009-03-20">
+    <creator>Gephi.org</creator>
+    <description>A Web network</description>
+  </meta>
+  <graph defaultedgetype="directed">
+    <attributes class="node">
+      <attribute id="0" title="url" type="string"/>
+      <attribute id="room" title="room" type="integer"/>
+      <attribute id="projects" title="projects" type="long"/>
+      <attribute id="price" title="price" type="double"/>
+      <attribute id="1" title="indegree" type="float"/>
+      <attribute id="members" title="members" type="liststring"/>
+      <attribute id="pins" title="pins" type="listboolean"/>
+      <attribute id="2" title="frog" type="boolean">
+        <default>true</default>
+      </attribute>
+    </attributes>
+    <attributes class="edge">
+      <attribute id="score" title="score" type="float"/>
+    </attributes>
+    <nodes>
+      <node id="0" label="Gephi">
+        <attvalues>
+          <attvalue for="0" value="http://gephi.org"/>
+          <attvalue for="1" value="1"/>
+          <attvalue for="room" value="10"/>
+          <attvalue for="price" value="10.02"/>
+          <attvalue for="projects" value="300"/>
+          <attvalue for="members" value="[Altomare, Sterpeto, Lino]"/>
+          <attvalue for="pins" value="[true, false, true, false]"/>
+        </attvalues>
+      </node>
+       <node id="5" label="Gephi">
+          <attvalues>
+            <attvalue for="0" value="http://test.gephi.org"/>
+            <attvalue for="1" value="2"/>
+          </attvalues>
+        </node>
+      <node id="1" label="Webatlas">
+        <attvalues>
+          <attvalue for="0" value="http://webatlas.fr"/>
+          <attvalue for="1" value="2"/>
+        </attvalues>
+      </node>
+      <node id="2" label="RTGI">
+        <attvalues>
+          <attvalue for="0" value="http://rtgi.fr"/>
+          <attvalue for="1" value="1"/>
+        </attvalues>
+      </node>
+      <node id="3" label=":BarabasiLab:Webatlas">
+        <attvalues>
+          <attvalue for="0" value="http://barabasilab.com"/>
+          <attvalue for="1" value="1"/>
+          <attvalue for="2" value="false"/>
+        </attvalues>
+      </node>
+    </nodes>
+    <edges>
+      <edge source="0" target="1" kind="KNOWS">
+          <attvalues>
+            <attvalue for="score" value="1.5"/>
+          </attvalues>
+      </edge>
+      <edge source="0" target="0" kind="BAZ">
+          <attvalues>
+            <attvalue for="foo" value="bar"/>
+            <attvalue for="score" value="2"/>
+          </attvalues>
+      </edge>
+      <edge source="0" target="2" kind="HAS_TICKET">
+          <attvalues>
+            <attvalue for="ajeje" value="brazorf"/>
+            <attvalue for="score" value="3"/>
+          </attvalues>
+      </edge>
+      <edge source="0" target="2" kind="KNOWS" />
+      <edge source="1" target="0" kind="KNOWS" />
+      <edge source="2" target="1" kind="KNOWS" />
+      <edge source="0" target="3" kind="KNOWS" />
+      <edge source="5" target="3" kind="KNOWS" />
+    </edges>
+  </graph>
+</gexf>

--- a/extended/src/test/resources/gexf/malformed.gexf
+++ b/extended/src/test/resources/gexf/malformed.gexf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gexf xmlns="http://gexf.net/1.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://gexf.net/1.3 http://gexf.net/1.3/gexf.xsd" version="1.2">
+  <meta lastmodifieddate="2009-03-20">
+    <creator>Gephi.org</creator>
+    <description>A Web network</description>
+  </meta>
+  <graph defaultedgetype="directed">
+    <attributes class="node">
+      </attribute>
+    <nodes>
+      <nodea id="0" label="Gephi">
+        <attvalues>
+      </node>
+    </edges>
+  </graph>
+</gexf>

--- a/extended/src/test/resources/gexf/single-node.gexf
+++ b/extended/src/test/resources/gexf/single-node.gexf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gexf version="1.2">
+  <graph defaultedgetype="directed">
+    <nodes>
+      <node id="0" label="bar">
+        <attvalues>
+          <attvalue for="0" value="http://gephi.org"/>
+        </attvalues>
+      </node>
+    </nodes>
+  </graph>
+</gexf>

--- a/extended/src/test/resources/gexf/single-rel.gexf
+++ b/extended/src/test/resources/gexf/single-rel.gexf
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gexf version="1.2">
+  <graph defaultedgetype="directed">
+     <edges>
+          <edge source="start" target="end"></edge>
+    </edges>
+  </graph>
+</gexf>


### PR DESCRIPTION
Fixes #4138

- Added procedures for reading GEXF files. 
- Copied and pasted code from APOC Core and put it into `XmlUtil.java`
- Changed parseXML method to be able to handle properties of gexf files. To handle the name of relations we parse the `kind` tag. While for node properties we change from doing the parse of the `data` tag to the `attvalue` tag. Also, to parse the label in the `node` tag you parse `labels` instead of `labels` as compared to how it is done for graphml.
- Multiple label support for nodes. Example `<node id=“0” label=“:Gephi:Webatlas”>`.
- Types tested: `string, integer, long, foat, double, boolean, liststring, listboolean`
- Improved `ExtendedUtil.convertValue` with toLowerCase(), to be used by both Parquet/Arrow and Gefx formats
- Improved ExtendedTestUtil
  - added arrays assertion to `assertMapEquals`
  - added `assertRelationship`
