### PR TITLE
Fixes #4444: update import/export documentation with correct extended formats

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/export/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/export/index.adoc
@@ -7,7 +7,7 @@
 Neo4j supports exporting whole databases via the https://neo4j.com/docs/operations-manual/current/backup/performing/[backup^] and https://neo4j.com/docs/operations-manual/current/tools/dump-load/[dump^] commands.
 It doesn't have support for exporting sub graphs or exporting data into standard data formats, which is where the APOC Extended library comes in.
 
-APOC Extended adds support for exporting data into various data formats, including XLS and Parquet.
+APOC Extended adds support for exporting data into various data formats, including XLS, Apache Arrow and Parquet.
 
 In addition to exporting data in these formats, we can choose to export the whole database, specified nodes and relationships, a virtual graph, or the results of a Cypher query.
 

--- a/docs/asciidoc/modules/ROOT/pages/import/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/import/index.adoc
@@ -4,7 +4,7 @@
 
 
 
-The APOC Extended library adds support for importing data from various data formats, including JSON, XML, XLS and Parquet.
+The APOC Extended library adds support for importing data from various data formats, including JSON, CSV, HTML, XLS, GEXF, Apache Arrow and Parquet.
 
 For more information on these procedures, see:
 

--- a/docs/asciidoc/modules/ROOT/pages/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/index.adoc
@@ -19,8 +19,8 @@ The guide covers the following areas:
 * xref::security-guidelines/index.adoc[] -- Guidelines on securing the APOC Extended library, and its environment.
 * xref::overview/index.adoc[] -- A list of all APOC Extended procedures and functions.
 * xref::config/index.adoc[] -- Configuration options used by the APOC Extended library.
-* xref::import/index.adoc[] -- A detailed guide to procedures that can be used to import data from different formats including JSON, CSV, and XLS.
-* xref::export/index.adoc[] -- A detailed guide to procedures that can be used to export data to different formats including JSON, CSV, GraphML, and Gephi.
+* xref::import/index.adoc[] -- A detailed guide to procedures that can be used to import data from different formats.
+* xref::export/index.adoc[] -- A detailed guide to procedures that can be used to export data to different formats.
 * xref::database-integration/index.adoc[] -- A detailed guide to procedures that can be used to integrate with other databases including relational databases, MongoDB, Couchbase, and ElasticSearch.
 * xref::graph-updates/index.adoc[] -- A detailed guide to procedures that can be used to apply graph updates.
 * xref::cypher-execution/index.adoc[] -- A detailed guide to procedures that can be used for Cypher scripting.


### PR DESCRIPTION
Fixes #4444

- Updated file formats on the export and import pages, removing those that refer to APOC Core.
- Removed file format from overview page to avoid potential inconsistencies