### PR TITLE
Try solving TeamCity errors in 5.25

### DIFF
--- a/extended/src/test/java/apoc/gephi/GephiMock.java
+++ b/extended/src/test/java/apoc/gephi/GephiMock.java
@@ -3,7 +3,6 @@ package apoc.gephi;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.RegexBody;
-import org.mockserver.socket.PortFactory;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -27,10 +26,9 @@ import static org.mockserver.model.RegexBody.regex;
  */
 public class GephiMock {
     private final ClientAndServer server;
-    private static final int PORT = PortFactory.findFreePort();
-    
+
     public GephiMock() {
-        this.server = ClientAndServer.startClientAndServer(PORT);
+        this.server = ClientAndServer.startClientAndServer(8080);
     }
 
     public void clearAllExpectations() {

--- a/extended/src/test/java/apoc/gephi/GephiMock.java
+++ b/extended/src/test/java/apoc/gephi/GephiMock.java
@@ -3,6 +3,7 @@ package apoc.gephi;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.RegexBody;
+import org.mockserver.socket.PortFactory;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -26,9 +27,10 @@ import static org.mockserver.model.RegexBody.regex;
  */
 public class GephiMock {
     private final ClientAndServer server;
-
+    private static final int PORT = PortFactory.findFreePort();
+    
     public GephiMock() {
-        this.server = ClientAndServer.startClientAndServer(8080);
+        this.server = ClientAndServer.startClientAndServer(PORT);
     }
 
     public void clearAllExpectations() {

--- a/extended/src/test/java/apoc/load/LoadCsvTest.java
+++ b/extended/src/test/java/apoc/load/LoadCsvTest.java
@@ -10,6 +10,7 @@ import org.junit.*;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
+import org.mockserver.socket.PortFactory;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Result;
@@ -46,7 +47,8 @@ import static org.neo4j.configuration.GraphDatabaseSettings.db_temporal_timezone
 public class LoadCsvTest {
 
     private static ClientAndServer mockServer;
-
+    private static final int PORT = PortFactory.findFreePort();
+    
     private static final List<Map<String, Object>> RESPONSE_BODY = List.of(
             Map.of("headFoo", "one", "headBar", "two"),
             Map.of("headFoo", "three", "headBar", "four"),
@@ -55,7 +57,7 @@ public class LoadCsvTest {
 
     @BeforeClass
     public static void startServer() {
-        mockServer = startClientAndServer(1080);
+        mockServer = startClientAndServer(PORT);
     }
 
     @AfterClass

--- a/extended/src/test/java/apoc/load/LoadCsvTest.java
+++ b/extended/src/test/java/apoc/load/LoadCsvTest.java
@@ -47,7 +47,7 @@ import static org.neo4j.configuration.GraphDatabaseSettings.db_temporal_timezone
 public class LoadCsvTest {
 
     private static ClientAndServer mockServer;
-    private static final int PORT = PortFactory.findFreePort();
+    private static int PORT;
     
     private static final List<Map<String, Object>> RESPONSE_BODY = List.of(
             Map.of("headFoo", "one", "headBar", "two"),
@@ -57,6 +57,7 @@ public class LoadCsvTest {
 
     @BeforeClass
     public static void startServer() {
+        PORT = PortFactory.findFreePort();
         mockServer = startClientAndServer(PORT);
     }
 
@@ -494,7 +495,7 @@ RETURN m.col_1,m.col_2,m.col_3
         String userPass = "user:password";
         String token = Util.encodeUserColonPassToBase64(userPass);
 
-        new MockServerClient("localhost", 1080)
+        new MockServerClient("localhost", PORT)
                 .when(
                         request()
                                 .withPath("/docs/csv")
@@ -511,7 +512,7 @@ RETURN m.col_1,m.col_2,m.col_3
                 );
 
         testResult(db, "CALL apoc.load.csv($url, {results:['map']}) YIELD map",
-                    map("url", "http://" + userPass + "@localhost:1080/docs/csv"),
+                    map("url", "http://" + userPass + "@localhost:" + PORT + "/docs/csv"),
                     (row) -> assertEquals(RESPONSE_BODY, row.stream().map(i->i.get("map")).collect(Collectors.toList()))
                 );
     }
@@ -521,7 +522,7 @@ RETURN m.col_1,m.col_2,m.col_3
         String userPass = "user:password";
         String token = Util.encodeUserColonPassToBase64(userPass);
 
-        new MockServerClient("localhost", 1080)
+        new MockServerClient("localhost", PORT)
                 .when(
                         request()
                                 .withMethod("POST")
@@ -539,7 +540,7 @@ RETURN m.col_1,m.col_2,m.col_3
                 );
 
         testResult(db, "CALL apoc.load.csvParams($url, $header, $payload, {results:['map','list','stringMap','strings']})",
-                    map("url", "http://" + userPass + "@localhost:1080/docs/csv",
+                    map("url", "http://" + userPass + "@localhost:" + PORT +"/docs/csv",
                         "header", map("method", "POST"),
                         "payload", "{\"query\":\"pagecache\",\"version\":\"3.5\"}"),
                     (row) -> assertEquals(RESPONSE_BODY, row.stream().map(i->i.get("map")).collect(Collectors.toList()))
@@ -551,7 +552,7 @@ RETURN m.col_1,m.col_2,m.col_3
         String userPass = "user:password";
         String token = Util.encodeUserColonPassToBase64(userPass);
 
-        new MockServerClient("localhost", 1080)
+        new MockServerClient("localhost", PORT)
                 .when(
                         request()
                                 .withMethod("POST")
@@ -570,7 +571,7 @@ RETURN m.col_1,m.col_2,m.col_3
                 );
 
         testResult(db, "CALL apoc.load.csvParams($url, $header, $payload, {results:['map','list','stringMap','strings']})",
-                    map("url", "http://localhost:1080/docs/csv",
+                    map("url", "http://localhost:" + PORT + "/docs/csv",
                         "header", map("method",
                                     "POST", "Authorization", "Basic " + token,
                                     "Content-Type", "application/json"),

--- a/extended/src/test/java/apoc/ml/WatsonTest.java
+++ b/extended/src/test/java/apoc/ml/WatsonTest.java
@@ -35,7 +35,6 @@ import static org.mockserver.model.HttpResponse.response;
 public class WatsonTest {
 
     private static ClientAndServer mockServer;
-    private static final int PORT = PortFactory.findFreePort();
 
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule();
@@ -44,17 +43,18 @@ public class WatsonTest {
 
     @BeforeClass
     public static void startServer() throws Exception {
+        int port = PortFactory.findFreePort();
         TestUtil.registerProcedure(db, Watson.class);
         
         String path = "/generation/text";
-        apocConfig().setProperty(APOC_ML_WATSON_URL, "http://localhost:1080" + path);
+        apocConfig().setProperty(APOC_ML_WATSON_URL, "http://localhost:" + port + path);
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         apocConfig().setProperty(APOC_ML_WATSON_PROJECT_ID, "fakeProjectId");
         
         File urlFileName = new File(getUrlFileName("watson.json").getFile());
         String body = FileUtils.readFileToString(urlFileName, UTF_8);
         
-        mockServer = startClientAndServer(PORT);
+        mockServer = startClientAndServer(port);
         mockServer.when(
                         request()
                                 .withMethod("POST")

--- a/extended/src/test/java/apoc/ml/WatsonTest.java
+++ b/extended/src/test/java/apoc/ml/WatsonTest.java
@@ -9,6 +9,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
+import org.mockserver.socket.PortFactory;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -34,6 +35,7 @@ import static org.mockserver.model.HttpResponse.response;
 public class WatsonTest {
 
     private static ClientAndServer mockServer;
+    private static final int PORT = PortFactory.findFreePort();
 
     @ClassRule
     public static DbmsRule db = new ImpermanentDbmsRule();
@@ -52,7 +54,7 @@ public class WatsonTest {
         File urlFileName = new File(getUrlFileName("watson.json").getFile());
         String body = FileUtils.readFileToString(urlFileName, UTF_8);
         
-        mockServer = startClientAndServer(1080);
+        mockServer = startClientAndServer(PORT);
         mockServer.when(
                         request()
                                 .withMethod("POST")

--- a/extended/src/test/java/apoc/util/ExtendedTestUtil.java
+++ b/extended/src/test/java/apoc/util/ExtendedTestUtil.java
@@ -121,9 +121,13 @@ public class ExtendedTestUtil {
      * but with multiple results
      */
     public static void testResultEventually(GraphDatabaseService db, String call, Consumer<Result> resultConsumer, long timeout) {
+        testResultEventually(db, call, Map.of(), resultConsumer, timeout);
+    }
+    
+    public static void testResultEventually(GraphDatabaseService db, String call, Map<String,Object> params, Consumer<Result> resultConsumer, long timeout) {
         assertEventually(() -> {
             try {
-                return db.executeTransactionally(call, Map.of(), r -> {
+                return db.executeTransactionally(call, params, r -> {
                     resultConsumer.accept(r);
                     return true;
                 });


### PR DESCRIPTION
- try solving qdrant query tests by adding testResultEventually, to retry it in case of errors [like this on](https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/11681558222/job/32529169731#step:10:4603)
```
org.neo4j.graphdb.QueryExecutionException: Failed to invoke procedure `apoc.vectordb.qdrant.query`: Caused by: java.net.SocketTimeoutException: Read timed out

```
they are very flaky and seems to happen only with query procedures.

- try solving WatsonTest by adding `PortFactory.findFreePort()` instead of `1080`
  - changed the remaining tests with fixed port `1080` as well, except the GephiMock since the gephi procedures has a default port value equal to 8080, so we should change each test to make them work (they don't seem to fail on TC anyway).
  - put `PortFactory.findFreePort()` in BeforeClass, otherwise we have an error e.g. with `LoadS3Testorg.mockserver.socket.PortFactoryjava.lang.NoClassDefFoundError: org/mockserver/socket/PortFactory`




Other errors should be solved separately [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4221)

![Bildschirmfoto 2024-11-05 um 19 33 44](https://github.com/user-attachments/assets/70bac019-e5c8-4598-9b27-447a3c0c356f)
