### PR TITLE
Provisionally fixed docker and upload-artifact errors in dev

### DIFF
--- a/.github/actions/test-gradle-project/action.yml
+++ b/.github/actions/test-gradle-project/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: ./gradlew --info -Pneo4jVersionOverride=$NEO4J_VERSION_CI :${{inputs.project-name}}:check --parallel
     - name: Archive test results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: always()
       with:
         name: ${{inputs.project-name}}-test-results

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "apoc-core"]
 	path = apoc-core
 	url = https://github.com/neo4j/apoc
-	branch = 5.22
+	branch = 5.23


### PR DESCRIPTION
Changed via `.gitmodules`, the docker and the mvn version to `5.23`, which is the latest present in docker hub and mvn repository,
and updated `upload-artifact` (which is not valid anymore), 

waiting for https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4179 (where the docker version is taken from Code Artifact, but currently don't work due to timeout exception)