### PR TITLE
Fixes #4232: The apoc.vectordb.configure(WEAVIATE', ..) procedure should append /v1 to url

### DIFF
--- a/extended/src/main/java/apoc/vectordb/VectorDb.java
+++ b/extended/src/main/java/apoc/vectordb/VectorDb.java
@@ -38,7 +38,9 @@ import static apoc.util.ExtendedUtil.listOfNumbersToFloatArray;
 import static apoc.util.ExtendedUtil.setProperties;
 import static apoc.util.JsonUtil.OBJECT_MAPPER;
 import static apoc.util.SystemDbUtil.withSystemDb;
-import static apoc.vectordb.VectorDbUtil.*;
+import static apoc.vectordb.VectorDbUtil.EmbeddingResult;
+import static apoc.vectordb.VectorDbUtil.appendVersionUrlIfNeeded;
+import static apoc.vectordb.VectorDbUtil.getEndpoint;
 import static apoc.vectordb.VectorEmbeddingConfig.ALL_RESULTS_KEY;
 import static apoc.vectordb.VectorEmbeddingConfig.MAPPING_KEY;
 
@@ -259,7 +261,7 @@ public class VectorDb {
             Node node = Util.mergeNode(transaction, label, null, Pair.of(SystemPropertyKeys.name.name(), configKey));
 
             Map mapping = (Map) config.get("mapping");
-            String host = (String) config.get("host");
+            String host = appendVersionUrlIfNeeded(type, (String) config.get("host"));
             Object credentials = config.get("credentials");
 
             if (host != null) {

--- a/extended/src/main/java/apoc/vectordb/VectorDbUtil.java
+++ b/extended/src/main/java/apoc/vectordb/VectorDbUtil.java
@@ -130,4 +130,18 @@ public class VectorDbUtil {
         config.put(METHOD_KEY, null);
         config.put(BODY_KEY, null);
     }
+
+    /**
+     * If the vectorDb is WEAVIATE and endpoint doesn't end with `/vN`, where N is a number,
+     * then add `/v1` to the endpoint
+     */
+    public static String appendVersionUrlIfNeeded(VectorDbHandler.Type type, String host) {
+        if (VectorDbHandler.Type.WEAVIATE == type) {
+            String regex = ".*(/v\\d+)$";
+            if (!host.matches(regex)) {
+                host = host + "/v1";
+            }
+        }
+        return host;
+    }
 }


### PR DESCRIPTION
Fixes #4232

Added appendVersionUrlIfNeeded method in VectorDbUtil used in apoc.vectordb.configure
If host does not terminate for /vNUMBER add /v1
