### PR TITLE
Fixes #1431: Disable custom procedure config

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/cypher-execution/cypher-based-procedures-functions.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/cypher-execution/cypher-based-procedures-functions.adoc
@@ -3,7 +3,14 @@
 :description: This section describes how to register custom Cypher statements as procedures and functions
 
 
+By default, the custom Cypher statements are enabled.
+We can disable it by setting the following property in `apoc.conf`:
 
+.apoc.conf
+[source,properties]
+----
+apoc.custom.procedures.enabled=false
+----
 
 include::partial$systemdbonly.note.adoc[]
 

--- a/extended/src/main/java/apoc/custom/CypherNewProcedures.java
+++ b/extended/src/main/java/apoc/custom/CypherNewProcedures.java
@@ -13,6 +13,7 @@ import org.neo4j.procedure.*;
 import java.util.stream.Stream;
 
 import static apoc.custom.CypherProceduresHandler.PREFIX;
+import static apoc.custom.CypherProceduresUtil.checkEnabled;
 import static apoc.util.SystemDbUtil.checkInSystemDb;
 
 
@@ -32,6 +33,8 @@ public class CypherNewProcedures {
         SystemDbUtil.checkInSystemLeader(db);
 
         SystemDbUtil.checkTargetDatabase(tx, databaseName, "Custom procedures/functions");
+
+        checkEnabled();
     }
 
     // TODO - change with @SystemOnlyProcedure

--- a/extended/src/main/java/apoc/custom/CypherProcedures.java
+++ b/extended/src/main/java/apoc/custom/CypherProcedures.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import static apoc.custom.CypherProceduresUtil.checkEnabled;
 import static org.neo4j.graphdb.QueryExecutionType.QueryType;
 import static apoc.custom.CypherProceduresHandler.*;
 import static apoc.util.ExtendedUtil.isQueryValid;
@@ -64,7 +65,7 @@ public class CypherProcedures {
                                  @Name(value = "mode", defaultValue = "read") String mode,
                                  @Name(value = "description", defaultValue = "") String description
     ) {
-        checkWriteAllowed(MSG_DEPRECATION);
+        checkEnabledAndWriteAllowed();
         Mode modeProcedure = CypherProceduresUtil.mode(mode);
         ProcedureSignature procedureSignature = new Signatures(PREFIX).asProcedureSignature(signature, description, modeProcedure);
         validateProcedure(statement, procedureSignature.inputSignature(), procedureSignature.outputSignature(), modeProcedure);
@@ -78,7 +79,7 @@ public class CypherProcedures {
     public void declareFunction(@Name("signature") String signature, @Name("statement") String statement,
                            @Name(value = "forceSingle", defaultValue = "false") boolean forceSingle,
                            @Name(value = "description", defaultValue = "") String description) throws ProcedureException {
-        checkWriteAllowed(MSG_DEPRECATION);
+        checkEnabledAndWriteAllowed();
         UserFunctionSignature userFunctionSignature = new Signatures(PREFIX).asFunctionSignature(signature, description);
         final Signatures signatures = new Signatures(PREFIX);
         final SignatureParser.FunctionContext functionContext = signatures.parseFunction(signature);
@@ -110,7 +111,7 @@ public class CypherProcedures {
     @Procedure(value = "apoc.custom.removeProcedure", mode = Mode.WRITE, deprecatedBy = "apoc.custom.dropProcedure")
     @Description("apoc.custom.removeProcedure(name) - remove the targeted custom procedure")
     public void removeProcedure(@Name("name") String name) {
-        checkWriteAllowed(MSG_DEPRECATION);
+        checkEnabledAndWriteAllowed();
         cypherProceduresHandler.removeProcedure(name);
     }
 
@@ -119,8 +120,13 @@ public class CypherProcedures {
     @Procedure(value = "apoc.custom.removeFunction", mode = Mode.WRITE, deprecatedBy = "apoc.custom.dropFunction")
     @Description("apoc.custom.removeFunction(name, type) - remove the targeted custom function")
     public void removeFunction(@Name("name") String name) {
-        checkWriteAllowed(MSG_DEPRECATION);
+        checkEnabledAndWriteAllowed();
         cypherProceduresHandler.removeFunction(name);
+    }
+
+    private static void checkEnabledAndWriteAllowed() {
+        checkEnabled();
+        checkWriteAllowed(MSG_DEPRECATION);
     }
 
     private void validateFunction(String statement, List<FieldSignature> input) {

--- a/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresHandler.java
@@ -96,13 +96,17 @@ public class CypherProceduresHandler extends LifecycleAdapter implements Availab
 
     @Override
     public void available() {
+        // we restore procs and function even with apoc.custom.procedures.enabled=false 
+        // to not create inconsistency between system nodes and apoc.custom.list
         restoreProceduresAndFunctions();
-        long refreshInterval = apocConfig().getInt(CUSTOM_PROCEDURES_REFRESH, 60000);
-        restoreProceduresHandle = jobScheduler.scheduleRecurring(REFRESH_GROUP, () -> {
-            if (getLastUpdate() > lastUpdate) {
-                restoreProceduresAndFunctions();
-            }
-        }, refreshInterval, refreshInterval, TimeUnit.MILLISECONDS);
+        if (isEnabled()) {
+            long refreshInterval = apocConfig().getInt(CUSTOM_PROCEDURES_REFRESH, 60000);
+            restoreProceduresHandle = jobScheduler.scheduleRecurring(REFRESH_GROUP, () -> {
+                if (getLastUpdate() > lastUpdate) {
+                    restoreProceduresAndFunctions();
+                }
+            }, refreshInterval, refreshInterval, TimeUnit.MILLISECONDS);
+        }
     }
 
     @Override

--- a/extended/src/main/java/apoc/custom/CypherProceduresUtil.java
+++ b/extended/src/main/java/apoc/custom/CypherProceduresUtil.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static apoc.ApocConfig.apocConfig;
 import static apoc.custom.CypherProceduresHandler.PREFIX;
 import static apoc.custom.Signatures.NUMBER_TYPE;
 import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.*;
@@ -29,7 +30,10 @@ import static org.neo4j.internal.kernel.api.procs.Neo4jTypes.NTString;
 
 public class CypherProceduresUtil {
     public static final String MAP_RESULT_TYPE = "MAPRESULT";
-
+    public static final String CUSTOM_PROCEDURES_ENABLED = "apoc.custom.procedures.enabled";
+    public static final String PROCEDURES_NOT_ENABLED_ERROR = "Custom procedures and functions have not been enabled." +
+            " Set 'apoc.custom.procedures.enabled=true' in your apoc.conf file located in the $NEO4J_HOME/conf/ directory.";
+    
     public static QualifiedName qualifiedName(@Name("name") String name) {
         String[] names = name.split("\\.");
         List<String> namespaceList = new ArrayList<>(names.length);
@@ -159,5 +163,15 @@ public class CypherProceduresUtil {
             case "GEO", "GEOMETRY" -> NTGeometry;
             default -> NTString;
         };
+    }
+    
+    public static boolean isEnabled() {
+        return apocConfig().getConfig().getBoolean(CUSTOM_PROCEDURES_ENABLED, true);
+    }
+
+    public static void checkEnabled() {
+        if (!isEnabled()) {
+            throw new RuntimeException(PROCEDURES_NOT_ENABLED_ERROR);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1431

it makes sense to create a config option, for consistency with other procedures that work similarly (apoc.trigger, uuid, ttl..), as disabling periodic refresh increases performance a bit.

The config name is `apoc.custom.procedures.enabled` instead of e.g. `apoc.custom.enabled`,
to be consistent with the `apoc.custom.procedures.refresh` setting.

But we can't disable it by default, because that would be a breaking change, so the default is true.
