### PR TITLE
[UHlskzgQ] Upgrade commons-io dependency to 2.17.0

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -113,8 +113,8 @@ dependencies {
     compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.0', withoutServers
 
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
-    // explicit update comomns.io version
-    implementation group: 'commons-io', name: 'commons-io', version: '2.9.0'
+    // explicit update commons.io version
+    implementation group: 'commons-io', name: 'commons-io', version: '2.17.0'
 
     compileOnly group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     testImplementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'


### PR DESCRIPTION
Bumps the commons-io dependency to 2.17.0

## Proposed Changes (Mandatory)

Bumps the commons-io dependency to 2.17.0. Ask for by a support case. In passing, it also fixes a typo in a related code comment.
