### PR TITLE
[NOID] Fixes #4133: switch default model for cypher/schema interactions to gpt-4o (#4143)

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/ml/openai.adoc
@@ -148,7 +148,7 @@ This procedure `apoc.ml.openai.chat` takes a list of maps of chat exchanges betw
 
 It uses the `/chat/create` API which is https://platform.openai.com/docs/api-reference/chat/create[documented here^].
 
-Additional configuration is passed to the API, the default model used is `gpt-3.5-turbo`.
+Additional configuration is passed to the API, the default model used is `gpt-4o`.
 
 .Chat Completion Call
 [source,cypher]
@@ -162,7 +162,7 @@ CALL apoc.ml.openai.chat([
 .Chat Completion Response
 ----
 {created=1684248203, id="chatcmpl-7GqBXZr94avd4fluYDi2fWEz7DIHL",
-object="chat.completion", model="gpt-3.5-turbo-0301",
+object="chat.completion", model="gpt-4o-0301",
 usage={completion_tokens=2, prompt_tokens=26, total_tokens=28},
 choices=[{finish_reason="stop", index=0, message={role="assistant", content="Earth."}}]}
 ----
@@ -269,7 +269,7 @@ RETURN m.title
 | name | description | mandatory
 | retries | The number of retries in case of API call failures | no, default `3`
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
-| model | The Open AI model | no, default `gpt-3.5-turbo`
+| model | The Open AI model | no, default `gpt-4o`
 | sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number
 |===
 
@@ -318,7 +318,7 @@ RETURN *
 |===
 | name | description | mandatory
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
-| model | The Open AI model | no, default `gpt-3.5-turbo`
+| model | The Open AI model | no, default `gpt-4o`
 | sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number
 |===
 
@@ -383,7 +383,7 @@ RETURN DISTINCT a.name
 | name | description | mandatory
 | count | The number of queries to retrieve | no, default `1`
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
-| model | The Open AI model | no, default `gpt-3.5-turbo`
+| model | The Open AI model | no, default `gpt-4o`
 | sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number
 |===
 
@@ -460,7 +460,7 @@ RETURN *
 |===
 | name | description | mandatory
 | apiKey | OpenAI API key | in case `apoc.openai.key` is not defined
-| model | The Open AI model | no, default `gpt-3.5-turbo`
+| model | The Open AI model | no, default `gpt-4o`
 | sample | The number of nodes to skip, e.g. a sample of 1000 will read every 1000th node. It's used as a parameter to `apoc.meta.data` procedure that computes the schema | no, default is a random number
 |===
 

--- a/full/src/main/java/apoc/ml/OpenAI.java
+++ b/full/src/main/java/apoc/ml/OpenAI.java
@@ -145,15 +145,7 @@ public class OpenAI {
             @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration)
             throws Exception {
         String model = (String) configuration.putIfAbsent("model", "gpt-4o");
-        return executeRequest(
-                        apiKey,
-                        configuration,
-                        "chat/completions",
-                        model,
-                        "messages",
-                        messages,
-                        "$",
-                        apocConfig)
+        return executeRequest(apiKey, configuration, "chat/completions", model, "messages", messages, "$", apocConfig)
                 .map(v -> (Map<String, Object>) v)
                 .map(MapResult::new);
         // https://platform.openai.com/docs/api-reference/chat/create

--- a/full/src/main/java/apoc/ml/OpenAI.java
+++ b/full/src/main/java/apoc/ml/OpenAI.java
@@ -144,7 +144,7 @@ public class OpenAI {
             @Name("api_key") String apiKey,
             @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration)
             throws Exception {
-        String model = configuration.putIfAbsent("model", "gpt-4o");
+        String model = (String) configuration.putIfAbsent("model", "gpt-4o");
         return executeRequest(
                         apiKey,
                         configuration,

--- a/full/src/main/java/apoc/ml/OpenAI.java
+++ b/full/src/main/java/apoc/ml/OpenAI.java
@@ -144,11 +144,12 @@ public class OpenAI {
             @Name("api_key") String apiKey,
             @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration)
             throws Exception {
+        String model = configuration.putIfAbsent("model", "gpt-4o");
         return executeRequest(
                         apiKey,
                         configuration,
                         "chat/completions",
-                        "gpt-3.5-turbo",
+                        model,
                         "messages",
                         messages,
                         "$",

--- a/full/src/main/java/apoc/ml/Prompt.java
+++ b/full/src/main/java/apoc/ml/Prompt.java
@@ -163,7 +163,7 @@ public class Prompt {
         if (assistantPrompt != null && !assistantPrompt.isBlank())
             prompt.add(Map.of("role", "assistant", "content", assistantPrompt));
         String apiKey = (String) conf.get("apiKey");
-        String model = (String) conf.getOrDefault("model", "gpt-3.5-turbo");
+        String model = (String) conf.getOrDefault("model", "gpt-4o");
         String result = OpenAI.executeRequest(
                         apiKey, Map.of(), "chat/completions", model, "messages", prompt, "$", apocConfig)
                 .map(v -> (Map<String, Object>) v)

--- a/full/src/test/java/apoc/ml/OpenAIAzureIT.java
+++ b/full/src/test/java/apoc/ml/OpenAIAzureIT.java
@@ -64,7 +64,7 @@ public class OpenAIAzureIT {
                 db,
                 "CALL apoc.ml.openai.completion('What color is the sky? Answer in one word: ', $apiKey, $conf)",
                 getParams(OPENAI_CHAT_URL),
-                (row) -> assertCompletion(row, "gpt-35-turbo"));
+                (row) -> assertCompletion(row, "gpt-4o"));
     }
 
     @Test
@@ -75,7 +75,7 @@ public class OpenAIAzureIT {
                         + "{role:\"user\", content:\"What planet do humans live on?\"}\n"
                         + "], $apiKey, $conf)",
                 getParams(OPENAI_COMPLETION_URL),
-                (row) -> assertChatCompletion(row, "gpt-35-turbo"));
+                (row) -> assertChatCompletion(row, "gpt-4o"));
     }
 
     private static Map<String, Object> getParams(String url) {

--- a/full/src/test/java/apoc/ml/PromptIT.java
+++ b/full/src/test/java/apoc/ml/PromptIT.java
@@ -176,15 +176,13 @@ public class PromptIT {
                                     s -> assertThat(s).contains("doesn't have"));
                 });
     }
-    
+
     @Test
     public void testQueryGpt35Turbo() {
-        testResult(db, "CALL apoc.ml.query($query, {model: 'gpt-3.5-turbo', retries: $retries, apiKey: $apiKey})",
-                Map.of(
-                        "query", "What movies has Tom Hanks acted in?",
-                        "retries", 2L,
-                        "apiKey", OPENAI_KEY
-                ),
+        testResult(
+                db,
+                "CALL apoc.ml.query($query, {model: 'gpt-3.5-turbo', retries: $retries, apiKey: $apiKey})",
+                Map.of("query", "What movies has Tom Hanks acted in?", "retries", 2L, "apiKey", OPENAI_KEY),
                 (r) -> {
                     List<Map<String, Object>> list = r.stream().collect(Collectors.toList());
                     assertThat(list).hasSize(12);

--- a/full/src/test/java/apoc/ml/PromptIT.java
+++ b/full/src/test/java/apoc/ml/PromptIT.java
@@ -179,18 +179,16 @@ public class PromptIT {
     
     @Test
     public void testQueryGpt35Turbo() {
-        testResult(db, """
-                CALL apoc.ml.query($query, {model: 'gpt-3.5-turbo', retries: $retries, apiKey: $apiKey})
-                """,
+        testResult(db, "CALL apoc.ml.query($query, {model: 'gpt-3.5-turbo', retries: $retries, apiKey: $apiKey})",
                 Map.of(
                         "query", "What movies has Tom Hanks acted in?",
                         "retries", 2L,
                         "apiKey", OPENAI_KEY
                 ),
                 (r) -> {
-                    List<Map<String, Object>> list = r.stream().toList();
-                    Assertions.assertThat(list).hasSize(12);
-                    Assertions.assertThat(list.stream()
+                    List<Map<String, Object>> list = r.stream().collect(Collectors.toList());
+                    assertThat(list).hasSize(12);
+                    assertThat(list.stream()
                                     .map(m -> m.get("query"))
                                     .filter(Objects::nonNull)
                                     .map(Object::toString)

--- a/full/src/test/java/apoc/ml/PromptIT.java
+++ b/full/src/test/java/apoc/ml/PromptIT.java
@@ -176,4 +176,26 @@ public class PromptIT {
                                     s -> assertThat(s).contains("doesn't have"));
                 });
     }
+    
+    @Test
+    public void testQueryGpt35Turbo() {
+        testResult(db, """
+                CALL apoc.ml.query($query, {model: 'gpt-3.5-turbo', retries: $retries, apiKey: $apiKey})
+                """,
+                Map.of(
+                        "query", "What movies has Tom Hanks acted in?",
+                        "retries", 2L,
+                        "apiKey", OPENAI_KEY
+                ),
+                (r) -> {
+                    List<Map<String, Object>> list = r.stream().toList();
+                    Assertions.assertThat(list).hasSize(12);
+                    Assertions.assertThat(list.stream()
+                                    .map(m -> m.get("query"))
+                                    .filter(Objects::nonNull)
+                                    .map(Object::toString)
+                                    .map(String::trim))
+                            .isNotEmpty();
+                });
+    }
 }


### PR DESCRIPTION
Fixes #4133

Cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/83358f5781539d6b73ba933e761066c6574c417f