### PR TITLE
Fix failing FileUtilsTest

### DIFF
--- a/extended/src/test/java/apoc/util/FileUtilsTest.java
+++ b/extended/src/test/java/apoc/util/FileUtilsTest.java
@@ -12,6 +12,7 @@ import org.neo4j.configuration.GraphDatabaseSettings;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
+import java.io.File;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 
@@ -19,6 +20,7 @@ import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
 import static org.junit.Assert.assertEquals;
 import static apoc.util.ExtendedTestUtil.MockURLAccessChecker;
+import static org.neo4j.configuration.GraphDatabaseSettings.load_csv_file_url_root;
 
 public class FileUtilsTest {
 
@@ -51,10 +53,10 @@ public class FileUtilsTest {
 
     @Before
     public void setUp() throws Exception {
-        importFolder = db.databaseLayout().databaseDirectory().toFile().getAbsolutePath() + "/import/";
+        importFolder = new File("import").toPath().toString();
         TEST_FILE_RELATIVE = Paths.get(importFolder, "test.csv").toUri().toString();
         if (testName.getMethodName().endsWith(TEST_WITH_DIRECTORY_IMPORT)) {
-            apocConfig().setProperty("server.directories.import", importFolder);
+            apocConfig().setProperty(load_csv_file_url_root.name(), importFolder);
         }
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         TestUtil.registerProcedure(db, Config.class);


### PR DESCRIPTION
Changed the FileUtilsTest.java to fix tests after [this change ](https://github.com/neo4j/apoc/commit/61ca0dd27509b1d3f5fa74d839c7ea03d07335a1)

See here: https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/14167656575/job/39703204445?pr=4397#step:10:6042
```
    org.junit.ComparisonFailure: expected:<file:///[target/test%20data/neo4j/data/databases/neo4j/import]/test.csv> but was:<file:///[home/runner/work/neo4j-apoc-procedures/neo4j-apoc-procedures/extended]/test.csv>
        at org.junit.Assert.assertEquals(Assert.java:117)
        at org.junit.Assert.assertEquals(Assert.java:146)
        at apoc.util.FileUtilsTest.changeFileDoubleSlashesUrlWithDirectoryImportConstrainedURIWithDirectoryImport(FileUtilsTest.java:95)
```