### PR TITLE
Fix another unresolved imports with IntelliJ 2024.1+

### DIFF
--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -60,7 +60,7 @@ task gitSubmoduleLoad {
 dependencies {
     // to fix unresolved imports with IntelliJ from version 2024.1.x
     compileOnly sourceSets.main.java
-
+    testImplementation sourceSets.main.java
 
     
     apt project(':processor')


### PR DESCRIPTION
Similar to [this one](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4193),
with newer version we have another unresolved import in extended test classes.

For example, without the `testImplementation sourceSets.main.java`, from `apoc.vectordb.PineconeTest` we cannot resolve the `apoc.ml.RestAPIConfig` imports