### PR TITLE
Bump APOC and Neo4j 5.26.x versions for release 5.26.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ downloadLicenses {
 
 allprojects {
     group = 'org.neo4j.procedure'
-    version = '5.26.0'
+    version = '5.26.1'
     archivesBaseName = 'apoc'
     description = """neo4j-apoc-procedures"""
 }
@@ -92,8 +92,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage': project.hasProperty("neo4jDockerEeOverride") ? project.getProperty("neo4jDockerEeOverride") : 'neo4j:5.26.0-enterprise',
-                'neo4jCommunityDockerImage': project.hasProperty("neo4jDockerCeOverride") ? project.getProperty("neo4jDockerCeOverride") : 'neo4j:5.26.0',
+                'neo4jDockerImage': project.hasProperty("neo4jDockerEeOverride") ? project.getProperty("neo4jDockerEeOverride") : 'neo4j:5.26.6-enterprise',
+                'neo4jCommunityDockerImage': project.hasProperty("neo4jDockerCeOverride") ? project.getProperty("neo4jDockerCeOverride") : 'neo4j:5.26.6',
                 'coreDir': 'apoc-core/core',
                 'testDockerBundle': false
 
@@ -152,7 +152,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "5.26.0"
+    neo4jVersion = "5.26.6"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '1.20.2'

--- a/docs/asciidoc/antora.yml
+++ b/docs/asciidoc/antora.yml
@@ -8,4 +8,4 @@ asciidoc:
     docs-version: "5.0"
     branch: "5.0"
     apoc-release-absolute: "5.0"
-    apoc-release: "5.26.0"
+    apoc-release: "5.26.1"

--- a/docs/asciidoc/modules/ROOT/partials/neo4j-server.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/neo4j-server.adoc
@@ -24,7 +24,7 @@ The version compatibility matrix explains the mapping between Neo4j and APOC ver
 [opts=header]
 |===
 |apoc version | neo4j version
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.26.0[5.26.0^] | 5.26.0 (5.26.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.26.1[5.26.1^] | 5.26.6 (5.26.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.25.0[5.25.0^] | 5.25.0 (5.25.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.24.0[5.24.0^] | 5.24.0 (5.24.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.23.0[5.23.0^] | 5.23.0 (5.23.x)

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -29,7 +29,7 @@ plugins {
     id 'org.neo4j.doc.build.docbook' version '1.0-alpha12'
 }
 
-if (!project.hasProperty('apocVersion')) { ext.apocVersion = '5.26.0' }
+if (!project.hasProperty('apocVersion')) { ext.apocVersion = '5.26.1' }
 
 ext {
     versionParts = apocVersion.split('-')

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -102,7 +102,7 @@ dependencies {
     // They need to be provided either through the database or in an extra .jar
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
     // same version as the one included in  neo4j `lib`
-    compileOnly group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '5.26.0'
+    compileOnly group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '5.26.3'
 
     compileOnly group: 'org.apache.poi', name: 'poi', version: '5.1.0', {
         exclude group: 'org.apache.commons', module: 'commons-collections4'

--- a/extra-dependencies/build.gradle
+++ b/extra-dependencies/build.gradle
@@ -75,7 +75,7 @@ ext {
 
 
 subprojects {
-    version = '5.26.0'
+    version = '5.26.1'
     group = 'org.neo4j.contrib'
 }
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,8 +1,8 @@
 :readme:
 :branch: 5.26
 :docs: https://neo4j.com/labs/apoc/5
-:apoc-release: 5.26.0
-:neo4j-version: 5.26.0
+:apoc-release: 5.26.1
+:neo4j-version: 5.26.6
 :img: https://raw.githubusercontent.com/neo4j-contrib/neo4j-apoc-procedures/{branch}/docs/images
 
 https://community.neo4j.com[image:https://img.shields.io/discourse/users?logo=discourse&server=https%3A%2F%2Fcommunity.neo4j.com[Discourse users]]


### PR DESCRIPTION
Bump APOC and Neo4j 5.26.x versions for release 5.26.1