### PR TITLE
Release 2026.04.0 (#4466) (#4500)

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "2026.04" ]
   pull_request:
-    branches: [ "dev" ]
+    branches: [ "2026.04" ]
 
 env:
   CODEARTIFACT_BUILD_SERVICE_LIVE_URL: ${{ secrets.CODEARTIFACT_BUILD_SERVICE_LIVE_URL }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "apoc-core"]
 	path = apoc-core
 	url = https://github.com/neo4j/apoc
-	branch = dev
+	branch = 2026.04

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ downloadLicenses {
 
 allprojects {
     group = 'org.neo4j.procedure'
-    version = '2026.05.0'
+    version = '2026.04.0'
     archivesBaseName = 'apoc'
     description = """neo4j-apoc-procedures"""
 }
@@ -92,8 +92,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage': project.hasProperty("neo4jDockerEeOverride") ? project.getProperty("neo4jDockerEeOverride") : 'neo4j:2026.05.0-enterprise',
-                'neo4jCommunityDockerImage': project.hasProperty("neo4jDockerCeOverride") ? project.getProperty("neo4jDockerCeOverride") : 'neo4j:2026.05.0',
+                'neo4jDockerImage': project.hasProperty("neo4jDockerEeOverride") ? project.getProperty("neo4jDockerEeOverride") : 'neo4j:2026.04.0-enterprise',
+                'neo4jCommunityDockerImage': project.hasProperty("neo4jDockerCeOverride") ? project.getProperty("neo4jDockerCeOverride") : 'neo4j:2026.04.0',
                 'coreDir': 'apoc-core/core',
                 'testDockerBundle': false,
                 'org.neo4j.io.pagecache.tracing.cursor.DefaultPageCursorTracer.CHECK_REPORTED_COUNTERS': 'true' // Extra assertions in kernel
@@ -157,7 +157,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "2026.05.0"
+    neo4jVersion = "2026.04.0"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '2.0.2'

--- a/docs/antora/publish.yml
+++ b/docs/antora/publish.yml
@@ -6,7 +6,7 @@ site:
 content:
   sources:
   - url: https://github.com/neo4j-contrib/neo4j-apoc-procedures
-    branches: ['2026.05.0', '5.26', '4.4', '4.3', '4.2', '4.1', '4.0']
+    branches: ['2026.04', '5.26', '4.4', '4.3', '4.2', '4.1', '4.0']
     start_path: docs/asciidoc
     exclude:
     - '!**/_includes/*'

--- a/docs/asciidoc/antora.yml
+++ b/docs/asciidoc/antora.yml
@@ -1,11 +1,11 @@
 name: apoc
-version: 2025.0
+version: 2026.0
 title: APOC Extended Documentation
 nav:
   - modules/ROOT/nav.adoc
 asciidoc:
   attributes:
-    docs-version: "2025.0"
-    branch: "2025.0"
-    apoc-release-absolute: "2025.0"
-    apoc-release: "2025.13.0"
+    docs-version: "2026.0"
+    branch: "2026.0"
+    apoc-release-absolute: "2026.0"
+    apoc-release: "2026.04.0"

--- a/docs/asciidoc/modules/ROOT/partials/neo4j-server.adoc
+++ b/docs/asciidoc/modules/ROOT/partials/neo4j-server.adoc
@@ -24,6 +24,27 @@ The version compatibility matrix explains the mapping between Neo4j and APOC ver
 [opts=header]
 |===
 |apoc version | neo4j version
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2026.04.0[2026.04.0^] | 2026.04.0 (2026.04.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2026.03.0[2026.03.0^] | 2026.03.1 (2026.03.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2026.02.0[2026.02.0^] | 2026.02.0 (2026.02.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2026.01.0[2026.01.0^] | 2026.01.0 (2026.01.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.12.0[2025.12.0^] | 2025.12.1 (2025.12.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.12.0[2025.12.0^] | 2025.12.1 (2025.12.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.11.0[2025.11.0^] | 2025.11.0 (2025.11.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.10.0[2025.10.0^] | 2025.10.0 (2025.10.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.09.0[2025.09.0^] | 2025.09.0 (2025.09.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.08.0[2025.08.0^] | 2025.08.0 (2025.08.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.07.0[2025.07.0^] | 2025.07.0 (2025.07.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.06.0[2025.06.0^] | 2025.06.0 (2025.06.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.05.0[2025.05.0^] | 2025.05.0 (2025.05.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.04.0[2025.04.0^] | 2025.04.0 (2025.04.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.03.0[2025.03.0^] | 2025.03.0 (2025.03.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.02.0[2025.02.0^] | 2025.02.0 (2025.02.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/2025.01.0[2025.01.0^] | 2025.01.0 (2025.01.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.26.0[5.26.0^] | 5.26.0 (5.26.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.25.0[5.25.0^] | 5.25.0 (5.25.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.24.0[5.24.0^] | 5.24.0 (5.24.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.23.0[5.23.0^] | 5.23.0 (5.23.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.22.0[5.22.0^] | 5.22.0 (5.22.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.21.0[5.21.0^] | 5.21.0 (5.21.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.20.0[5.20.0^] | 5.20.0 (5.20.x)
@@ -46,7 +67,7 @@ The version compatibility matrix explains the mapping between Neo4j and APOC ver
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.3.1[5.3.1^] | 5.3.0 (5.3.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.2.0[5.2.0^] | 5.2.0 (5.2.x)
 | https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/5.1.0[5.1.0^] | 5.1.0 (5.1.x)
-| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.18[4.4.0.18^] | 4.4.0 (4.4.x)
+| https://github.com/neo4j-contrib/neo4j-apoc-procedures/releases/4.4.0.36[4.4.0.36^] | 4.4.0 (4.4.x)
 |===
 
 // end::version-matrix[]

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -30,7 +30,7 @@ plugins {
 }
 
 
-if (!project.hasProperty('apocVersion')) { ext.apocVersion = '2026.05.0' }
+if (!project.hasProperty('apocVersion')) { ext.apocVersion = '2026.04.0' }
 
 ext {
     versionParts = apocVersion.split('-')

--- a/extended-it/src/test/java/apoc/neo4j/docker/StartupExtendedTest.java
+++ b/extended-it/src/test/java/apoc/neo4j/docker/StartupExtendedTest.java
@@ -7,7 +7,6 @@ import apoc.util.TestContainerUtil;
 import apoc.util.TestContainerUtil.Neo4jVersion;
 import apoc.util.TestUtil;
 import org.apache.commons.io.FileUtils;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.neo4j.driver.Session;
 
@@ -40,7 +39,6 @@ import static org.junit.Assert.fail;
  * so we need to set the environment variable `NEO4JVERSION=<correctVersion>`, e.g. `NEO4JVERSION=5.25.1`,
  * which is valued via {@link TestContainerUtil#executeGradleTasks(File, String...)} present in APOC Core and therefore not modifiable by APOC Extended
  */
-@Ignore
 public class StartupExtendedTest {
     private static final String APOC_HELP_QUERY = "CALL apoc.help('') YIELD core, type, name WHERE core = $core and type = $type RETURN name";
     private static final List<String> EXPECTED_EXTENDED_NAMES_CYPHER_5;

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -102,7 +102,7 @@ dependencies {
     // They need to be provided either through the database or in an extra .jar
     compileOnly group: 'org.neo4j', name: 'neo4j', version: neo4jVersionEffective
     // same version as the one included in  neo4j `lib`
-    compileOnly group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '5.20.0'
+    compileOnly group: 'org.neo4j.driver', name: 'neo4j-java-driver', version: '6.0.4'
 
     compileOnly group: 'org.apache.poi', name: 'poi', version: '5.1.0', {
         exclude group: 'org.apache.commons', module: 'commons-collections4'

--- a/extra-dependencies/build.gradle
+++ b/extra-dependencies/build.gradle
@@ -108,7 +108,7 @@ ext {
 
 
 subprojects {
-    version = '2026.05.0'
+    version = '2026.04.0'
     group = 'org.neo4j.contrib'
 }
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,8 +1,8 @@
 :readme:
-:branch: 2025.04.0
+:branch: 2026.04.0
 :docs: https://neo4j.com/labs/apoc/5
-:apoc-release: 2025.04.0
-:neo4j-version: 2025.04.0
+:apoc-release: 2026.04.0
+:neo4j-version: 2026.04.0
 :img: https://raw.githubusercontent.com/neo4j-contrib/neo4j-apoc-procedures/{branch}/docs/images
 
 https://community.neo4j.com[image:https://img.shields.io/discourse/users?logo=discourse&server=https%3A%2F%2Fcommunity.neo4j.com[Discourse users]]


### PR DESCRIPTION
Manual cherry-pick of https://github.com/neo4j-contrib/neo4j-apoc-procedures/commit/acb73194c0c5b06b54c0f44877dfa5e2a6073953