### PR TITLE
Fix TeamCity BoltConnection compilation error for release 5.26.1

### DIFF
--- a/extended/src/main/java/apoc/bolt/BoltConnection.java
+++ b/extended/src/main/java/apoc/bolt/BoltConnection.java
@@ -159,7 +159,7 @@ public class BoltConnection {
         if (config.isVirtual()) {
             List<Label> labels = new ArrayList<>();
             node.labels().forEach(l -> labels.add(Label.label(l)));
-            VirtualNode virtualNode = new VirtualNode(node.id(), node.elementId(), labels.toArray(new Label[0]), node.asMap());
+            VirtualNode virtualNode = new VirtualNode(node.id(), labels.toArray(new Label[0]), node.asMap());
             nodesCache.put(node.id(), virtualNode);
             return virtualNode;
         } else
@@ -172,7 +172,7 @@ public class BoltConnection {
         if (config.isVirtual()) {
             VirtualNode start = (VirtualNode) nodesCache.getOrDefault(relationship.startNodeId(), new VirtualNode(relationship.startNodeId()));
             VirtualNode end = (VirtualNode) nodesCache.getOrDefault(relationship.endNodeId(), new VirtualNode(relationship.endNodeId()));
-            VirtualRelationship virtualRelationship = new VirtualRelationship(relationship.id(), relationship.elementId(), start, end, RelationshipType.withName(relationship.type()), relationship.asMap());
+            VirtualRelationship virtualRelationship = new VirtualRelationship(relationship.id(), start, end, RelationshipType.withName(relationship.type()), relationship.asMap());
             return virtualRelationship;
         } else
             return Util.map("entityType", internalValue.type().name(), "type", relationship.type(), "id", relationship.id(), "start", relationship.startNodeId(), "end", relationship.endNodeId(), "properties", relationship.asMap());


### PR DESCRIPTION
Fix TeamCity BoltConnection compilation error for release 5.26.1.

The error is:
```
[14:50:27]W:	 [Step 5/7]                      ^
[14:50:27]W:	 [Step 5/7] /opt/teamcity-agent/work/af99a1b2d35610b6/neo4j-apoc-procedures/extended/src/main/java/apoc/bolt/BoltConnection.java:162: error: no suitable constructor found for VirtualNode(long,String,Label[],Map<String,Object>)
[14:50:27]W:	 [Step 5/7]             VirtualNode virtualNode = new VirtualNode(node.id(), node.elementId(), labels.toArray(new Label[0]), node.asMap());
[14:50:27]W:	 [Step 5/7]                                       ^
[14:50:27]W:	 [Step 5/7]     constructor VirtualNode.VirtualNode(Label[],Map<String,Object>) is not applicable
[14:50:27]W:	 [Step 5/7]       (actual and formal argument lists differ in length)
[14:50:27]W:	 [Step 5/7]     constructor VirtualNode.VirtualNode(long,Label[],Map<String,Object>) is not applicable
[14:50:27]W:	 [Step 5/7]       (actual and formal argument lists differ in length)
[14:50:27]W:	 [Step 5/7]     constructor VirtualNode.VirtualNode(long) is not applicable
[14:50:27]W:	 [Step 5/7]       (actual and formal argument lists differ in length)
[14:50:27]W:	 [Step 5/7]     constructor VirtualNode.VirtualNode(Node,List<String>) is not applicable
[14:50:27]W:	 [Step 5/7]       (actual and formal argument lists differ in length)
[14:50:27]W:	 [Step 5/7] /opt/teamcity-agent/work/af99a1b2d35610b6/neo4j-apoc-procedures/extended/src/main/java/apoc/bolt/BoltConnection.java:175: error: no suitable constructor found for VirtualRelationship(long,String,VirtualNode,VirtualNode,RelationshipType,Map<String,Object>)
[14:50:27]W:	 [Step 5/7]             VirtualRelationship virtualRelationship = new VirtualRelationship(relationship.id(), relationship.elementId(), start, end, RelationshipType.withName(relationship.type()), relationship.asMap());
[14:50:27]W:	 [Step 5/7]                                                       ^
[14:50:27]W:	 [Step 5/7]     constructor VirtualRelationship.VirtualRelationship(Node,Node,RelationshipType,Map<String,Object>) is not applicable
[14:50:27]W:	 [Step 5/7]       (actual and formal argument lists differ in length)
[14:50:27]W:	 [Step 5/7]     constructor VirtualRelationship.VirtualRelationship(Node,Node,RelationshipType) is not applicable
[14:50:27]W:	 [Step 5/7]       (actual and formal argument lists differ in length)
[14:50:27]W:	 [Step 5/7]     constructor VirtualRelationship.VirtualRelationship(long,Node,Node,RelationshipType,Map<String,Object>) is not applicable
[14:50:27]W:	 [Step 5/7]       (actual and formal argument lists differ in length)
[14:50:27]W:	 [Step 5/7] /opt/teamcity-agent/work/af99a1b2d35610b6/neo4j-apoc-procedures/extended/src/main/java/apoc/generate/Neo4jGraphGenerator.java:36: warning: [removal] getId() in Entity has been deprecated and marked for removal
```


Apparently the current constructor no longer exists in TeamCity.

I didn't understand why this happens, since in both the [dev](https://github.com/neo4j/apoc/blob/dev/common/src/main/java/apoc/result/VirtualNode.java#L61) branch and [5.26](https://github.com/neo4j/apoc/blob/5.26/common/src/main/java/apoc/result/VirtualNode.java#L61) core have that constructor.
We can give it a try by changing constructor to one that seems to exist on TeamCity.
