### PR TITLE
Fix versions for calver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ def collectNeo4jReleases() {
 
     // We sort considering that X.Y.Z-SOMETHING should be considered lower than X.Y.Z --> it's not a lexicographical ordering
     return releases
-            .findAll { it >= "3.0" }
+            .findAll {it.tokenize(".").first().toInteger() >= 3 }
             .sort{ o1, o2 -> orderVersion(o1) <=> orderVersion(o2) }
             .reverse()
 }
@@ -116,7 +116,6 @@ task versions <<  {
     def versions = []
     for (neo4jRelease in neo4jReleases) {
         def prefix = neo4jRelease.substring(0,Math.min(4,neo4jRelease.length()))
-        if (prefix < "3.0") continue;
 
         def apocVersion = findApocVersion(neo4jToApoc, neo4jRelease, prefix)
         if (apocVersion != null) {

--- a/versions.json
+++ b/versions.json
@@ -1,5 +1,77 @@
 [
     {
+        "neo4j": "2025.04.0",
+        "neo4jVersion": "2025.04.0",
+        "apoc": "2025.04.0",
+        "version": "2025.04.0",
+        "url": "http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.04.0",
+        "homepageUrl": "http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.04.0",
+        "jar": "https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/2025.04.0/apoc-2025.04.0-extended.jar",
+        "downloadUrl": "https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/2025.04.0/apoc-2025.04.0-extended.jar",
+        "sha1": "b886d1eb5ff5c6ffa192c1de8d06e427687beb71",
+        "sha256": "638cee7423af5dfd0bf580633a6dd30a937c475ef1e76ae3888e34313a924162",
+        "md5": "4299f78596ad9a8bf98c9ad6c5633694",
+        "config": {
+            "+:dbms.security.procedures.unrestricted": [
+                "apoc.*"
+            ]
+        }
+    },
+    {
+        "neo4j": "2025.03.0",
+        "neo4jVersion": "2025.03.0",
+        "apoc": "2025.03.0",
+        "version": "2025.03.0",
+        "url": "http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.03.0",
+        "homepageUrl": "http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.03.0",
+        "jar": "https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/2025.03.0/apoc-2025.03.0-extended.jar",
+        "downloadUrl": "https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/2025.03.0/apoc-2025.03.0-extended.jar",
+        "sha1": "6bf4ed9a0c5ce4563efd35519aea50254b7db6cd",
+        "sha256": "ca1a3fa3cfb2694cf1be6d4bda0ffc3d9aada57d8f22c7ceda2b7aeffcb52ddb",
+        "md5": "0adb0eed93488afd8a5c45a2500e624b",
+        "config": {
+            "+:dbms.security.procedures.unrestricted": [
+                "apoc.*"
+            ]
+        }
+    },
+    {
+        "neo4j": "2025.02.0",
+        "neo4jVersion": "2025.02.0",
+        "apoc": "2025.02.0",
+        "version": "2025.02.0",
+        "url": "http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.02.0",
+        "homepageUrl": "http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.02.0",
+        "jar": "https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/2025.02.0/apoc-2025.02.0-extended.jar",
+        "downloadUrl": "https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/2025.02.0/apoc-2025.02.0-extended.jar",
+        "sha1": "c43473f95f051972d818d4fc2485f23d0ce3f870",
+        "sha256": "43296cc778dca77b3f25074b02cb834b7950609e8e66142ebc2753415c3b820c",
+        "md5": "e054c477eb48d53aa0d55c1b0c6263f8",
+        "config": {
+            "+:dbms.security.procedures.unrestricted": [
+                "apoc.*"
+            ]
+        }
+    },
+    {
+        "neo4j": "2025.01.0",
+        "neo4jVersion": "2025.01.0",
+        "apoc": "2025.01.0",
+        "version": "2025.01.0",
+        "url": "http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.01.0",
+        "homepageUrl": "http://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.01.0",
+        "jar": "https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/2025.01.0/apoc-2025.01.0-extended.jar",
+        "downloadUrl": "https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/2025.01.0/apoc-2025.01.0-extended.jar",
+        "sha1": "31f77376eb18f84b3b16ccca19fef774c0fd8f8b",
+        "sha256": "1e14b59ec1bc1a2ddb9d49cf8440630e03c971a6d56bf796e987403b15261f5a",
+        "md5": "64546913280881f7334e3014cd5d4ae7",
+        "config": {
+            "+:dbms.security.procedures.unrestricted": [
+                "apoc.*"
+            ]
+        }
+    },
+    {
         "neo4j": "5.26.6",
         "neo4jVersion": "5.26.6",
         "apoc": "5.26.0",


### PR DESCRIPTION
Fixes to allow for the new 2025.x to be added to the versions.json.

Originally fixed here: https://github.com/neo4j/apoc/pull/785