### PR TITLE
fix CI errors - 2025.11 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,10 +37,8 @@ repositories {
                 password System.getenv('CODEARTIFACT_TOKEN')
             }
         }
-        // TEST - maybe remove the else
-    } else {
-        mavenCentral()
     }
+    mavenCentral()
     maven {
         url "https://repo.gradle.org/gradle/libs-releases"
     }


### PR DESCRIPTION
The error happens in 2025.10 too: https://github.com/neo4j-contrib/neo4j-apoc-procedures/pull/4512