### PR TITLE
Try fixing tests with core jars in 2025.04

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -38,7 +38,8 @@ startParameter.excludedTaskNames = [
 // e.g. StartupExtendedTest, where the core jar is created by executing `shadowJar` directly in the `apoc-core`
 // not when a `gradle shadow` or a `gradle build` is executed in this root project folder
 gradle.settingsEvaluated {
-    if (!startParameter.taskNames.any { it.startsWith(":extended-it") }) {
+    if (startParameter.taskNames.any { it == "shadow" || it == "build" }) {
+        println 'exclude :core:shadowJar for tasks: ' + startParameter.taskNames
         startParameter.excludedTaskNames.add(':core:shadowJar')
     }
 }


### PR DESCRIPTION
## Fix

Not sure why this error has not occurred previously (maybe because of [this core change](https://github.com/neo4j/apoc/pull/755/commits/e53797f2c917fb971d314a7bf1d8cf38219dd26c#diff-00d5c5c00ed3cf7739c15c300a5fee228e88590bf4c026e719b2732c07ffc3bfR25)?)

Since the following errors are all about core's jar not found with testcontainer, 
I tried to remove `':core:shadowJar'` from the excluded task for test, 
because probably by not building the core jar when `./gradlew test <args>` is executed in TeamCity, 
it is not created, hence the errors.

I guess we still need to exclude it for `shadow` and `build` as before, 
because this error could happen again: https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/3597


## Errors
They are all similar and cover some tests using both extended and core jar,
 i.e. 
- `DataVirtualizationCatalogClusterRoutingTest.classMethod `
-  `StartupExtendedTest.checkCoreAndExtendedWithExtraDependenciesJars`
- `StartupExtendedTest.checkCoreWithExtraDependenciesJars`
- `CoreExtendedTest.matchesSpreadsheet `
- `CoreExtendedTest.checkForCoreAndExtended`
- `BoltTest.classMethod `

Here are some of them:

- Error 1
```
======= Failed test run #1 ==========
  java.lang.RuntimeException: Failed to copy /opt/teamcity-agent/work/af99a1b2d35610b6/neo4j-apoc-procedures/extended-it/build/test-core/jar/apoc-2025.04.0-core.jar to ../build/plugins/apoc-2025.04.0-core.jar
    at apoc.util.TestContainerUtil.createNeo4jContainer(TestContainerUtil.java:182)
    at apoc.util.TestContainerUtil.createEnterpriseDB(TestContainerUtil.java:113)
    at apoc.util.TestcontainersCausalCluster.createInstance(TestcontainersCausalCluster.java:173)
    at apoc.util.TestcontainersCausalCluster.lambda$create$5(TestcontainersCausalCluster.java:110)
    at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
    at java.base/java.util.stream.IntPipeline$1$1.accept(IntPipeline.java:180)
    at java.base/java.util.stream.Streams$RangeIntSpliterator.forEachRemaining(Streams.java:104)
    at java.base/java.util.Spliterator$OfInt.forEachRemaining(Spliterator.java:712)
    at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
    at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
    at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
    at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
    at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
    at apoc.util.TestcontainersCausalCluster.create(TestcontainersCausalCluster.java:130)
    at apoc.util.TestContainerUtil.createEnterpriseCluster(TestContainerUtil.java:89)
    at apoc.dv.DataVirtualizationCatalogClusterRoutingTest.setupCluster(DataVirtualizationCatalogClusterRoutingTest.java:49)
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at java.base/java.lang.reflect.Method.invoke(Method.java:580)

Caused by: java.nio.file.NoSuchFileException: /opt/teamcity-agent/work/af99a1b2d35610b6/neo4j-apoc-procedures/extended-it/build/test-core/jar/apoc-2025.04.0-core.jar
  at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
  at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
  at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
  at java.base/sun.nio.fs.UnixFileSystem.copy(UnixFileSystem.java:1005)
  at java.base/sun.nio.fs.UnixFileSystemProvider.copy(UnixFileSystemProvider.java:300)
  at java.base/java.nio.file.Files.copy(Files.java:1304)
  at apoc.util.TestContainerUtil.createNeo4jContainer(TestContainerUtil.java:180)
  ... 44 more
....


```

- Error 2
```
======= Failed test run #1 ==========
  java.lang.RuntimeException: Failed to copy /opt/teamcity-agent/work/af99a1b2d35610b6/neo4j-apoc-procedures/extended-it/build/test-core/jar/apoc-2025.04.0-core.jar to ../build/plugins/apoc-2025.04.0-core.jar
    at apoc.util.TestContainerUtil.createNeo4jContainer(TestContainerUtil.java:182)
    at apoc.util.TestContainerUtil.createEnterpriseDB(TestContainerUtil.java:113)
    at apoc.neo4j.docker.BoltTest.setUp(BoltTest.java:55)
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at java.base/java.lang.reflect.Method.invoke(Method.java:580)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
    at org.junit.internal.runners.statements.RunBefores.invokeMethod(RunBefores.java:33)
    at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:24)
    at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
    at org.neo4j.test.rule.ExternalResource$1.evaluate(ExternalResource.java:38)
    at org.junit.rules.RunRules.evaluate(RunRules.java:20)
    at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
    at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.runTestClass(JUnitTestClassExecutor.java:112)
    at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:58)
    at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.execute(JUnitTestClassExecutor.java:40)
    at org.gradle.api.internal.tasks.testing.junit.AbstractJUnitTestClassProcessor.processTestClass(AbstractJUnitTestClassProcessor.java:54)
    at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:53)
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
    at java.base/java.lang.reflect.Method.invoke(Method.java:580)
    at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:36)
    at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
    at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
    at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:92)
    at jdk.proxy1/jdk.proxy1.$Proxy4.processTestClass(Unknown Source)
    at org.gradle.api.internal.tasks.testing.worker.TestWorker$2.run(TestWorker.java:183)
    at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:132)
    at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:103)
    at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:63)
    at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
    at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:121)
    at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:71)
    at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
    at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
  Caused by: java.nio.file.NoSuchFileException: /opt/teamcity-agent/work/af99a1b2d35610b6/neo4j-apoc-procedures/extended-it/build/test-core/jar/apoc-2025.04.0-core.jar
    at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)

...

Caused by: java.nio.file.NoSuchFileException: /opt/teamcity-agent/work/af99a1b2d35610b6/neo4j-apoc-procedures/extended-it/build/test-core/jar/apoc-2025.04.0-core.jar
  at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
  at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
  at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
  at java.base/sun.nio.fs.UnixFileSystem.copy(UnixFileSystem.java:1005)
  at java.base/sun.nio.fs.UnixFileSystemProvider.copy(UnixFileSystemProvider.java:300)
  at java.base/java.nio.file.Files.copy(Files.java:1304)
  at apoc.util.TestContainerUtil.createNeo4jContainer(TestContainerUtil.java:180)
  ... 44 more
```