### PR TITLE
Fixes #4355: The apoc.metrics.get throws an URLAccessChecker error

### DIFF
--- a/extended-it/src/test/java/apoc/neo4j/docker/MetricsTest.java
+++ b/extended-it/src/test/java/apoc/neo4j/docker/MetricsTest.java
@@ -62,12 +62,13 @@ public class MetricsTest {
         }
     }
     
-    // TODO: Investigate broken test. It hangs for more than 30 seconds for no reason.
     @Test
-    @Ignore
     public void shouldGetMetrics() {
         session.executeRead(tx -> tx.run("RETURN 1 AS num;").consume());
-        String metricKey = "neo4j.system.check_point.total_time";
+        String metricKey = "neo4j.database.system.check_point.total_time";
+        
+        // --> TODO - USE THIS ? session.run("CALL apoc.metrics.list").list()
+        
         assertEventually(() -> {
                     try {
                         return session.run("CALL apoc.metrics.get($metricKey)",
@@ -76,6 +77,7 @@ public class MetricsTest {
                                 .get(0)
                                 .asMap();
                     } catch (Exception e) {
+                        System.out.println("e = " + e);
                         return Map.<String, Object>of();
                     }
                 },

--- a/extended/src/main/java/apoc/metrics/Metrics.java
+++ b/extended/src/main/java/apoc/metrics/Metrics.java
@@ -8,7 +8,6 @@ import apoc.load.util.LoadCsvConfig;
 import apoc.util.CompressionAlgo;
 import apoc.util.ExtendedFileUtils;
 import apoc.util.FileUtils;
-import apoc.util.SupportedProtocols;
 import apoc.util.Util;
 import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.logging.Log;
@@ -191,9 +190,7 @@ public class Metrics {
         String url = file.getAbsolutePath();
         CountingReader reader = null;
         try {
-            reader = FileUtils.getStreamConnection(SupportedProtocols.file, url, null, null, urlAccessChecker)
-                    .toCountingInputStream(CompressionAlgo.NONE.name())
-                    .asReader();
+            reader = FileUtils.readerFor(url, CompressionAlgo.NONE.name(), urlAccessChecker);
             return new LoadCsv()
                     .streamCsv(url, new LoadCsvConfig(config), reader)
                     .filter(Metrics.duplicatedHeaderRows)

--- a/extended/src/main/java/apoc/metrics/Metrics.java
+++ b/extended/src/main/java/apoc/metrics/Metrics.java
@@ -118,7 +118,7 @@ public class Metrics {
         }
     }
 
-    @Procedure(mode=Mode.DBMS)
+    @Procedure
     @Description("apoc.metrics.list() - get a list of available metrics")
     public Stream<Neo4jMeasuredMetric> list() {
         File metricsDir = ExtendedFileUtils.getMetricsDirectory();
@@ -204,7 +204,7 @@ public class Metrics {
         }
     }
 
-    @Procedure(mode=Mode.DBMS)
+    @Procedure
     @Description("apoc.metrics.storage(directorySetting) - retrieve storage metrics about the devices Neo4j uses for data storage. " +
             "directorySetting may be any valid neo4j directory setting name, such as 'server.directories.data'.  If null is provided " +
             "as a directorySetting, you will get back all available directory settings.  For a list of available directory settings, " +
@@ -239,7 +239,7 @@ public class Metrics {
                 .map(StorageMetric::fromStoragePair);
     }
 
-    @Procedure(mode=Mode.DBMS)
+    @Procedure
     @Description("apoc.metrics.get(metricName, {}) - retrieve a system metric by its metric name. Additional configuration options may be passed matching the options available for apoc.load.csv.")
     /**
      * This method is a specialization of apoc.load.csv, it just happens that the directory and file path

--- a/extended/src/main/java/apoc/metrics/Metrics.java
+++ b/extended/src/main/java/apoc/metrics/Metrics.java
@@ -5,10 +5,7 @@ import apoc.export.util.CountingReader;
 import apoc.load.CSVResult;
 import apoc.load.LoadCsv;
 import apoc.load.util.LoadCsvConfig;
-import apoc.util.CompressionAlgo;
-import apoc.util.ExtendedFileUtils;
-import apoc.util.FileUtils;
-import apoc.util.Util;
+import apoc.util.*;
 import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.*;
@@ -190,7 +187,9 @@ public class Metrics {
         String url = file.getAbsolutePath();
         CountingReader reader = null;
         try {
-            reader = FileUtils.readerFor(url, CompressionAlgo.NONE.name(), urlAccessChecker);
+            reader = FileUtils.getStreamConnection(SupportedProtocols.file, url, null, null, urlAccessChecker)
+                    .toCountingInputStream(CompressionAlgo.NONE.name())
+                    .asReader();
             return new LoadCsv()
                     .streamCsv(url, new LoadCsvConfig(config), reader)
                     .filter(Metrics.duplicatedHeaderRows)


### PR DESCRIPTION
Fixes #4355

The problem is due to the Mode of the procedure.
With DBMS, the [URLAccessChecker.checkURL(url)](https://github.com/neo4j/apoc/blob/dev/common/src/main/java/apoc/util/FileUtils.java#L70) blocks the execution and throws the `LOAD ... is not allowed for user ...` error, because reading CSVs requires the procedure to be `READ`  (which is the default mode). 
Consistently with apoc.load.csv and the other load procedures


## Changes

- Fixed the bug removing the `Procedure.Mode` annotation [from the 3 procedures](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4357/files#diff-3715b84a6cdfdc34f78575e994d7f1176b4282b4403db476949ab11e6d3128d3R120)
- De-ignored the `shouldGetMetrics` test
- The `neo4j.system.check_point.total_time` doesn't work, as has been replaced by `neo4j.database.system.check_point.total_time` setting
  - Therefore changed the `shouldGetMetrics` test to check all possible metrics retrieved via the `apoc.metrics.list` procedure 
- added a println in the `shouldGetMetrics` catch block to facilitate debug in case of CI error
- ~Changed [`getStreamConnection` to `readerFor`](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4357/files#diff-3715b84a6cdfdc34f78575e994d7f1176b4282b4403db476949ab11e6d3128d3R193), consistently with the apoc.load.csv procedure (see [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/dev/extended/src/main/java/apoc/load/LoadCsv.java#L58))~ 
not possible, since in this way it prepends `/var/lib/neo4j/import` to path, see [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/13371834633/job/37341901435?pr=4357#step:10:6946)