### PR TITLE
Removed org.apache.commons.collections from OpenAI

### DIFF
--- a/extended/src/main/java/apoc/ml/OpenAI.java
+++ b/extended/src/main/java/apoc/ml/OpenAI.java
@@ -3,11 +3,11 @@ package apoc.ml;
 import apoc.ApocConfig;
 import apoc.Extended;
 import apoc.result.MapResult;
+import apoc.util.ExtendedMapUtils;
 import apoc.util.ExtendedUtil;
 import apoc.util.JsonUtil;
 import apoc.util.Util;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.procedure.Context;
@@ -225,7 +225,7 @@ public class OpenAI {
     public Stream<MapResult> chatCompletion(@Name("messages") List<Map<String, Object>> messages, @Name("api_key") String apiKey, @Name(value = "configuration", defaultValue = "{}") Map<String, Object> configuration) throws Exception {
         boolean failOnError = isFailOnError(configuration);
         if (checkNullInput(messages, failOnError)) return Stream.empty();
-        messages = messages.stream().filter(MapUtils::isNotEmpty).toList();
+        messages = messages.stream().filter(ExtendedMapUtils::isNotEmpty).toList();
         if (checkEmptyInput(messages, failOnError)) return Stream.empty();
         configuration.putIfAbsent("model", GPT_4O_MODEL);
         return executeRequest(apiKey, configuration, "chat/completions", (String) configuration.get("model"), "messages", messages, "$", apocConfig, urlAccessChecker)

--- a/extended/src/main/java/apoc/util/ExtendedMapUtils.java
+++ b/extended/src/main/java/apoc/util/ExtendedMapUtils.java
@@ -11,4 +11,8 @@ public class ExtendedMapUtils {
     public static boolean isEmpty(final Map<?,?> map) {
         return map == null || map.isEmpty();
     }
+
+    public static boolean isNotEmpty(final Map<?,?> map) {
+        return !isEmpty(map);
+    }
 }


### PR DESCRIPTION
Removed org.apache.commons.collections from OpenAI

Otherwise, the following error could be thrown
```
java.lang.ClassNotFoundException: org.apache.commons.collections.MapUtils
```