### PR TITLE
Fixes #4321: support s3 for non-aws storage

### DIFF
--- a/docs/asciidoc/modules/ROOT/partials/s3-protocol.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/s3-protocol.adoc
@@ -18,3 +18,30 @@ The S3 URL must be in the following format:
 (where the sessionToken is optional) or
 * `s3://endpoint:port/bucket/key`
 if the accessKey, secretKey, and the optional sessionToken are provided in the environment variables
+
+=== S3 protocol without SSL certificates checking
+
+To run S3 on providers that do not need SSL certificates, such as a minio container created in the following way:
+
+[source, bash]
+----
+docker run -p 9000:9000 -p 9001:9001 \
+  -e "MINIO_ROOT_USER=accessTestKey" \
+  -e "MINIO_ROOT_PASSWORD=secretTestKey" \
+  -e "MINIO_DEFAULT_BUCKETS=test" \
+  bitnami/minio:2025.1.20
+----
+
+we need to put in the `neo4j.conf` this setting:
+[source, config]
+----
+server.jvm.additional=-Dcom.amazonaws.sdk.disableCertChecking=true
+----
+
+Therefore, using this setting and the above minio container,
+the correct way to retrieve CSV file named `foo.csv` from the `test` bucket is:
+
+[source,cypher]
+----
+CALL apoc.load.csv('s3://127.0.0.1:9000/test/foo.csv?accessKey=accessTestKey&secretKey=secretTestKey')
+----

--- a/extended-it/src/test/java/apoc/s3/LoadS3MinioTest.java
+++ b/extended-it/src/test/java/apoc/s3/LoadS3MinioTest.java
@@ -1,0 +1,153 @@
+package apoc.s3;
+
+import apoc.export.csv.ExportCSV;
+import apoc.export.graphml.ExportGraphML;
+import apoc.export.json.ExportJson;
+import apoc.load.LoadCsv;
+import apoc.load.LoadJson;
+import apoc.load.Xml;
+import apoc.util.TestUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.time.Duration;
+import java.util.Map;
+
+import static apoc.ApocConfig.*;
+import static apoc.util.MapUtil.map;
+import static apoc.util.TestUtil.testCall;
+import static apoc.util.TestUtil.testResult;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class LoadS3MinioTest {
+
+    private static final String ACCESS_KEY = "testAccessKey";
+    private static final String SECRET_KEY = "testSecretKey";
+    private static final String BUCKET_NAME = "test";
+    private static GenericContainer<?> minioContainer;
+
+    @ClassRule
+    public static DbmsRule db = new ImpermanentDbmsRule();
+    
+    @BeforeClass
+    public static void init() throws Throwable {
+        // to make Minio work
+        System.setProperty("com.amazonaws.sdk.disableCertChecking", "true");
+
+        TestUtil.registerProcedure(db, 
+                ExportCSV.class, ExportGraphML.class, ExportJson.class, 
+                LoadCsv.class, LoadJson.class, Xml.class);
+
+        apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
+        apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
+        apocConfig().setProperty(APOC_IMPORT_FILE_USE_NEO4J_CONFIG, false);
+
+        db.executeTransactionally("CREATE (f:User1:User {name:'foo'})-[:KNOWS]->(b:User {name:'bar'})");
+
+        minioContainer = new GenericContainer<>("bitnami/minio:2025.1.20")
+                .withExposedPorts(9000, 9001)
+                .withEnv("MINIO_ROOT_USER", ACCESS_KEY)
+                .withEnv("MINIO_ROOT_PASSWORD", SECRET_KEY)
+                .withEnv("MINIO_DEFAULT_BUCKETS", BUCKET_NAME)
+                .waitingFor(
+                        Wait.forLogMessage(".*Bucket created successfully.*\\n", 1)
+                                .withStartupTimeout(Duration.ofSeconds(30))
+                );
+
+        minioContainer.start();
+    }
+
+    @AfterClass
+    public static void destroy() {
+        minioContainer.close();
+    }
+
+
+    private static String getUrl(String fileName) {
+        return String.format(
+                "s3://%s:%s/%s/%s?accessKey=%s&secretKey=%s",
+                minioContainer.getHost(),
+                minioContainer.getMappedPort(9000),
+                BUCKET_NAME,
+                fileName,
+                ACCESS_KEY,
+                SECRET_KEY
+        );
+    }
+
+    @Test
+    public void testLoadCsvS3() throws Exception {
+        
+        String url = getUrl("test.csv");
+
+        testCall(db, "CALL apoc.export.csv.all($url, {})",
+                map("url", url),
+                r -> assertEquals(url, r.get("file"))
+        );
+
+        testResult(db, "CALL apoc.load.csv($url)",
+                map("url", url),
+                r -> {
+                    ResourceIterator<Map> values = r.columnAs("map");
+                    Map row = values.next();
+                    assertEquals(":User:User1", row.get("_labels"));
+                    row = values.next();
+                    assertEquals(":User", row.get("_labels"));
+                    row = values.next();
+                    assertEquals("KNOWS", row.get("_type"));
+                    assertFalse(values.hasNext());
+                });
+    }
+
+    @Test
+    public void testLoadJsonS3() throws Exception {
+        String url = getUrl("test.json");
+
+        testCall(db, "CALL apoc.export.json.all($url)",
+                map("url", url),
+                r -> assertEquals(url, r.get("file"))
+        );
+        
+        testResult(db, "CALL apoc.load.json($url,'')",
+                map("url", url),
+                r -> {
+                    ResourceIterator<Map> values = r.columnAs("value");
+                    Map row = values.next();
+                    assertEquals("node", row.get("type"));
+                    row = values.next();
+                    assertEquals("node", row.get("type"));
+                    row = values.next();
+                    assertEquals("relationship", row.get("type"));
+                    assertFalse(values.hasNext());
+                });
+    }
+
+    @Test
+    public void testLoadXmlS3() throws Exception {
+        String url = getUrl("test.xml");
+
+        testCall(db, "CALL apoc.export.graphml.all($url, {})",
+                map("url", url),
+                r -> assertEquals(url, r.get("file"))
+        );
+
+        testResult(db, "CALL apoc.load.xml($url,'')",
+                map("url", url),
+                r -> {
+                    ResourceIterator<Map> values = r.columnAs("value");
+                    Map row = values.next();
+                    assertEquals("graphml", row.get("_type"));
+                    assertFalse(values.hasNext());
+                });
+    }
+
+
+}

--- a/extended-it/src/test/java/apoc/s3/LoadS3MinioTest.java
+++ b/extended-it/src/test/java/apoc/s3/LoadS3MinioTest.java
@@ -41,7 +41,8 @@ public class LoadS3MinioTest {
     public static void init() throws Throwable {
         // to make Minio work
         System.setProperty("com.amazonaws.sdk.disableCertChecking", "true");
-
+        System.setProperty("com.amazonaws.services.s3.disableGetObjectMD5Validation", "true");
+        
         TestUtil.registerProcedure(db, 
                 ExportCSV.class, ExportGraphML.class, ExportJson.class, 
                 LoadCsv.class, LoadJson.class, Xml.class);
@@ -67,6 +68,9 @@ public class LoadS3MinioTest {
 
     @AfterClass
     public static void destroy() {
+        System.clearProperty("com.amazonaws.services.s3.disableGetObjectMD5Validation");
+        System.clearProperty("com.amazonaws.sdk.disableCertChecking");
+        
         minioContainer.close();
     }
 


### PR DESCRIPTION
- [x] Fix CI error: https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/13281586355/job/37108087979?pr=4351#step:10:7085
Fixed [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4351#:~:text=try%20with%20clearProperty)

---

Fixes #4321

The test with a minio instance present [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/4.3.0.2/full/src/test/java/apoc/load/LoadS3Test.java) does not work as a "real" instance.
In fact, using an instance pointing to localhost, it fails with TODO error.
To fix it, just put the java property `Dcom.amazonaws.sdk.disableCertChecking=true` that executes the if present [here](https://github.com/neo4j/apoc/blob/dev/common/src/main/java/apoc/util/s3/S3ParamsExtractor.java#L132).


Therefore, added test and docs.



### TestContainer considerations 

Used [bitnami/minio](https://hub.docker.com/r/bitnami/minio) since the official [minio](https://hub.docker.com/r/minio/minio) image doesn't work in test container.


Using the official minio, it doesn't start without any error.

We should do: https://stackoverflow.com/questions/55402610/configuring-minio-server-for-use-with-testcontainers,
it works flakily in any case, sometimes throws an `Timeout waiting for result with exception ... Not ready yet`.
Moreover, it requires an additional container (`minio:mc`), and additional code to create a bucket (since `MINIO_DEFAULT_BUCKETS` env doesn't exist).

Tried with [TestContainer using a docker-compose as well](https://github.com/vga91/neo4j-apoc-procedures/pull/470/files#diff-46f1450c82b9077b07eeef97987fb06a54452977818f15c28e33843050c0d0a6), but without success.
