### PR TITLE
Fix enterprise-it-test-support not found in TeamCity

### DIFF
--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -144,18 +144,6 @@ dependencies {
     // These dependencies affect the tests only, they will not be packaged in the resulting .jar
     testImplementation project(':test-utils')
     testImplementation project(':core')
-    //testImplementation project(path: ':core')
-    
-    
-//    testImplementation project(path: ':core', configuration: 'default')
-
-//    testImplementation(project(':core')) {
-//        exclude group: 'com.neo4j', module: 'enterprise-it-test-support'
-//    }
-
-//    testImplementation project(':core'), {
-//        exclude group: 'com.neo4j'//, module: 'enterprise-it-test-support-2025.04.0'
-//    }
     testImplementation group: 'org.apache.poi', name: 'poi', version: '5.1.0', {
         exclude group: 'org.apache.commons', module: 'commons-collections4'
     }
@@ -195,14 +183,6 @@ dependencies {
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'
         exclude group: 'ch.qos.logback', module: 'logback-classic'
-
-        // exclude group: 'com.neo4j', module: 'enterprise-it-test-support'
-//
-//        resolutionStrategy.eachDependency { details ->
-//            if (details.requested.group == 'com.neo4j' && details.requested.name == 'enterprise-it-test-support') {
-//                details.useTarget "com.neo4j:enterprise-it-test-support:$neo4jVersionEffective" // dummy
-//            }
-//        }
     }
 }
 

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -144,6 +144,18 @@ dependencies {
     // These dependencies affect the tests only, they will not be packaged in the resulting .jar
     testImplementation project(':test-utils')
     testImplementation project(':core')
+    //testImplementation project(path: ':core')
+    
+    
+//    testImplementation project(path: ':core', configuration: 'default')
+
+//    testImplementation(project(':core')) {
+//        exclude group: 'com.neo4j', module: 'enterprise-it-test-support'
+//    }
+
+//    testImplementation project(':core'), {
+//        exclude group: 'com.neo4j'//, module: 'enterprise-it-test-support-2025.04.0'
+//    }
     testImplementation group: 'org.apache.poi', name: 'poi', version: '5.1.0', {
         exclude group: 'org.apache.commons', module: 'commons-collections4'
     }
@@ -183,6 +195,14 @@ dependencies {
     configurations.all {
         exclude group: 'org.slf4j', module: 'slf4j-nop'
         exclude group: 'ch.qos.logback', module: 'logback-classic'
+
+        // exclude group: 'com.neo4j', module: 'enterprise-it-test-support'
+//
+//        resolutionStrategy.eachDependency { details ->
+//            if (details.requested.group == 'com.neo4j' && details.requested.name == 'enterprise-it-test-support') {
+//                details.useTarget "com.neo4j:enterprise-it-test-support:$neo4jVersionEffective" // dummy
+//            }
+//        }
     }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,6 +31,7 @@ startParameter.excludedTaskNames = [
         ':core:publish',
         ':common:publish',
         ':test-utils:publish'
+       // ':core:compileTestJava'
 ]
 
 // the :core:shadowJar should be used only for integration tests with both core and extended jars

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,8 +30,8 @@ startParameter.excludedTaskNames = [
         ':test-utils:test',
         ':core:publish',
         ':common:publish',
-        ':test-utils:publish'
-       // ':core:compileTestJava'
+        ':test-utils:publish',
+        ':core:compileTestJava'
 ]
 
 // the :core:shadowJar should be used only for integration tests with both core and extended jars


### PR DESCRIPTION
### Error
```
[09:32:46]W:	 [Step 3/4] > Could not resolve all files for configuration ':core:testCompileClasspath'.
[09:32:46] :	 [Step 3/4] 18 actionable tasks: 18 executed
[09:32:46]W:	 [Step 3/4]    > Could not find com.neo4j:enterprise-it-test-support:2025.04.0.
[09:32:46]W:	 [Step 3/4]      Searched in the following locations:
[09:32:46] :	 [Step 3/4] Some of the file system contents retained in the virtual file system are on file systems that Gradle doesn't support watching. The relevant state was discarded to ensure changes to these locations are properly detected. You can override this by explicitly enabling file system watching.
[09:32:46]W:	 [Step 3/4]        - https://repo.maven.apache.org/maven2/com/neo4j/enterprise-it-test-support/2025.04.0/enterprise-it-test-support-2025.04.0.pom
[09:32:46]W:	 [Step 3/4]        - https://repo.gradle.org/gradle/libs-releases/com/neo4j/enterprise-it-test-support/2025.04.0/enterprise-it-test-support-2025.04.0.pom
[09:32:46]W:	 [Step 3/4]        - file:/opt/teamcity-agent/work/af99a1b2d35610b6/repository/com/neo4j/enterprise-it-test-support/2025.04.0/enterprise-it-test-support-2025.04.0.pom
[09:32:46]W:	 [Step 3/4]      Required by:
[09:32:46]W:	 [Step 3/4]          project :core
```

### Solution
Excluded the `:core:compileTestJava` task from `settings.gradle`.


---

Tried excluding `enterprise-it-test-support` this way, but `./gradlew tests ...` tries to resolve `enterprise-it-test-support` anyway since it execute `:core:compileTestJava`
```
    testImplementation(project(':core')) {
        exclude group: 'com.neo4j', module: 'enterprise-it-test-support'
    }
```