### PR TITLE
Fixes #4169: $path configuration parameter adds terminating slash

### DIFF
--- a/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
+++ b/extended/src/main/java/apoc/ml/OpenAIRequestHandler.java
@@ -40,7 +40,8 @@ abstract class OpenAIRequestHandler {
     public String getFullUrl(String method, Map<String, Object> procConfig, ApocConfig apocConfig) {
         return Stream.of(getEndpoint(procConfig, apocConfig), method, getApiVersion(procConfig, apocConfig))
                 .filter(StringUtils::isNotBlank)
-                .collect(Collectors.joining("/"));
+                .collect(Collectors.joining("/"))
+                .replaceAll("/\\?", "?"); // Remove terminating endpoint
     }
 
     enum Type {

--- a/extended/src/test/java/apoc/ml/OpenAIAzureIT.java
+++ b/extended/src/test/java/apoc/ml/OpenAIAzureIT.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static apoc.ml.OpenAI.API_TYPE_CONF_KEY;
+import static apoc.ml.OpenAI.PATH_CONF_KEY;
 import static apoc.ml.MLUtil.*;
 import static apoc.ml.OpenAITestResultUtils.CHAT_COMPLETION_QUERY;
 import static apoc.ml.OpenAITestResultUtils.COMPLETION_QUERY;
@@ -60,6 +61,19 @@ public class OpenAIAzureIT {
     public void embedding() {
         testCall(db, EMBEDDING_QUERY,
                 getParams(OPENAI_EMBEDDING_URL),
+                OpenAITestResultUtils::assertEmbeddings);
+    }
+
+    @Test
+    public void embeddingFixPath() {
+        Map<String, Object> params = Map.of("apiKey", OPENAI_KEY,
+                "conf", Map.of(ENDPOINT_CONF_KEY, OPENAI_EMBEDDING_URL,
+                        API_TYPE_CONF_KEY, OpenAIRequestHandler.Type.AZURE.name(),
+                        API_VERSION_CONF_KEY, OPENAI_AZURE_API_VERSION,
+                        PATH_CONF_KEY, "openai/deployments/text-embedding-ada-002/embeddings"
+                ));
+        testCall(db, EMBEDDING_QUERY,
+                params,
                 OpenAITestResultUtils::assertEmbeddings);
     }
 


### PR DESCRIPTION
Fixes #4169

The user probably had an unrelated problem with the issue,
as the 502 error should be a temporary bad gateway error.

In fact, the following command from curl, works both with and without the terminating slash.
```
curl  https://apoc-testing.openai.azure.com/openai/deployments/text-embedding-ada-002/embeddings/?api-version\=2023-07-01-preview\
  -H 'Content-Type: application/json' \
  -H 'api-key: <OPENAI_API_KEY>' \
  -d '{"input": ["Some Text"]}'
```

In any case, we made the change, as it is syntactically more correct, and to prevent potential errors that might occur in the future or with other non-OpenAI/Azure endpoints.

Anyway, we created a test case similar to the issue one.
