### PR TITLE
Fix Teamcity error for release 5.26.3

### DIFF
--- a/extended-it/build.gradle
+++ b/extended-it/build.gradle
@@ -11,6 +11,7 @@ description = 'APOC :: Apoc Extended Integration Tests Module'
 
 test {
     maxParallelForks = 1
+    environment "NEO4JVERSION", neo4jVersionEffective
 }
 
 dependencies {


### PR DESCRIPTION
The error is not replicable in github action (see [here](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4505) ) 
but only with TC, so not sure if it work.


The TC fails with the below error.
This is because APOC Core has the version 5.26.17 (not yet publicly released) while APOC Extended has the 5.26.16.

The error is about the neo4j container tests which have both Core and Extended plugin.

We cannot change the version set in Core gradle [here](https://github.com/neo4j/apoc/blob/release/5.26.17/build.gradle#L17) from Extended, 
since is imported via git submodule.

But we can try a workaround by setting `"NEO4JVERSION", neo4jVersionEffective` [in the gradle](https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4506/files#diff-8ce60b14d7b473af8b84c4295258f759851600ba20e1afef0b841ab8d8450539R14).
This will override the neo4j version in the `TestContainerUtil.executeGradleTasks` method, which have a `String neo4jVersionOverride = System.getenv("NEO4JVERSION");` [here](https://github.com/neo4j/apoc/blob/release/5.26.17/test-utils/src/main/java/apoc/util/TestContainerUtil.java#L244).

----

The Teamcity error is:
```
======= Failed test run #1 ==========
  org.gradle.tooling.BuildException: Could not execute build using connection to Gradle distribution 'https://services.gradle.org/distributions/gradle-8.4-bin.zip'.
    at org.gradle.tooling.internal.consumer.ExceptionTransformer.transform(ExceptionTransformer.java:51)
    at org.gradle.tooling.internal.consumer.ExceptionTransformer.transform(ExceptionTransformer.java:29)
    ...
  Caused by: org.gradle.internal.exceptions.LocationAwareException: Execution failed for task ':processor:compileJava'.
    at org.gradle.initialization.exception.DefaultExceptionAnalyser.transform(DefaultExceptionAnalyser.java:93)
    at org.gradle.initialization.exception.DefaultExceptionAnalyser.collectFailures(DefaultExceptionAnalyser.java:59)
    ...
  Caused by: org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':processor:compileJava'.
    at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:38)
    ...
  Caused by: org.gradle.api.internal.artifacts.ivyservice.DefaultLenientConfiguration$ArtifactResolveException: Could not resolve all files for configuration ':processor:compileClasspath'.
    at org.gradle.api.internal.artifacts.configurations.DefaultConfiguration.mapFailure(DefaultConfiguration.java:1711)
    at org.gradle.internal.execution.impl.DefaultExecutionEngine$1.execute(DefaultExecutionEngine.java:64)
    ...
  Caused by: org.gradle.internal.resolve.ModuleVersionNotFoundException: Could not find org.neo4j:neo4j:5.26.17.
  Searched in the following locations:
    - https://repo.maven.apache.org/maven2/org/neo4j/neo4j/5.26.17/neo4j-5.26.17.pom
    - https://repo.gradle.org/gradle/libs-releases/org/neo4j/neo4j/5.26.17/neo4j-5.26.17.pom
    - file:/home/teamcity/.m2/repository/org/neo4j/neo4j/5.26.17/neo4j-5.26.17.pom
  Required by:
      project :processor
```


The failing tests are:
```
apoc.dv.DataVirtualizationCatalogClusterRoutingTest.classMethod
apoc.neo4j.docker.BoltTest.classMethod
apoc.neo4j.docker.CoreExtendedTest.checkForCoreAndExtended
apoc.neo4j.docker.CoreExtendedTest.matchesSpreadsheet
apoc.neo4j.docker.StartupExtendedTest.checkCoreWithExtraDependenciesJars
apoc.neo4j.docker.StartupExtendedTest.checkCoreAndExtendedWithExtraDependenciesJars
```

