### PR TITLE
Fixes #4355: The apoc.metrics.get throws an URLAccessChecker error

### DIFF
--- a/extended-it/src/test/java/apoc/neo4j/docker/MetricsTest.java
+++ b/extended-it/src/test/java/apoc/neo4j/docker/MetricsTest.java
@@ -5,7 +5,6 @@ import apoc.util.TestContainerUtil.ApocPackage;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Session;
@@ -29,8 +28,6 @@ import static org.neo4j.test.assertion.Assert.assertEventually;
  * @author as
  * @since 13.02.19
  */
-// TODO Investigate why this test is not working. Possibly increase timeout for container
-@Ignore
 public class MetricsTest {
 
     private static Neo4jContainerExtension neo4jContainer;
@@ -63,24 +60,32 @@ public class MetricsTest {
         }
     }
     
-    // TODO: Investigate broken test. It hangs for more than 30 seconds for no reason.
     @Test
-    @Ignore
     public void shouldGetMetrics() {
         session.executeRead(tx -> tx.run("RETURN 1 AS num;").consume());
-        String metricKey = "neo4j.system.check_point.total_time";
+
+        List<String> metricsList = session.run("CALL apoc.metrics.list")
+                .list(i -> i.get("name").asString());
+        
+        for (String metric: metricsList) {
+            metricsGetAssertion(metric);
+        }
+    }
+
+    private void metricsGetAssertion(String metric) {
         assertEventually(() -> {
                     try {
                         return session.run("CALL apoc.metrics.get($metricKey)",
-                                map("metricKey", metricKey))
+                                        map("metricKey", metric))
                                 .list()
                                 .get(0)
                                 .asMap();
                     } catch (Exception e) {
+                        System.out.println("e = " + e);
                         return Map.<String, Object>of();
                     }
                 },
-                map -> Set.of("timestamp", "metric", "map").equals(map.keySet()) && map.get("metric").equals(metricKey),
+                map -> Set.of("timestamp", "metric", "map").equals(map.keySet()) && map.get("metric").equals(metric),
                 30L, TimeUnit.SECONDS);
     }
 

--- a/extended/src/main/java/apoc/metrics/Metrics.java
+++ b/extended/src/main/java/apoc/metrics/Metrics.java
@@ -8,7 +8,6 @@ import apoc.load.util.LoadCsvConfig;
 import apoc.util.CompressionAlgo;
 import apoc.util.ExtendedFileUtils;
 import apoc.util.FileUtils;
-import apoc.util.SupportedProtocols;
 import apoc.util.Util;
 import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.logging.Log;
@@ -118,7 +117,7 @@ public class Metrics {
         }
     }
 
-    @Procedure(mode=Mode.DBMS)
+    @Procedure
     @Description("apoc.metrics.list() - get a list of available metrics")
     public Stream<Neo4jMeasuredMetric> list() {
         File metricsDir = ExtendedFileUtils.getMetricsDirectory();
@@ -191,9 +190,7 @@ public class Metrics {
         String url = file.getAbsolutePath();
         CountingReader reader = null;
         try {
-            reader = FileUtils.getStreamConnection(SupportedProtocols.file, url, null, null, urlAccessChecker)
-                    .toCountingInputStream(CompressionAlgo.NONE.name())
-                    .asReader();
+            reader = FileUtils.readerFor(url, CompressionAlgo.NONE.name(), urlAccessChecker);
             return new LoadCsv()
                     .streamCsv(url, new LoadCsvConfig(config), reader)
                     .filter(Metrics.duplicatedHeaderRows)
@@ -204,7 +201,7 @@ public class Metrics {
         }
     }
 
-    @Procedure(mode=Mode.DBMS)
+    @Procedure
     @Description("apoc.metrics.storage(directorySetting) - retrieve storage metrics about the devices Neo4j uses for data storage. " +
             "directorySetting may be any valid neo4j directory setting name, such as 'server.directories.data'.  If null is provided " +
             "as a directorySetting, you will get back all available directory settings.  For a list of available directory settings, " +
@@ -239,7 +236,7 @@ public class Metrics {
                 .map(StorageMetric::fromStoragePair);
     }
 
-    @Procedure(mode=Mode.DBMS)
+    @Procedure
     @Description("apoc.metrics.get(metricName, {}) - retrieve a system metric by its metric name. Additional configuration options may be passed matching the options available for apoc.load.csv.")
     /**
      * This method is a specialization of apoc.load.csv, it just happens that the directory and file path

--- a/extended/src/main/java/apoc/metrics/Metrics.java
+++ b/extended/src/main/java/apoc/metrics/Metrics.java
@@ -5,10 +5,7 @@ import apoc.export.util.CountingReader;
 import apoc.load.CSVResult;
 import apoc.load.LoadCsv;
 import apoc.load.util.LoadCsvConfig;
-import apoc.util.CompressionAlgo;
-import apoc.util.ExtendedFileUtils;
-import apoc.util.FileUtils;
-import apoc.util.Util;
+import apoc.util.*;
 import org.neo4j.graphdb.security.URLAccessChecker;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.*;
@@ -190,7 +187,9 @@ public class Metrics {
         String url = file.getAbsolutePath();
         CountingReader reader = null;
         try {
-            reader = FileUtils.readerFor(url, CompressionAlgo.NONE.name(), urlAccessChecker);
+            reader = FileUtils.getStreamConnection(SupportedProtocols.file, url, null, null, urlAccessChecker)
+                    .toCountingInputStream(CompressionAlgo.NONE.name())
+                    .asReader();
             return new LoadCsv()
                     .streamCsv(url, new LoadCsvConfig(config), reader)
                     .filter(Metrics.duplicatedHeaderRows)


### PR DESCRIPTION
Fixes #4355

Cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4357