### PR TITLE
[UHlskzgQ] Upgrade commons-io dependency to 2.17.0

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -37,8 +37,7 @@ Apache-2.0
   commons-configuration2-2.8.0.jar
   commons-csv-1.9.0.jar
   commons-daemon-1.0.13.jar
-  commons-io-2.15.1.jar
-  commons-io-2.9.0.jar
+  commons-io-2.17.0.jar
   commons-lang-2.6.jar
   commons-lang3-3.14.0.jar
   commons-logging-1.2.jar
@@ -122,15 +121,15 @@ Apache-2.0
   jcip-annotations-1.0-1.jar
   jctools-core-3.3.0.jar
   jettison-1.5.4.jar
-  jetty-http-9.4.53.v20231009.jar
-  jetty-io-9.4.53.v20231009.jar
-  jetty-security-9.4.53.v20231009.jar
-  jetty-server-9.4.53.v20231009.jar
-  jetty-servlet-9.4.53.v20231009.jar
-  jetty-util-9.4.53.v20231009.jar
-  jetty-util-ajax-9.4.53.v20231009.jar
-  jetty-webapp-9.4.53.v20231009.jar
-  jetty-xml-9.4.53.v20231009.jar
+  jetty-http-9.4.56.v20240826.jar
+  jetty-io-9.4.56.v20240826.jar
+  jetty-security-9.4.56.v20240826.jar
+  jetty-server-9.4.56.v20240826.jar
+  jetty-servlet-9.4.56.v20240826.jar
+  jetty-util-9.4.56.v20240826.jar
+  jetty-util-ajax-9.4.56.v20240826.jar
+  jetty-webapp-9.4.56.v20240826.jar
+  jetty-xml-9.4.56.v20240826.jar
   jffi-1.2.16-native.jar
   jffi-1.2.16.jar
   jmespath-java-1.12.770.jar

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -67,8 +67,7 @@ Apache-2.0
   commons-configuration2-2.8.0.jar
   commons-csv-1.9.0.jar
   commons-daemon-1.0.13.jar
-  commons-io-2.15.1.jar
-  commons-io-2.9.0.jar
+  commons-io-2.17.0.jar
   commons-lang-2.6.jar
   commons-lang3-3.14.0.jar
   commons-logging-1.2.jar
@@ -152,15 +151,15 @@ Apache-2.0
   jcip-annotations-1.0-1.jar
   jctools-core-3.3.0.jar
   jettison-1.5.4.jar
-  jetty-http-9.4.53.v20231009.jar
-  jetty-io-9.4.53.v20231009.jar
-  jetty-security-9.4.53.v20231009.jar
-  jetty-server-9.4.53.v20231009.jar
-  jetty-servlet-9.4.53.v20231009.jar
-  jetty-util-9.4.53.v20231009.jar
-  jetty-util-ajax-9.4.53.v20231009.jar
-  jetty-webapp-9.4.53.v20231009.jar
-  jetty-xml-9.4.53.v20231009.jar
+  jetty-http-9.4.56.v20240826.jar
+  jetty-io-9.4.56.v20240826.jar
+  jetty-security-9.4.56.v20240826.jar
+  jetty-server-9.4.56.v20240826.jar
+  jetty-servlet-9.4.56.v20240826.jar
+  jetty-util-9.4.56.v20240826.jar
+  jetty-util-ajax-9.4.56.v20240826.jar
+  jetty-webapp-9.4.56.v20240826.jar
+  jetty-xml-9.4.56.v20240826.jar
   jffi-1.2.16-native.jar
   jffi-1.2.16.jar
   jmespath-java-1.12.770.jar
@@ -340,15 +339,15 @@ Eclipse Distribution License - v 1.0
 Eclipse Public License - Version 1.0
   javax-websocket-client-impl-9.4.53.v20231009.jar
   javax-websocket-server-impl-9.4.53.v20231009.jar
-  jetty-http-9.4.53.v20231009.jar
-  jetty-io-9.4.53.v20231009.jar
-  jetty-security-9.4.53.v20231009.jar
-  jetty-server-9.4.53.v20231009.jar
-  jetty-servlet-9.4.53.v20231009.jar
-  jetty-util-9.4.53.v20231009.jar
-  jetty-util-ajax-9.4.53.v20231009.jar
-  jetty-webapp-9.4.53.v20231009.jar
-  jetty-xml-9.4.53.v20231009.jar
+  jetty-http-9.4.56.v20240826.jar
+  jetty-io-9.4.56.v20240826.jar
+  jetty-security-9.4.56.v20240826.jar
+  jetty-server-9.4.56.v20240826.jar
+  jetty-servlet-9.4.56.v20240826.jar
+  jetty-util-9.4.56.v20240826.jar
+  jetty-util-ajax-9.4.56.v20240826.jar
+  jetty-webapp-9.4.56.v20240826.jar
+  jetty-xml-9.4.56.v20240826.jar
   websocket-api-9.4.53.v20231009.jar
   websocket-client-9.4.53.v20231009.jar
   websocket-common-9.4.53.v20231009.jar

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -113,8 +113,8 @@ dependencies {
     compileOnly group: 'org.apache.hadoop', name: 'hadoop-common', version: '3.4.0', withoutServers
 
     implementation group: 'org.apache.commons', name: 'commons-math3', version: '3.6.1'
-    // explicit update comomns.io version
-    implementation group: 'commons-io', name: 'commons-io', version: '2.9.0'
+    // explicit update commons.io version
+    implementation group: 'commons-io', name: 'commons-io', version: '2.17.0'
 
     compileOnly group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'
     testImplementation group: 'org.apache.commons', name: 'commons-text', version: '1.10.0'


### PR DESCRIPTION
Bumps the commons-io dependency to 2.17.0

## Proposed Changes (Mandatory)

Bumps the commons-io dependency to 2.17.0. Ask for by a support case. In passing, it also fixes a typo in a related code comment.