### PR TITLE
Try again to solve remaining TeamCity errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,6 +134,6 @@ ext {
     neo4jVersion = "5.24.1"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
-    testContainersVersion = '1.18.3'
+    testContainersVersion = '1.19.1'
     apacheArrowVersion = '15.0.0'
 }

--- a/extended-it/src/test/java/apoc/couchbase/CouchbaseTestUtils.java
+++ b/extended-it/src/test/java/apoc/couchbase/CouchbaseTestUtils.java
@@ -18,6 +18,7 @@ import org.testcontainers.containers.Container;
 import org.testcontainers.couchbase.BucketDefinition;
 import org.testcontainers.couchbase.CouchbaseContainer;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -64,6 +65,7 @@ public class CouchbaseTestUtils {
 
     public static boolean fillDB(Cluster cluster) {
         Bucket couchbaseBucket = cluster.bucket(BUCKET_NAME);
+        couchbaseBucket.waitUntilReady(Duration.ofMinutes(1));
         Collection collection = couchbaseBucket.defaultCollection();
         collection.insert("artist:vincent_van_gogh", VINCENT_VAN_GOGH);
         QueryResult queryResult = cluster.query(String.format(QUERY, BUCKET_NAME),

--- a/extended/src/test/java/apoc/export/csv/ExportCsvTest.java
+++ b/extended/src/test/java/apoc/export/csv/ExportCsvTest.java
@@ -50,6 +50,9 @@ public class ExportCsvTest {
     @ClassRule
     public static TemporaryFolder storeDir = new TemporaryFolder();
     
+    @ClassRule
+    public static TemporaryFolder hdfsDir = new TemporaryFolder();
+    
     private static GraphDatabaseService db;
     private static DatabaseManagementService dbms;
 
@@ -64,7 +67,7 @@ public class ExportCsvTest {
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
         db.executeTransactionally("CREATE (f:User1:User {name:'foo',age:42,male:true,kids:['a','b','c']})-[:KNOWS]->(b:User {name:'bar',age:42}),(c:User {age:12})");
         db.executeTransactionally("CREATE (f:Address1:Address {name:'Andrea', city: 'Milano', street:'Via Garibaldi, 7'})-[:NEXT_DELIVERY]->(a:Address {name: 'Bar Sport'}), (b:Address {street: 'via Benni'})");
-        miniDFSCluster = HdfsTestUtils.getLocalHDFSCluster();
+        miniDFSCluster = HdfsTestUtils.getLocalHDFSCluster(hdfsDir.getRoot());
     }
 
     @AfterClass

--- a/extended/src/test/java/apoc/export/parquet/ParquetHdfsTest.java
+++ b/extended/src/test/java/apoc/export/parquet/ParquetHdfsTest.java
@@ -7,6 +7,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
@@ -29,6 +30,9 @@ public class ParquetHdfsTest {
     }
 
     @ClassRule
+    public static TemporaryFolder hdfsDir = new TemporaryFolder();
+
+    @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule()
             .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath());
 
@@ -37,7 +41,7 @@ public class ParquetHdfsTest {
     @BeforeClass
     public static void setUp() throws Exception {
         beforeClassCommon(db);
-        miniDFSCluster = HdfsTestUtils.getLocalHDFSCluster();
+        miniDFSCluster = HdfsTestUtils.getLocalHDFSCluster(hdfsDir.getRoot());
     }
 
     @Before

--- a/extended/src/test/java/apoc/load/LoadHdfsTest.java
+++ b/extended/src/test/java/apoc/load/LoadHdfsTest.java
@@ -8,10 +8,12 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.jupiter.api.AfterAll;
 
+import org.junit.rules.TemporaryFolder;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -28,6 +30,9 @@ import static org.junit.Assert.assertEquals;
 
 public class LoadHdfsTest {
 
+    @ClassRule
+    public static TemporaryFolder hdfsDir = new TemporaryFolder();
+    
     @Rule
     public DbmsRule db = new ImpermanentDbmsRule();
 
@@ -36,7 +41,7 @@ public class LoadHdfsTest {
     @Before public void setUp() throws Exception {
         TestUtil.registerProcedure(db, LoadCsv.class);
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
-        miniDFSCluster = HdfsTestUtils.getLocalHDFSCluster();
+        miniDFSCluster = HdfsTestUtils.getLocalHDFSCluster(hdfsDir.getRoot());
 		FileSystem fs = miniDFSCluster.getFileSystem();
 		String fileName = "test.csv";
 		Path file = new Path(fileName);

--- a/extended/src/test/java/apoc/load/LoadLdapContainerTest.java
+++ b/extended/src/test/java/apoc/load/LoadLdapContainerTest.java
@@ -74,7 +74,7 @@ public class LoadLdapContainerTest {
     }
 
     private static void testLoadLDAPCommon(int port, boolean ssl) {
-        Map<String, Object> conn = Map.of("ldapHost", "localhost:" + port, 
+        Map<String, Object> conn = Map.of("ldapHost", ldap.getHost() + ":" + port, 
                 "loginDN", "cn=admin,dc=example,dc=org", 
                 "loginPW", "admin", 
                 "ssl", ssl);

--- a/extended/src/test/java/apoc/util/HdfsTestUtils.java
+++ b/extended/src/test/java/apoc/util/HdfsTestUtils.java
@@ -40,11 +40,10 @@ public class HdfsTestUtils {
         }
     }
     
-    public static MiniDFSCluster getLocalHDFSCluster() throws Exception {
+    public static MiniDFSCluster getLocalHDFSCluster(File hdfsPath) throws Exception {
     	setHadoopHomeWindows();
     	Configuration conf = new HdfsConfiguration();
     	conf.set("fs.defaultFS", "hdfs://localhost");
-		File hdfsPath = new File(System.getProperty("user.dir") + File.separator + "hadoop" + File.separator + "hdfs");
         hdfsPath.setWritable(true);
         conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, hdfsPath.getAbsolutePath());
 		MiniDFSCluster miniDFSCluster = new MiniDFSCluster.Builder(conf)


### PR DESCRIPTION
- [postgres error](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4206/files#diff-6ed3fdf3d5797eee9c7a40a83c97f842d06b51fa65fd349e90c4bca1326af1e9R135): added periodical check to idle connection, as the result of `pg_stat_activity` Is not always immediately updated
```
, stderr=)
java.lang.AssertionError: Current pg_stat_activity is: Container.ExecResult(exitCode=0, stdout= state
--------
 idle
 active
(2 rows)
, stderr=)
```

- [couchbase error](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4206/files#diff-7ef8b14be52bbb28a69e471aa541a4401063f38c4f23bf6b4be6855c15132610R68): the error could be the initial bucket not being properly loaded when I call the subsequent methods, as there is a BUCKET_OPEN_IN_PROGRESS, added a waitUntilReady to try to fix it 
```
com.couchbase.client.core.error.AmbiguousTimeoutException: InsertRequest, Reason: TIMEOUT {"cancelled":true,"completed":true,"coreId":"0x666b438600000001","idempotent":false,"reason":"TIMEOUT","requestId":2,"requestType":"InsertRequest","retried":14,"retryReasons":["BUCKET_OPEN_IN_PROGRESS"],"service":{"bucket":"mybucket","collection":"_default","documentId":"artist:vincent_van_gogh","opaque":"0x1","scope":"_default","type":"kv","vbucket":0},"timeoutMs":2500,"timings":{"encodingMicros":18005,"totalMicros":3022454}}
```

- [ldap error](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4206/files#diff-59f76e4a6e7af7e79562a3503aaae0574b111178a0921ef998b5991ce4afb0b5R77): not sure why it only appeared now, but changed localhost to `GenericContainer.getHost()`, as the docker server may not be on 127.0.0.1 using TeamCity
```
Caused by: LDAPException(resultCode=91 (connect error), errorMessage='An error occurred while attempting to establish a connection to server localhost/127.0.0.1:32777:  ConnectException(Connection refused)
```


- [hdfs error](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4206/files#diff-bfa60f885065d390ef38613747d120f5a31533930df40bf15aaf480f4aea464dR43), looks like the hdfs/hadoop folder is corrupted for some reason, replaced the path with a TemporaryFolder
```
org.apache.hadoop.hdfs.server.common.InconsistentFSStateException: Directory /opt/teamcity-agent/work/af99a1b2d35610b6/neo4j-apoc-procedures/extended/hadoop/hdfs/name-0-1 is in an inconsistent state: storage directory does not exist or is not accessible.

```

- Also, updated test container version like the Core one