### PR TITLE
Fixes #4182: The huggingface examples return strange results

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
@@ -161,9 +161,11 @@ For the https://huggingface.co/[HuggingFace API], we have to define the config `
 For example:
 [source,cypher]
 ----
-CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $huggingFaceApiKey, 
-{endpoint: 'https://api-inference.huggingface.co/models/gpt2', apiType: 'HUGGINGFACE', model: 'gpt2', path: ''})
+CALL apoc.ml.openai.completion('The sky has a [MASK] color', $huggingFaceApiKey,
+{endpoint: 'https://api-inference.huggingface.co/models/google-bert/bert-base-uncased', apiType: 'HUGGINGFACE'})
 ----
+
+With gpt2 or other text completion models the answers are not valid.
 
 Or also, by using the https://docs.cohere.com/docs[Cohere API], where we have to define `path: '''` not to add the `/completions` suffix to the URL:
 [source,cypher]

--- a/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
@@ -161,7 +161,7 @@ For the https://huggingface.co/[HuggingFace API], we have to define the config `
 For example:
 [source,cypher]
 ----
-CALL apoc.ml.openai.completion('The sky has a [MASK] color', $huggingFaceApiKey,
+CALL apoc.ml.openai.completion('[MASK] is the color of the sky', $huggingFaceApiKey,
 {endpoint: 'https://api-inference.huggingface.co/models/google-bert/bert-base-uncased', apiType: 'HUGGINGFACE'})
 ----
 

--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 import static apoc.ExtendedApocConfig.APOC_ML_OPENAI_TYPE;
 import static apoc.ExtendedApocConfig.APOC_OPENAI_KEY;
 import static apoc.ml.MLUtil.*;
+import static apoc.ml.RestAPIConfig.METHOD_KEY;
 
 
 @Extended
@@ -103,6 +104,8 @@ public class OpenAI {
             }
             case HUGGINGFACE -> {
                 configForPayload.putIfAbsent("inputs", inputs);
+                configuration.putIfAbsent(PATH_CONF_KEY, "");
+                headers.putIfAbsent(METHOD_KEY, "POST");
                 configuration.putIfAbsent(JSON_PATH_CONF_KEY, "$[0]");
             }
             case ANTHROPIC -> {

--- a/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
@@ -1,6 +1,7 @@
 package apoc.ml;
 
 import apoc.util.TestUtil;
+import apoc.util.Util;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
@@ -44,18 +45,17 @@ public class OpenAIOpenLMIT {
     public void completionWithHuggingFace() {
         String huggingFaceApiKey = System.getenv("HF_API_TOKEN");
         Assume.assumeNotNull("No HF_API_TOKEN environment configured", huggingFaceApiKey);
-        
-        String modelId = "gpt2";
+
+        String modelId = "google-bert/bert-base-uncased";
         Map<String, String> conf = Map.of(ENDPOINT_CONF_KEY, "https://api-inference.huggingface.co/models/" + modelId,
-                API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.HUGGINGFACE.name(),
-                PATH_CONF_KEY, "",
-                MODEL_CONF_KEY, modelId
+                API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.HUGGINGFACE.name()
         );
-        testCall(db, COMPLETION_QUERY,
+
+        testCall(db, "CALL apoc.ml.openai.completion('The sky has a [MASK] color', $apiKey, $conf)",
                 Map.of("conf", conf, "apiKey", huggingFaceApiKey),
                 (row) -> {
                     var result = (Map<String,Object>) row.get("value");
-                    String generatedText = (String) result.get("generated_text");
+                    String generatedText = (String) result.get("sequence");
                     assertTrue(generatedText.toLowerCase().contains("blue"),
                             "Actual generatedText is " + generatedText);
                 });

--- a/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIOpenLMIT.java
@@ -1,7 +1,6 @@
 package apoc.ml;
 
 import apoc.util.TestUtil;
-import apoc.util.Util;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
@@ -51,7 +50,7 @@ public class OpenAIOpenLMIT {
                 API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.HUGGINGFACE.name()
         );
 
-        testCall(db, "CALL apoc.ml.openai.completion('The sky has a [MASK] color', $apiKey, $conf)",
+        testCall(db, "CALL apoc.ml.openai.completion('[MASK] is the color of the sky', $apiKey, $conf)",
                 Map.of("conf", conf, "apiKey", huggingFaceApiKey),
                 (row) -> {
                     var result = (Map<String,Object>) row.get("value");


### PR DESCRIPTION
Fixes #4182


With `gpt2` and similar, the answers are not always valid.
Changed test case to `google-bert/bert-base-uncased`

Added `PATH_CONF_KEY` and `METHOD_KEY` as optional configurations, if not present, since some models fail with `method: 'GET'`, 

and the `path: ''` causes a fail or an incorrect result depending on the model.