### PR TITLE
Fix 2025.09 conflict startup errors

### DIFF
--- a/extra-dependencies/build.gradle
+++ b/extra-dependencies/build.gradle
@@ -95,6 +95,14 @@ ext {
 
         // javax
         exclude group: 'javax.servlet', module: 'javax.servlet-api'
+
+        // org.apache.logging
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-api'
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
+        exclude group: 'org.apache.logging.log4j', module: 'log4j-layout-template-json'
+        
+        // commons.io
+        exclude group: 'commons-io', module: 'commons-io'
     }
 }
 

--- a/extra-dependencies/xls/build.gradle
+++ b/extra-dependencies/xls/build.gradle
@@ -18,11 +18,10 @@ jar {
 }
 
 dependencies {
-    implementation group: 'org.apache.poi', name: 'poi', version: '5.2.5', commonExclusions
-    implementation group: 'org.apache.poi', name: 'poi-ooxml-lite', version: '5.2.5', commonExclusions
-    implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.2.5' , commonExclusions
-    implementation group: 'org.apache.xmlbeans', name: 'xmlbeans', version: '5.2.1', commonExclusions
+    implementation group: 'org.apache.poi', name: 'poi', version: '5.4.1', commonExclusions
+    implementation group: 'org.apache.poi', name: 'poi-ooxml-lite', version: '5.4.1', commonExclusions
+    implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.4.1', commonExclusions
+    implementation group: 'org.apache.xmlbeans', name: 'xmlbeans', version: '5.3.0', commonExclusions
     implementation group: 'com.github.virtuald', name: 'curvesapi', version: '1.08', commonExclusions
-    implementation group: 'commons-io', name: 'commons-io', version: '2.17.0', commonExclusions
-    implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.4', commonExclusions
+    implementation group: 'org.apache.commons', name: 'commons-collections4', version: '4.5.0', commonExclusions
 }


### PR DESCRIPTION
As we can see here: 
with 2025.09 we have this error:
```

```

By isolating the cause,
the problem is caused by apoc-xls-dependencies, which in fact has this dependency tree
TODO


Therefore TODO