### PR TITLE
Added note to solve a potential ModuleVersionNotFoundException in case of Neo4j inconsistencies

### DIFF
--- a/extended-it/src/test/java/apoc/neo4j/docker/StartupExtendedTest.java
+++ b/extended-it/src/test/java/apoc/neo4j/docker/StartupExtendedTest.java
@@ -27,8 +27,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-/*
- This test is just to verify if the APOC procedures and functions are correctly deployed into a Neo4j instance without any startup issue.
+/**
+ * This test is just to verify if the APOC procedures and functions are correctly deployed into a Neo4j instance without any startup issue.
+ * <br/>
+ * NOTE: if we have an error like `Caused by: org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find org.neo4j:neo4j:5.25.0.`,
+ * there is probably inconsistency between the neo4j version of APOC Core and the Extended version,
+ * so we need to set the environment variable `NEO4JVERSION=<correctVersion>`, e.g. `NEO4JVERSION=5.25.1`,
+ * which is valued via {@link TestContainerUtil#executeGradleTasks(File, String...)} present in APOC Core and therefore not modifiable by APOC Extended
  */
 public class StartupExtendedTest {
     private static final String APOC_HELP_QUERY = "CALL apoc.help('') YIELD core, type, name WHERE core = $core and type = $type RETURN name";


### PR DESCRIPTION
Added `NOTE` in StartupExtendedTest, 
to solve a potential `ModuleVersionNotFoundException` via an environment variable in case of Neo4j inconsistencies.

For instance, this error happened with the 5.25 branch, where [the Extended Neo4j version is 5.25.1](https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/5.25/build.gradle#L155) (existing),
[while the Core one is 5.25.0](https://github.com/neo4j/apoc/blob/5.25/build.gradle#L172) (not existing).

Therefore, we added a comment with the resolution, in case of potential similar errors in the future.