### PR TITLE
[NOID] Updated dependencies to mitigate vulnerabilities

### DIFF
--- a/docs/asciidoc/modules/ROOT/pages/database-integration/redis.adoc
+++ b/docs/asciidoc/modules/ROOT/pages/database-integration/redis.adoc
@@ -45,7 +45,7 @@ Here is a list of all available Redis procedures:
 == Install Dependencies
 
 The Redis procedures have dependencies on a client library that is not included in the APOC Library.
-You can download it from https://github.com/lettuce-io/lettuce-core/releases/tag/6.2.5.RELEASE[the lettuce-core repository](except for `netty` jars because they are already included within neo4j)
+You can download it from https://github.com/lettuce-io/lettuce-core/releases/tag/6.5.4.RELEASE[the lettuce-core repository](except for `netty` jars because they are already included within neo4j)
 or https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/download/{apoc-release}/apoc-redis-dependencies-{apoc-release}.jar[apoc repository]
 Once that file is downloaded, it should be placed in the `plugins` directory and the Neo4j Server restarted.
 

--- a/extra-dependencies/redis/build.gradle
+++ b/extra-dependencies/redis/build.gradle
@@ -19,7 +19,7 @@ jar {
 }
 
 dependencies {
-    implementation group: 'io.lettuce', name: 'lettuce-core', version: '6.2.5.RELEASE', {
+    implementation group: 'io.lettuce', name: 'lettuce-core', version: '6.5.4.RELEASE', {
         exclude group: 'io.netty'
     }
 }

--- a/full/build.gradle
+++ b/full/build.gradle
@@ -134,8 +134,8 @@ dependencies {
     compileOnly group: 'com.couchbase.client', name: 'java-client', version: '3.3.0', withoutJacksons
     testImplementation group: 'com.couchbase.client', name: 'java-client', version: '3.3.0', withoutJacksons
 
-    compileOnly group: 'io.lettuce', name: 'lettuce-core', version: '6.2.5.RELEASE'
-    testImplementation group: 'io.lettuce', name: 'lettuce-core', version: '6.2.5.RELEASE'
+    compileOnly group: 'io.lettuce', name: 'lettuce-core', version: '6.5.4.RELEASE'
+    testImplementation group: 'io.lettuce', name: 'lettuce-core', version: '6.5.4.RELEASE'
 
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
 


### PR DESCRIPTION
Update lettuce-core to 6.5.4.RELEASE to mitigate CVE-2024-47535, CVE-2025-24970 and CVE-2025-25193
