### PR TITLE
Try fixing Parquet 5.26.4 TeamCity errors

### DIFF
--- a/extended-it/src/test/java/apoc/azure/ParquetAzureStorageTest.java
+++ b/extended-it/src/test/java/apoc/azure/ParquetAzureStorageTest.java
@@ -1,35 +1,24 @@
 package apoc.azure;
 
 import apoc.export.parquet.ParquetTestUtil;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
 import java.util.Map;
 
 import static apoc.export.parquet.ParquetTest.MAPPING_ALL;
-import static apoc.export.parquet.ParquetTestUtil.beforeClassCommon;
 import static apoc.export.parquet.ParquetTestUtil.beforeCommon;
 import static apoc.export.parquet.ParquetTestUtil.testImportAllCommon;
 import static apoc.util.ExtendedITUtil.EXTENDED_RESOURCES_PATH;
-import static apoc.util.GoogleCloudStorageContainerExtension.gcsUrl;
 import static apoc.util.TestUtil.testResult;
 
 public class ParquetAzureStorageTest extends AzureStorageBaseTest {
 
     private final String EXPORT_FILENAME = "test_all.parquet";
 
-    @ClassRule
-    public static DbmsRule db = new ImpermanentDbmsRule();
-
-    @BeforeClass
-    public static void beforeClass() {
-        beforeClassCommon(db);
-    }
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
 
     @Before
     public void before() {

--- a/extended-it/src/test/java/apoc/gc/ParquetGoogleCloudStorageTest.java
+++ b/extended-it/src/test/java/apoc/gc/ParquetGoogleCloudStorageTest.java
@@ -2,11 +2,7 @@ package apoc.gc;
 
 import apoc.export.parquet.ParquetTestUtil;
 import apoc.util.GoogleCloudStorageContainerExtension;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -16,7 +12,7 @@ import static apoc.ApocConfig.APOC_EXPORT_FILE_ENABLED;
 import static apoc.ApocConfig.APOC_IMPORT_FILE_ENABLED;
 import static apoc.ApocConfig.apocConfig;
 import static apoc.export.parquet.ParquetTest.MAPPING_ALL;
-import static apoc.export.parquet.ParquetTestUtil.beforeClassCommon;
+import static apoc.export.parquet.ParquetTestUtil.registerProcedures;
 import static apoc.export.parquet.ParquetTestUtil.testImportAllCommon;
 import static apoc.util.GoogleCloudStorageContainerExtension.gcsUrl;
 import static apoc.util.TestUtil.testResult;
@@ -28,15 +24,15 @@ public class ParquetGoogleCloudStorageTest {
     public static GoogleCloudStorageContainerExtension gcs;
 
 
-    @ClassRule
-    public static DbmsRule db = new ImpermanentDbmsRule();
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
 
-    @BeforeClass
-    public static void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
-        
-        beforeClassCommon(db);
+
+        registerProcedures(db);
 
         gcs = new GoogleCloudStorageContainerExtension()
                 .withMountedResourceFile(FILENAME, "/folder/" + FILENAME);
@@ -44,8 +40,8 @@ public class ParquetGoogleCloudStorageTest {
         gcs.start();
     }
 
-    @AfterClass
-    public static void tearDown() {
+    @After
+    public void tearDown() {
         gcs.close();
         db.shutdown();
     }

--- a/extended-it/src/test/java/apoc/s3/ParquetS3Test.java
+++ b/extended-it/src/test/java/apoc/s3/ParquetS3Test.java
@@ -3,10 +3,7 @@ package apoc.s3;
 import apoc.export.parquet.ParquetTestUtil;
 import apoc.util.collection.Iterators;
 import apoc.util.s3.S3BaseTest;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.*;
 import org.neo4j.test.rule.DbmsRule;
 import org.neo4j.test.rule.ImpermanentDbmsRule;
 
@@ -15,7 +12,6 @@ import java.util.Collections;
 import java.util.Map;
 
 import static apoc.export.parquet.ParquetTest.MAPPING_ALL;
-import static apoc.export.parquet.ParquetTestUtil.beforeClassCommon;
 import static apoc.export.parquet.ParquetTestUtil.beforeCommon;
 import static apoc.util.TestUtil.testCall;
 import static apoc.util.TestUtil.testResult;
@@ -27,13 +23,8 @@ public class ParquetS3Test extends S3BaseTest {
 
     private final String EXPORT_FILENAME = "test_all.parquet";
 
-    @ClassRule
-    public static DbmsRule db = new ImpermanentDbmsRule();
-
-    @BeforeClass
-    public static void beforeClass() {
-        beforeClassCommon(db);
-    }
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule();
 
     @Before
     public void before() {

--- a/extended/src/test/java/apoc/export/parquet/ParquetTest.java
+++ b/extended/src/test/java/apoc/export/parquet/ParquetTest.java
@@ -25,7 +25,6 @@ import static apoc.ApocConfig.apocConfig;
 import static apoc.export.parquet.ExportParquet.EXPORT_TO_FILE_PARQUET_ERROR;
 import static apoc.export.parquet.ParquetTestUtil.assertBarRel;
 import static apoc.export.parquet.ParquetTestUtil.assertNodeAndLabel;
-import static apoc.export.parquet.ParquetTestUtil.beforeClassCommon;
 import static apoc.export.parquet.ParquetTestUtil.beforeCommon;
 import static apoc.export.parquet.ParquetTestUtil.testImportAllCommon;
 import static apoc.util.TestUtil.testCall;
@@ -50,14 +49,10 @@ public class ParquetTest {
         directory.mkdirs();
     }
 
-    @ClassRule
-    public static DbmsRule db = new ImpermanentDbmsRule()
+    @Rule
+    public DbmsRule db = new ImpermanentDbmsRule()
             .withSetting(GraphDatabaseSettings.load_csv_file_url_root, directory.toPath().toAbsolutePath());
-
-    @BeforeClass
-    public static void beforeClass() {
-        beforeClassCommon(db);
-    }
+    
 
     @Before
     public void before() {
@@ -125,7 +120,7 @@ public class ParquetTest {
         assertFails("CALL apoc.import.parquet('ignore.parquet')", LOAD_FROM_FILE_ERROR);
     }
 
-    private static void assertFails(String call, String expectedErrMsg) {
+    private void assertFails(String call, String expectedErrMsg) {
         try {
             testCall(db, call, r -> fail("Should fail due to " + expectedErrMsg));
         } catch (Exception e) {
@@ -140,7 +135,7 @@ public class ParquetTest {
         testStreamRoundtripAllCommon();
     }
 
-    private static void testStreamRoundtripAllCommon() {
+    private void testStreamRoundtripAllCommon() {
         // given - when
         final byte[] bytes = db.executeTransactionally("CALL apoc.export.parquet.all.stream()",
                 Map.of(),
@@ -227,7 +222,7 @@ public class ParquetTest {
                 ParquetTestUtil::extractFileName));
     }
 
-    public static void testReturnNodeAndRelCommon(Supplier<Object> supplier) {
+    public void testReturnNodeAndRelCommon(Supplier<Object> supplier) {
         db.executeTransactionally("CREATE (:ParquetNode{idStart:1})-[:BAR {idRel: 'one'}]->(:Other {idOther: datetime('2020')})");
         db.executeTransactionally("CREATE (:ParquetNode{idStart:2})-[:BAR {idRel: 'two'}]->(:Other {idOther: datetime('1999')})");
 

--- a/extended/src/test/java/apoc/export/parquet/ParquetTestUtil.java
+++ b/extended/src/test/java/apoc/export/parquet/ParquetTestUtil.java
@@ -39,11 +39,13 @@ import static org.junit.Assert.assertTrue;
 
 public class ParquetTestUtil {
 
-    public static void beforeClassCommon(GraphDatabaseService db) {
+    public static void registerProcedures(GraphDatabaseService db) {
         TestUtil.registerProcedure(db, ExportParquet.class, ImportParquet.class, LoadParquet.class, Graphs.class, Meta.class);
     }
-
+    
     public static void beforeCommon(GraphDatabaseService db) {
+        registerProcedures(db);
+
         db.executeTransactionally("MATCH (n) DETACH DELETE n");
 
         db.executeTransactionally("CREATE (f:User {name:'Adam',age:42,male:true,kids:['Sam','Anna','Grace', 'Qwe'], born:localdatetime('2015-05-18T19:32:24.000'), place:point({latitude: 13.1, longitude: 33.46789, height: 100.0})})-[:KNOWS {since: 1993, bffSince: duration('P5M1.5D')}]->(b:User {name:'Jim',age:42})");
@@ -52,6 +54,7 @@ public class ParquetTestUtil {
         apocConfig().setProperty(APOC_IMPORT_FILE_ENABLED, true);
         apocConfig().setProperty(APOC_EXPORT_FILE_ENABLED, true);
     }
+
 
     public static void testImportAllCommon(GraphDatabaseService db, Map<String, Object> params) {
         // remove current data


### PR DESCRIPTION
Try fixing TC error isolating the test database by replacing the static `@ClassRule` with a per-test `@Rule` and joining `beforeClassCommon` and `beforeClass` in `ParquetTestUtil.java`.

I guess are flaky tests since the Parquet procedure have remained unchanged for a while and these errors have never occurred on TeamCity afaik.
Although I could not explicitly replicate the failures locally, 
the flakiness might be caused by concurrent test executions sharing the same database state (e.g., tests executing `MATCH (n) DETACH DELETE n` while others are asserting node counts).
Creating a fresh database instance for each test should prevent these errors and resolve the flakiness.


### TeamCity errors
```
java.lang.AssertionError: expected:<List{String("User")}> but was:<StringArray[Another]>
  at org.junit.Assert.fail(Assert.java:89)
  at org.junit.Assert.failNotEquals(Assert.java:835)
  at org.junit.Assert.assertEquals(Assert.java:120)
  at org.junit.Assert.assertEquals(Assert.java:146)
  at apoc.export.parquet.ParquetTestUtil.assertNodeAndLabel(ParquetTestUtil.java:103)
  at apoc.export.parquet.ParquetTestUtil.assertFirstUserNode(ParquetTestUtil.java:119)
  at apoc.export.parquet.ParquetTestUtil.roundtripLoadAllAssertions(ParquetTestUtil.java:89)
  at apoc.util.TestUtil.testResult(TestUtil.java:189)
  at apoc.export.parquet.ParquetTest.testRoundtripWithMultipleBatches(ParquetTest.java:182)
  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
....
....

java.lang.AssertionError: expected:<List{String("User")}> but was:<StringArray[Another]>
  at org.junit.Assert.fail(Assert.java:89)
  at org.junit.Assert.failNotEquals(Assert.java:835)
  at org.junit.Assert.assertEquals(Assert.java:120)
  at org.junit.Assert.assertEquals(Assert.java:146)
  at apoc.export.parquet.ParquetTestUtil.assertNodeAndLabel(ParquetTestUtil.java:103)
  at apoc.export.parquet.ParquetTestUtil.assertFirstUserNode(ParquetTestUtil.java:119)
  at apoc.export.parquet.ParquetTestUtil.roundtripLoadAllAssertions(ParquetTestUtil.java:89)
  at apoc.util.TestUtil.testResult(TestUtil.java:189)
  at apoc.s3.ParquetS3Test.testFileRoundtripParquetAll(ParquetS3Test.java:54)
  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
  at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.base/java.lang.reflect.Method.invoke(Method.java:568)
  at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
```