### PR TITLE
Fix antora build error with 2025.04

### DIFF
--- a/docs/asciidoc/antora.yml
+++ b/docs/asciidoc/antora.yml
@@ -1,11 +1,11 @@
 name: apoc
-version: 5.0
+version: 2025.04
 title: APOC Extended Documentation
 nav:
   - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
-    docs-version: "5.0"
-    branch: "5.0"
-    apoc-release-absolute: "5.0"
+    docs-version: "2025.04"
+    branch: "2025.04"
+    apoc-release-absolute: "2025.04"
     apoc-release: "2025.04.0"


### PR DESCRIPTION
Changed `antora.yml` versions, to fix the following error with 2025.04: https://github.com/neo4j-documentation/docs-refresh/actions/runs/15046973230/job/42291889362#step:6:18
```
[14:02:45.282] FATAL (antora): Duplicate nav in 5@apoc: modules/ROOT/nav.adoc
    1: docs/asciidoc/modules/ROOT/nav.adoc in https://github.com/neo4j-contrib/neo4j-apoc-procedures (branch: 2025.04 | start path: docs/asciidoc)
    2: docs/asciidoc/modules/ROOT/nav.adoc in https://github.com/neo4j-contrib/neo4j-apoc-procedures (branch: 5.26 | start path: docs/asciidoc)
    Cause: Error
        at ContentCatalog.addFile (/home/runner/work/docs-refresh/docs-refresh/node_modules/@antora/content-classifier/lib/content-catalog.js:147:17)
        at /home/runner/work/docs-refresh/docs-refresh/node_modules/@antora/content-classifier/lib/classify-content.js:39:87
        at Array.forEach (<anonymous>)
        at /home/runner/work/docs-refresh/docs-refresh/node_modules/@antora/content-classifier/lib/classify-content.js:39:13
        at Map.forEach (<anonymous>)
        at GeneratorContext.classifyContent (/home/runner/work/docs-refresh/docs-refresh/node_modules/@antora/content-classifier/lib/classify-content.js:35:6)
        at /home/runner/work/docs-refresh/docs-refresh/node_modules/@antora/site-generator/lib/generate-site.js:[20](https://github.com/neo4j-documentation/docs-refresh/actions/runs/15046973230/job/42291889362#step:6:21):38
```

The `npm run build` doesn't work locally because we have the error 
```
[12:16:56.865] FATAL (antora): Failed to download UI bundle: https://s3-eu-west-1.amazonaws.com/static-content.neo4j.com/build/ui-bundle.zip
    Cause: Error
```

To replicate it locally we executed the following command:
```
antora --fetch --stacktrace labs-docs.yml
```


To test that the change works, changed the [labs-docs.yml in the docs-refresh repo](https://github.com/neo4j-documentation/docs-refresh/blob/master/labs-docs.yml) to:
```
  sources:
  - url: https://github.com/neo4j-contrib/neo4j-apoc-procedures
    branches: ['fix-antora-build-error-2025.04', '5.26', '4.4', '4.3', '4.2', '4.1', '4.0']
```

