### PR TITLE
Fix TeamCity errors for 5.26

### DIFF
--- a/extended-it/src/test/java/apoc/couchbase/CouchbaseTestUtils.java
+++ b/extended-it/src/test/java/apoc/couchbase/CouchbaseTestUtils.java
@@ -18,6 +18,7 @@ import com.couchbase.client.java.manager.collection.CollectionSpec;
 import com.couchbase.client.java.query.QueryResult;
 import com.couchbase.client.java.query.QueryScanConsistency;
 import org.testcontainers.containers.Container;
+import org.testcontainers.couchbase.BucketDefinition;
 import org.testcontainers.couchbase.CouchbaseContainer;
 
 import java.time.Duration;
@@ -141,7 +142,8 @@ public class CouchbaseTestUtils {
         // 7.x support stably multi collections and scopes
         couchbase = new CouchbaseContainer("couchbase/server:7.6.4")
                 .withStartupAttempts(3)
-                .withCredentials(USERNAME, PASSWORD);
+                .withCredentials(USERNAME, PASSWORD)
+                .withBucket(new BucketDefinition(BUCKET_NAME));
         couchbase.start();
 
         ClusterEnvironment environment = ClusterEnvironment.create();
@@ -153,10 +155,6 @@ public class CouchbaseTestUtils {
 
         Cluster cluster = Cluster.connect(seedNodes, ClusterOptions.clusterOptions(USERNAME, PASSWORD).environment(environment));
 
-        cluster.buckets().createBucket(
-                BucketSettings.create(BUCKET_NAME)
-        );
-        
         boolean isFilled = fillDB(cluster);
         HOST = getUrl(couchbase);
         Bucket bucket = cluster.bucket(BUCKET_NAME);

--- a/extended-it/src/test/java/apoc/couchbase/CouchbaseTestUtils.java
+++ b/extended-it/src/test/java/apoc/couchbase/CouchbaseTestUtils.java
@@ -3,10 +3,12 @@ package apoc.couchbase;
 import apoc.couchbase.document.CouchbaseJsonDocument;
 import com.couchbase.client.core.env.SeedNode;
 import com.couchbase.client.core.io.CollectionIdentifier;
+import com.couchbase.client.core.service.ServiceType;
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.Cluster;
 import com.couchbase.client.java.ClusterOptions;
 import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.diagnostics.WaitUntilReadyOptions;
 import com.couchbase.client.java.json.JsonArray;
 import com.couchbase.client.java.json.JsonObject;
 import com.couchbase.client.java.env.ClusterEnvironment;
@@ -65,7 +67,9 @@ public class CouchbaseTestUtils {
 
     public static boolean fillDB(Cluster cluster) {
         Bucket couchbaseBucket = cluster.bucket(BUCKET_NAME);
-        couchbaseBucket.waitUntilReady(Duration.ofMinutes(5));
+        WaitUntilReadyOptions waitOptions = WaitUntilReadyOptions.waitUntilReadyOptions()
+                .serviceTypes(ServiceType.QUERY);
+        couchbaseBucket.waitUntilReady(Duration.ofMinutes(5), waitOptions);
         Collection collection = couchbaseBucket.defaultCollection();
         collection.insert("artist:vincent_van_gogh", VINCENT_VAN_GOGH);
         QueryResult queryResult = cluster.query(String.format(QUERY, BUCKET_NAME),

--- a/extended-it/src/test/java/apoc/vectordb/WeaviateTest.java
+++ b/extended-it/src/test/java/apoc/vectordb/WeaviateTest.java
@@ -561,7 +561,7 @@ public class WeaviateTest {
                     db,
                     query,
                     params,
-                    "Caused by: java.io.FileNotFoundException: http://127.0.0.1:" + HOST.split(":")[1] + "/v3/graphql"
+                    "Caused by: java.io.FileNotFoundException"
             );
             return;
         }


### PR DESCRIPTION
- Fix `apoc.vectordb.WeaviateTest.queryVectorsWithSystemDbStorageWithUrlV3Version`
  - Changed `Caused by: java.io.FileNotFoundException: http://127.0.0.1:` with `Caused by: java.io.FileNotFoundException`, since the error can be either `"FileNotFoundException: http://localhost"`, or `"FileNotFoundException: http://127.0.0.1"` / other address, therefore generalized it.

The TC error is:
```
java.lang.AssertionError: Actual err. message is: Failed to invoke procedure `apoc.vectordb.weaviate.queryAndUpdate`: Caused by: java.io.FileNotFoundException: http://172.17.0.1:32897/v3/graphql
  at org.junit.Assert.fail(Assert.java:89)
```




- Fix `apoc.couchbase.CouchbaseIT.classMethod`
  - Upgraded image version
  - ~Separated container startup and bucket creation handling~ it works locally but not in gh action, as we have an error `    com.couchbase.client.core.error.ServiceNotAvailableException: The query service is not available in the cluster. `
  - Increased timeout to wait for the bucket to be ready
  - Added `waitOptions` to `waitUntilReady()` 

The TC error is:
```
com.couchbase.client.core.error.UnambiguousTimeoutException: WaitUntilReady timed out {"bucket":"mybucket","checkedServices":[],"currentState":"OFFLINE","desiredState":"ONLINE","services":{"kv":[{"lastConnectAttemptFailure":"Did not observe any item or terminal signal within 10000ms in 'source(MonoDefer)' (and no fallback has been configured)","state":"connecting"},{"lastConnectAttemptFailure":"Did not observe any item or terminal signal within 10000ms in 'source(MonoDefer)' (and no fallback has been configured)","namespace":"mybucket","state":"connecting"}],"mgmt":[{"lastConnectAttemptFailure":"Did not observe any item or terminal signal within 10000ms in 'source(MonoDefer)' (and no fallback has been configured)","state":"connecting"}]},"state":{"current_stage":"CONFIG_LOAD","current_stage_since_ms":61331,"timings_ms":{},"total_ms":61331},"timeoutMs":60000}
  at app//com.couchbase.client.java.AsyncUtils.block(AsyncUtils.java:51)
  at app//com.couchbase.client.java.Bucket.waitUntilReady(Bucket.java:229)
  at app//apoc.couchbase.CouchbaseTestUtils.fillDB(CouchbaseTestUtils.java:68)
  at app//apoc.couchbase.CouchbaseTestUtils.createCouchbaseContainer(CouchbaseTestUtils.java:153)
```