### PR TITLE
Fixes #4233: Improve Weaviate error handling

### DIFF
--- a/extended-it/src/test/java/apoc/vectordb/WeaviateTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/WeaviateTest.java
@@ -456,6 +456,19 @@ public class WeaviateTest {
     }
 
     @Test
+    public void queryWithWrongEmbeddingSize() {
+        Map<String, Object> conf = map(ALL_RESULTS_KEY, true,
+                FIELDS_KEY, FIELDS,
+                HEADERS_KEY, READONLY_AUTHORIZATION);
+
+        String expectedErrMsg = "distance between entrypoint and query node: vector lengths don't match: 4 vs 3";
+        
+        assertFails(db, "CALL apoc.vectordb.weaviate.query($host, 'TestCollection', [0.2, 0.1, 0.9], null, 5, $conf)",
+                map("host", HOST, "conf", conf),
+                expectedErrMsg);
+    }
+
+    @Test
     public void queryVectorsWithCreateRelWithoutVectorResult() {
 
         db.executeTransactionally("CREATE (:Start)-[:TEST {myId: 'one'}]->(:End), (:Start)-[:TEST {myId: 'two'}]->(:End)");

--- a/extended/src/main/java/apoc/vectordb/Weaviate.java
+++ b/extended/src/main/java/apoc/vectordb/Weaviate.java
@@ -4,6 +4,7 @@ import apoc.Extended;
 import apoc.ml.RestAPIConfig;
 import apoc.result.ListResult;
 import apoc.result.MapResult;
+import apoc.util.CollectionUtils;
 import apoc.util.UrlResolver;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -243,7 +244,7 @@ public class Weaviate {
                 v -> {
                     Map<String, Map> mapResult = (Map<String, Map>) v;
                     List<Map> errors = (List<Map>) mapResult.get("errors");
-                    if (!errors.isEmpty()) {
+                    if ( CollectionUtils.isNotEmpty(errors) ) {
                         String message = "An error occurred during Weaviate API response: \n" + StringUtils.join(errors, "\n");
                         throw new RuntimeException(message);
                     }


### PR DESCRIPTION
Fixes #4233

Added clearer error messages when response has `"errors"` field populated, instead of returning NullPointerException