### PR TITLE
Fixes #4141: apoc.load.jdbcUpdate inside apoc.periodic.iterate leaves idle connections from 5.19 and forward

### DIFF
--- a/extended-it/src/test/java/apoc/load/PostgresJdbcTest.java
+++ b/extended-it/src/test/java/apoc/load/PostgresJdbcTest.java
@@ -1,11 +1,14 @@
 package apoc.load;
 
+import apoc.periodic.Periodic;
+import apoc.text.Strings;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.neo4j.graphdb.Result;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 import org.testcontainers.containers.JdbcDatabaseContainer;
@@ -15,8 +18,11 @@ import java.sql.SQLException;
 import java.util.Map;
 
 import static apoc.util.TestUtil.testCall;
-import static org.junit.Assert.assertEquals;
+import static apoc.util.TestUtil.testResult;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class PostgresJdbcTest extends AbstractJdbcTest {
 
@@ -32,7 +38,7 @@ public class PostgresJdbcTest extends AbstractJdbcTest {
     public static void setUp() throws Exception {
         postgress = new PostgreSQLContainer().withInitScript("init_postgres.sql");
         postgress.start();
-        TestUtil.registerProcedure(db,Jdbc.class);
+        TestUtil.registerProcedure(db,Jdbc.class, Periodic.class, Strings.class);
         db.executeTransactionally("CALL apoc.load.driver('org.postgresql.Driver')");
     }
 
@@ -90,5 +96,76 @@ public class PostgresJdbcTest extends AbstractJdbcTest {
                                 "credentials", Util.map("user", postgress.getUsername(), "password", postgress.getPassword()))),
                 (row) -> assertResult(row));
     }
-    
+
+    @Test
+    public void testIssue4141PeriodicIterateWithJdbc() throws Exception {
+        var config = Util.map("url", postgress.getJdbcUrl(),
+                "config", Util.map("schema", "test",
+                        "credentials", Util.map("user", postgress.getUsername(), "password", postgress.getPassword())));
+
+        String query = "WITH range(0, 100) as list UNWIND list as l CREATE (n:MyNode{id: l})";
+
+        db.executeTransactionally(query, Map.of(), Result::resultAsString);
+
+        // Redundant, only to reproduce issue 4141
+        query = "CALL apoc.load.driver(\"org.postgresql.Driver\")";
+
+        db.executeTransactionally(query, Map.of(), Result::resultAsString);
+
+        // To replicate the 4141 issue case,
+        // we cannot use container.getJdbcUrl() because it does not provide the url with username and password
+        String jdbUrl = getUrl(postgress);
+        
+        query = """
+                CALL apoc.periodic.iterate(
+                    "MATCH (n:MyNode) return n",
+                    "WITH n, apoc.text.format('insert into nodes (my_id) values (\\\\\\'%d\\\\\\')',[n.id]) AS sql CALL apoc.load.jdbcUpdate('$url',sql) YIELD row AS row2 return row2,n",
+                    {batchsize: 10,parallel: true})
+                yield operations
+                """.replace("$url", jdbUrl);
+
+        // check that periodic iterate doesn't throw errors
+        testResult(db, query, config, this::assertPeriodicIterate);
+
+        assertPgStatActivityHasOnlyActiveState();
+    }
+
+    private static void assertPgStatActivityHasOnlyActiveState() throws Exception {
+        // connect to postgres and execute the query `select state from pg_stat_activity`
+        String psql = postgress.execInContainer(
+                "psql", "postgresql://test:test@localhost/test", "-c", "select state from pg_stat_activity;")
+                .toString();
+        
+        assertTrue("Current pg_stat_activity is: " + psql, psql.contains("active"));
+        
+        // the result without the https://github.com/neo4j-contrib/neo4j-apoc-procedures/issues/4141 change
+        // is not deterministic, can be `too many clients already` or (not very often) `idle`
+        assertFalse("Current pg_stat_activity is: " + psql,
+                psql.contains("too many clients already") || psql.contains("idle"));
+
+    }
+
+    private void assertPeriodicIterate(Result result) {
+        Map<String, Object> res = result.next();
+        Map<String, Object> operations = (Map<String, Object>) res.get("operations");
+
+        long failed = (Long) operations.get("failed");
+        assertEquals(0L, failed);
+
+        long committed = (Long) operations.get("committed");
+        assertEquals(101L, committed);
+        
+        assertFalse(result.hasNext());
+    }
+
+    private static String getUrl(JdbcDatabaseContainer container) {
+        return String.format(
+                "jdbc:postgresql://%s:%s@%s:%s/%s?loggerLevel=OFF",
+                container.getUsername(),
+                container.getPassword(),
+                container.getContainerIpAddress(),
+                container.getMappedPort(5432),
+                container.getDatabaseName()
+        );
+    }
 }

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -83,7 +83,7 @@ dependencies {
         exclude group: 'org.apache.commons', module: 'commons-io'
         exclude group: 'org.apache.commons', module: 'commons-lang3'
     }
-    implementation group: 'us.fatehi', name: 'schemacrawler', version: '16.20.8'
+    implementation group: 'us.fatehi', name: 'schemacrawler', version: '16.22.2'
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.17.0', withoutJacksons
 
     // These will be dependencies not packaged with the .jar

--- a/extended/src/main/java/apoc/load/Jdbc.java
+++ b/extended/src/main/java/apoc/load/Jdbc.java
@@ -73,7 +73,7 @@ public class Jdbc {
         String url = getUrlOrKey(urlOrKey);
         String query = getSqlOrKey(tableOrSelect);
         try {
-            Connection connection = getConnection(url,loadJdbcConfig).get();
+            Connection connection = (Connection) getConnection(url,loadJdbcConfig, Connection.class);
             // see https://jdbc.postgresql.org/documentation/91/query.html#query-with-cursors
             connection.setAutoCommit(loadJdbcConfig.isAutoCommit());
             try {
@@ -114,7 +114,7 @@ public class Jdbc {
         String url = getUrlOrKey(urlOrKey);
         LoadJdbcConfig jdbcConfig = new LoadJdbcConfig(config);
         try {
-            Connection connection = getConnection(url,jdbcConfig).get();
+            Connection connection = (Connection) getConnection(url,jdbcConfig, Connection.class);
             try {
                 PreparedStatement stmt = connection.prepareStatement(query,ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
                 stmt.setFetchSize(5000);

--- a/extended/src/main/java/apoc/model/Model.java
+++ b/extended/src/main/java/apoc/model/Model.java
@@ -10,6 +10,7 @@ import schemacrawler.schema.*;
 import schemacrawler.schemacrawler.SchemaCrawlerOptions;
 import schemacrawler.schemacrawler.SchemaCrawlerOptionsBuilder;
 import schemacrawler.tools.utility.SchemaCrawlerUtility;
+import us.fatehi.utility.datasource.DatabaseConnectionSource;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -60,8 +61,8 @@ public class Model {
 
         SchemaCrawlerOptions options = SchemaCrawlerOptionsBuilder.newSchemaCrawlerOptions();
 
-        Catalog catalog = SchemaCrawlerUtility.getCatalog(getConnection(url, new LoadJdbcConfig(config)),
-                options);
+        DatabaseConnectionSource connectionSource = (DatabaseConnectionSource) getConnection( url, new LoadJdbcConfig(config), DatabaseConnectionSource.class );
+        Catalog catalog = SchemaCrawlerUtility.getCatalog(connectionSource, options);
 
         DatabaseModel databaseModel = new DatabaseModel();
 

--- a/extended/src/test/resources/init_postgres.sql
+++ b/extended/src/test/resources/init_postgres.sql
@@ -88,3 +88,5 @@ CREATE TABLE ARRAY_TABLE (
 );
 INSERT INTO ARRAY_TABLE ("NAME", "INT_VALUES", "DOUBLE_VALUES")
 VALUES ('John', '{ 1, 2, 3}', '{ 1.0, 2.0, 3.0 }');
+
+CREATE TABLE nodes (id serial PRIMARY KEY, my_id integer);


### PR DESCRIPTION
Fixes #4141

The problem should be related to [this change](https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/f978417fb40085269ca23ed18dc317d6bef7b587), using the `DatabaseConnectionSources` the issue error is (flakily) caused,
while with `Connection` it works correctly.


Strangely using the Postgres' issue version, the error is not replicable via `TestContainer`,
while can be replicated with the default present version: 9.6.12.
Maybe because the user version has some special configuration, or the test container is slightly different from the non-test version.

In any case, even with that version, the problem occurs infrequently, about 1 time every 10/15, most of the time you get a `“FATAL: sorry, too many clients already”` instead of an `"idle"` connection,
which is not the case with the reported changes.

We could also solve the problem by downgrading the `schemacrawler` version, 
but it is not recommended, since it has vulnerabilities.
