### PR TITLE
Try fixing flaky MongoDb TeamCity tests 2025.01

### DIFF
--- a/extended-it/src/test/java/apoc/mongodb/MongoTestBase.java
+++ b/extended-it/src/test/java/apoc/mongodb/MongoTestBase.java
@@ -53,7 +53,7 @@ import static org.neo4j.test.assertion.Assert.assertEventually;
 public class MongoTestBase {
     enum MongoVersion {
         FOUR("mongo:4", "mongo"),
-        LATEST("mongo:7.0.4", "mongosh");
+        LATEST("mongo:7.0.17", "mongosh");
 
         public final String dockerImg;
         public final String shell;


### PR DESCRIPTION
Try fixing flaky MongoDb TeamCity tests 2025.01.

Unfortunately, the error does not seem replicable either locally or on Gh action.

Try these two ways that could alleviate the problems:
- Added maxSize and maxConnectionIdleTime
- Upgraded mongo 7.x.x version

The TeamCity problem is:
```
apoc.mongodb.MongoTest.shouldNotFailsIfUriHasNotCollectionNameButIsPresentInConfig

java.lang.AssertionError: 
Expecting actual:
  false
to satisfy:
  Generic condition. See predicate for condition details.
java.lang.AssertionError:
Expecting actual:
  false
to satisfy:
  Generic condition. See predicate for condition details.
  at org.neo4j.test.assertion.Assert.lambda$assertEventually$0(Assert.java:73)
  at org.awaitility.core.AssertionCondition.lambda$new$0(AssertionCondition.java:53)
  at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:248)
  at org.awaitility.core.ConditionAwaiter$ConditionPoller.call(ConditionAwaiter.java:235)

------- Stdout: -------
numConnectionsMap = {current=3, available=838857, totalCreated=168, rejected=0, active=1, threaded=3, exhaustIsMaster=0, exhaustHello=0, awaitingTopologyChanges=0}
```