### PR TITLE
Fix CI - update cache version

### DIFF
--- a/.github/actions/setup-gradle-cache/action.yaml
+++ b/.github/actions/setup-gradle-cache/action.yaml
@@ -4,7 +4,7 @@ description: "Setups cache for Gradle"
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -116,7 +116,7 @@ jobs:
         with:
           java-version: '21'
           distribution: 'temurin'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches

--- a/extended/src/main/java/apoc/agg/AggregationExtended.java
+++ b/extended/src/main/java/apoc/agg/AggregationExtended.java
@@ -14,7 +14,7 @@ import org.neo4j.procedure.UserAggregationUpdate;
 
 import java.util.Map;
 import java.util.function.BiPredicate;
-// TEST CI
+
 @Extended
 public class AggregationExtended {
 

--- a/extended/src/main/java/apoc/agg/AggregationExtended.java
+++ b/extended/src/main/java/apoc/agg/AggregationExtended.java
@@ -14,7 +14,7 @@ import org.neo4j.procedure.UserAggregationUpdate;
 
 import java.util.Map;
 import java.util.function.BiPredicate;
-
+// TEST CI
 @Extended
 public class AggregationExtended {
 


### PR DESCRIPTION
Test CI

Fix this error: https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/13266561703/job/37035384043?pr=4339#step:1:25
```
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```
