### PR TITLE
Various small docs fixes

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/comparing-graphs/graph-difference.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/comparing-graphs/graph-difference.adoc
@@ -1,4 +1,5 @@
-== `apoc.diff.graphs` procedure
+[[apoc.diff.graphs]]
+= `apoc.diff.graphs` procedure
 
 The procedure accepts 2 string argument, the `source` and the `dest`, representing 2 queries to compare,
 and an optional `config` map as a 3rd parameter.

--- a/docs/asciidoc/modules/ROOT/pages/comparing-graphs/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/comparing-graphs/index.adoc
@@ -1,0 +1,11 @@
+[[comparing-graphs]]
+= Comparing Graph
+:description: This chapter describes procedures that can be used to perform graph comparisons.
+
+
+
+The APOC Extended library adds extra functionality for comparing graphs.
+
+For more information on how to use these procedures, see:
+
+* xref::comparing-graphs/graph-difference.adoc[]

--- a/docs/asciidoc/modules/ROOT/pages/comparing-graphs/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/comparing-graphs/index.adoc
@@ -4,7 +4,7 @@
 
 
 
-The APOC Extended library adds extra functionality for comparing graphs.
+The APOC Extended library adds extra functionalities for comparing graphs.
 
 For more information on how to use these procedures, see:
 

--- a/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/index.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/index.adoc
@@ -42,7 +42,7 @@ Besides the above config, the `apoc.vectordb.<type>.get` and the `apoc.vectordb.
 |===
 
 
-= Ad-hoc procedures
+== Ad-hoc procedures
 
 See the following pages for more details on specific vector db procedures
 
@@ -53,7 +53,7 @@ See the following pages for more details on specific vector db procedures
 - xref:./milvus.adoc[Milvus]
 
 
-= Store Vector db info (i.e. `apoc.vectordb.configure`)
+== Store Vector db info (i.e. `apoc.vectordb.configure`)
 
 We can save some info in the System Database to be reused later, that is the host, login credentials, and mapping,
 to be used in `*.get` and `.*query` procedures, except for the `apoc.vectordb.custom.get` one.

--- a/docs/asciidoc/modules/ROOT/pages/operational/rebind.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/operational/rebind.adoc
@@ -1,3 +1,5 @@
+[[rebind]]
+= Rebind entities
 APOC provides a list of functions to rebind nodes and relationships:
 
 * `apoc.node.rebind(node)`


### PR DESCRIPTION
Various small docs fixes

- Added tag titles to solve errors like this:
<img width="655" height="310" alt="Screenshot 2025-08-29 at 09 37 54" src="https://github.com/user-attachments/assets/5fc28411-9784-4e3d-8902-e45a5692f792" />


- Fixed subheading formatting in vector db overview page: docs/asciidoc/modules/ROOT/pages/database-integration/vectordb/index.adoc

- Added missing overview page of comparing graph section