### PR TITLE
Fixes #4262: Add startup test for SLF4J

### DIFF
--- a/extended-it/build.gradle
+++ b/extended-it/build.gradle
@@ -16,7 +16,6 @@ test {
 dependencies {
     apt project(':processor')
     apt group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective   // mandatory to run @ServiceProvider based META-INF code generation
-    api group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.36'
 
     def withoutJacksons = {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'

--- a/extended-it/build.gradle
+++ b/extended-it/build.gradle
@@ -16,6 +16,7 @@ test {
 dependencies {
     apt project(':processor')
     apt group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective   // mandatory to run @ServiceProvider based META-INF code generation
+    api group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.36'
 
     def withoutJacksons = {
         exclude group: 'com.fasterxml.jackson.core', module: 'jackson-annotations'


### PR DESCRIPTION
Fixes #4262

Add the equivalent of this test: https://github.com/neo4j/apoc/pull/274/files
for ApocStartupExtendedTest.java,
to check that the SLF4J: Failed to load class is not present