### PR TITLE
Fix GexfTest with map comparison

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,7 @@ subprojects {
         archiveClassifier = 'javadoc'
     }
     test {
-        include '**/GexfTest.class'//, '**/AtomicTest.class'
+        //exclude '**/CypherProceduresClusterTest.class'//, '**/AtomicTest.class'
 
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,

--- a/extended/src/test/java/apoc/load/GexfTest.java
+++ b/extended/src/test/java/apoc/load/GexfTest.java
@@ -55,7 +55,7 @@ public class GexfTest {
                             "_children", List.of(
                                 map(
                                     "_type", "node",
-                                    "id", "0",     // Nota: potrebbe essere Integer 0 a seconda del parser
+                                    "id", "0",
                                     "label", "bar",
                                     "_children", List.of(
                                         map(


### PR DESCRIPTION
Fix failing test: https://github.com/neo4j-contrib/neo4j-apoc-procedures/actions/runs/21705377641/job/62597486909?pr=4524#step:10:8328

Changed string comparison to map comparison, using [assertMapEquals](https://github.com/neo4j-contrib/neo4j-apoc-procedures/blob/dev/extended/src/test/java/apoc/util/ExtendedTestUtil.java#L75),
since with 2026.x version the key ordering is different.