### PR TITLE
Try solving TeamCity errors in 5.26 (#4220)

### DIFF
--- a/extended/src/test/java/apoc/gephi/GephiMock.java
+++ b/extended/src/test/java/apoc/gephi/GephiMock.java
@@ -3,6 +3,7 @@ package apoc.gephi;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.RegexBody;
+import org.mockserver.socket.PortFactory;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -26,9 +27,13 @@ import static org.mockserver.model.RegexBody.regex;
  */
 public class GephiMock {
     private final ClientAndServer server;
+    private final int PORT;
+    public final String HOST;
 
     public GephiMock() {
-        this.server = ClientAndServer.startClientAndServer(8080);
+        PORT = PortFactory.findFreePort();
+        HOST = "http://localhost:" + PORT;
+        this.server = ClientAndServer.startClientAndServer(PORT);
     }
 
     public void clearAllExpectations() {
@@ -40,7 +45,7 @@ public class GephiMock {
     }
 
     public void mockSuccess(String workspace, GephiEntity... entities) {
-        new MockServerClient("localhost", 8080)
+        new MockServerClient("localhost", PORT)
                 .when(request()
                         .withMethod("POST")
                         .withPath("/" + workspace)

--- a/extended/src/test/java/apoc/gephi/GephiTest.java
+++ b/extended/src/test/java/apoc/gephi/GephiTest.java
@@ -51,8 +51,9 @@ public class GephiTest {
                 node(0, "Foo"), 
                 node(1, "Bar"), 
                 relationship(0, "KNOWS",0, 1));
-        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,$workspace,p) yield nodes, relationships, format return *",
-                map("workspace", GEPHI_WORKSPACE),
+        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add($host,$workspace,p) yield nodes, relationships, format return *",
+                map("host", gephiMock.HOST,
+                        "workspace", GEPHI_WORKSPACE),
                 r -> {
                     assertEquals(2L, r.get("nodes"));
                     assertEquals(1L, r.get("relationships"));
@@ -67,8 +68,9 @@ public class GephiTest {
                 node(0, "Foo"), 
                 node(1, "Bar"), 
                 relationship(0, "KNOWS",0, 1, "7.2"));
-        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,$workspace,p,'weight') yield nodes, relationships, format return *",
-                map("workspace", GEPHI_WORKSPACE),
+        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add($host,$workspace,p,'weight') yield nodes, relationships, format return *",
+                map("host", gephiMock.HOST, 
+                        "workspace", GEPHI_WORKSPACE),
                 r -> {
                     assertEquals(2L, r.get("nodes"));
                     assertEquals(1L, r.get("relationships"));
@@ -83,8 +85,9 @@ public class GephiTest {
                 node(0, "Foo"), 
                 node(1, "Bar"), 
                 relationship(0, "KNOWS",0, 1));
-        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,$workspace,p,'test') yield nodes, relationships, format return *",
-                map("workspace", GEPHI_WORKSPACE),
+        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add($host,$workspace,p,'test') yield nodes, relationships, format return *",
+                map("host", gephiMock.HOST,
+                        "workspace", GEPHI_WORKSPACE),
                 r -> {
                     assertEquals(2L, r.get("nodes"));
                     assertEquals(1L, r.get("relationships"));
@@ -99,8 +102,9 @@ public class GephiTest {
                 node(0, "Foo"), 
                 node(1, "Bar"), 
                 relationship(0, "KNOWS",0, 1, "7.2", Set.of("foo")));
-        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,$workspace,p,'weight',['foo']) yield nodes, relationships, format return *",
-                map("workspace", GEPHI_WORKSPACE),
+        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add($host,$workspace,p,'weight',['foo']) yield nodes, relationships, format return *",
+                map("host", gephiMock.HOST,
+                        "workspace", GEPHI_WORKSPACE),
                 r -> {
                     assertEquals(2L, r.get("nodes"));
                     assertEquals(1L, r.get("relationships"));
@@ -115,8 +119,9 @@ public class GephiTest {
                 node(0, "Foo"),
                 node(1, "Bar"),
                 relationship(0, "KNOWS",0, 1, "7.2"));
-        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,$workspace,p,'weight',['faa','fee']) yield nodes, relationships, format return *",
-                map("workspace", GEPHI_WORKSPACE),
+        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add($host,$workspace,p,'weight',['faa','fee']) yield nodes, relationships, format return *",
+                map("host", gephiMock.HOST,
+                        "workspace", GEPHI_WORKSPACE),
                 r -> {
                     assertEquals(2L, r.get("nodes"));
                     assertEquals(1L, r.get("relationships"));
@@ -131,8 +136,9 @@ public class GephiTest {
                 node(0, "Foo"),
                 node(1, "Bar"),
                 relationship(0, "KNOWS",0, 1, "7.2"));
-        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add(null,$workspace,p,'weight',['directed','label']) yield nodes, relationships, format return *",
-                map("workspace", GEPHI_WORKSPACE),
+        testCall(db, "MATCH p = (:Foo)-->() WITH p CALL apoc.gephi.add($host,$workspace,p,'weight',['directed','label']) yield nodes, relationships, format return *",
+                map("host", gephiMock.HOST,
+                        "workspace", GEPHI_WORKSPACE),
                 r -> {
                     assertEquals(2L, r.get("nodes"));
                     assertEquals(1L, r.get("relationships"));

--- a/extended/src/test/java/apoc/load/LoadCsvTest.java
+++ b/extended/src/test/java/apoc/load/LoadCsvTest.java
@@ -10,6 +10,7 @@ import org.junit.*;
 import org.mockserver.client.MockServerClient;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
+import org.mockserver.socket.PortFactory;
 import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.QueryExecutionException;
@@ -47,7 +48,8 @@ import static org.neo4j.configuration.GraphDatabaseSettings.db_temporal_timezone
 public class LoadCsvTest {
 
     private static ClientAndServer mockServer;
-
+    private static int PORT;
+    
     private static final List<Map<String, Object>> RESPONSE_BODY = List.of(
             Map.of("headFoo", "one", "headBar", "two"),
             Map.of("headFoo", "three", "headBar", "four"),
@@ -56,7 +58,8 @@ public class LoadCsvTest {
 
     @BeforeClass
     public static void startServer() {
-        mockServer = startClientAndServer(1080);
+        PORT = PortFactory.findFreePort();
+        mockServer = startClientAndServer(PORT);
     }
 
     @AfterClass
@@ -492,7 +495,7 @@ RETURN m.col_1,m.col_2,m.col_3
         String userPass = "user:password";
         String token = Util.encodeUserColonPassToBase64(userPass);
 
-        new MockServerClient("localhost", 1080)
+        new MockServerClient("localhost", PORT)
                 .when(
                         request()
                                 .withPath("/docs/csv")
@@ -509,7 +512,7 @@ RETURN m.col_1,m.col_2,m.col_3
                 );
 
         testResult(db, "CALL apoc.load.csv($url, {results:['map']}) YIELD map",
-                    map("url", "http://" + userPass + "@localhost:1080/docs/csv"),
+                    map("url", "http://" + userPass + "@localhost:" + PORT + "/docs/csv"),
                     (row) -> assertEquals(RESPONSE_BODY, row.stream().map(i->i.get("map")).collect(Collectors.toList()))
                 );
     }
@@ -519,7 +522,7 @@ RETURN m.col_1,m.col_2,m.col_3
         String userPass = "user:password";
         String token = Util.encodeUserColonPassToBase64(userPass);
 
-        new MockServerClient("localhost", 1080)
+        new MockServerClient("localhost", PORT)
                 .when(
                         request()
                                 .withMethod("POST")
@@ -537,7 +540,7 @@ RETURN m.col_1,m.col_2,m.col_3
                 );
 
         testResult(db, "CALL apoc.load.csvParams($url, $header, $payload, {results:['map','list','stringMap','strings']})",
-                    map("url", "http://" + userPass + "@localhost:1080/docs/csv",
+                    map("url", "http://" + userPass + "@localhost:" + PORT +"/docs/csv",
                         "header", map("method", "POST"),
                         "payload", "{\"query\":\"pagecache\",\"version\":\"3.5\"}"),
                     (row) -> assertEquals(RESPONSE_BODY, row.stream().map(i->i.get("map")).collect(Collectors.toList()))
@@ -549,7 +552,7 @@ RETURN m.col_1,m.col_2,m.col_3
         String userPass = "user:password";
         String token = Util.encodeUserColonPassToBase64(userPass);
 
-        new MockServerClient("localhost", 1080)
+        new MockServerClient("localhost", PORT)
                 .when(
                         request()
                                 .withMethod("POST")
@@ -568,7 +571,7 @@ RETURN m.col_1,m.col_2,m.col_3
                 );
 
         testResult(db, "CALL apoc.load.csvParams($url, $header, $payload, {results:['map','list','stringMap','strings']})",
-                    map("url", "http://localhost:1080/docs/csv",
+                    map("url", "http://localhost:" + PORT + "/docs/csv",
                         "header", map("method",
                                     "POST", "Authorization", "Basic " + token,
                                     "Content-Type", "application/json"),

--- a/extended/src/test/java/apoc/ml/WatsonTest.java
+++ b/extended/src/test/java/apoc/ml/WatsonTest.java
@@ -9,6 +9,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.Header;
+import org.mockserver.socket.PortFactory;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -42,17 +43,18 @@ public class WatsonTest {
 
     @BeforeClass
     public static void startServer() throws Exception {
+        int port = PortFactory.findFreePort();
         TestUtil.registerProcedure(db, Watson.class);
         
         String path = "/generation/text";
-        apocConfig().setProperty(APOC_ML_WATSON_URL, "http://localhost:1080" + path);
+        apocConfig().setProperty(APOC_ML_WATSON_URL, "http://localhost:" + port + path);
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         apocConfig().setProperty(APOC_ML_WATSON_PROJECT_ID, "fakeProjectId");
         
         File urlFileName = new File(getUrlFileName("watson.json").getFile());
         String body = FileUtils.readFileToString(urlFileName, UTF_8);
         
-        mockServer = startClientAndServer(1080);
+        mockServer = startClientAndServer(port);
         mockServer.when(
                         request()
                                 .withMethod("POST")

--- a/extended/src/test/java/apoc/util/ExtendedTestUtil.java
+++ b/extended/src/test/java/apoc/util/ExtendedTestUtil.java
@@ -126,9 +126,13 @@ public class ExtendedTestUtil {
      * but with multiple results
      */
     public static void testResultEventually(GraphDatabaseService db, String call, Consumer<Result> resultConsumer, long timeout) {
+        testResultEventually(db, call, Map.of(), resultConsumer, timeout);
+    }
+    
+    public static void testResultEventually(GraphDatabaseService db, String call, Map<String,Object> params, Consumer<Result> resultConsumer, long timeout) {
         assertEventually(() -> {
             try {
-                return db.executeTransactionally(call, Map.of(), r -> {
+                return db.executeTransactionally(call, params, r -> {
                     resultConsumer.accept(r);
                     return true;
                 });


### PR DESCRIPTION
- Cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/c686650295ff9de91d5f6de9ebf22eaa2299cebe

- Added the same `PortFactory.findFreePort()` fix to `GephiMock` (by also changing the tests), 
to prevent future `port already used` errors