### PR TITLE
Fixex #4256: Obfuscate JDBC Password in query.log

### DIFF
--- a/extended/src/main/java/apoc/load/Jdbc.java
+++ b/extended/src/main/java/apoc/load/Jdbc.java
@@ -14,16 +14,31 @@ import org.neo4j.procedure.Procedure;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.time.ZoneId;
-import java.util.*;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.UUID;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static apoc.load.util.JdbcUtil.*;
+import static apoc.load.util.JdbcUtil.getConnection;
+import static apoc.load.util.JdbcUtil.getSqlOrKey;
+import static apoc.load.util.JdbcUtil.getUrlOrKey;
+import static apoc.load.util.JdbcUtil.obfuscateJdbcUrl;
 
 /**
  * @author mh
@@ -96,10 +111,7 @@ public class Jdbc {
                 throw sqle;
             }
         } catch (Exception e) {
-            log.error(String.format("Cannot execute SQL statement `%s`.%nError:%n%s", query, e.getMessage()),e);
-            String errorMessage = "Cannot execute SQL statement `%s`.%nError:%n%s";
-            if(e.getMessage().contains("No suitable driver")) errorMessage="Cannot execute SQL statement `%s`.%nError:%n%s%n%s";
-            throw new RuntimeException(String.format(errorMessage, query, e.getMessage(), "Please download and copy the JDBC driver into $NEO4J_HOME/plugins,more details at https://neo4j-contrib.github.io/neo4j-apoc-procedures/#_load_jdbc_resources"), e);
+            throw logsErrorAndThrowsException(e, query, log);
         }
     }
 
@@ -134,11 +146,22 @@ public class Jdbc {
                 throw sqle;
             }
         } catch (Exception e) {
-            log.error(String.format("Cannot execute SQL statement `%s`.%nError:%n%s", query, e.getMessage()),e);
-            String errorMessage = "Cannot execute SQL statement `%s`.%nError:%n%s";
-            if(e.getMessage().contains("No suitable driver")) errorMessage="Cannot execute SQL statement `%s`.%nError:%n%s%n%s";
-            throw new RuntimeException(String.format(errorMessage, query, e.getMessage(), "Please download and copy the JDBC driver into $NEO4J_HOME/plugins,more details at https://neo4j-contrib.github.io/neo4j-apoc-procedures/#_load_jdbc_resources"), e);
+            throw logsErrorAndThrowsException(e, query, log);
         }
+    }
+
+    private static RuntimeException logsErrorAndThrowsException(Exception e, String query, Log log) {
+        String errorMessage = "Cannot execute SQL statement `%s`.%nError:%n%s";
+        String exceptionMsg = e.getMessage();
+
+        if(e.getMessage().contains("No suitable driver")) {
+            errorMessage = "Cannot execute SQL statement `%s`.%nError:%n%s%n%s";
+            exceptionMsg = obfuscateJdbcUrl(e.getMessage());
+        }
+
+        Exception ex = new Exception(exceptionMsg);
+        log.error(String.format("Cannot execute SQL statement `%s`.%nError:%n%s", query, exceptionMsg), ex);
+        return new RuntimeException(String.format(errorMessage, query, exceptionMsg, "Please download and copy the JDBC driver into $NEO4J_HOME/plugins, more details at https://neo4j-contrib.github.io/neo4j-apoc-procedures/#_load_jdbc_resources"), ex);
     }
 
     static void closeIt(Log log, AutoCloseable...closeables) {

--- a/extended/src/main/java/apoc/load/util/JdbcUtil.java
+++ b/extended/src/main/java/apoc/load/util/JdbcUtil.java
@@ -81,4 +81,8 @@ public class JdbcUtil {
     public static String getSqlOrKey(String sqlOrKey) {
         return sqlOrKey.contains(" ") ? sqlOrKey : Util.getLoadUrlByConfigFile(LOAD_TYPE, sqlOrKey, "sql").orElse("SELECT * FROM " + sqlOrKey);
     }
+
+    public static String obfuscateJdbcUrl(String query) {
+        return query.replaceAll("(jdbc:[^:]+://)([^\\s\\\"']+)", "$1*******");
+    }
 }

--- a/extended/src/test/java/apoc/load/JdbcTest.java
+++ b/extended/src/test/java/apoc/load/JdbcTest.java
@@ -5,13 +5,19 @@ import apoc.util.MapUtil;
 import apoc.util.TestUtil;
 import apoc.util.Util;
 import apoc.util.collection.Iterators;
-import org.junit.*;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.dbms.api.DatabaseManagementService;
+import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.QueryExecutionException;
-import org.neo4j.test.rule.DbmsRule;
-import org.neo4j.test.rule.ImpermanentDbmsRule;
+import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 
 import java.lang.reflect.InvocationTargetException;
 import java.sql.Connection;
@@ -25,15 +31,21 @@ import java.time.ZoneId;
 import java.util.Map;
 
 import static apoc.ApocConfig.apocConfig;
+import static apoc.util.ExtendedTestUtil.assertFails;
+import static apoc.util.ExtendedTestUtil.getLogFileContent;
 import static apoc.util.MapUtil.map;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class JdbcTest extends AbstractJdbcTest {
 
     @Rule
-    public DbmsRule db = new ImpermanentDbmsRule();
+    public TemporaryFolder STORE_DIR = new TemporaryFolder();
+
+    private GraphDatabaseService db;
+    private DatabaseManagementService dbms;
 
     private Connection conn;
 
@@ -47,6 +59,9 @@ public class JdbcTest extends AbstractJdbcTest {
 
     @Before
     public void setUp() throws Exception {
+        dbms = new TestDatabaseManagementServiceBuilder(STORE_DIR.getRoot().toPath()).build();
+        db = dbms.database(GraphDatabaseSettings.DEFAULT_DATABASE_NAME);
+
         apocConfig().setProperty("apoc.jdbc.derby.url","jdbc:derby:derbyDB");
         apocConfig().setProperty("apoc.jdbc.test.sql","SELECT * FROM PERSON");
         apocConfig().setProperty("apoc.jdbc.testparams.sql","SELECT * FROM PERSON WHERE NAME = ?");
@@ -77,11 +92,6 @@ public class JdbcTest extends AbstractJdbcTest {
         System.clearProperty("derby.user.apoc");
     }
 
-    @AfterAll
-    public void tearDownAll() {
-        db.shutdown();
-    }
-
     @Test
     public void testLoadJdbc() throws Exception {
         testCall(db, "CALL apoc.load.jdbc('jdbc:derby:derbyDB','PERSON')",
@@ -109,6 +119,21 @@ public class JdbcTest extends AbstractJdbcTest {
     public void testLoadJdbcParams() throws Exception {
         testCall(db, "CALL apoc.load.jdbc('jdbc:derby:derbyDB','SELECT * FROM PERSON WHERE NAME = ?',['John'])", //  YIELD row RETURN row
                 (row) -> assertResult(row));
+    }
+
+    @Test
+    public void testExceptionAndLogWithObfuscatedUrl() {
+        String url = "jdbc:ajeje://localhost:3306/data_mart?user=root&password=root";
+        String errorMsgWithObfuscatedUrl = "No suitable driver found for jdbc:ajeje://*******";
+        
+        // obfuscated exception
+        assertFails(db, "CALL apoc.load.jdbc($url,'SELECT * FROM PERSON WHERE NAME = ?',['John'])",
+                Map.of("url", url),
+                errorMsgWithObfuscatedUrl
+        );
+
+        // obfuscated log in `debug.log` 
+        assertTrue(getLogFileContent().contains(errorMsgWithObfuscatedUrl));
     }
 
     @Test

--- a/extended/src/test/java/apoc/load/LoadLdapTest.java
+++ b/extended/src/test/java/apoc/load/LoadLdapTest.java
@@ -1,7 +1,6 @@
 package apoc.load;
 
 
-import apoc.util.FileUtils;
 import apoc.util.TestUtil;
 import com.unboundid.ldap.sdk.LDAPConnection;
 import com.unboundid.ldap.sdk.SearchResult;
@@ -18,13 +17,11 @@ import org.neo4j.test.TestDatabaseManagementServiceBuilder;
 import org.zapodot.junit.ldap.EmbeddedLdapRule;
 import org.zapodot.junit.ldap.EmbeddedLdapRuleBuilder;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 
 import static apoc.ApocConfig.apocConfig;
+import static apoc.util.ExtendedTestUtil.getLogFileContent;
 import static apoc.util.TestUtil.testCall;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -94,15 +91,6 @@ public class LoadLdapTest {
         // the config without dot after loadldap should print a log warn
         String logWarn = "Not to cause breaking-change, the current config `apoc.loadldapmyldap.config` is valid";
         assertTrue(getLogFileContent().contains(logWarn));
-    }
-
-    private static String getLogFileContent() {
-        try {
-            File logFile = new File(FileUtils.getLogDirectory(), "debug.log");
-            return Files.readString(logFile.toPath());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     private void testWithStringConfigCommon(String key) {

--- a/extended/src/test/java/apoc/util/ExtendedTestUtil.java
+++ b/extended/src/test/java/apoc/util/ExtendedTestUtil.java
@@ -12,6 +12,9 @@ import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.internal.helpers.collection.Iterators;
 import org.neo4j.test.assertion.Assert;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -139,6 +142,15 @@ public class ExtendedTestUtil {
         } catch (Exception e) {
             String actualErrMsg = e.getMessage();
             assertTrue("Actual err. message is: " + actualErrMsg, actualErrMsg.contains(expectedErrMsg));
+        }
+    }
+
+    public static String getLogFileContent() {
+        try {
+            File logFile = new File(FileUtils.getLogDirectory(), "debug.log");
+            return Files.readString(logFile.toPath());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
     }
 }


### PR DESCRIPTION
Fixex #4256

To solve the related issue, we suggest the user to use these 2 parameters:
```
db.logs.query.obfuscate_literals=true
db.logs.query.parameter_logging_enabled=false
```
and he agrees with the tip.

In any case, even with these changes, we still need to handle some errors correctly.


Added a custom exception to obfuscate in logs and the returning RuntimeException, 
since the connection string may contain the password.

Therefore, executing:
```
CALL apoc.load.jdbc("jdbc:notexistent://localhost:3306/data_mart?user=root&password=root","products")
```

the following exception (and log) will be returned:
```
java.sql.SQLException:
No suitable driver found for jdbc:notexistent://***
```

instead of the previous one:
```
java.sql.SQLException:
No suitable driver found for jdbc:notexistent://localhost:3306/data_mart?user=root&password=root
```