### PR TITLE
[NOID] Fixes #4197: apoc.monitor.store fails for block stores (#4223)

### DIFF
--- a/full-it/src/test/java/apoc/full/it/monitor/StoreInfoProcedureEnterpriseTest.java
+++ b/full-it/src/test/java/apoc/full/it/monitor/StoreInfoProcedureEnterpriseTest.java
@@ -1,18 +1,16 @@
 package apoc.full.it.monitor;
 
-import apoc.util.Neo4jContainerExtension;
-import apoc.util.TestContainerUtil;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import org.neo4j.driver.Session;
-
-import java.util.List;
-
 import static apoc.util.TestContainerUtil.createEnterpriseDB;
 import static apoc.util.TestContainerUtil.testCall;
 import static org.junit.Assert.assertNotNull;
+
+import apoc.util.Neo4jContainerExtension;
+import apoc.util.TestContainerUtil;
+import java.util.List;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.neo4j.driver.Session;
 
 public class StoreInfoProcedureEnterpriseTest {
     private static Neo4jContainerExtension neo4jContainer;

--- a/full-it/src/test/java/apoc/full/it/monitor/StoreInfoProcedureEnterpriseTest.java
+++ b/full-it/src/test/java/apoc/full/it/monitor/StoreInfoProcedureEnterpriseTest.java
@@ -1,0 +1,47 @@
+package apoc.full.it.monitor;
+
+import apoc.util.Neo4jContainerExtension;
+import apoc.util.TestContainerUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.neo4j.driver.Session;
+
+import java.util.List;
+
+import static apoc.util.TestContainerUtil.createEnterpriseDB;
+import static apoc.util.TestContainerUtil.testCall;
+import static org.junit.Assert.assertNotNull;
+
+public class StoreInfoProcedureEnterpriseTest {
+    private static Neo4jContainerExtension neo4jContainer;
+    private static Session session;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.FULL), true);
+        neo4jContainer.start();
+
+        session = neo4jContainer.getSession();
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        session.close();
+        neo4jContainer.close();
+    }
+
+    @Test
+    public void testGetStoreInfo() {
+        testCall(session, "CALL apoc.monitor.store()", (row) -> {
+            assertNotNull(row.get("logSize"));
+            assertNotNull(row.get("stringStoreSize"));
+            assertNotNull(row.get("arrayStoreSize"));
+            assertNotNull(row.get("nodeStoreSize"));
+            assertNotNull(row.get("relStoreSize"));
+            assertNotNull(row.get("propStoreSize"));
+            assertNotNull(row.get("totalStoreSize"));
+        });
+    }
+}

--- a/full/src/main/java/apoc/monitor/Store.java
+++ b/full/src/main/java/apoc/monitor/Store.java
@@ -44,7 +44,7 @@ public class Store {
 
         Database database = ((GraphDatabaseAPI) db).getDependencyResolver().resolveDependency(Database.class);
         // This will work only on Record format databases. Has to be updated when any additional format is available
-        RecordDatabaseLayout databaseLayout = RecordDatabaseLayout.cast(database.getDatabaseLayout());
+        RecordDatabaseLayout databaseLayout = RecordDatabaseLayout.convert(database.getDatabaseLayout());
         return Stream.of(new StoreInfoResult(
                 getDirectorySize(databaseLayout.getTransactionLogsDirectory().toFile()),
                 databaseLayout.propertyStringStore().toFile().length(),


### PR DESCRIPTION
Fixes #4197

Cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/4044f236bd6644c9247e32a510b7cf3b9111e99c