### PR TITLE
Fix dev CI error with 2025.08 version

### DIFF
--- a/extended/src/test/java/apoc/diff/DiffExtendedGraphTest.java
+++ b/extended/src/test/java/apoc/diff/DiffExtendedGraphTest.java
@@ -43,11 +43,11 @@ public class DiffExtendedGraphTest {
         session = neo4jContainer.getSession();
 
         try (Session session = driver.session()) {
-            session.writeTransaction(tx -> tx.run(String.format("CREATE DATABASE %s;", secondDb)).consume());
+            session.executeWrite(tx -> tx.run(String.format("CREATE DATABASE %s;", secondDb)).consume());
         }
         try (Session session = driver.session(SessionConfig.forDatabase(secondDb))) {
-            session.writeTransaction(tx -> tx.run("CREATE CONSTRAINT IF NOT EXISTS FOR (p:Person) REQUIRE p.name IS UNIQUE;").consume());
-            session.writeTransaction(tx -> tx.run("CREATE (m:Person:Other {name: 'Michael Jordan', age: 54}), \n" +
+            session.executeWrite(tx -> tx.run("CREATE CONSTRAINT IF NOT EXISTS FOR (p:Person) REQUIRE p.name IS UNIQUE;").consume());
+            session.executeWrite(tx -> tx.run("CREATE (m:Person:Other {name: 'Michael Jordan', age: 54}), \n" +
                     "(q:Person {name: 'Jerry Burton', age: 23}), \n" +
                     "(p:Person {name: 'Jack William', age: 22}), \n" +
                     "(q)-[:KNOWS{since:1999, time:time('125035.556+0100')}]->(p);").consume());


### PR DESCRIPTION
## CI error

https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/17149363631/job/48651871627?pr=4462#step:11:4904
```
/home/runner/work/neo4j-apoc-procedures/neo4j-apoc-procedures/extended/src/test/java/apoc/diff/DiffExtendedGraphTest.java:46: error: cannot find symbol
            session.writeTransaction(tx -> tx.run(String.format("CREATE DATABASE %s;", secondDb)).consume());
                   ^
  symbol:   method writeTransaction((tx)->tx.r[...]ume())
  location: variable session of type Session
/home/runner/work/neo4j-apoc-procedures/neo4j-apoc-procedures/extended/src/test/java/apoc/diff/DiffExtendedGraphTest.java:49: error: cannot find symbol
            session.writeTransaction(tx -> tx.run("CREATE CONSTRAINT IF NOT EXISTS FOR (p:Person) REQUIRE p.name IS UNIQUE;").consume());
```


## Fix 

Not sure it solves the error because it's about 2025.08 version not yet released publicly, while up to 2025.07 it works correctly.
Anyway `'writeTransaction(org.neo4j.driver.TransactionWork<T>)'` is deprecated so maybe is removed in 2025.08 (even if was not marked for removal), so I guess changing it to non-deprecated `executeWrite(..)`, as present in other tests, will solve the error