### PR TITLE
Fixes #1383: Add procedure to compare indexes and constraints

### DIFF
--- a/extended/src/main/java/apoc/result/CompareIdxToCons.java
+++ b/extended/src/main/java/apoc/result/CompareIdxToCons.java
@@ -1,0 +1,36 @@
+package apoc.result;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public abstract class CompareIdxToCons {
+    public List<String> commonProps;
+    public Map<String, Object> onlyIdxProps;
+    public Map<String, Object> onlyConstraintsProps;
+
+    public CompareIdxToCons() {
+        this.commonProps = new ArrayList<>();
+        this.onlyIdxProps = new HashMap<>();
+        this.onlyConstraintsProps = new HashMap<>();
+    }
+
+    public void addCommonProps(List<String> commonProps) {
+        this.commonProps.addAll(commonProps);
+        // sort and remove duplicates
+        this.commonProps = this.commonProps.stream()
+                .sorted()
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    public void putOnlyIdxProps(String name, List<String> properties) {
+        this.onlyIdxProps.put(name, properties);
+    }
+
+    public void putOnlyConstraintsProps(String name, List<String> properties) {
+        this.onlyConstraintsProps.put(name, properties);
+    }
+}

--- a/extended/src/main/java/apoc/result/CompareIdxToConsNodes.java
+++ b/extended/src/main/java/apoc/result/CompareIdxToConsNodes.java
@@ -1,0 +1,10 @@
+package apoc.result;
+
+public class CompareIdxToConsNodes extends CompareIdxToCons {
+    public String label;
+
+    public CompareIdxToConsNodes(String label) {
+        super();
+        this.label = label;
+    }
+}

--- a/extended/src/main/java/apoc/result/CompareIdxToConsRels.java
+++ b/extended/src/main/java/apoc/result/CompareIdxToConsRels.java
@@ -1,0 +1,11 @@
+package apoc.result;
+
+public class CompareIdxToConsRels extends CompareIdxToCons {
+
+    public String relationshipType;
+
+    public CompareIdxToConsRels(String relationshipType) {
+        super();
+        this.relationshipType = relationshipType;
+    }
+}

--- a/extended/src/main/java/apoc/schema/SchemaConfigExtended.java
+++ b/extended/src/main/java/apoc/schema/SchemaConfigExtended.java
@@ -1,0 +1,52 @@
+package apoc.schema;
+
+import java.util.*;
+
+public class SchemaConfigExtended {
+    private static final String LABELS_KEY = "labels";
+    private static final String EXCLUDE_LABELS_KEY = "excludeLabels";
+    private static final String RELATIONSHIPS_KEY = "relationships";
+    private static final String EXCLUDE_RELATIONSHIPS_KEY = "excludeRelationships";
+
+    private final Set<String> labels;
+    private final Set<String> excludeLabels;
+    private final Set<String> relationships;
+    private final Set<String> excludeRelationships;
+
+    public Set<String> getLabels() {
+        return labels;
+    }
+
+    public Set<String> getExcludeLabels() {
+        return excludeLabels;
+    }
+
+    public Set<String> getRelationships() {
+        return relationships;
+    }
+
+    public Set<String> getExcludeRelationships() {
+        return excludeRelationships;
+    }
+
+    public SchemaConfigExtended(Map<String, Object> config) {
+        config = config != null ? config : Collections.emptyMap();
+        this.labels = new HashSet<>((Collection<String>) config.getOrDefault(LABELS_KEY, Collections.EMPTY_SET));
+        this.excludeLabels =
+                new HashSet<>((Collection<String>) config.getOrDefault(EXCLUDE_LABELS_KEY, Collections.EMPTY_SET));
+        validateParameters(this.labels, this.excludeLabels, LABELS_KEY, EXCLUDE_LABELS_KEY);
+        this.relationships =
+                new HashSet<>((Collection<String>) config.getOrDefault(RELATIONSHIPS_KEY, Collections.EMPTY_SET));
+        this.excludeRelationships = new HashSet<>(
+                (Collection<String>) config.getOrDefault(EXCLUDE_RELATIONSHIPS_KEY, Collections.EMPTY_SET));
+        validateParameters(this.relationships, this.excludeRelationships, RELATIONSHIPS_KEY, EXCLUDE_RELATIONSHIPS_KEY);
+    }
+
+    private void validateParameters(
+            Set<String> include, Set<String> exclude, String includeParameterType, String excludeParameterType) {
+        if (!include.isEmpty() && !exclude.isEmpty())
+            throw new IllegalArgumentException(String.format(
+                    "Parameters %s and %s are both valuated. Please check parameters and valuate only one.",
+                    includeParameterType, excludeParameterType));
+    }
+}

--- a/extended/src/main/java/apoc/schema/SchemasExtended.java
+++ b/extended/src/main/java/apoc/schema/SchemasExtended.java
@@ -1,0 +1,303 @@
+package apoc.schema;
+
+import apoc.Extended;
+import apoc.result.*;
+import apoc.util.CollectionUtils;
+import apoc.util.Util;
+import apoc.util.collection.Iterables;
+import org.apache.commons.lang3.StringUtils;
+import org.neo4j.common.EntityType;
+import org.neo4j.common.TokenNameLookup;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.schema.ConstraintDefinition;
+import org.neo4j.graphdb.schema.Schema;
+import org.neo4j.internal.kernel.api.InternalIndexState;
+import org.neo4j.internal.kernel.api.PopulationProgress;
+import org.neo4j.internal.kernel.api.SchemaRead;
+import org.neo4j.internal.kernel.api.TokenRead;
+import org.neo4j.internal.kernel.api.exceptions.LabelNotFoundKernelException;
+import org.neo4j.internal.kernel.api.exceptions.schema.IndexNotFoundKernelException;
+import org.neo4j.internal.schema.IndexDescriptor;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.Statement;
+import org.neo4j.procedure.*;
+import org.neo4j.token.api.TokenConstants;
+
+import java.util.*;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static apoc.schema.SchemasExtendedUtil.*;
+import static org.apache.arrow.vector.dictionary.DictionaryEncoder.getIndexType;
+import static org.neo4j.graphdb.schema.ConstraintType.UNIQUENESS;
+import static org.neo4j.internal.schema.SchemaUserDescription.TOKEN_LABEL;
+import static org.neo4j.internal.schema.SchemaUserDescription.TOKEN_REL_TYPE;
+
+@Extended
+public class SchemasExtended {
+
+    @Context
+    public Transaction tx;
+
+    @Context
+    public KernelTransaction ktx;
+
+    @Procedure(value = "apoc.schema.node.compareIndexesAndConstraints", mode = Mode.SCHEMA)
+    @Description("CALL apoc.schema.node.compareIndexesAndConstraints($config) - to compare node constraints and indexes")
+    public Stream<CompareIdxToConsNodes> compareIndexesAndConstraints(@Name(value = "config",defaultValue = "{}") Map<String,Object> config) {
+        return indexesAndConstraintsForNode(config, tx, ktx,
+                compareConstraintIdxFunction(CompareIdxToConsNodes.class));
+    }
+
+    @Procedure(value = "apoc.schema.relationship.compareIndexesAndConstraints", mode = Mode.SCHEMA)
+    @Description("CALL apoc.schema.relationship.compareIndexesAndConstraints($config) - to compare rel constraints and indexes")
+    public Stream<CompareIdxToConsRels> compareIndexesAndConstraintsForRelationships(@Name(value = "config",defaultValue = "{}") Map<String,Object> config) {
+        return indexesAndConstraintsForRelationships(config, tx, ktx, compareConstraintIdxFunction(CompareIdxToConsRels.class));
+    }
+    
+
+
+    private static <R extends CompareIdxToCons> BiFunction<Stream<Object>, Stream<Object>, Stream<R>> compareConstraintIdxFunction(Class<R> clazz) {
+        return (constraintNodeInfoStream, indexNodeInfoStream) -> {
+            final List<Object> constraints = constraintNodeInfoStream.toList();
+            final List<Object> indexes = indexNodeInfoStream.toList();
+
+            Map<String, R> resultMap = new TreeMap<>();
+
+            indexes.forEach(i -> {
+                final Object labelOrType = getInfoLabelOrType(i);
+                if (labelOrType instanceof String) {
+                    addCommonAndOnlyIdxProps(constraints, addObjectIfAbsent(resultMap, (String) labelOrType, clazz), i);
+                }
+                if (labelOrType instanceof List) {
+                    final List<String> labels = (List<String>) labelOrType;
+                    labels.forEach(lbl -> {
+                        addCommonAndOnlyIdxProps(constraints, addObjectIfAbsent(resultMap, lbl, clazz), i);
+                    });
+                }
+            });
+
+            constraints.forEach(i -> {
+                List<String> props = new ArrayList<>();
+                String type = null;
+                String name = null;
+                if (clazz.isAssignableFrom(IndexConstraintNodeInfo.class)) {
+                    IndexConstraintNodeInfo info = (IndexConstraintNodeInfo) i;
+                    props = info.properties;
+                    type = info.type;
+                    name = info.name;
+                }
+                if (clazz.isAssignableFrom(IndexConstraintRelationshipInfo.class)) {
+                    IndexConstraintRelationshipInfo info = (IndexConstraintRelationshipInfo) i;
+                    props = info.properties;
+                    name = info.name;
+                }
+                final Object labelOrType = getInfoLabelOrType(i);
+                addObjectIfAbsent(resultMap, (String) labelOrType, clazz).putOnlyConstraintsProps(name, props);
+            });
+
+            return resultMap.values().stream();
+        };
+    }
+
+    private static void addCommonAndOnlyIdxProps(List<Object> constraints, CompareIdxToCons compareIdxToCons, Object index) {
+        List<String> props = new ArrayList<>();
+        String type = null;
+        String name = null;
+        if (index instanceof IndexConstraintNodeInfo info) {
+            props = info.properties;
+            type = info.type;
+            name = info.name;
+        } 
+        if (index instanceof IndexConstraintRelationshipInfo info) {
+            props = info.properties;
+            type = info.type;
+            name = info.name;
+        }
+
+        // UNIQUENESS constraints also produce an analogous index, so the properties is necessary in common
+        if (UNIQUENESS.name().equals(type)) {
+            compareIdxToCons.addCommonProps(props);
+        } else {
+            List<String> finalProps = props;
+            String finalName = name;
+            constraints.stream()
+                    .filter(cons -> {
+                        final Object idxLabelOrType = getInfoLabelOrType(index);
+                        final Object constraintLabelOrType = getInfoLabelOrType(cons);
+
+                        List<String> consProps = new ArrayList<>();
+                        List<String> indexProps = new ArrayList<>();
+                        if (index instanceof IndexConstraintNodeInfo info) {
+                            indexProps = info.properties;
+                            consProps = ((IndexConstraintNodeInfo) cons).properties;
+                        } else if (index instanceof IndexConstraintRelationshipInfo info) {
+                            indexProps = info.properties;
+                            consProps = ((IndexConstraintRelationshipInfo) cons).properties;
+                        }
+
+                        return idxLabelOrType.equals(constraintLabelOrType)
+                                && indexProps != null
+                                && consProps != null
+                                && CollectionUtils.isEqualCollection(indexProps, consProps);
+                    })
+                    .findFirst()
+                    .ifPresentOrElse(pres -> {
+                                compareIdxToCons.addCommonProps(finalProps);
+                                constraints.remove(pres);
+                            },
+                            () -> compareIdxToCons.putOnlyIdxProps(finalName, finalProps)
+                    );
+        }
+    }
+
+    public static <T> T indexesAndConstraintsForNode(Map<String,Object> config, Transaction tx, KernelTransaction ktx, BiFunction<Stream<Object>, Stream<Object>, T> function) {
+        Schema schema = tx.schema();
+
+        SchemaConfigExtended schemaConfig = new SchemaConfigExtended(config);
+        Set<String> includeLabels = schemaConfig.getLabels();
+        Set<String> excludeLabels = schemaConfig.getExcludeLabels();
+
+        try (Statement ignore = ktx.acquireStatement()) {
+            TokenRead tokenRead = ktx.tokenRead();
+
+            SchemaRead schemaRead = ktx.schemaRead();
+            Iterable<IndexDescriptor> indexesIterator;
+            Iterable<ConstraintDefinition> constraintsIterator;
+            final Predicate<ConstraintDefinition> isNodeConstraint =
+                    constraintDefinition -> Util.isNodeCategory(constraintDefinition.getConstraintType());
+
+            if (includeLabels.isEmpty()) {
+
+                Iterator<IndexDescriptor> allIndex = schemaRead.indexesGetAll();
+
+                indexesIterator = getIndexesFromSchema(
+                        allIndex,
+                        index -> index.schema().entityType().equals(EntityType.NODE)
+                                && Arrays.stream(index.schema().getEntityTokenIds())
+                                .noneMatch(id -> {
+                                    try {
+                                        return excludeLabels.contains(tokenRead.nodeLabelName(id));
+                                    } catch (LabelNotFoundKernelException e) {
+                                        return false;
+                                    }
+                                }));
+
+                Iterable<ConstraintDefinition> allConstraints = schema.getConstraints();
+                constraintsIterator = StreamSupport.stream(allConstraints.spliterator(), false)
+                        .filter(isNodeConstraint)
+                        .filter(constraint ->
+                                !excludeLabels.contains(constraint.getLabel().name()))
+                        .collect(Collectors.toList());
+            } else {
+                constraintsIterator = includeLabels.stream()
+                        .filter(label -> !excludeLabels.contains(label) && tokenRead.nodeLabel(label) != -1)
+                        .flatMap(label -> {
+                            Iterable<ConstraintDefinition> constraintsForType =
+                                    schema.getConstraints(Label.label(label));
+                            return StreamSupport.stream(constraintsForType.spliterator(), false)
+                                    .filter(isNodeConstraint);
+                        })
+                        .collect(Collectors.toList());
+
+                indexesIterator = includeLabels.stream()
+                        .filter(label -> !excludeLabels.contains(label) && tokenRead.nodeLabel(label) != -1)
+                        .flatMap(label -> {
+                            Iterable<IndexDescriptor> indexesForLabel =
+                                    () -> schemaRead.indexesGetForLabel(tokenRead.nodeLabel(label));
+                            return StreamSupport.stream(indexesForLabel.spliterator(), false);
+                        })
+                        .collect(Collectors.toList());
+            }
+
+            Stream<Object> constraintNodeInfoStream = StreamSupport.stream(
+                            constraintsIterator.spliterator(), false)
+                    .map(constraintDescriptor ->
+                            nodeInfoFromConstraintDefinition(constraintDescriptor, tokenRead, false, ktx))
+                    .sorted(Comparator.comparing(i -> i.label.toString()))
+                    .map(x -> (Object) x);
+
+            Stream<Object> indexNodeInfoStream = StreamSupport.stream(
+                            indexesIterator.spliterator(), false)
+                    .map(indexDescriptor ->
+                            nodeInfoFromIndexDefinition(indexDescriptor, schemaRead, tokenRead, false))
+                    .sorted(Comparator.comparing(i -> i.label.toString()))
+                    .map(x -> (Object) x);
+
+            return function.apply(constraintNodeInfoStream, indexNodeInfoStream);
+        }
+    }
+
+    public static  <T> T indexesAndConstraintsForRelationships(Map<String,Object> config, Transaction tx, KernelTransaction ktx, BiFunction<Stream<Object>, Stream<Object>, T> function) {
+        Schema schema = tx.schema();
+
+        SchemaConfigExtended schemaConfig = new SchemaConfigExtended(config);
+        Set<String> includeRelationships = schemaConfig.getRelationships();
+        Set<String> excludeRelationships = schemaConfig.getExcludeRelationships();
+
+        try (Statement ignore = ktx.acquireStatement()) {
+            TokenRead tokenRead = ktx.tokenRead();
+            SchemaRead schemaRead = ktx.schemaRead();
+            Iterable<ConstraintDefinition> constraintsIterator;
+            Iterable<IndexDescriptor> indexesIterator;
+
+            final Predicate<ConstraintDefinition> isRelConstraint =
+                    constraintDefinition -> Util.isRelationshipCategory(constraintDefinition.getConstraintType());
+
+            if (!includeRelationships.isEmpty()) {
+                constraintsIterator = includeRelationships.stream()
+                        .filter(type -> !excludeRelationships.contains(type)
+                                && tokenRead.relationshipType(type) != TokenConstants.NO_TOKEN)
+                        .flatMap(type -> {
+                            Iterable<ConstraintDefinition> constraintsForType =
+                                    schema.getConstraints(RelationshipType.withName(type));
+                            return StreamSupport.stream(constraintsForType.spliterator(), false)
+                                    .filter(isRelConstraint);
+                        })
+                        .collect(Collectors.toList());
+
+                indexesIterator = includeRelationships.stream()
+                        .filter(type -> !excludeRelationships.contains(type)
+                                && tokenRead.relationshipType(type) != TokenConstants.NO_TOKEN)
+                        .flatMap(type -> {
+                            Iterable<IndexDescriptor> indexesForRelType =
+                                    () -> schemaRead.indexesGetForRelationshipType(tokenRead.relationshipType(type));
+                            return StreamSupport.stream(indexesForRelType.spliterator(), false);
+                        })
+                        .collect(Collectors.toList());
+            } else {
+                Iterable<ConstraintDefinition> allConstraints = schema.getConstraints();
+                constraintsIterator = StreamSupport.stream(allConstraints.spliterator(), false)
+                        .filter(isRelConstraint)
+                        .filter(constraint -> !excludeRelationships.contains(
+                                constraint.getRelationshipType().name()))
+                        .collect(Collectors.toList());
+
+                Iterator<IndexDescriptor> allIndex = schemaRead.indexesGetAll();
+                indexesIterator = getIndexesFromSchema(
+                        allIndex,
+                        index -> index.schema().entityType().equals(EntityType.RELATIONSHIP)
+                                && Arrays.stream(index.schema().getEntityTokenIds())
+                                .noneMatch(id ->
+                                        excludeRelationships.contains(tokenRead.relationshipTypeGetName(id))));
+            }
+
+            Stream<Object> constraintRelationshipInfoStream = StreamSupport.stream(
+                            constraintsIterator.spliterator(), false)
+                    .map(c -> relationshipInfoFromConstraintDefinition(c, true));
+
+            Stream<Object> indexRelationshipInfoStream = StreamSupport.stream(
+                            indexesIterator.spliterator(), false)
+                    .map(index -> relationshipInfoFromIndexDescription(index, tokenRead, schemaRead, true));
+
+            return function.apply(constraintRelationshipInfoStream, indexRelationshipInfoStream);
+        }
+    }
+
+}

--- a/extended/src/main/java/apoc/schema/SchemasExtendedUtil.java
+++ b/extended/src/main/java/apoc/schema/SchemasExtendedUtil.java
@@ -1,0 +1,209 @@
+package apoc.schema;
+
+import apoc.result.CompareIdxToCons;
+import apoc.result.IndexConstraintNodeInfo;
+import apoc.result.IndexConstraintRelationshipInfo;
+import apoc.util.collection.Iterables;
+import org.apache.commons.lang3.StringUtils;
+import org.neo4j.common.TokenNameLookup;
+import org.neo4j.graphdb.schema.ConstraintDefinition;
+import org.neo4j.internal.kernel.api.InternalIndexState;
+import org.neo4j.internal.kernel.api.PopulationProgress;
+import org.neo4j.internal.kernel.api.SchemaRead;
+import org.neo4j.internal.kernel.api.exceptions.schema.IndexNotFoundKernelException;
+import org.neo4j.internal.schema.IndexDescriptor;
+import org.neo4j.kernel.api.KernelTransaction;
+
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
+
+import static org.apache.arrow.vector.dictionary.DictionaryEncoder.getIndexType;
+import static org.neo4j.internal.schema.SchemaUserDescription.TOKEN_LABEL;
+import static org.neo4j.internal.schema.SchemaUserDescription.TOKEN_REL_TYPE;
+
+public class SchemasExtendedUtil {
+    public static final String IDX_NOT_FOUND = "NOT_FOUND";
+
+    public static IndexConstraintNodeInfo nodeInfoFromIndexDefinition(
+            IndexDescriptor indexDescriptor, SchemaRead schemaRead, TokenNameLookup tokens, Boolean useStoredName) {
+        int[] labelIds = indexDescriptor.schema().getEntityTokenIds();
+        int length = labelIds.length;
+        final Object labelName;
+        if (length == 0) {
+            labelName = TOKEN_LABEL;
+        } else {
+            final List<String> labels = IntStream.of(labelIds)
+                    .mapToObj(tokens::labelGetName)
+                    .sorted()
+                    .collect(Collectors.toList());
+            labelName = labels.size() > 1 ? labels : labels.get(0);
+        }
+        // to handle LOOKUP indexes
+        List<String> properties = IntStream.of(indexDescriptor.schema().getPropertyIds())
+                .mapToObj(tokens::propertyKeyGetName)
+                .collect(Collectors.toList());
+
+        // Pretty print for index name
+        final String schemaInfoName = getSchemaInfoName(labelName, properties);
+        final String userDescription = indexDescriptor.userDescription(tokens);
+        try {
+            return new IndexConstraintNodeInfo(
+                    useStoredName ? indexDescriptor.getName() : schemaInfoName,
+                    labelName,
+                    properties,
+                    schemaRead.indexGetState(indexDescriptor).toString(),
+                    getIndexType(indexDescriptor),
+                    schemaRead.indexGetState(indexDescriptor).equals(InternalIndexState.FAILED)
+                            ? schemaRead.indexGetFailure(indexDescriptor)
+                            : "NO FAILURE",
+                    getPopulationProgress(indexDescriptor, schemaRead),
+                    schemaRead.indexSize(indexDescriptor),
+                    schemaRead.indexUniqueValuesSelectivity(indexDescriptor),
+                    userDescription);
+        } catch (IndexNotFoundKernelException e) {
+            return new IndexConstraintNodeInfo(
+                    schemaInfoName,
+                    labelName,
+                    properties,
+                    IDX_NOT_FOUND,
+                    getIndexType(indexDescriptor),
+                    IDX_NOT_FOUND,
+                    0,
+                    0,
+                    0,
+                    userDescription);
+        }
+    }
+
+    public static IndexConstraintRelationshipInfo relationshipInfoFromIndexDescription(
+            IndexDescriptor indexDescriptor, TokenNameLookup tokens, SchemaRead schemaRead, Boolean useStoredName) {
+        int[] relIds = indexDescriptor.schema().getEntityTokenIds();
+        int length = relIds.length;
+        // to handle LOOKUP indexes
+        final Object relName;
+        if (length == 0) {
+            relName = TOKEN_REL_TYPE;
+        } else {
+            final List<String> rels = IntStream.of(relIds)
+                    .mapToObj(tokens::relationshipTypeGetName)
+                    .sorted()
+                    .collect(Collectors.toList());
+            relName = rels.size() > 1 ? rels : rels.get(0);
+        }
+        final List<String> properties = Arrays.stream(indexDescriptor.schema().getPropertyIds())
+                .mapToObj(tokens::propertyKeyGetName)
+                .collect(Collectors.toList());
+
+        // Pretty print for index name
+        final String name = useStoredName ? indexDescriptor.getName() : getSchemaInfoName(relName, properties);
+        final String schemaType = getIndexType(indexDescriptor);
+
+        String indexStatus;
+        try {
+            indexStatus = schemaRead.indexGetState(indexDescriptor).toString();
+        } catch (IndexNotFoundKernelException e) {
+            indexStatus = IDX_NOT_FOUND;
+        }
+
+        return new IndexConstraintRelationshipInfo(name, schemaType, properties, indexStatus, relName);
+    }
+
+    public static String getIndexType(IndexDescriptor indexDescriptor) {
+        return indexDescriptor.getIndexType().name();
+    }
+
+    public static IndexConstraintRelationshipInfo relationshipInfoFromConstraintDefinition(
+            ConstraintDefinition constraintDefinition, Boolean useStoredName) {
+        return new IndexConstraintRelationshipInfo(
+                useStoredName
+                        ? constraintDefinition.getName()
+                        : String.format("CONSTRAINT %s", constraintDefinition.toString()),
+                constraintDefinition.getConstraintType().name(),
+                Iterables.asList(constraintDefinition.getPropertyKeys()),
+                "",
+                constraintDefinition.getRelationshipType().name());
+    }
+    public static long getPopulationProgress(IndexDescriptor indexDescriptor, SchemaRead schemaRead)
+            throws IndexNotFoundKernelException {
+        PopulationProgress populationProgress = schemaRead.indexGetPopulationProgress(indexDescriptor);
+        // when the index is failed the getTotal() is equal to 0
+        long populationTotal = populationProgress.getTotal();
+        if (populationTotal == 0) {
+            return 0L;
+        }
+        return populationProgress.getCompleted() / populationTotal * 100;
+    }
+
+
+    public static String getSchemaInfoName(Object labelOrType, List<String> properties) {
+        final String labelOrTypeAsString =
+                labelOrType instanceof String ? (String) labelOrType : StringUtils.join(labelOrType, ",");
+        return String.format(":%s(%s)", labelOrTypeAsString, StringUtils.join(properties, ","));
+    }
+    /**
+     * ConstraintInfo info from ConstraintDefinition
+     *
+     * @param constraintDefinition
+     * @param tokens
+     * @return
+     */
+    public static IndexConstraintNodeInfo nodeInfoFromConstraintDefinition(
+            ConstraintDefinition constraintDefinition, TokenNameLookup tokens, Boolean useStoredName, KernelTransaction ktx) {
+        String labelName = constraintDefinition.getLabel().name();
+        List<String> properties = Iterables.asList(constraintDefinition.getPropertyKeys());
+        return new IndexConstraintNodeInfo(
+                // Pretty print for index name
+                useStoredName
+                        ? constraintDefinition.getName()
+                        : String.format(":%s(%s)", labelName, StringUtils.join(properties, ",")),
+                labelName,
+                properties,
+                StringUtils.EMPTY,
+                constraintDefinition.getConstraintType().name(),
+                "NO FAILURE",
+                0,
+                0,
+                0,
+                nodeConstraintCypher5Compatibility(
+                        ktx.schemaRead()
+                                .constraintGetForName(constraintDefinition.getName())
+                                .userDescription(tokens),
+                        useStoredName));
+    }
+
+    public static String nodeConstraintCypher5Compatibility(String userDescription, Boolean useStoredName) {
+        if (useStoredName) {
+            return userDescription;
+        } else {
+            // Revert to old description on Cypher 5 for backwards compatibility.
+            return userDescription.replace("'NODE PROPERTY UNIQUENESS'", "'UNIQUENESS'");
+        }
+    }
+    public static List<IndexDescriptor> getIndexesFromSchema(
+            Iterator<IndexDescriptor> allIndex, Predicate<IndexDescriptor> indexDescriptorPredicate) {
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(allIndex, Spliterator.ORDERED), false)
+                .filter(indexDescriptorPredicate)
+                .collect(Collectors.toList());
+    }
+
+    public static Object getInfoLabelOrType(Object idxOrCons) {
+        if (idxOrCons instanceof IndexConstraintNodeInfo) {
+            return ((IndexConstraintNodeInfo) idxOrCons).label;
+        }
+        return ((IndexConstraintRelationshipInfo) idxOrCons).relationshipType;
+    }
+
+    public static <T extends CompareIdxToCons> T addObjectIfAbsent(Map<String, T> map, String label, Class<T> clazz) {
+        return map.compute(label,
+                (k, v) -> Objects.requireNonNullElseGet(v, () -> {
+                    try {
+                        return clazz.getConstructor(String.class).newInstance(label);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+                }));
+    }
+}

--- a/extended/src/test/java/apoc/schema/SchemasExtendedTest.java
+++ b/extended/src/test/java/apoc/schema/SchemasExtendedTest.java
@@ -1,0 +1,146 @@
+package apoc.schema;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.neo4j.configuration.GraphDatabaseSettings;
+import org.neo4j.graphdb.Result;
+import org.neo4j.test.rule.DbmsRule;
+import org.neo4j.test.rule.ImpermanentDbmsRule;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static apoc.util.TestUtil.registerProcedure;
+import static apoc.util.TestUtil.testResult;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class SchemasExtendedTest {
+
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule()
+            .withSetting(GraphDatabaseSettings.procedure_unrestricted, Collections.singletonList("apoc.*"));
+
+    @Before
+    public void setUp() throws Exception {
+        registerProcedure(db, SchemasExtended.class);
+    }
+
+    @Test
+    public void testCompareIndexesAndConstraints() {
+        db.executeTransactionally("CREATE INDEX FOR (n:Person) ON (n.surname)");
+        db.executeTransactionally("CREATE CONSTRAINT FOR (n:Person) REQUIRE (n.address) IS UNIQUE");
+        db.executeTransactionally("CREATE INDEX FOR (n:Movie) ON (n.name)");
+        db.executeTransactionally("CREATE FULLTEXT INDEX fullSecondIdx FOR (n:Person|Another) ON EACH [n.weightProp]");
+
+        testResult(db, "CALL apoc.schema.node.compareIndexesAndConstraints()", (res) -> {
+            Map<String, Object> row = res.next();
+            assertAnyLabels(row);
+            row = res.next();
+            assertEquals(Map.of(":[Another, Person],(weightProp)", List.of("weightProp")), row.get("onlyIdxProps"));
+            assertEquals("Another", row.get("label"));
+            assertEquals(emptyMap(), row.get("onlyConstraintsProps"));
+            assertEquals(emptyList(), row.get("commonProps"));
+            row = res.next();
+            assertMovieLabel(row);
+            row = res.next();
+            Map<String, List<String>> expected = Map.of(":[Another, Person],(weightProp)", List.of("weightProp"),
+                    ":Person(surname)", List.of("surname"));
+            assertEquals(expected, row.get("onlyIdxProps"));
+            assertEquals("Person", row.get("label"));
+            assertEquals(emptyMap(), row.get("onlyConstraintsProps"));
+            assertEquals(List.of("address"), row.get("commonProps"));
+            assertFalse(res.hasNext());
+        });
+
+        testResult(db, "CALL apoc.schema.node.compareIndexesAndConstraints({labels: ['Movie', 'NotExistent']})", (res) -> {
+            Map<String, Object> row = res.next();
+            assertMovieLabel(row);
+            assertFalse(res.hasNext());
+        });
+
+        testResult(db, "CALL apoc.schema.node.compareIndexesAndConstraints({excludeLabels: ['Person', 'NotExistent']})", (res) -> {
+            Map<String, Object> row = res.next();
+            assertAnyLabels(row);
+            row = res.next();
+            assertMovieLabel(row);
+            assertFalse(res.hasNext());
+        });
+    }
+
+    private static void assertAnyLabels(Map<String, Object> row) {
+        assertEquals(Map.of(":<any-labels>()", emptyList()), row.get("onlyIdxProps"));
+        assertEquals("<any-labels>", row.get("label"));
+        assertEquals(emptyMap(), row.get("onlyConstraintsProps"));
+        assertEquals(emptyList(), row.get("commonProps"));
+    }
+
+    private static void assertMovieLabel(Map<String, Object> row) {
+        assertEquals(Map.of(":Movie(name)", List.of("name")), row.get("onlyIdxProps"));
+        assertEquals("Movie", row.get("label"));
+        assertEquals(emptyMap(), row.get("onlyConstraintsProps"));
+        assertEquals(emptyList(), row.get("commonProps"));
+    }
+
+    @Test
+    public void testCompareIndexesAndConstraintsRel() {
+        db.executeTransactionally("CALL db.index.fulltext.createRelationshipIndex('fullIdxRel', ['TYPE_1', 'TYPE_2'], ['alpha', 'beta'])");
+        db.executeTransactionally("CREATE INDEX rel_index_name FOR ()-[r:KNOWS]-() ON (r.since)");
+
+        testResult(db, "CALL apoc.schema.relationship.compareIndexesAndConstraints()", (res) -> {
+            Map<String, Object> row = res.next();
+            assertAnyTypes(row);
+            row = res.next();
+            assertKnowsType(row);
+            row = res.next();
+            assertType1AndType2(res, row);
+            assertFalse(res.hasNext());
+        });
+
+        testResult(db, "CALL apoc.schema.relationship.compareIndexesAndConstraints({relationships: ['TYPE_1', 'NOT_EXISTENT']})", (res) -> {
+            Map<String, Object> row = res.next();
+            assertType1AndType2(res, row);
+            assertFalse(res.hasNext());
+        });
+
+        testResult(db, "CALL apoc.schema.relationship.compareIndexesAndConstraints({excludeRelationships: ['TYPE_2', 'NOT_EXISTENT']})", (res) -> {
+            Map<String, Object> row = res.next();
+            assertAnyTypes(row);
+            row = res.next();
+            assertKnowsType(row);
+            assertFalse(res.hasNext());
+        });
+    }
+
+    private static void assertKnowsType(Map<String, Object> row) {
+        assertEquals("KNOWS", row.get("relationshipType"));
+        assertEquals(Map.of(":KNOWS(since)", List.of("since")), row.get("onlyIdxProps"));
+        assertEquals(emptyMap(), row.get("onlyConstraintsProps"));
+        assertEquals(emptyList(), row.get("commonProps"));
+    }
+
+    private static void assertAnyTypes(Map<String, Object> row) {
+        assertEquals("<any-types>", row.get("relationshipType"));
+        assertEquals(Map.of(":<any-types>()", emptyList()), row.get("onlyIdxProps"));
+        assertEquals(emptyMap(), row.get("onlyConstraintsProps"));
+        assertEquals(emptyList(), row.get("commonProps"));
+    }
+
+    private static void assertType1AndType2(Result res, Map<String, Object> row) {
+        assertEquals(Map.of(":[TYPE_1, TYPE_2],(alpha,beta)", List.of("alpha", "beta")), row.get("onlyIdxProps"));
+        assertEquals("TYPE_1", row.get("relationshipType"));
+        assertEquals(emptyMap(), row.get("onlyConstraintsProps"));
+        assertEquals(emptyList(), row.get("commonProps"));
+        row = res.next();
+        assertEquals(Map.of(":[TYPE_1, TYPE_2],(alpha,beta)", List.of("alpha", "beta")), row.get("onlyIdxProps"));
+        assertEquals("TYPE_2", row.get("relationshipType"));
+        assertEquals(emptyMap(), row.get("onlyConstraintsProps"));
+        assertEquals(emptyList(), row.get("commonProps"));
+    }
+}


### PR DESCRIPTION
TODO - docs
Fixes #1383

    public List<String> commonProps;
    public Map<String, Object> onlyIdxProps;
    public Map<String, Object> onlyConstraintsProps;

The issue had been started but then discontinued, 
if I remember correctly following the split between Extended and Core.

- Moved the bare minimum from Core's Schema.java to Extended to make the procedures work