### PR TITLE
Remove stored map of Procedure Handlers

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "dev", "5.26" ]
   pull_request:
-    branches: [ "dev" ]
+    branches: [ "dev", "5.26" ]
 
 env:
   CODEARTIFACT_DOWNLOAD_URL: ${{ secrets.CODEARTIFACT_DOWNLOAD_URL }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "apoc-core"]
 	path = apoc-core
 	url = https://github.com/neo4j/apoc
-	branch = 5.26_availabilitylistener_registry_update
+	branch = 5.26

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "apoc-core"]
 	path = apoc-core
 	url = https://github.com/neo4j/apoc
-	branch = dev
+	branch = 5.26_availabilitylistener_registry_update

--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
     neo4jVersion = "5.26.0"
     // instead we apply the override logic here
-    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion + "-SNAPSHOT"
+    neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.20.2'
     apacheArrowVersion = '15.0.0'
 }

--- a/extended-it/src/test/java/apoc/neo4j/docker/StartupExtendedTest.java
+++ b/extended-it/src/test/java/apoc/neo4j/docker/StartupExtendedTest.java
@@ -116,8 +116,8 @@ public class StartupExtendedTest {
         final List<String> procedureNames = getNames(session, APOC_HELP_QUERY,
                 Map.of("core", true, "type", "procedure") );
 
-        assertEquals(sorted(ApocSignatures.PROCEDURES), procedureNames);
-        assertEquals(sorted(ApocSignatures.FUNCTIONS), functionNames);
+        assertEquals(sorted(ApocSignatures.PROCEDURES_CYPHER_5), procedureNames);
+        assertEquals(sorted(ApocSignatures.FUNCTIONS_CYPHER_5), functionNames);
     }
 
     private static List<String> getNames(Session session, String query, Map<String, Object> params) {

--- a/extended/src/main/java/apoc/ExtendedApocGlobalComponents.java
+++ b/extended/src/main/java/apoc/ExtendedApocGlobalComponents.java
@@ -8,7 +8,6 @@ import apoc.ttl.TTLLifeCycle;
 import apoc.uuid.Uuid;
 import apoc.uuid.UuidHandler;
 import org.neo4j.annotations.service.ServiceProvider;
-import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.kernel.availability.AvailabilityListener;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.lifecycle.Lifecycle;
@@ -17,16 +16,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 @ServiceProvider
 public class ExtendedApocGlobalComponents implements ApocGlobalComponents {
 
-    private final Map<GraphDatabaseService,CypherProceduresHandler> cypherProcedureHandlers = new ConcurrentHashMap<>();
-
     @Override
     public Map<String, Lifecycle> getServices(GraphDatabaseAPI db, ApocExtensionFactory.Dependencies dependencies) {
-
 
         CypherProceduresHandler cypherProcedureHandler = new CypherProceduresHandler(
                 db,
@@ -35,7 +30,6 @@ public class ExtendedApocGlobalComponents implements ApocGlobalComponents {
                 dependencies.log().getUserLog(CypherProcedures.class),
                 dependencies.globalProceduresRegistry()
         );
-        cypherProcedureHandlers.put(db, cypherProcedureHandler);
 
         return Map.of(
 
@@ -66,7 +60,6 @@ public class ExtendedApocGlobalComponents implements ApocGlobalComponents {
 
     @Override
     public Iterable<AvailabilityListener> getListeners(GraphDatabaseAPI db, ApocExtensionFactory.Dependencies dependencies) {
-        CypherProceduresHandler cypherProceduresHandler = cypherProcedureHandlers.get(db);
-        return cypherProceduresHandler==null ? Collections.emptyList() : Collections.singleton(cypherProceduresHandler);
+        return Collections.emptyList();
     }
 }

--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -28,7 +28,6 @@ import org.neo4j.kernel.api.procedure.CallableProcedure;
 import org.neo4j.kernel.api.procedure.CallableUserFunction;
 import org.neo4j.kernel.api.procedure.Context;
 import org.neo4j.kernel.api.procedure.GlobalProcedures;
-import org.neo4j.kernel.availability.AvailabilityListener;
 import org.neo4j.kernel.impl.util.ValueUtils;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
@@ -63,7 +62,7 @@ import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.AnyType;
 import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.NTAny;
 import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.NTMap;
 
-public class CypherProceduresHandler extends LifecycleAdapter implements AvailabilityListener {
+public class CypherProceduresHandler extends LifecycleAdapter {
     public static final String PREFIX = "custom";
     public static final String FUNCTION = "function";
     public static final String PROCEDURE = "procedure";
@@ -95,7 +94,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
     }
 
     @Override
-    public void available() {
+    public void start() {
         restoreProceduresAndFunctions();
         long refreshInterval = apocConfig().getInt(CUSTOM_PROCEDURES_REFRESH, 60000);
         restoreProceduresHandle = jobScheduler.scheduleRecurring(REFRESH_GROUP, () -> {
@@ -106,7 +105,7 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
     }
 
     @Override
-    public void unavailable() {
+    public void stop() {
         if (restoreProceduresHandle != null) {
             restoreProceduresHandle.cancel();
         }

--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -28,6 +28,7 @@ import org.neo4j.kernel.api.procedure.CallableProcedure;
 import org.neo4j.kernel.api.procedure.CallableUserFunction;
 import org.neo4j.kernel.api.procedure.Context;
 import org.neo4j.kernel.api.procedure.GlobalProcedures;
+import org.neo4j.kernel.availability.AvailabilityListener;
 import org.neo4j.kernel.impl.util.ValueUtils;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
@@ -62,7 +63,7 @@ import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.AnyType;
 import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.NTAny;
 import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.NTMap;
 
-public class CypherProceduresHandler extends LifecycleAdapter {
+public class CypherProceduresHandler extends LifecycleAdapter implements AvailabilityListener {
     public static final String PREFIX = "custom";
     public static final String FUNCTION = "function";
     public static final String PROCEDURE = "procedure";
@@ -94,7 +95,7 @@ public class CypherProceduresHandler extends LifecycleAdapter {
     }
 
     @Override
-    public void start() {
+    public void available() {
         restoreProceduresAndFunctions();
         long refreshInterval = apocConfig().getInt(CUSTOM_PROCEDURES_REFRESH, 60000);
         restoreProceduresHandle = jobScheduler.scheduleRecurring(REFRESH_GROUP, () -> {
@@ -105,7 +106,7 @@ public class CypherProceduresHandler extends LifecycleAdapter {
     }
 
     @Override
-    public void stop() {
+    public void unavailable() {
         if (restoreProceduresHandle != null) {
             restoreProceduresHandle.cancel();
         }


### PR DESCRIPTION
Instead of storing a map of the custom procedure handler to reference as a listener, which can cause a memory leak, common has been updated to find listeners and then add them. This means we can remove the map.