### PR TITLE
Fix ApocSignatures.PROCEDURES not found in StartupExtendedTest due to Cypher25 introduction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,8 +73,8 @@ subprojects {
 
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_21
+        targetCompatibility = JavaVersion.VERSION_21
     }
 
     task mySourcesJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
     neo4jVersion = "5.26.0"
     // instead we apply the override logic here
-    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion + "-SNAPSHOT"
+    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.20.2'
     apacheArrowVersion = '15.0.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -73,8 +73,8 @@ subprojects {
 
 
     java {
-        sourceCompatibility = JavaVersion.VERSION_21
-        targetCompatibility = JavaVersion.VERSION_21
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     task mySourcesJar(type: Jar) {

--- a/extended-it/src/test/java/apoc/neo4j/docker/StartupExtendedTest.java
+++ b/extended-it/src/test/java/apoc/neo4j/docker/StartupExtendedTest.java
@@ -88,7 +88,9 @@ public class StartupExtendedTest {
                                                     Consumer<Session> sessionConsumer) {
         for (var version: Neo4jVersion.values()) {
 
-            try (final Neo4jContainerExtension neo4jContainer = neo4jContainerCreation.apply(version)) {
+            try (final Neo4jContainerExtension neo4jContainer = neo4jContainerCreation.apply(version)
+                    .withNeo4jConfig("internal.dbms.cypher.enable_experimental_versions", "true")
+            ) {
                 // add extra-deps before starting it
                 ExtendedTestContainerUtil.addExtraDependencies();
                 neo4jContainer.start();
@@ -110,14 +112,23 @@ public class StartupExtendedTest {
     }
 
     private void checkCoreProcsAndFuncsExistence(Session session) {
-        final List<String> functionNames = getNames(session, APOC_HELP_QUERY,
+        final List<String> functionCypher5Names = getNames(session, "CYPHER 5 " + APOC_HELP_QUERY,
                 Map.of("core", true, "type", "function") );
 
-        final List<String> procedureNames = getNames(session, APOC_HELP_QUERY,
+        final List<String> procedureCypher5Names = getNames(session, "CYPHER 5 " + APOC_HELP_QUERY,
                 Map.of("core", true, "type", "procedure") );
 
-        assertEquals(sorted(ApocSignatures.PROCEDURES), procedureNames);
-        assertEquals(sorted(ApocSignatures.FUNCTIONS), functionNames);
+        assertEquals(sorted(ApocSignatures.PROCEDURES_CYPHER_5), procedureCypher5Names);
+        assertEquals(sorted(ApocSignatures.FUNCTIONS_CYPHER_5), functionCypher5Names);
+        
+        final List<String> functionCypher25Names = getNames(session, "CYPHER 25 " + APOC_HELP_QUERY,
+                Map.of("core", true, "type", "function") );
+
+        final List<String> procedureCypher25Names = getNames(session, "CYPHER 25 " + APOC_HELP_QUERY,
+                Map.of("core", true, "type", "procedure") );
+
+        assertEquals(sorted(ApocSignatures.PROCEDURES_CYPHER_25), procedureCypher25Names);
+        assertEquals(sorted(ApocSignatures.FUNCTIONS_CYPHER_25), functionCypher25Names);
     }
 
     private static List<String> getNames(Session session, String query, Map<String, Object> params) {

--- a/extended/src/main/resources/extended.txt
+++ b/extended/src/main/resources/extended.txt
@@ -92,7 +92,6 @@ apoc.load.directory.async.removeAll
 apoc.load.driver
 apoc.load.html
 apoc.load.htmlPlainText
-apoc.load.jsonParams
 apoc.load.jdbc
 apoc.load.jdbcUpdate
 apoc.load.ldap

--- a/extended/src/main/resources/extended.txt
+++ b/extended/src/main/resources/extended.txt
@@ -92,6 +92,7 @@ apoc.load.directory.async.removeAll
 apoc.load.driver
 apoc.load.html
 apoc.load.htmlPlainText
+apoc.load.jsonParams
 apoc.load.jdbc
 apoc.load.jdbcUpdate
 apoc.load.ldap


### PR DESCRIPTION
TODO: waiting for https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4230 merge??


Fix the cannot find symbol CI error, see [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/11707717937/job/32716503891?pr=4222#step:10:1855)

```
/home/runner/work/neo4j-apoc-procedures/neo4j-apoc-procedures/extended-it/src/test/java/apoc/neo4j/docker/StartupExtendedTest.java:119: error: cannot find symbol
        assertEquals(sorted(ApocSignatures.PROCEDURES), procedureNames);
```

The error is caused by the following changes in core, 
- https://github.com/neo4j/apoc/commit/8509584bf5d77efd77dd03f166757777072c7541
- https://github.com/neo4j/apoc/commit/f0c8172dac61db06fd6a02879d8794bbe993b54c

which reflects apoc extended: https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4208#discussion_r1816613431

Therefore, changed tests in a similar way as [StartupCore test  ](https://github.com/neo4j/apoc/commit/f0c8172dac61db06fd6a02879d8794bbe993b54c#diff-1e523af12b4239c89ed9f1656e99912150f81a5fc31e7492beb7fd79a56203b5R159)


----

If we don't change anything we have this error: https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/11777623730/job/32802388039?pr=4225#step:10:4819

If we put the procedure in extended.txt we have these 2 errors: https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/11778250428/job/32804296390?pr=4225

This because load.jsonParams currently is in both cypher5 core and cypher25 extended.
So we have remove it manually (waiting for core removal).