### PR TITLE
Fixes #4396: The JdbcUtil.obfuscateJdbcUrl doens't work for Oracle JDBC URLs

### DIFF
--- a/extended/src/main/java/apoc/load/util/JdbcUtil.java
+++ b/extended/src/main/java/apoc/load/util/JdbcUtil.java
@@ -158,7 +158,14 @@ public class JdbcUtil {
         return sqlOrKey.contains(" ") ? sqlOrKey : Util.getLoadUrlByConfigFile(LOAD_TYPE, sqlOrKey, "sql").orElse("SELECT * FROM " + sqlOrKey);
     }
 
+    // Helper method to call the function being tested
     public static String obfuscateJdbcUrl(String query) {
-        return query.replaceAll("(jdbc:[^:]+://)([^\\s\\\"']+)", "$1*******");
+        // General case for most databases
+        query = query.replaceAll("(jdbc:[^:]+://)[^\\s\\\"']+", "$1*******");
+
+        // Special case for Oracle Thin Driver
+        query = query.replaceAll("(jdbc:oracle:thin:)[^\\s\\\"']+", "$1*******");
+
+        return query;
     }
 }

--- a/extended/src/test/java/apoc/load/util/JdbcUtilTest.java
+++ b/extended/src/test/java/apoc/load/util/JdbcUtilTest.java
@@ -1,0 +1,57 @@
+package apoc.load.util;
+
+import org.junit.Test;
+
+import static apoc.load.util.JdbcUtil.obfuscateJdbcUrl;
+import static org.junit.Assert.assertEquals;
+
+public class JdbcUtilTest {
+    @Test
+    public void testObfuscateMysqlJdbcUrl() {
+        String input = "jdbc:mysql://myserver:3306/mydb?user=admin&password=secret";
+        String expected = "jdbc:mysql://*******";
+        assertEquals(expected, obfuscateJdbcUrl(input));
+    }
+
+    @Test
+    public void testObfuscatePostgresJdbcUrl() {
+        String input = "jdbc:postgresql://db.example.com:5432/sales?user=postgres&password=mypass";
+        String expected = "jdbc:postgresql://*******";
+        assertEquals(expected, obfuscateJdbcUrl(input));
+    }
+
+    @Test
+    public void testObfuscateOracleJdbcUrl() {
+        String input = "jdbc:oracle:thin:scott/tiger@dbhost:1521/ORCL";
+        String expected = "jdbc:oracle:thin:*******";
+        assertEquals(expected, obfuscateJdbcUrl(input));
+    }
+
+    @Test
+    public void testObfuscateOracleJdbcUrlWithSpecialChars() {
+        String input = "jdbc:oracle:thin:user1/P@ssw0rd@prod-db:1521/serviceName";
+        String expected = "jdbc:oracle:thin:*******";
+        assertEquals(expected, obfuscateJdbcUrl(input));
+    }
+
+    @Test
+    public void testObfuscateSqlServerJdbcUrl() {
+        String input = "jdbc:sqlserver://dbserver:1433;databaseName=TestDB;user=sa;password=pass";
+        String expected = "jdbc:sqlserver://*******";
+        assertEquals(expected, obfuscateJdbcUrl(input));
+    }
+
+    @Test
+    public void testObfuscateJdbcUrlWithNoCredentials() {
+        String input = "jdbc:mysql://myserver:3306/mydb";
+        String expected = "jdbc:mysql://*******";
+        assertEquals(expected, obfuscateJdbcUrl(input));
+    }
+
+    @Test
+    public void testObfuscateJdbcUrlWithAdditionalParams() {
+        String input = "jdbc:mysql://myserver:3306/mydb?ssl=true&connectTimeout=5000";
+        String expected = "jdbc:mysql://*******";
+        assertEquals(expected, obfuscateJdbcUrl(input));
+    }
+}


### PR DESCRIPTION
Fixes #4396

- Fixed the bug for Oracle URL
- Created unit test for JdbcUtil