### PR TITLE
Add note in StartupExtendedTest, in order to solve a potential ModuleVersionNotFoundException in case of Neo4j inconsistencies (#4317)

### DIFF
--- a/extended-it/src/test/java/apoc/neo4j/docker/StartupExtendedTest.java
+++ b/extended-it/src/test/java/apoc/neo4j/docker/StartupExtendedTest.java
@@ -26,8 +26,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-/*
- This test is just to verify if the APOC procedures and functions are correctly deployed into a Neo4j instance without any startup issue.
+/**
+ * This test is just to verify if the APOC procedures and functions are correctly deployed into a Neo4j instance without any startup issue.
+ * <br/>
+ * NOTE: if we have an error like `Caused by: org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find org.neo4j:neo4j:5.25.0.`,
+ * there is probably inconsistency between the neo4j version of APOC Core and the Extended version,
+ * so we need to set the environment variable `NEO4JVERSION=<correctVersion>`, e.g. `NEO4JVERSION=5.25.1`,
+ * which is valued via {@link TestContainerUtil#executeGradleTasks(File, String...)} present in APOC Core and therefore not modifiable by APOC Extended
  */
 public class StartupExtendedTest {
     private static final String APOC_HELP_QUERY = "CALL apoc.help('') YIELD core, type, name WHERE core = $core and type = $type RETURN name";


### PR DESCRIPTION
Cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/6bb59e9b065648f392d77e9c82b07f6e97f61a42