### PR TITLE
Fix enterprise-it-test-support not found in TeamCity (#4430)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -30,7 +30,8 @@ startParameter.excludedTaskNames = [
         ':test-utils:test',
         ':core:publish',
         ':common:publish',
-        ':test-utils:publish'
+        ':test-utils:publish',
+        ':core:compileTestJava'
 ]
 
 // the :core:shadowJar should be used only for integration tests with both core and extended jars

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,7 +38,8 @@ startParameter.excludedTaskNames = [
 // e.g. StartupExtendedTest, where the core jar is created by executing `shadowJar` directly in the `apoc-core`
 // not when a `gradle shadow` or a `gradle build` is executed in this root project folder
 gradle.settingsEvaluated {
-    if (!startParameter.taskNames.any { it.startsWith(":extended-it") }) {
+    if (startParameter.taskNames.any { it == "shadow" || it == "build" }) {
+        println 'exclude :core:shadowJar for tasks: ' + startParameter.taskNames
         startParameter.excludedTaskNames.add(':core:shadowJar')
     }
 }


### PR DESCRIPTION
Fixes https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4432
Fixes https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4430

Cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/643dbc12d86d5f2bdae5b4a5d966a16d3e523e62

Cherry-pick https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/0db6844b2387c441387cfbc874cd5b0e211f21ea