### PR TITLE
Fixing CODEARTIFACT_DOWNLOAD_URL to be able to retrieve both CI and Release artifacts (#4354)

### DIFF
--- a/.github/actions/test-gradle-project/action.yml
+++ b/.github/actions/test-gradle-project/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: ./gradlew --info -Pneo4jVersionOverride=$NEO4JVERSION -Pneo4jDockerEeOverride=$NEO4J_DOCKER_EE_OVERRIDE -Pneo4jDockerCeOverride=$NEO4J_DOCKER_CE_OVERRIDE :${{inputs.project-name}}:check --parallel
     - name: Archive test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
         name: ${{inputs.project-name}}-test-results

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -78,7 +78,7 @@ jobs:
           ./gradlew --no-daemon --info -Pneo4jVersionOverride=$NEO4JVERSION --init-script init.gradle clean
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3.28.8
         with:
           languages: ${{ matrix.language }}
 
@@ -86,7 +86,7 @@ jobs:
         run: ./gradlew --info -Pneo4jVersionOverride=$NEO4JVERSION compileJava compileTestJava
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3.28.8
         with:
           category: "/language:${{matrix.language}}"
   

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -7,7 +7,7 @@ on:
     branches: [ "5.26" ]
 
 env:
-  CODEARTIFACT_DOWNLOAD_URL: ${{ secrets.CODEARTIFACT_DOWNLOAD_URL }}
+  CODEARTIFACT_BUILD_SERVICE_LIVE_URL: ${{ secrets.CODEARTIFACT_BUILD_SERVICE_LIVE_URL }}
   CODEARTIFACT_USERNAME: ${{ secrets.CODEARTIFACT_USERNAME }}
   ECR_NEO4J_DOCKER_URL: ${{ secrets.ECR_NEO4J_DOCKER_URL }}
   BRANCH_NAME: ${{ github.event.pull_request.base.ref }}
@@ -45,25 +45,32 @@ jobs:
       - uses: ./.github/actions/setup-jdk
       - uses: ./.github/actions/setup-gradle-cache
 
-      - name: Determine latest neo4j CI version and docker images
+      - name: Determine CODEARTIFACT_DOWNLOAD_URL, NEO4JVERSION and Docker Image environment variables
         run: |
-          neo4j_version_base=$(grep -e "neo4jVersion = .*" build.gradle | cut -d '=' -f 2 | tr -d \'\" | tr -d ' ')
-          echo "neo4j_version_base=$neo4j_version_base"
-          NEO4JVERSION=`aws codeartifact list-package-versions --domain build-service-live --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --repository ci-live --format maven --namespace org.neo4j --package neo4j --sort-by PUBLISHED_TIME --query "versions[?starts_with(version,'$neo4j_version_base')] | [0].version" | tr -d '" '`
-          echo "NEO4JVERSION=$NEO4JVERSION" >> "$GITHUB_ENV"
-          echo "Found NEO4JVERSION=$NEO4JVERSION"
-          if [[ $BRANCH_NAME =~ ^5.[0-9]+$ ]]; then
-            NEO4J_DOCKER_EE_OVERRIDE="neo4j:$neo4j_version_base-enterprise"
-            NEO4J_DOCKER_CE_OVERRIDE="neo4j:$neo4j_version_base"
-          else
-            NEO4J_DOCKER_CE_OVERRIDE="$ECR_NEO4J_DOCKER_URL:$neo4j_version_base-community-debian-nightly"
-            NEO4J_DOCKER_EE_OVERRIDE="$ECR_NEO4J_DOCKER_URL:$neo4j_version_base-enterprise-debian-nightly"
-          fi
-          echo "NEO4J_DOCKER_EE_OVERRIDE=$NEO4J_DOCKER_EE_OVERRIDE" >> "$GITHUB_ENV"
-          echo "Found NEO4J_DOCKER_EE_OVERRIDE=$NEO4J_DOCKER_EE_OVERRIDE"
-          echo "NEO4J_DOCKER_CE_OVERRIDE=$NEO4J_DOCKER_CE_OVERRIDE" >> "$GITHUB_ENV"
-          echo "Found NEO4J_DOCKER_CE_OVERRIDE=$NEO4J_DOCKER_CE_OVERRIDE"
           echo "Current branch BRANCH_NAME=$BRANCH_NAME"
+          neo4j_version_base=$(grep -e "neo4jVersion = .*" build.gradle | cut -d '=' -f 2 | tr -d \'\" | tr -d ' ')
+          if [[ $BRANCH_NAME == "dev" ]]; then
+            echo "Running on dev branch and so pointing to ci-live repository in AWS CodeArtifact for CI artifacts"
+            CODEARTIFACT_DOWNLOAD_URL="$CODEARTIFACT_BUILD_SERVICE_LIVE_URL/maven/ci-live"
+            NEO4JVERSION=`aws --no-cli-pager codeartifact list-package-versions --domain build-service-live --domain-owner ${{ secrets.AWS_ACCOUNT_ID }}  --repository ci-live --format maven --namespace org.neo4j --package neo4j --sort-by PUBLISHED_TIME --status Published --query "versions[?starts_with(version, '$neo4j_version_base')].version | [0]" --output json | sed 's/"//g'`
+            NEO4J_DOCKER_CE_OVERRIDE="$ECR_NEO4J_DOCKER_URL/build-service/neo4j:$neo4j_version_base-community-debian-nightly"
+            NEO4J_DOCKER_EE_OVERRIDE="$ECR_NEO4J_DOCKER_URL/build-service/neo4j:$neo4j_version_base-enterprise-debian-nightly"
+          else
+            echo "Running on branch $BRANCH_NAME and so pointing to release-live repository in AWS CodeArtifact for release artifacts"
+            CODEARTIFACT_DOWNLOAD_URL="$CODEARTIFACT_BUILD_SERVICE_LIVE_URL/maven/release-live"
+            NEO4JVERSION=$neo4j_version_base
+            NEO4J_DOCKER_CE_OVERRIDE="neo4j:$neo4j_version_base"
+            NEO4J_DOCKER_EE_OVERRIDE="neo4j:$neo4j_version_base-enterprise"
+          fi
+          echo "CODEARTIFACT_DOWNLOAD_URL=$CODEARTIFACT_DOWNLOAD_URL" >> "$GITHUB_ENV"
+
+          echo "Found NEO4JVERSION=$NEO4JVERSION"
+          echo "Found NEO4J_DOCKER_CE_OVERRIDE=$NEO4J_DOCKER_CE_OVERRIDE"
+          echo "Found NEO4J_DOCKER_EE_OVERRIDE=$NEO4J_DOCKER_EE_OVERRIDE"
+
+          echo "NEO4JVERSION=$NEO4JVERSION" >> "$GITHUB_ENV"
+          echo "NEO4J_DOCKER_CE_OVERRIDE=$NEO4J_DOCKER_CE_OVERRIDE" >> "$GITHUB_ENV"
+          echo "NEO4J_DOCKER_EE_OVERRIDE=$NEO4J_DOCKER_EE_OVERRIDE" >> "$GITHUB_ENV"
 
       - name: Compile Java
         run: |
@@ -120,25 +127,32 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
 
-      - name: Determine latest neo4j CI version and docker images
+      - name: Determine CODEARTIFACT_DOWNLOAD_URL, NEO4JVERSION and Docker Image environment variables
         run: |
+          echo "Current branch BRANCH_NAME=$BRANCH_NAME"
           neo4j_version_base=$(grep -e "neo4jVersion = .*" build.gradle | cut -d '=' -f 2 | tr -d \'\" | tr -d ' ')
-          echo "neo4j_version_base=$neo4j_version_base"
-          NEO4JVERSION=`aws codeartifact list-package-versions --domain build-service-live --domain-owner ${{ secrets.AWS_ACCOUNT_ID }} --repository ci-live --format maven --namespace org.neo4j --package neo4j --sort-by PUBLISHED_TIME --query "versions[?starts_with(version,'$neo4j_version_base')] | [0].version" | tr -d '" '`
-          echo "NEO4JVERSION=$NEO4JVERSION" >> "$GITHUB_ENV"
-          echo "Found NEO4JVERSION=$NEO4JVERSION"
-          if [[ $BRANCH_NAME =~ ^5.[0-9]+$ ]]; then
-            NEO4J_DOCKER_EE_OVERRIDE="neo4j:$neo4j_version_base-enterprise"
-            NEO4J_DOCKER_CE_OVERRIDE="neo4j:$neo4j_version_base"
-          else
+          if [[ $BRANCH_NAME == "dev" ]]; then
+            echo "Running on dev branch and so pointing to ci-live repository in AWS CodeArtifact for CI artifacts"
+            CODEARTIFACT_DOWNLOAD_URL="$CODEARTIFACT_BUILD_SERVICE_LIVE_URL/maven/ci-live"
+            NEO4JVERSION=`aws --no-cli-pager codeartifact list-package-versions --domain build-service-live --domain-owner ${{ secrets.AWS_ACCOUNT_ID }}  --repository ci-live --format maven --namespace org.neo4j --package neo4j --sort-by PUBLISHED_TIME --status Published --query "versions[?starts_with(version, '$neo4j_version_base')].version | [0]" --output json | sed 's/"//g'`
             NEO4J_DOCKER_CE_OVERRIDE="$ECR_NEO4J_DOCKER_URL/build-service/neo4j:$neo4j_version_base-community-debian-nightly"
             NEO4J_DOCKER_EE_OVERRIDE="$ECR_NEO4J_DOCKER_URL/build-service/neo4j:$neo4j_version_base-enterprise-debian-nightly"
+          else
+            echo "Running on branch $BRANCH_NAME and so pointing to release-live repository in AWS CodeArtifact for release artifacts"
+            CODEARTIFACT_DOWNLOAD_URL="$CODEARTIFACT_BUILD_SERVICE_LIVE_URL/maven/release-live"
+            NEO4JVERSION=$neo4j_version_base
+            NEO4J_DOCKER_CE_OVERRIDE="neo4j:$neo4j_version_base"
+            NEO4J_DOCKER_EE_OVERRIDE="neo4j:$neo4j_version_base-enterprise"
           fi
-          echo "NEO4J_DOCKER_EE_OVERRIDE=$NEO4J_DOCKER_EE_OVERRIDE" >> "$GITHUB_ENV"
-          echo "Found NEO4J_DOCKER_EE_OVERRIDE=$NEO4J_DOCKER_EE_OVERRIDE"
-          echo "NEO4J_DOCKER_CE_OVERRIDE=$NEO4J_DOCKER_CE_OVERRIDE" >> "$GITHUB_ENV"
+          echo "CODEARTIFACT_DOWNLOAD_URL=$CODEARTIFACT_DOWNLOAD_URL" >> "$GITHUB_ENV"
+
+          echo "Found NEO4JVERSION=$NEO4JVERSION"
           echo "Found NEO4J_DOCKER_CE_OVERRIDE=$NEO4J_DOCKER_CE_OVERRIDE"
-          echo "Current branch BRANCH_NAME=$BRANCH_NAME"
+          echo "Found NEO4J_DOCKER_EE_OVERRIDE=$NEO4J_DOCKER_EE_OVERRIDE"
+
+          echo "NEO4JVERSION=$NEO4JVERSION" >> "$GITHUB_ENV"
+          echo "NEO4J_DOCKER_CE_OVERRIDE=$NEO4J_DOCKER_CE_OVERRIDE" >> "$GITHUB_ENV"
+          echo "NEO4J_DOCKER_EE_OVERRIDE=$NEO4J_DOCKER_EE_OVERRIDE" >> "$GITHUB_ENV"
 
       - name: Init gradle
         run: |

--- a/extended/src/main/java/apoc/cypher/CypherExtended.java
+++ b/extended/src/main/java/apoc/cypher/CypherExtended.java
@@ -18,6 +18,7 @@ import org.neo4j.graphdb.QueryStatistics;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.security.URLAccessChecker;
+import org.neo4j.internal.kernel.api.procs.ProcedureCallContext;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
@@ -83,6 +84,9 @@ public class CypherExtended {
 
     @Context
     public URLAccessChecker urlAccessChecker;
+
+    @Context
+    public ProcedureCallContext procedureCallContext;
 
     @Procedure(name = "apoc.cypher.runFile", mode = WRITE)
     @Description("apoc.cypher.runFile(file or url,[{statistics:true,timeout:10,parameters:{}}]) - runs each statement in the file, all semicolon separated - currently no schema operations")
@@ -386,7 +390,7 @@ public class CypherExtended {
     @Procedure
     @Description("apoc.cypher.parallel(fragment, `paramMap`, `keyList`) yield value - executes fragments in parallel through a list defined in `paramMap` with a key `keyList`")
     public Stream<CypherStatementMapResult> parallel(@Name("fragment") String fragment, @Name("params") Map<String, Object> params, @Name("parallelizeOn") String key) {
-        if (params == null) return runCypherQuery(tx, fragment, params);
+        if (params == null) return runCypherQuery(tx, fragment, params, procedureCallContext);
         if (key == null || !params.containsKey(key))
             throw new RuntimeException("Can't parallelize on key " + key + " available keys " + params.keySet());
         Object value = params.get(key);
@@ -473,7 +477,7 @@ public class CypherExtended {
     @Procedure
     @Description("apoc.cypher.parallel2(fragment, `paramMap`, `keyList`) yield value - executes fragments in parallel batches through a list defined in `paramMap` with a key `keyList`")
     public Stream<CypherStatementMapResult> parallel2(@Name("fragment") String fragment, @Name("params") Map<String, Object> params, @Name("parallelizeOn") String key) {
-        if (params == null) return runCypherQuery(tx, fragment, params);
+        if (params == null) return runCypherQuery(tx, fragment, params, procedureCallContext);
         if (StringUtils.isEmpty(key) || !params.containsKey(key))
             throw new RuntimeException("Can't parallelize on key " + key + " available keys " + params.keySet() + ". Note that parallelizeOn parameter must be not empty");
         Object value = params.get(key);

--- a/extended/src/main/java/apoc/cypher/CypherExtended.java
+++ b/extended/src/main/java/apoc/cypher/CypherExtended.java
@@ -18,7 +18,6 @@ import org.neo4j.graphdb.QueryStatistics;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.security.URLAccessChecker;
-import org.neo4j.internal.kernel.api.procs.ProcedureCallContext;
 import org.neo4j.logging.Log;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
@@ -84,9 +83,6 @@ public class CypherExtended {
 
     @Context
     public URLAccessChecker urlAccessChecker;
-
-    @Context
-    public ProcedureCallContext procedureCallContext;
 
     @Procedure(name = "apoc.cypher.runFile", mode = WRITE)
     @Description("apoc.cypher.runFile(file or url,[{statistics:true,timeout:10,parameters:{}}]) - runs each statement in the file, all semicolon separated - currently no schema operations")
@@ -390,7 +386,7 @@ public class CypherExtended {
     @Procedure
     @Description("apoc.cypher.parallel(fragment, `paramMap`, `keyList`) yield value - executes fragments in parallel through a list defined in `paramMap` with a key `keyList`")
     public Stream<CypherStatementMapResult> parallel(@Name("fragment") String fragment, @Name("params") Map<String, Object> params, @Name("parallelizeOn") String key) {
-        if (params == null) return runCypherQuery(tx, fragment, params, procedureCallContext);
+        if (params == null) return runCypherQuery(tx, fragment, params);
         if (key == null || !params.containsKey(key))
             throw new RuntimeException("Can't parallelize on key " + key + " available keys " + params.keySet());
         Object value = params.get(key);
@@ -477,7 +473,7 @@ public class CypherExtended {
     @Procedure
     @Description("apoc.cypher.parallel2(fragment, `paramMap`, `keyList`) yield value - executes fragments in parallel batches through a list defined in `paramMap` with a key `keyList`")
     public Stream<CypherStatementMapResult> parallel2(@Name("fragment") String fragment, @Name("params") Map<String, Object> params, @Name("parallelizeOn") String key) {
-        if (params == null) return runCypherQuery(tx, fragment, params, procedureCallContext);
+        if (params == null) return runCypherQuery(tx, fragment, params);
         if (StringUtils.isEmpty(key) || !params.containsKey(key))
             throw new RuntimeException("Can't parallelize on key " + key + " available keys " + params.keySet() + ". Note that parallelizeOn parameter must be not empty");
         Object value = params.get(key);


### PR DESCRIPTION
Cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/96b1bd11c184d785416d0bf3b38c333fced390ef

Cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/f3bb30d7da680ea887e796acce8f55b3b991c0e7


Reverted https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/96b1bd11c184d785416d0bf3b38c333fced390ef#diff-0be321a488b8e1a039cef51ff786b8142a2eac4a76f7585ff6121e4fc588dfc9 , no longer valid in 5.26