### PR TITLE
Try fixing 5.24 TeamCity errors

### DIFF
--- a/extended-it/src/test/java/apoc/couchbase/CouchbaseTestUtils.java
+++ b/extended-it/src/test/java/apoc/couchbase/CouchbaseTestUtils.java
@@ -132,8 +132,8 @@ public class CouchbaseTestUtils {
     }
 
     protected static void createCouchbaseContainer() {
-        // 7.0 support stably multi collections and scopes
-        couchbase = new CouchbaseContainer("couchbase/server:7.0.0")
+        // 7.x support stably multi collections and scopes
+        couchbase = new CouchbaseContainer("couchbase/server:7.2.6")
                 .withStartupAttempts(3)
                 .withCredentials(USERNAME, PASSWORD)
                 .withBucket(new BucketDefinition(BUCKET_NAME));

--- a/extended/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/extended/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -19,8 +19,6 @@ import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.dbms.api.DatabaseManagementService;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
-import org.neo4j.test.rule.DbmsRule;
-import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;

--- a/extended/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/extended/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -14,7 +14,11 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.dbms.api.DatabaseManagementService;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -45,19 +49,19 @@ public class ExportCsvTest {
             ",,,,,,,,\"0\",\"1\",\"KNOWS\"%n" +
             ",,,,,,,,\"3\",\"4\",\"NEXT_DELIVERY\"%n");
 
-    private static File directory = new File("target/import");
-    static { //noinspection ResultOfMethodCallIgnored
-        directory.mkdirs();
-    }
-
     @ClassRule
-    public static DbmsRule db = new ImpermanentDbmsRule()
-            .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath());
+    public static TemporaryFolder storeDir = new TemporaryFolder();
+    
+    private static GraphDatabaseService db;
+    private static DatabaseManagementService dbms;
 
     private static MiniDFSCluster miniDFSCluster;
 
     @BeforeClass
     public static void setUp() throws Exception {
+        dbms = new TestDatabaseManagementServiceBuilder(storeDir.getRoot().toPath()).build();
+        db = dbms.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
+        
         TestUtil.registerProcedure(db, ExportCSV.class, Graphs.class);
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
         db.executeTransactionally("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})");
@@ -70,7 +74,7 @@ public class ExportCsvTest {
         if (miniDFSCluster!= null) {
             miniDFSCluster.shutdown();
         }
-        db.shutdown();
+        dbms.shutdown();
     }
 
     @Test


### PR DESCRIPTION
Try solving the following errors which happens in TeamCity, but not with GitHub Action.

- Exception in `apoc.export.csv.ExportCsvTest`
Non replicated locally.
It could be a corrupt folder or one that requires special permissions for some reason.
To try to fix it, we changed the folder to junit's `TemporaryFolder`
```
org.apache.hadoop.hdfs.server.common.InconsistentFSStateException: Directory /opt/teamcity-agent/work/af99a1b2d35610b6/neo4j-apoc-procedures/extended/hadoop/hdfs/name-0-1 is in an inconsistent state: file VERSION has layoutVersion missing.
  at app//org.apache.hadoop.hdfs.server.common.StorageInfo.getProperty(StorageInfo.java:256)
  at app//org.apache.hadoop.hdfs.server.common.StorageInfo.setLayoutVersion(StorageInfo.java:218)
  at app//org.apache.hadoop.hdfs.server.common.StorageInfo.setFieldsFromProperties(StorageInfo.java:173)
  at app//org.apache.hadoop.hdfs.server.namenode.NNStorage.setFieldsFromProperties(NNStorage.java:662)
```

- Exception in `apoc.couchbase.CouchbaseIT.classMethod`
Even locally the image gives problems with Apple M1 processors, but with a somewhat different error.
But by updating the image to 7.2.6 the problem disappears. 
We can test if the fix also works with the following error in TeamCity:
```
com.couchbase.client.core.error.AmbiguousTimeoutException: InsertRequest, Reason: TIMEOUT {"cancelled":true,"completed":true,"coreId":"0xb884cdab00000001","idempotent":false,"reason":"TIMEOUT","requestId":2,"requestType":"InsertRequest","retried":14,"retryReasons":["BUCKET_OPEN_IN_PROGRESS"],"service":{"bucket":"mybucket","collection":"_default","documentId":"artist:vincent_van_gogh","opaque":"0x1","scope":"_default","type":"kv","vbucket":0},"timeoutMs":2500,"timings":{"encodingMicros":11109,"totalMicros":2819046}}
  at app//com.couchbase.client.java.AsyncUtils.block(AsyncUtils.java:51)
  at app//com.couchbase.client.java.Collection.insert(Collection.java:389)
...
...

  Suppressed: java.lang.Exception: The above exception was originally thrown by another thread at the following location.
    at com.couchbase.client.core.msg.BaseRequest.cancel(BaseRequest.java:184)
    at com.couchbase.client.core.msg.Request.cancel(Request.java:70)
    at com.couchbase.client.core.Timer.lambda$register$2(Timer.java:157)
    at com.couchbase.client.core.deps.io.netty.util.HashedWheelTimer$HashedWheelTimeout.run(HashedWheelTimer.java:715)
    at com.couchbase.client.core.deps.io.netty.util.concurrent.ImmediateExecutor.execute(ImmediateExecutor.java:34)
    at com.couchbase.client.core.deps.io.netty.util.HashedWheelTimer$HashedWheelTimeout.expire(HashedWheelTimer.java:703)
    at com.couchbase.client.core.deps.io.netty.util.HashedWheelTimer$HashedWheelBucket.expireTimeouts(HashedWheelTimer.java:790)
    at com.couchbase.client.core.deps.io.netty.util.HashedWheelTimer$Worker.run(HashedWheelTimer.java:503)
    at com.couchbase.client.core.deps.io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
    at java.base/java.lang.Thread.run(Thread.java:840)
```


- The following error does not always occur locally, but is flaky and occurs only from the second boot onward.
It should be a problem similar to [this issue](https://github.com/osixia/docker-openldap/issues/400).
To solve it, I then added volumes, [similar to what was written here](https://github.com/osixia/docker-openldap/issues/400#issuecomment-581107929).
This way it works even starting it 4/5 times.
```
Caused by: org.neo4j.internal.kernel.api.exceptions.ProcedureException: Failed to invoke procedure `apoc.load.ldap`: Caused by: java.net.ConnectException: Connection refused
...
...
Caused by: java.lang.RuntimeException: java.lang.RuntimeException: LDAPException(resultCode=91 (connect error), errorMessage='An error occurred while attempting to connect to server localhost:32806:  IOException(LDAPException(resultCode=91 (connect error), errorMessage='An error occurred while attempting to establish a connection to server localhost/127.0.0.1:32806:  ConnectException(Connection refused), ldapSDKVersion=6.0.11, revision=8b21d0a4c6eb8b5c3e60a96fc3e9e13b9c2f650f'))')
  at apoc.load.LoadLdap$LDAPManager.executeSearch(LoadLdap.java:128)
  at apoc.load.LoadLdap.ldapQuery(LoadLdap.java:36)
```