### PR TITLE
Fixed compile error with 5.24 and provisionally fixed docker and upload-artifact errors

### DIFF
--- a/.github/actions/test-gradle-project/action.yml
+++ b/.github/actions/test-gradle-project/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: ./gradlew --info -Pneo4jVersionOverride=$NEO4J_VERSION_CI :${{inputs.project-name}}:check --parallel
     - name: Archive test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: ${{inputs.project-name}}-test-results

--- a/.github/actions/test-gradle-project/action.yml
+++ b/.github/actions/test-gradle-project/action.yml
@@ -12,10 +12,10 @@ runs:
     - uses: ./.github/actions/setup-gradle-cache
     - name: Run compile tests 
       shell: bash
-      run: ./gradlew --info -Pneo4jVersionOverride=$NEO4J_VERSION_CI :${{inputs.project-name}}:compileJava :${{inputs.project-name}}:compileTestJava
+      run: ./gradlew :${{inputs.project-name}}:compileJava :${{inputs.project-name}}:compileTestJava
     - name: Run tests
       shell: bash
-      run: ./gradlew --info -Pneo4jVersionOverride=$NEO4J_VERSION_CI :${{inputs.project-name}}:check --parallel
+      run: ./gradlew :${{inputs.project-name}}:check --parallel
     - name: Archive test results
       uses: actions/upload-artifact@v3
       if: always()

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -44,7 +44,7 @@ jobs:
         run: |
           neo4j_version_base=$(grep -e "neo4jVersion = .*" build.gradle | cut -d '=' -f 2 | tr -d \'\" | tr -d ' ')
           echo "neo4j_version_base=$neo4j_version_base"
-          echo "NEO4J_VERSION_CI=5.23.0" >> "$GITHUB_ENV"
+          echo "NEO4J_VERSION_CI=5.24.0" >> "$GITHUB_ENV"
       
       - name: Compile Java
         run: |
@@ -101,7 +101,7 @@ jobs:
         run: |
           neo4j_version_base=$(grep -e "neo4jVersion = .*" build.gradle | cut -d '=' -f 2 | tr -d \'\" | tr -d ' ')
           echo "neo4j_version_base=$neo4j_version_base"
-          echo "NEO4J_VERSION_CI=5.23.0" >> "$GITHUB_ENV"
+          echo "NEO4J_VERSION_CI=5.24.0" >> "$GITHUB_ENV"
 
       - name: Init gradle
         run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -44,7 +44,7 @@ jobs:
         run: |
           neo4j_version_base=$(grep -e "neo4jVersion = .*" build.gradle | cut -d '=' -f 2 | tr -d \'\" | tr -d ' ')
           echo "neo4j_version_base=$neo4j_version_base"
-          echo "NEO4J_VERSION_CI=5.24.0" >> "$GITHUB_ENV"
+          echo "NEO4J_VERSION_CI=5.24.1" >> "$GITHUB_ENV"
       
       - name: Compile Java
         run: |
@@ -101,7 +101,7 @@ jobs:
         run: |
           neo4j_version_base=$(grep -e "neo4jVersion = .*" build.gradle | cut -d '=' -f 2 | tr -d \'\" | tr -d ' ')
           echo "neo4j_version_base=$neo4j_version_base"
-          echo "NEO4J_VERSION_CI=5.24.0" >> "$GITHUB_ENV"
+          echo "NEO4J_VERSION_CI=5.24.1" >> "$GITHUB_ENV"
 
       - name: Init gradle
         run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -44,9 +44,7 @@ jobs:
         run: |
           neo4j_version_base=$(grep -e "neo4jVersion = .*" build.gradle | cut -d '=' -f 2 | tr -d \'\" | tr -d ' ')
           echo "neo4j_version_base=$neo4j_version_base"
-          NEO4J_VERSION_CI=`aws codeartifact list-package-versions --domain build-service-live --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --repository ci-live --format maven --namespace org.neo4j --package neo4j --sort-by PUBLISHED_TIME --query "versions[?starts_with(version,'$neo4j_version_base')] | [0].version" | tr -d '" '`
-          echo "NEO4J_VERSION_CI=$NEO4J_VERSION_CI" >> "$GITHUB_ENV"
-          echo "Found NEO4j_VERSION_CI=$NEO4J_VERSION_CI"
+          echo "NEO4J_VERSION_CI=5.23.0" >> "$GITHUB_ENV"
       
       - name: Compile Java
         run: |
@@ -103,9 +101,7 @@ jobs:
         run: |
           neo4j_version_base=$(grep -e "neo4jVersion = .*" build.gradle | cut -d '=' -f 2 | tr -d \'\" | tr -d ' ')
           echo "neo4j_version_base=$neo4j_version_base"
-          NEO4J_VERSION_CI=`aws codeartifact list-package-versions --domain build-service-live --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --repository ci-live --format maven --namespace org.neo4j --package neo4j --sort-by PUBLISHED_TIME --query "versions[?starts_with(version,'$neo4j_version_base')] | [0].version" | tr -d '" '`
-          echo "NEO4J_VERSION_CI=$NEO4J_VERSION_CI" >> "$GITHUB_ENV"
-          echo "Found NEO4j_VERSION_CI=$NEO4J_VERSION_CI"
+          echo "NEO4J_VERSION_CI=5.23.0" >> "$GITHUB_ENV"
 
       - name: Init gradle
         run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -23,41 +23,23 @@ jobs:
       matrix:
         language: [ 'java', 'javascript' ]
     steps:
-      - name: Configure AWS CLI
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
-      
-      - name: Configure CodeArtifact Authentication Token 
-        run: |
-          CODEARTIFACT_TOKEN=`aws codeartifact get-authorization-token --domain build-service-live --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --query authorizationToken --output text`
-          echo "::add-mask::$CODEARTIFACT_TOKEN"
-          echo "CODEARTIFACT_TOKEN=$CODEARTIFACT_TOKEN" >> "$GITHUB_ENV"
-
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-jdk
       - uses: ./.github/actions/setup-gradle-cache
-
-      - name: Determine latest neo4j CI version
-        run: |
-          neo4j_version_base=$(grep -e "neo4jVersion = .*" build.gradle | cut -d '=' -f 2 | tr -d \'\" | tr -d ' ')
-          echo "neo4j_version_base=$neo4j_version_base"
-          echo "NEO4J_VERSION_CI=5.24.1" >> "$GITHUB_ENV"
       
       - name: Compile Java
         run: |
           chmod +x gradlew
-          ./gradlew --no-daemon --info -Pneo4jVersionOverride=$NEO4J_VERSION_CI --init-script init.gradle clean
+          ./gradlew --no-daemon --init-script init.gradle clean
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
       
-      - name: Compile
-        run: ./gradlew --info -Pneo4jVersionOverride=$NEO4J_VERSION_CI compileJava compileTestJava
+      # Autobuild attempts to build any compiled languages 
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
@@ -71,19 +53,6 @@ jobs:
         project: [ 'extended', 'extended-it' ]
     runs-on: ubuntu-latest
     steps:
-      - name: Configure AWS CLI
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: eu-west-1
-      
-      - name: Configure CodeArtifact Authentication Token 
-        run: |
-          CODEARTIFACT_TOKEN=`aws codeartifact get-authorization-token --domain build-service-live --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --query authorizationToken --output text`
-          echo "::add-mask::$CODEARTIFACT_TOKEN"
-          echo "CODEARTIFACT_TOKEN=$CODEARTIFACT_TOKEN" >> "$GITHUB_ENV"
-
       - uses: actions/checkout@v2
       - name: Set up JDK 17
         uses: actions/setup-java@v2
@@ -96,17 +65,11 @@ jobs:
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-      
-      - name: Determine latest neo4j CI version
-        run: |
-          neo4j_version_base=$(grep -e "neo4jVersion = .*" build.gradle | cut -d '=' -f 2 | tr -d \'\" | tr -d ' ')
-          echo "neo4j_version_base=$neo4j_version_base"
-          echo "NEO4J_VERSION_CI=5.24.1" >> "$GITHUB_ENV"
 
       - name: Init gradle
         run: |
           chmod +x gradlew
-          ./gradlew --info -Pneo4jVersionOverride=$NEO4J_VERSION_CI --init-script init.gradle
+          ./gradlew --init-script init.gradle
 
       - name: Run ${{ matrix.project }} tests
         uses: ./.github/actions/test-gradle-project

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "apoc-core"]
 	path = apoc-core
 	url = https://github.com/neo4j/apoc
-	branch = 5.22
+	branch = 5.24

--- a/build.gradle
+++ b/build.gradle
@@ -91,8 +91,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise-debian' : 'neo4j:5.24.0-enterprise',
-                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-debian' : 'neo4j:5.24.0',
+                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise-debian' : 'neo4j:5.24.1-enterprise',
+                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-debian' : 'neo4j:5.24.1',
                 'coreDir': 'apoc-core/core',
                 'testDockerBundle': false
 

--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.24.0"
+    neo4jVersion = "5.24.1"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.18.3'

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ downloadLicenses {
 
 allprojects {
     group = 'org.neo4j.procedure'
-    version = '5.23.0'
+    version = '5.24.0'
     archivesBaseName = 'apoc'
     description = """neo4j-apoc-procedures"""
 }
@@ -91,8 +91,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise-debian' : 'neo4j:5.23.0-enterprise',
-                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-debian' : 'neo4j:5.23.0',
+                'neo4jDockerImage' : System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-enterprise-debian' : 'neo4j:5.24.0-enterprise',
+                'neo4jCommunityDockerImage': System.getProperty("NEO4JVERSION") ? 'neo4j:' + System.getProperty("NEO4JVERSION") + '-debian' : 'neo4j:5.24.0',
                 'coreDir': 'apoc-core/core',
                 'testDockerBundle': false
 
@@ -151,7 +151,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.23.0"
+    neo4jVersion = "5.24.0"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.18.3'

--- a/build.gradle
+++ b/build.gradle
@@ -28,17 +28,7 @@ repositories {
     /*maven {  // this contains the neo4j 4.0.0-beta jars
     url "https://neo4j.bintray.com/community/"
 }*/
-    if (System.getenv("CODEARTIFACT_DOWNLOAD_URL") ?: "" != "") {
-        maven {
-            url System.getenv('CODEARTIFACT_DOWNLOAD_URL')
-            credentials {
-                username System.getenv('CODEARTIFACT_USERNAME')
-                password System.getenv('CODEARTIFACT_TOKEN')
-            }
-        }
-    } else {
-        mavenCentral()
-    }
+    mavenCentral()
     maven {
         url "https://repo.gradle.org/gradle/libs-releases"
     }
@@ -53,17 +43,7 @@ subprojects {
         /*maven {  // this contains the neo4j 4.0.0-beta jars
         url "https://neo4j.bintray.com/community/"
     }*/
-        if (System.getenv("CODEARTIFACT_DOWNLOAD_URL") ?: "" != "") {
-            maven {
-                url System.getenv('CODEARTIFACT_DOWNLOAD_URL')
-                credentials {
-                    username System.getenv('CODEARTIFACT_USERNAME')
-                    password System.getenv('CODEARTIFACT_TOKEN')
-                }
-            }
-        } else {
-            mavenCentral()
-        }
+        mavenCentral()
         maven {
             url "https://repo.gradle.org/gradle/libs-releases"
         }

--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -6,7 +6,7 @@ import apoc.ExtendedSystemPropertyKeys;
 import apoc.SystemPropertyKeys;
 import apoc.util.Util;
 import org.apache.commons.lang3.tuple.Pair;
-import org.neo4j.collection.RawIterator;
+import org.neo4j.collection.ResourceRawIterator;
 import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -26,6 +26,7 @@ import org.neo4j.kernel.api.CypherScope;
 import org.neo4j.kernel.api.ResourceMonitor;
 import org.neo4j.kernel.api.procedure.CallableProcedure;
 import org.neo4j.kernel.api.procedure.CallableUserFunction;
+import org.neo4j.kernel.api.procedure.Context;
 import org.neo4j.kernel.api.procedure.GlobalProcedures;
 import org.neo4j.kernel.availability.AvailabilityListener;
 import org.neo4j.kernel.impl.util.ValueUtils;
@@ -253,7 +254,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
             final boolean isStatementNull = statement == null;
             globalProceduresRegistry.register(new CallableProcedure.BasicProcedure(signature) {
                 @Override
-                public RawIterator<AnyValue[], ProcedureException> apply(org.neo4j.kernel.api.procedure.Context ctx, AnyValue[] input, ResourceMonitor resourceMonitor) throws ProcedureException {
+                public ResourceRawIterator<AnyValue[], ProcedureException> apply(Context ctx, AnyValue[] input, ResourceMonitor resourceMonitor) throws ProcedureException {
                     if (isStatementNull) {
                         final String error = String.format("There is no procedure with the name `%s` registered for this database instance. " +
                                 "Please ensure you've spelled the procedure name correctly and that the procedure is properly deployed.", name);


### PR DESCRIPTION
Created another PR, waiting for: https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4179,
which fails due to timeout exception.

- Changed references and gitmodule to 5.24
- Fixed compile error with 5.24 version due to Neo4j change, see here: https://github.com/neo4j/neo4j/commit/2f2dc348047c02036a3ded6d01dae4c74b9579e1
- Removed code artifact implementation from ci.yaml, so that we download neo4j from mvn repository and dockerhub
- updated `upload-artifact` version (which is not valid anymore)




~try solving https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/11167910649/job/31045136258?pr=4199#step:9:2191~