### PR TITLE
Fix unresolved imports with IntelliJ 2024.1+

### DIFF
--- a/extended-it/build.gradle
+++ b/extended-it/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     }
 
     implementation project(":extended")
+    testImplementation project(':extended').sourceSets.main.allJava
 
     testImplementation group: 'us.fatehi', name: 'schemacrawler-mysql', version: '16.20.8'
     testImplementation group: 'org.postgresql', name: 'postgresql', version: '42.1.4'

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -52,7 +52,9 @@ task gitSubmoduleLoad {
 }
 
 dependencies {
-
+    // to fix unresolved imports with IntelliJ from version 2024.1.x
+    compileOnly sourceSets.main.java
+    
     apt project(':processor')
     apt group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective   // mandatory to run @ServiceProvider based META-INF code generation
 


### PR DESCRIPTION
With newer versions of IntelliJ (from 2024.1.x),
the imports of other java classes in extended are not properly detected without this fix.

See the Slack discussion: https://neo4j.slack.com/archives/C136J23GE/p1723459229156629

----
EDIT:
Added another commit, since a similar problem occurs in `extended-it` module, 
that is, we cannot import classes, if they are from the module`extended`, in another package name.

Therefore, without the change committed,
```
testImplementation project(':extended').sourceSets.main.allJava
```
we cannot e.g. import `JdbcUtil` (coming from package `apoc.load.util`) into class `` (package `apoc.load`), 
even if this line is present:

```
implementation project(":extended")
```