### PR TITLE
Fixes #4245: Add integration test to check that apache.commons.collections is not present anymore

### DIFF
--- a/extended-it/src/test/java/apoc/util/WeaviateTestUtil.java
+++ b/extended-it/src/test/java/apoc/util/WeaviateTestUtil.java
@@ -35,7 +35,7 @@ public class WeaviateTestUtil {
     public static final String ID_1 = "8ef2b3a7-1e56-4ddd-b8c3-2ca8901ce308";
     public static final String ID_2 = "9ef2b3a7-1e56-4ddd-b8c3-2ca8901ce308";
 
-    public static String HOST_WEAVIATE;
+    public static String HOST;
     public static final int WEAVIATE_PORT = 8080;
 
     public static final String WEAVIATE_CREATE_COLLECTION_APOC = "CALL apoc.vectordb.weaviate.createCollection($host, 'TestCollection', 'cosine', 4, $conf)";

--- a/extended-it/src/test/java/apoc/util/WeaviateTestUtil.java
+++ b/extended-it/src/test/java/apoc/util/WeaviateTestUtil.java
@@ -1,0 +1,71 @@
+package apoc.util;
+
+import org.testcontainers.weaviate.WeaviateContainer;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import static apoc.ml.RestAPIConfig.HEADERS_KEY;
+import static apoc.util.Util.map;
+import static apoc.vectordb.VectorDbTestUtil.EntityType.FALSE;
+import static apoc.vectordb.VectorDbTestUtil.assertBerlinResult;
+import static apoc.vectordb.VectorDbTestUtil.assertLondonResult;
+import static apoc.vectordb.VectorDbTestUtil.getAuthHeader;
+import static org.junit.Assert.assertNotNull;
+
+public class WeaviateTestUtil {
+    public static final List<String> FIELDS = List.of("city", "foo");
+    public static final String ADMIN_KEY = "jane-secret-key";
+    public static final String READONLY_KEY = "ian-secret-key";
+    public static final String COLLECTION_NAME = "TestCollection";
+
+    public static final WeaviateContainer WEAVIATE_CONTAINER = new WeaviateContainer("semitechnologies/weaviate:1.24.5")
+            .withEnv("AUTHENTICATION_APIKEY_ENABLED", "true")
+            .withEnv("AUTHENTICATION_APIKEY_ALLOWED_KEYS", ADMIN_KEY + "," + READONLY_KEY)
+            .withEnv("AUTHENTICATION_APIKEY_USERS", "jane@doe.com,ian-smith")
+            .withEnv("AUTHORIZATION_ADMINLIST_ENABLED", "true")
+            .withEnv("AUTHORIZATION_ADMINLIST_USERS", "jane@doe.com,john@doe.com")
+            .withEnv("AUTHORIZATION_ADMINLIST_READONLY_USERS", "ian-smith,roberta@doe.com");
+
+    public static final Map<String, String> ADMIN_AUTHORIZATION = getAuthHeader(ADMIN_KEY);
+    public static final Map<String, String> READONLY_AUTHORIZATION = getAuthHeader(READONLY_KEY);
+    public static final Map<String, Object> ADMIN_HEADER_CONF = map(HEADERS_KEY, ADMIN_AUTHORIZATION);
+
+    public static final String ID_1 = "8ef2b3a7-1e56-4ddd-b8c3-2ca8901ce308";
+    public static final String ID_2 = "9ef2b3a7-1e56-4ddd-b8c3-2ca8901ce308";
+
+    public static String HOST;
+    public static final int WEAVIATE_PORT = 8080;
+
+    public static final String WEAVIATE_CREATE_COLLECTION_APOC = "CALL apoc.vectordb.weaviate.createCollection($host, 'TestCollection', 'cosine', 4, $conf)";
+
+    public static final String WEAVIATE_DELETE_COLLECTION_APOC = "CALL apoc.vectordb.weaviate.deleteCollection($host, $collectionName, $conf)";
+
+    public static final String WEAVIATE_QUERY_APOC = "CALL apoc.vectordb.weaviate.query($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf) YIELD score, vector, id, metadata RETURN * ORDER BY id";
+
+    public static final String WEAVIATE_DELETE_VECTOR_APOC = "CALL apoc.vectordb.weaviate.delete($host, 'TestCollection', ['7ef2b3a7-1e56-4ddd-b8c3-2ca8901ce308', '7ef2b3a7-1e56-4ddd-b8c3-2ca8901ce309'], $conf)";
+
+    public static final String WEAVIATE_UPSERT_QUERY = """
+                CALL apoc.vectordb.weaviate.upsert($host, 'TestCollection',
+                [
+                    {id: $id1, vector: [0.05, 0.61, 0.76, 0.74], metadata: {city: "Berlin", foo: "one"}},
+                    {id: $id2, vector: [0.19, 0.81, 0.75, 0.11], metadata: {city: "London", foo: "two"}},
+                    {id: '7ef2b3a7-1e56-4ddd-b8c3-2ca8901ce308', vector: [0.19, 0.81, 0.75, 0.11], metadata: {foo: "baz"}},
+                    {id: '7ef2b3a7-1e56-4ddd-b8c3-2ca8901ce309', vector: [0.19, 0.81, 0.75, 0.11], metadata: {foo: "baz"}}
+                ],
+                $conf)
+                """;
+
+    public static void queryVectorsAssertions(Iterator<Map<String, Object>> r) {
+        Map<String, Object> row = r.next();
+        assertBerlinResult(row, ID_1, FALSE);
+        assertNotNull(row.get("score"));
+        assertNotNull(row.get("vector"));
+
+        row = r.next();
+        assertLondonResult(row, ID_2, FALSE);
+        assertNotNull(row.get("score"));
+        assertNotNull(row.get("vector"));
+    }
+}

--- a/extended-it/src/test/java/apoc/util/WeaviateTestUtil.java
+++ b/extended-it/src/test/java/apoc/util/WeaviateTestUtil.java
@@ -35,7 +35,7 @@ public class WeaviateTestUtil {
     public static final String ID_1 = "8ef2b3a7-1e56-4ddd-b8c3-2ca8901ce308";
     public static final String ID_2 = "9ef2b3a7-1e56-4ddd-b8c3-2ca8901ce308";
 
-    public static String HOST;
+    public static String HOST_WEAVIATE;
     public static final int WEAVIATE_PORT = 8080;
 
     public static final String WEAVIATE_CREATE_COLLECTION_APOC = "CALL apoc.vectordb.weaviate.createCollection($host, 'TestCollection', 'cosine', 4, $conf)";

--- a/extended-it/src/test/java/apoc/vectordb/WeaviateEnterpriseTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/WeaviateEnterpriseTest.java
@@ -1,0 +1,108 @@
+package apoc.vectordb;
+
+import apoc.util.MapUtil;
+import apoc.util.Neo4jContainerExtension;
+import apoc.util.TestContainerUtil;
+import apoc.util.WeaviateTestUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.neo4j.driver.Session;
+
+import java.util.List;
+import java.util.Map;
+
+import static apoc.ml.RestAPIConfig.HEADERS_KEY;
+import static apoc.util.TestContainerUtil.createEnterpriseDB;
+import static apoc.util.TestContainerUtil.testCall;
+import static apoc.util.TestContainerUtil.testCallEmpty;
+import static apoc.util.TestContainerUtil.testResult;
+import static apoc.util.Util.map;
+import static apoc.util.WeaviateTestUtil.ADMIN_AUTHORIZATION;
+import static apoc.util.WeaviateTestUtil.ADMIN_HEADER_CONF;
+import static apoc.util.WeaviateTestUtil.COLLECTION_NAME;
+import static apoc.util.WeaviateTestUtil.FIELDS;
+import static apoc.util.WeaviateTestUtil.HOST;
+import static apoc.util.WeaviateTestUtil.ID_1;
+import static apoc.util.WeaviateTestUtil.ID_2;
+import static apoc.util.WeaviateTestUtil.WEAVIATE_CONTAINER;
+import static apoc.util.WeaviateTestUtil.WEAVIATE_CREATE_COLLECTION_APOC;
+import static apoc.util.WeaviateTestUtil.WEAVIATE_DELETE_COLLECTION_APOC;
+import static apoc.util.WeaviateTestUtil.WEAVIATE_DELETE_VECTOR_APOC;
+import static apoc.util.WeaviateTestUtil.WEAVIATE_PORT;
+import static apoc.util.WeaviateTestUtil.WEAVIATE_QUERY_APOC;
+import static apoc.util.WeaviateTestUtil.WEAVIATE_UPSERT_QUERY;
+import static apoc.vectordb.VectorEmbeddingConfig.ALL_RESULTS_KEY;
+import static apoc.vectordb.VectorEmbeddingConfig.FIELDS_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+
+public class WeaviateEnterpriseTest {
+
+    @ClassRule
+    public static TemporaryFolder storeDir = new TemporaryFolder();
+    private static Neo4jContainerExtension neo4jContainer;
+    private static Session session;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        // We build the project, the artifact will be placed into ./build/libs
+        neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.EXTENDED), true);
+        neo4jContainer.start();
+        session = neo4jContainer.getSession();
+
+        WEAVIATE_CONTAINER.start();
+        HOST = "http://host.docker.internal:" + WEAVIATE_CONTAINER.getMappedPort(WEAVIATE_PORT);
+
+        testCall(session, WEAVIATE_CREATE_COLLECTION_APOC,
+                map("host", HOST, "conf", ADMIN_HEADER_CONF),
+                r -> {
+                    Map value = (Map) r.get("value");
+                    assertEquals("TestCollection", value.get("class"));
+                });
+
+        testResult(session, WEAVIATE_UPSERT_QUERY,
+                map("host", HOST, "id1", ID_1, "id2", ID_2, "conf", ADMIN_HEADER_CONF),
+                r -> {
+                    Map<String, Object> row = r.next();
+                    Map<String, Object> value = (Map<String, Object>) row.get("value");
+
+                    assertEquals(COLLECTION_NAME, value.get("class"));
+
+                    while (r.hasNext()) {
+                        row = r.next();
+                        value = (Map<String, Object>) row.get("value");
+                        assertEquals(COLLECTION_NAME, value.get("class"));
+                    }
+                    assertFalse(r.hasNext());
+                });
+
+        // -- delete vector
+        testCall(session, WEAVIATE_DELETE_VECTOR_APOC,
+                map("host", HOST, "conf", ADMIN_HEADER_CONF),
+                r -> {
+                    List value = (List) r.get("value");
+                    assertEquals(List.of("7ef2b3a7-1e56-4ddd-b8c3-2ca8901ce308", "7ef2b3a7-1e56-4ddd-b8c3-2ca8901ce309"), value);
+                });
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        testCallEmpty(session, WEAVIATE_DELETE_COLLECTION_APOC,
+                MapUtil.map("host", HOST, "collectionName", COLLECTION_NAME, "conf", ADMIN_HEADER_CONF)
+        );
+        session.close();
+        neo4jContainer.close();
+        WEAVIATE_CONTAINER.stop();
+    }
+
+    @Test
+    public void queryVectors() {
+        testResult(session,  WEAVIATE_QUERY_APOC,
+                map("host", HOST, "conf", map(ALL_RESULTS_KEY, true, FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION)),
+                WeaviateTestUtil::queryVectorsAssertions);
+    }
+}

--- a/extended-it/src/test/java/apoc/vectordb/WeaviateEnterpriseTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/WeaviateEnterpriseTest.java
@@ -10,6 +10,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.neo4j.driver.Session;
+import org.testcontainers.containers.Network;
 
 import java.util.List;
 import java.util.Map;
@@ -24,7 +25,7 @@ import static apoc.util.WeaviateTestUtil.ADMIN_AUTHORIZATION;
 import static apoc.util.WeaviateTestUtil.ADMIN_HEADER_CONF;
 import static apoc.util.WeaviateTestUtil.COLLECTION_NAME;
 import static apoc.util.WeaviateTestUtil.FIELDS;
-import static apoc.util.WeaviateTestUtil.HOST;
+import static apoc.util.WeaviateTestUtil.HOST_WEAVIATE;
 import static apoc.util.WeaviateTestUtil.ID_1;
 import static apoc.util.WeaviateTestUtil.ID_2;
 import static apoc.util.WeaviateTestUtil.WEAVIATE_CONTAINER;
@@ -49,23 +50,32 @@ public class WeaviateEnterpriseTest {
 
     @BeforeClass
     public static void setUp() throws Exception {
+        Network network = Network.newNetwork();
+        
         // We build the project, the artifact will be placed into ./build/libs
-        neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.EXTENDED), true);
+        neo4jContainer = createEnterpriseDB(List.of(TestContainerUtil.ApocPackage.EXTENDED), true)
+                .withNetwork(network)
+                .withNetworkAliases("neo4j");
         neo4jContainer.start();
         session = neo4jContainer.getSession();
 
+        String weaviateAlias = "weaviate";
+        WEAVIATE_CONTAINER.withNetwork(network)
+                .withNetworkAliases(weaviateAlias)
+                .withExposedPorts(WEAVIATE_PORT);
         WEAVIATE_CONTAINER.start();
-        HOST = "http://host.docker.internal:" + WEAVIATE_CONTAINER.getMappedPort(WEAVIATE_PORT);
+        
+        HOST_WEAVIATE = weaviateAlias + ":" + WEAVIATE_PORT;
 
         testCall(session, WEAVIATE_CREATE_COLLECTION_APOC,
-                map("host", HOST, "conf", ADMIN_HEADER_CONF),
+                map("host", HOST_WEAVIATE, "conf", ADMIN_HEADER_CONF),
                 r -> {
                     Map value = (Map) r.get("value");
                     assertEquals("TestCollection", value.get("class"));
                 });
 
         testResult(session, WEAVIATE_UPSERT_QUERY,
-                map("host", HOST, "id1", ID_1, "id2", ID_2, "conf", ADMIN_HEADER_CONF),
+                map("host", HOST_WEAVIATE, "id1", ID_1, "id2", ID_2, "conf", ADMIN_HEADER_CONF),
                 r -> {
                     Map<String, Object> row = r.next();
                     Map<String, Object> value = (Map<String, Object>) row.get("value");
@@ -82,7 +92,7 @@ public class WeaviateEnterpriseTest {
 
         // -- delete vector
         testCall(session, WEAVIATE_DELETE_VECTOR_APOC,
-                map("host", HOST, "conf", ADMIN_HEADER_CONF),
+                map("host", HOST_WEAVIATE, "conf", ADMIN_HEADER_CONF),
                 r -> {
                     List value = (List) r.get("value");
                     assertEquals(List.of("7ef2b3a7-1e56-4ddd-b8c3-2ca8901ce308", "7ef2b3a7-1e56-4ddd-b8c3-2ca8901ce309"), value);
@@ -92,7 +102,7 @@ public class WeaviateEnterpriseTest {
     @AfterClass
     public static void tearDown() throws Exception {
         testCallEmpty(session, WEAVIATE_DELETE_COLLECTION_APOC,
-                MapUtil.map("host", HOST, "collectionName", COLLECTION_NAME, "conf", ADMIN_HEADER_CONF)
+                MapUtil.map("host", HOST_WEAVIATE, "collectionName", COLLECTION_NAME, "conf", ADMIN_HEADER_CONF)
         );
         session.close();
         neo4jContainer.close();
@@ -102,7 +112,7 @@ public class WeaviateEnterpriseTest {
     @Test
     public void queryVectors() {
         testResult(session,  WEAVIATE_QUERY_APOC,
-                map("host", HOST, "conf", map(ALL_RESULTS_KEY, true, FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION)),
+                map("host", HOST_WEAVIATE, "conf", map(ALL_RESULTS_KEY, true, FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION)),
                 WeaviateTestUtil::queryVectorsAssertions);
     }
 }

--- a/extended-it/src/test/java/apoc/vectordb/WeaviateEnterpriseTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/WeaviateEnterpriseTest.java
@@ -25,7 +25,7 @@ import static apoc.util.WeaviateTestUtil.ADMIN_AUTHORIZATION;
 import static apoc.util.WeaviateTestUtil.ADMIN_HEADER_CONF;
 import static apoc.util.WeaviateTestUtil.COLLECTION_NAME;
 import static apoc.util.WeaviateTestUtil.FIELDS;
-import static apoc.util.WeaviateTestUtil.HOST_WEAVIATE;
+import static apoc.util.WeaviateTestUtil.HOST;
 import static apoc.util.WeaviateTestUtil.ID_1;
 import static apoc.util.WeaviateTestUtil.ID_2;
 import static apoc.util.WeaviateTestUtil.WEAVIATE_CONTAINER;
@@ -65,17 +65,17 @@ public class WeaviateEnterpriseTest {
                 .withExposedPorts(WEAVIATE_PORT);
         WEAVIATE_CONTAINER.start();
         
-        HOST_WEAVIATE = weaviateAlias + ":" + WEAVIATE_PORT;
+        HOST = weaviateAlias + ":" + WEAVIATE_PORT;
 
         testCall(session, WEAVIATE_CREATE_COLLECTION_APOC,
-                map("host", HOST_WEAVIATE, "conf", ADMIN_HEADER_CONF),
+                map("host", HOST, "conf", ADMIN_HEADER_CONF),
                 r -> {
                     Map value = (Map) r.get("value");
                     assertEquals("TestCollection", value.get("class"));
                 });
 
         testResult(session, WEAVIATE_UPSERT_QUERY,
-                map("host", HOST_WEAVIATE, "id1", ID_1, "id2", ID_2, "conf", ADMIN_HEADER_CONF),
+                map("host", HOST, "id1", ID_1, "id2", ID_2, "conf", ADMIN_HEADER_CONF),
                 r -> {
                     Map<String, Object> row = r.next();
                     Map<String, Object> value = (Map<String, Object>) row.get("value");
@@ -92,7 +92,7 @@ public class WeaviateEnterpriseTest {
 
         // -- delete vector
         testCall(session, WEAVIATE_DELETE_VECTOR_APOC,
-                map("host", HOST_WEAVIATE, "conf", ADMIN_HEADER_CONF),
+                map("host", HOST, "conf", ADMIN_HEADER_CONF),
                 r -> {
                     List value = (List) r.get("value");
                     assertEquals(List.of("7ef2b3a7-1e56-4ddd-b8c3-2ca8901ce308", "7ef2b3a7-1e56-4ddd-b8c3-2ca8901ce309"), value);
@@ -102,7 +102,7 @@ public class WeaviateEnterpriseTest {
     @AfterClass
     public static void tearDown() throws Exception {
         testCallEmpty(session, WEAVIATE_DELETE_COLLECTION_APOC,
-                MapUtil.map("host", HOST_WEAVIATE, "collectionName", COLLECTION_NAME, "conf", ADMIN_HEADER_CONF)
+                MapUtil.map("host", HOST, "collectionName", COLLECTION_NAME, "conf", ADMIN_HEADER_CONF)
         );
         session.close();
         neo4jContainer.close();
@@ -112,7 +112,7 @@ public class WeaviateEnterpriseTest {
     @Test
     public void queryVectors() {
         testResult(session,  WEAVIATE_QUERY_APOC,
-                map("host", HOST_WEAVIATE, "conf", map(ALL_RESULTS_KEY, true, FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION)),
+                map("host", HOST, "conf", map(ALL_RESULTS_KEY, true, FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION)),
                 WeaviateTestUtil::queryVectorsAssertions);
     }
 }

--- a/extended-it/src/test/java/apoc/vectordb/WeaviateTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/WeaviateTest.java
@@ -4,6 +4,7 @@ import apoc.ml.Prompt;
 import apoc.util.ExtendedTestUtil;
 import apoc.util.MapUtil;
 import apoc.util.TestUtil;
+import apoc.util.WeaviateTestUtil;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -15,7 +16,6 @@ import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.test.TestDatabaseManagementServiceBuilder;
-import org.testcontainers.weaviate.WeaviateContainer;
 
 import java.util.List;
 import java.util.Map;
@@ -27,6 +27,21 @@ import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testCallEmpty;
 import static apoc.util.TestUtil.testResult;
 import static apoc.util.Util.map;
+import static apoc.util.WeaviateTestUtil.ADMIN_AUTHORIZATION;
+import static apoc.util.WeaviateTestUtil.ADMIN_HEADER_CONF;
+import static apoc.util.WeaviateTestUtil.ADMIN_KEY;
+import static apoc.util.WeaviateTestUtil.COLLECTION_NAME;
+import static apoc.util.WeaviateTestUtil.FIELDS;
+import static apoc.util.WeaviateTestUtil.HOST;
+import static apoc.util.WeaviateTestUtil.ID_1;
+import static apoc.util.WeaviateTestUtil.ID_2;
+import static apoc.util.WeaviateTestUtil.READONLY_AUTHORIZATION;
+import static apoc.util.WeaviateTestUtil.WEAVIATE_CONTAINER;
+import static apoc.util.WeaviateTestUtil.WEAVIATE_CREATE_COLLECTION_APOC;
+import static apoc.util.WeaviateTestUtil.WEAVIATE_DELETE_COLLECTION_APOC;
+import static apoc.util.WeaviateTestUtil.WEAVIATE_DELETE_VECTOR_APOC;
+import static apoc.util.WeaviateTestUtil.WEAVIATE_QUERY_APOC;
+import static apoc.util.WeaviateTestUtil.WEAVIATE_UPSERT_QUERY;
 import static apoc.vectordb.VectorDbHandler.Type.WEAVIATE;
 import static apoc.vectordb.VectorDbTestUtil.EntityType.FALSE;
 import static apoc.vectordb.VectorDbTestUtil.EntityType.NODE;
@@ -37,12 +52,17 @@ import static apoc.vectordb.VectorDbTestUtil.assertNodesCreated;
 import static apoc.vectordb.VectorDbTestUtil.assertReadOnlyProcWithMappingResults;
 import static apoc.vectordb.VectorDbTestUtil.assertRelsCreated;
 import static apoc.vectordb.VectorDbTestUtil.dropAndDeleteAll;
-import static apoc.vectordb.VectorDbTestUtil.getAuthHeader;
 import static apoc.vectordb.VectorDbTestUtil.ragSetup;
 import static apoc.vectordb.VectorEmbeddingConfig.ALL_RESULTS_KEY;
 import static apoc.vectordb.VectorEmbeddingConfig.FIELDS_KEY;
 import static apoc.vectordb.VectorEmbeddingConfig.MAPPING_KEY;
-import static apoc.vectordb.VectorMappingConfig.*;
+import static apoc.vectordb.VectorMappingConfig.EMBEDDING_KEY;
+import static apoc.vectordb.VectorMappingConfig.ENTITY_KEY;
+import static apoc.vectordb.VectorMappingConfig.METADATA_KEY;
+import static apoc.vectordb.VectorMappingConfig.MODE_KEY;
+import static apoc.vectordb.VectorMappingConfig.MappingMode;
+import static apoc.vectordb.VectorMappingConfig.NODE_LABEL;
+import static apoc.vectordb.VectorMappingConfig.REL_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -54,29 +74,7 @@ import static org.neo4j.configuration.GraphDatabaseSettings.SYSTEM_DATABASE_NAME
 
 
 public class WeaviateTest {
-    private static final List<String> FIELDS = List.of("city", "foo");
-    private static final String ADMIN_KEY = "jane-secret-key";
-    private static final String READONLY_KEY = "ian-secret-key";
-    private static final String COLLECTION_NAME = "TestCollection";
 
-    private static final WeaviateContainer WEAVIATE_CONTAINER = new WeaviateContainer("semitechnologies/weaviate:1.24.5")
-            .withEnv("AUTHENTICATION_APIKEY_ENABLED", "true")
-            .withEnv("AUTHENTICATION_APIKEY_ALLOWED_KEYS", ADMIN_KEY + "," + READONLY_KEY)
-            .withEnv("AUTHENTICATION_APIKEY_USERS", "jane@doe.com,ian-smith")
-            
-            .withEnv("AUTHORIZATION_ADMINLIST_ENABLED", "true")
-            .withEnv("AUTHORIZATION_ADMINLIST_USERS", "jane@doe.com,john@doe.com")
-            .withEnv("AUTHORIZATION_ADMINLIST_READONLY_USERS", "ian-smith,roberta@doe.com");
-
-    private static final Map<String, String> ADMIN_AUTHORIZATION = getAuthHeader(ADMIN_KEY);
-    private static final Map<String, String> READONLY_AUTHORIZATION = getAuthHeader(READONLY_KEY);
-    private static final Map<String, Object> ADMIN_HEADER_CONF = map(HEADERS_KEY, ADMIN_AUTHORIZATION);
-    
-    private static final String ID_1 = "8ef2b3a7-1e56-4ddd-b8c3-2ca8901ce308";
-    private static final String ID_2 = "9ef2b3a7-1e56-4ddd-b8c3-2ca8901ce308";
-    
-    private static String HOST;
-    
     @ClassRule
     public static TemporaryFolder storeDir = new TemporaryFolder();
 
@@ -96,23 +94,14 @@ public class WeaviateTest {
 
         TestUtil.registerProcedure(db, Weaviate.class, VectorDb.class, Prompt.class);
 
-        testCall(db, "CALL apoc.vectordb.weaviate.createCollection($host, 'TestCollection', 'cosine', 4, $conf)",
+        testCall(db, WEAVIATE_CREATE_COLLECTION_APOC,
                 MapUtil.map("host", HOST, "conf", ADMIN_HEADER_CONF),
                 r -> {
                     Map value = (Map) r.get("value");
                     assertEquals("TestCollection", value.get("class"));
                 });
 
-        testResult(db, """
-                        CALL apoc.vectordb.weaviate.upsert($host, 'TestCollection',
-                        [
-                            {id: $id1, vector: [0.05, 0.61, 0.76, 0.74], metadata: {city: "Berlin", foo: "one"}},
-                            {id: $id2, vector: [0.19, 0.81, 0.75, 0.11], metadata: {city: "London", foo: "two"}},
-                            {id: '7ef2b3a7-1e56-4ddd-b8c3-2ca8901ce308', vector: [0.19, 0.81, 0.75, 0.11], metadata: {foo: "baz"}},
-                            {id: '7ef2b3a7-1e56-4ddd-b8c3-2ca8901ce309', vector: [0.19, 0.81, 0.75, 0.11], metadata: {foo: "baz"}}
-                        ],
-                        $conf)
-                        """,
+        testResult(db, WEAVIATE_UPSERT_QUERY,
                 MapUtil.map("host", HOST, "id1", ID_1, "id2", ID_2, "conf", ADMIN_HEADER_CONF),
                 r -> {
                     ResourceIterator<Map> values = r.columnAs("value");
@@ -124,9 +113,7 @@ public class WeaviateTest {
                 });
         
         // -- delete vector
-        testCall(db, "CALL apoc.vectordb.weaviate.delete($host, 'TestCollection', " +
-                     "['7ef2b3a7-1e56-4ddd-b8c3-2ca8901ce308', '7ef2b3a7-1e56-4ddd-b8c3-2ca8901ce309']" +
-                     ", $conf) ",
+        testCall(db, WEAVIATE_DELETE_VECTOR_APOC,
                 map("host", HOST, "conf", ADMIN_HEADER_CONF),
                 r -> {
                     List value = (List) r.get("value");
@@ -136,7 +123,7 @@ public class WeaviateTest {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        testCallEmpty(db, "CALL apoc.vectordb.weaviate.deleteCollection($host, $collectionName, $conf)",
+        testCallEmpty(db, WEAVIATE_DELETE_COLLECTION_APOC,
                 MapUtil.map("host", HOST, "collectionName", COLLECTION_NAME, "conf", ADMIN_HEADER_CONF)
         );
 
@@ -209,20 +196,9 @@ public class WeaviateTest {
 
     @Test
     public void queryVectors() {
-        testResult(db, "CALL apoc.vectordb.weaviate.query($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf) " +
-                       " YIELD score, vector, id, metadata RETURN * ORDER BY id",
+        testResult(db, WEAVIATE_QUERY_APOC,
                 map("host", HOST, "conf", map(ALL_RESULTS_KEY, true, FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION)),
-                r -> {
-                    Map<String, Object> row = r.next();
-                    assertBerlinResult(row, ID_1, FALSE);
-                    assertNotNull(row.get("score"));
-                    assertNotNull(row.get("vector"));
-
-                    row = r.next();
-                    assertLondonResult(row, ID_2, FALSE);
-                    assertNotNull(row.get("score"));
-                    assertNotNull(row.get("vector"));
-                }); 
+                WeaviateTestUtil::queryVectorsAssertions);
     }
 
     @Test

--- a/extended-it/src/test/java/apoc/vectordb/WeaviateTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/WeaviateTest.java
@@ -1,7 +1,6 @@
 package apoc.vectordb;
 
 import apoc.ml.Prompt;
-import apoc.util.ExtendedTestUtil;
 import apoc.util.MapUtil;
 import apoc.util.TestUtil;
 import apoc.util.WeaviateTestUtil;
@@ -32,7 +31,7 @@ import static apoc.util.WeaviateTestUtil.ADMIN_HEADER_CONF;
 import static apoc.util.WeaviateTestUtil.ADMIN_KEY;
 import static apoc.util.WeaviateTestUtil.COLLECTION_NAME;
 import static apoc.util.WeaviateTestUtil.FIELDS;
-import static apoc.util.WeaviateTestUtil.HOST_WEAVIATE;
+import static apoc.util.WeaviateTestUtil.HOST;
 import static apoc.util.WeaviateTestUtil.ID_1;
 import static apoc.util.WeaviateTestUtil.ID_2;
 import static apoc.util.WeaviateTestUtil.READONLY_AUTHORIZATION;
@@ -62,6 +61,7 @@ import static apoc.vectordb.VectorMappingConfig.METADATA_KEY;
 import static apoc.vectordb.VectorMappingConfig.MODE_KEY;
 import static apoc.vectordb.VectorMappingConfig.MappingMode;
 import static apoc.vectordb.VectorMappingConfig.NODE_LABEL;
+import static apoc.vectordb.VectorMappingConfig.NO_FIELDS_ERROR_MSG;
 import static apoc.vectordb.VectorMappingConfig.REL_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -90,19 +90,19 @@ public class WeaviateTest {
         sysDb = databaseManagementService.database(SYSTEM_DATABASE_NAME);
         
         WEAVIATE_CONTAINER.start();
-        HOST_WEAVIATE = WEAVIATE_CONTAINER.getHttpHostAddress();
+        HOST = WEAVIATE_CONTAINER.getHttpHostAddress();
 
         TestUtil.registerProcedure(db, Weaviate.class, VectorDb.class, Prompt.class);
 
         testCall(db, WEAVIATE_CREATE_COLLECTION_APOC,
-                MapUtil.map("host", HOST_WEAVIATE, "conf", ADMIN_HEADER_CONF),
+                MapUtil.map("host", HOST, "conf", ADMIN_HEADER_CONF),
                 r -> {
                     Map value = (Map) r.get("value");
                     assertEquals("TestCollection", value.get("class"));
                 });
 
         testResult(db, WEAVIATE_UPSERT_QUERY,
-                MapUtil.map("host", HOST_WEAVIATE, "id1", ID_1, "id2", ID_2, "conf", ADMIN_HEADER_CONF),
+                MapUtil.map("host", HOST, "id1", ID_1, "id2", ID_2, "conf", ADMIN_HEADER_CONF),
                 r -> {
                     ResourceIterator<Map> values = r.columnAs("value");
                     assertEquals(COLLECTION_NAME, values.next().get("class"));
@@ -114,7 +114,7 @@ public class WeaviateTest {
         
         // -- delete vector
         testCall(db, WEAVIATE_DELETE_VECTOR_APOC,
-                map("host", HOST_WEAVIATE, "conf", ADMIN_HEADER_CONF),
+                map("host", HOST, "conf", ADMIN_HEADER_CONF),
                 r -> {
                     List value = (List) r.get("value");
                     assertEquals(List.of("7ef2b3a7-1e56-4ddd-b8c3-2ca8901ce308", "7ef2b3a7-1e56-4ddd-b8c3-2ca8901ce309"), value);
@@ -124,7 +124,7 @@ public class WeaviateTest {
     @AfterClass
     public static void tearDown() throws Exception {
         testCallEmpty(db, WEAVIATE_DELETE_COLLECTION_APOC,
-                MapUtil.map("host", HOST_WEAVIATE, "collectionName", COLLECTION_NAME, "conf", ADMIN_HEADER_CONF)
+                MapUtil.map("host", HOST, "collectionName", COLLECTION_NAME, "conf", ADMIN_HEADER_CONF)
         );
 
         WEAVIATE_CONTAINER.stop();
@@ -139,7 +139,7 @@ public class WeaviateTest {
     @Test
     public void getInfo() {
         testResult(db, "CALL apoc.vectordb.weaviate.info($host, $collectionName, $conf)",
-                map("host", HOST_WEAVIATE, "collectionName", COLLECTION_NAME, "conf", map(ALL_RESULTS_KEY, true, HEADERS_KEY, READONLY_AUTHORIZATION)),
+                map("host", HOST, "collectionName", COLLECTION_NAME, "conf", map(ALL_RESULTS_KEY, true, HEADERS_KEY, READONLY_AUTHORIZATION)),
                 r -> {
                     Map<String, Object> row = r.next();
                     Map value = (Map) row.get("value");
@@ -152,7 +152,7 @@ public class WeaviateTest {
         assertFails(
                 db,
                 "CALL apoc.vectordb.weaviate.info($host, 'wrong_collection', $conf)",
-                map("host", HOST_WEAVIATE, "collectionName", COLLECTION_NAME, "conf", map(ALL_RESULTS_KEY, true, HEADERS_KEY, READONLY_AUTHORIZATION)),
+                map("host", HOST, "collectionName", COLLECTION_NAME, "conf", map(ALL_RESULTS_KEY, true, HEADERS_KEY, READONLY_AUTHORIZATION)),
                 "java.io.FileNotFoundException"
         );
     }
@@ -160,7 +160,7 @@ public class WeaviateTest {
     @Test
     public void getVectorsWithReadOnlyApiKey() {
         testResult(db, "CALL apoc.vectordb.weaviate.get($host, 'TestCollection', [$id1], $conf)",
-                map("host", HOST_WEAVIATE, "id1", ID_1, "conf", map(ALL_RESULTS_KEY, true, HEADERS_KEY, READONLY_AUTHORIZATION)),
+                map("host", HOST, "id1", ID_1, "conf", map(ALL_RESULTS_KEY, true, HEADERS_KEY, READONLY_AUTHORIZATION)),
                 r -> {
                     Map<String, Object> row = r.next();
                     assertBerlinResult(row, ID_1, FALSE);
@@ -172,7 +172,7 @@ public class WeaviateTest {
     public void writeOperationWithReadOnlyUser() {
         try {
             testCall(db, "CALL apoc.vectordb.weaviate.deleteCollection($host, 'TestCollection', $conf)",
-                    map("host", HOST_WEAVIATE, 
+                    map("host", HOST, 
                             "conf", map(HEADERS_KEY, READONLY_AUTHORIZATION)
                     ),
                     r -> fail()
@@ -185,7 +185,7 @@ public class WeaviateTest {
     @Test
     public void getVectorsWithoutVectorResult() {
         testResult(db, "CALL apoc.vectordb.weaviate.get($host, 'TestCollection', [$id1], $conf)",
-                map("host", HOST_WEAVIATE, "id1", ID_1, "conf", map(HEADERS_KEY, ADMIN_AUTHORIZATION)),
+                map("host", HOST, "id1", ID_1, "conf", map(HEADERS_KEY, ADMIN_AUTHORIZATION)),
                 r -> {
                     Map<String, Object> row = r.next();
                     assertEquals(Map.of("city", "Berlin", "foo", "one"), row.get("metadata"));
@@ -197,7 +197,7 @@ public class WeaviateTest {
     @Test
     public void queryVectors() {
         testResult(db, WEAVIATE_QUERY_APOC,
-                map("host", HOST_WEAVIATE, "conf", map(ALL_RESULTS_KEY, true, FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION)),
+                map("host", HOST, "conf", map(ALL_RESULTS_KEY, true, FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION)),
                 WeaviateTestUtil::queryVectorsAssertions);
     }
 
@@ -205,7 +205,7 @@ public class WeaviateTest {
     public void queryVectorsWithoutVectorResult() {
         testResult(db, "CALL apoc.vectordb.weaviate.query($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf) " +
                        " YIELD score, vector, id, metadata, node RETURN * ORDER BY id",
-                map("host", HOST_WEAVIATE, "conf", map( FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION)),
+                map("host", HOST, "conf", map( FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION)),
                 r -> {
                     Map<String, Object> row = r.next();
                     assertEquals(Map.of("city", "Berlin", "foo", "one"), row.get("metadata"));
@@ -225,7 +225,7 @@ public class WeaviateTest {
     public void queryVectorsWithYield() {
         testResult(db, "CALL apoc.vectordb.weaviate.query($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf) " +
                        "YIELD metadata, id RETURN * ORDER BY id",
-                map("host", HOST_WEAVIATE, "conf", map(ALL_RESULTS_KEY, true, FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION)),
+                map("host", HOST, "conf", map(ALL_RESULTS_KEY, true, FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION)),
                 r -> {
                     assertBerlinResult(r.next(), ID_1, FALSE);
                     assertLondonResult(r.next(), ID_2, FALSE);
@@ -238,7 +238,7 @@ public class WeaviateTest {
                         CALL apoc.vectordb.weaviate.query($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7],
                         '{operator: Equal, valueString: "London", path: ["city"]}',
                         5, $conf) YIELD metadata, id RETURN * ORDER BY id""",
-                map("host", HOST_WEAVIATE, "conf", map(ALL_RESULTS_KEY, true, FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION)),
+                map("host", HOST, "conf", map(ALL_RESULTS_KEY, true, FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION)),
                 r -> {
                     assertLondonResult(r.next(), ID_2, FALSE);
                 });
@@ -248,7 +248,7 @@ public class WeaviateTest {
     public void queryVectorsWithLimit() {
         testResult(db, """
                         CALL apoc.vectordb.weaviate.query($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7], null, 1, $conf) YIELD metadata, id RETURN * ORDER BY id""",
-                map("host", HOST_WEAVIATE, "conf", map(ALL_RESULTS_KEY, true, FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION)),
+                map("host", HOST, "conf", map(ALL_RESULTS_KEY, true, FIELDS_KEY, FIELDS, HEADERS_KEY, ADMIN_AUTHORIZATION)),
                 r -> {
                     assertBerlinResult(r.next(), ID_1, FALSE);
                 });
@@ -269,7 +269,7 @@ public class WeaviateTest {
         );
         testResult(db, "CALL apoc.vectordb.weaviate.queryAndUpdate($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf) " +
                        "YIELD score, vector, id, metadata, node RETURN * ORDER BY id",
-                map("host", HOST_WEAVIATE, "conf", conf),
+                map("host", HOST, "conf", conf),
                 r -> {
                     Map<String, Object> row = r.next();
                     assertBerlinResult(row, ID_1, NODE);
@@ -289,7 +289,7 @@ public class WeaviateTest {
 
         testResult(db, "CALL apoc.vectordb.weaviate.queryAndUpdate($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf) " +
                        " YIELD score, vector, id, metadata, node RETURN * ORDER BY id",
-                map("host", HOST_WEAVIATE, "conf", conf),
+                map("host", HOST, "conf", conf),
                 r -> {
                     Map<String, Object> row = r.next();
                     assertBerlinResult(row, ID_1, NODE);
@@ -319,7 +319,7 @@ public class WeaviateTest {
                 METADATA_KEY, "foo"));
         testResult(db, "CALL apoc.vectordb.weaviate.queryAndUpdate($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf) " +
                        " YIELD score, vector, id, metadata, node RETURN * ORDER BY id",
-                map("host", HOST_WEAVIATE, "conf", conf),
+                map("host", HOST, "conf", conf),
                 r -> {
                     Map<String, Object> row = r.next();
                     assertBerlinResult(row, ID_1, NODE);
@@ -348,7 +348,7 @@ public class WeaviateTest {
                         METADATA_KEY, "foo"));
 
         testResult(db, "CALL apoc.vectordb.weaviate.getAndUpdate($host, 'TestCollection', [$id1, $id2], $conf)",
-                map("host", HOST_WEAVIATE, "id1", ID_1, "id2", ID_2, "conf", conf),
+                map("host", HOST, "id1", ID_1, "id2", ID_2, "conf", conf),
                 r -> {
                     Map<String, Object> row = r.next();
                     assertBerlinResult(row, ID_1, NODE);
@@ -377,7 +377,7 @@ public class WeaviateTest {
 
         testResult(db, "CALL apoc.vectordb.weaviate.get($host, 'TestCollection', [$id1, $id2], $conf) " +
                        "YIELD vector, id, metadata, node RETURN * ORDER BY id",
-                MapUtil.map("host", HOST_WEAVIATE, "id1", ID_1, "id2", ID_2, "conf", conf),
+                MapUtil.map("host", HOST, "id1", ID_1, "id2", ID_2, "conf", conf),
                 r -> assertReadOnlyProcWithMappingResults(r, "node")
         );
     }
@@ -395,7 +395,7 @@ public class WeaviateTest {
                 METADATA_KEY, "foo"));
         testResult(db, "CALL apoc.vectordb.weaviate.queryAndUpdate($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf) " +
                        " YIELD score, vector, id, metadata, rel RETURN * ORDER BY id",
-                map("host", HOST_WEAVIATE, "conf", conf),
+                map("host", HOST, "conf", conf),
                 r -> {
                     Map<String, Object> row = r.next();
                     assertBerlinResult(row, ID_1, REL);
@@ -426,7 +426,7 @@ public class WeaviateTest {
 
         testResult(db, "CALL apoc.vectordb.weaviate.query($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf) " +
                        " YIELD score, vector, id, metadata, rel RETURN * ORDER BY id",
-                MapUtil.map("host", HOST_WEAVIATE, "conf", conf),
+                MapUtil.map("host", HOST, "conf", conf),
                 r -> assertReadOnlyProcWithMappingResults(r, "rel")
         );
     }
@@ -440,7 +440,7 @@ public class WeaviateTest {
         String expectedErrMsg = "distance between entrypoint and query node: vector lengths don't match: 4 vs 3";
         
         assertFails(db, "CALL apoc.vectordb.weaviate.query($host, 'TestCollection', [0.2, 0.1, 0.9], null, 5, $conf)",
-                map("host", HOST_WEAVIATE, "conf", conf),
+                map("host", HOST, "conf", conf),
                 expectedErrMsg);
     }
 
@@ -457,7 +457,7 @@ public class WeaviateTest {
         );
         testResult(db, "CALL apoc.vectordb.weaviate.queryAndUpdate($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf) " +
                        " YIELD score, vector, id, metadata, rel RETURN * ORDER BY id",
-                map("host", HOST_WEAVIATE, "conf", conf),
+                map("host", HOST, "conf", conf),
                 r -> {
                     Map<String, Object> row = r.next();
                     Map<String, Object> props = ((Entity) row.get("rel")).getAllProperties();
@@ -482,21 +482,21 @@ public class WeaviateTest {
     @Test
     public void queryVectorsWithSystemDbStorage() {
         String keyConfig = "weaviate-config-foo";
-        String baseUrl = "http://" + HOST_WEAVIATE + "/v1";
+        String baseUrl = "http://" + HOST + "/v1";
         assertQueryVectorsWithSystemDbStorage(keyConfig, baseUrl, false);
     }
 
     @Test
     public void queryVectorsWithSystemDbStorageWithUrlWithoutVersion() {
         String keyConfig = "weaviate-config-foo";
-        String baseUrl = "http://" + HOST_WEAVIATE;
+        String baseUrl = "http://" + HOST;
         assertQueryVectorsWithSystemDbStorage(keyConfig, baseUrl, false);
     }
 
     @Test
     public void queryVectorsWithSystemDbStorageWithUrlV3Version() {
         String keyConfig = "weaviate-config-foo";
-        String baseUrl = "http://" + HOST_WEAVIATE + "/v3";
+        String baseUrl = "http://" + HOST + "/v3";
         assertQueryVectorsWithSystemDbStorage(keyConfig, baseUrl, true);
     }
 
@@ -523,7 +523,7 @@ public class WeaviateTest {
                     """
                 ,
                 MapUtil.map(
-                        "host", HOST_WEAVIATE,
+                        "host", HOST,
                         "id1", ID_1,
                         "conf", conf,
                         "confPrompt", MapUtil.map(API_KEY_CONF, openAIKey),
@@ -561,7 +561,7 @@ public class WeaviateTest {
                     db,
                     query,
                     params,
-                    "Caused by: java.io.FileNotFoundException: http://127.0.0.1:" + HOST_WEAVIATE.split(":")[1] + "/v3/graphql"
+                    "Caused by: java.io.FileNotFoundException: http://127.0.0.1:" + HOST.split(":")[1] + "/v3/graphql"
             );
             return;
         }
@@ -610,7 +610,7 @@ public class WeaviateTest {
                 HEADERS_KEY, ADMIN_AUTHORIZATION));
         String query = "CALL apoc.vectordb.weaviate.query($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf) " +
                 " YIELD score, vector, id, metadata RETURN * ORDER BY id";
-        ExtendedTestUtil.assertFails(db, query, params, NO_FIELDS_ERROR_MSG);
+        assertFails(db, query, params, NO_FIELDS_ERROR_MSG);
     }
 
     @Test
@@ -638,6 +638,6 @@ public class WeaviateTest {
                         NODE_LABEL, "Test",
                         ENTITY_KEY, "myId")));
         String query = "CALL apoc.vectordb.weaviate.queryAndUpdate($host, 'TestCollection', [0.2, 0.1, 0.9, 0.7], null, 5, $conf) YIELD score, vector, id, metadata, node RETURN * ORDER BY id";
-        ExtendedTestUtil.assertFails(db, query, params, NO_FIELDS_ERROR_MSG);
+        assertFails(db, query, params, NO_FIELDS_ERROR_MSG);
     }
 }

--- a/extended/src/test/java/apoc/vectordb/VectorDbTestUtil.java
+++ b/extended/src/test/java/apoc/vectordb/VectorDbTestUtil.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertTrue;
 
 public class VectorDbTestUtil {
     
-    enum EntityType { NODE, REL, FALSE }
+    public enum EntityType { NODE, REL, FALSE }
     
     public static void dropAndDeleteAll(GraphDatabaseService db) {
         db.executeTransactionally("MATCH (n) DETACH DELETE n");


### PR DESCRIPTION
Fixes #4245

Created TestContainer's network using Weaviate and Neo4j containers,
to check that the Apache error is no longer present with enterprise neo4j too.

Created WeaviateTestUtil.java

With neo4j embedded it works even with `org.apache.commons.collections.MapUtils` imported.
