### PR TITLE
Fix TeamCity error with 2026.04.0 release

### DIFF
--- a/extended-it/src/test/java/apoc/neo4j/docker/CypherEnterpriseExtendedTest.java
+++ b/extended-it/src/test/java/apoc/neo4j/docker/CypherEnterpriseExtendedTest.java
@@ -36,7 +36,7 @@ public class CypherEnterpriseExtendedTest {
                                                            "CREATE (n:ReturnQuery {id:id})-[:REL {idRel: id}]->(:Other {idOther: id})";
     private static final String CREATE_RESULT_NODES = "UNWIND range(0,3) as id \n" +
                                                       "CREATE (n:Result {id:id})-[:REL {idRel: id}]->(:Other {idOther: id})";
-    private static final String SIMPLE_RETURN_QUERIES = "MATCH (n:ReturnQuery) RETURN n";
+    private static final String SIMPLE_RETURN_QUERIES = "MATCH (n:ReturnQuery) ORDER BY n.id RETURN n";
 
     private static final String SET_RETURN_FILE = "set_and_return.cypher";
     private static final String MATCH_RETURN_FILE = "match_and_return.cypher";
@@ -291,7 +291,7 @@ public class CypherEnterpriseExtendedTest {
         String query = """
                 MATCH (n:ReturnQuery) WITH COLLECT(n) AS list
                 CALL apoc.cypher.mapParallel('MATCH (_)-[r:REL]->(o:Other) RETURN r, o', {}, list)
-                YIELD value RETURN value""";
+                YIELD value ORDER BY value.idOther RETURN value""";
         Map<String, Object> params = Map.of("file", SIMPLE_RETURN_QUERIES);
 
         testCypherMapParallelCommon(query, params);


### PR DESCRIPTION
The following errors were not replicated locally or on GitHub Actions, so not really sure it could work.
Moreover, the failing procedures haven't been modified in a long time. 

It could be an ordering issue: perhaps, sporadically, the MATCH is not ordered, even though it should be since it’s supposed to follow the node creation order. 

Try adding an `ORDER BY ..` and see if TeamCity turns green.

---


### TC Errors

```
apoc.neo4j.docker.CypherEnterpriseExtendedTest.testRunFilesWithResultsAndStatisticsFalse

org.assertj.core.error.AssertJMultipleFailuresError:
[Cypher: CALL apoc.cypher.runFilesReadOnly([$file], {statistics: false})
Params: {file=match_and_return.cypher}
Results (4 rows):
Record<{row: 0, result: {n: node<8>}, fileName: "match_and_return.cypher"}>
Record<{row: 1, result: {n: node<32>}, fileName: "match_and_return.cypher"}>
Record<{row: 2, result: {n: node<34>}, fileName: "match_and_return.cypher"}>
Record<{row: 3, result: {n: node<36>}, fileName: "match_and_return.cypher"}>] (1 failure)
-- failure 1 --expected:<{id=0}> but was:<{id=3}>
at CypherEnterpriseExtendedTest.assertReturnQueryNode(CypherEnterpriseExtendedTest.java:475)
org.assertj.core.error.AssertJMultipleFailuresError:
[Cypher: CALL apoc.cypher.runFilesReadOnly([$file], {statistics: false})
Params: {file=match_and_return.cypher}
Results (4 rows):
Record<{row: 0, result: {n: node<8>}, fileName: "match_and_return.cypher"}>
Record<{row: 1, result: {n: node<32>}, fileName: "match_and_return.cypher"}>
Record<{row: 2, result: {n: node<34>}, fileName: "match_and_return.cypher"}>
Record<{row: 3, result: {n: node<36>}, fileName: "match_and_return.cypher"}>] (1 failure)
-- failure 1 --expected:<{id=0}> but was:<{id=3}>
at CypherEnterpriseExtendedTest.assertReturnQueryNode(CypherEnterpriseExtendedTest.java:475)
  at app//apoc.util.TestContainerUtil.lambda$testResult$4(TestContainerUtil.java:303)
  at app//org.neo4j.driver.internal.InternalSession.lambda$transaction$7(InternalSession.java:163)
  at app//org.neo4j.driver.internal.retry.ExponentialBackoffRetryLogic.retry(ExponentialBackoffRetryLogic.java:119)
  at app//org.neo4j.driver.internal.InternalSession.lambda$transaction$8(InternalSession.java:160)
  at app//org.neo4j.driver.internal.observation.util.ObservationUtil.observe(ObservationUtil.java:40)
  at app//org.neo4j.driver.internal.InternalSession.transaction(InternalSession.java:160)
  at app//org.neo4j.driver.internal.InternalSession.execute(InternalSession.java:145)
  at app//org.neo4j.driver.internal.InternalSession.executeWrite(InternalSession.java:123)
  at app//org.neo4j.driver.Session.executeWrite(Session.java:123)
  ```

```
apoc.neo4j.docker.CypherEnterpriseExtendedTest.testCypherMapParallelWithResults

org.assertj.core.error.AssertJMultipleFailuresError:
[Cypher: MATCH (n:ReturnQuery) WITH COLLECT(n) AS list
CALL apoc.cypher.mapParallel('MATCH (_)-[r:REL]->(o:Other) RETURN r, o', {}, list)
YIELD value RETURN value
Params: {file=MATCH (n:ReturnQuery) RETURN n}
Results (4 rows):
Record<{value: {r: relationship<1152921504606846976>, o: node<1>}}>
Record<{value: {r: relationship<1152921504606846986>, o: node<11>}}>
Record<{value: {r: relationship<1152921504606846988>, o: node<13>}}>
Record<{value: {r: relationship<1152921504606846990>, o: node<15>}}>] (1 failure)
-- failure 1 --expected:<{idOther=0}> but was:<{idOther=3}>
at CypherEnterpriseExtendedTest.assertOtherNodeAndRel(CypherEnterpriseExtendedTest.java:442)
org.assertj.core.error.AssertJMultipleFailuresError:
[Cypher: MATCH (n:ReturnQuery) WITH COLLECT(n) AS list
CALL apoc.cypher.mapParallel('MATCH (_)-[r:REL]->(o:Other) RETURN r, o', {}, list)
YIELD value RETURN value
Params: {file=MATCH (n:ReturnQuery) RETURN n}
```

```
apoc.neo4j.docker.CypherEnterpriseExtendedTest.testRunReadFilesWithResults

org.assertj.core.error.AssertJMultipleFailuresError:
[Cypher: CALL apoc.cypher.runFilesReadOnly([$file])
Params: {file=match_and_return.cypher}
Results (4 rows):
Record<{row: 0, result: {n: node<2>}, fileName: "match_and_return.cypher"}>
Record<{row: 1, result: {n: node<4>}, fileName: "match_and_return.cypher"}>
Record<{row: 2, result: {n: node<6>}, fileName: "match_and_return.cypher"}>
Record<{row: 3, result: {n: node<16>}, fileName: "match_and_return.cypher"}>] (1 failure)
-- failure 1 --expected:<{id=0}> but was:<{id=1}>
at CypherEnterpriseExtendedTest.assertReturnQueryNode(CypherEnterpriseExtendedTest.java:475)
org.assertj.core.error.AssertJMultipleFailuresError:
[Cypher: CALL apoc.cypher.runFilesReadOnly([$file])
Params: {file=match_and_return.cypher}
Results (4 rows):
Record<{row: 0, result: {n: node<2>}, fileName: "match_and_return.cypher"}>
Record<{row: 1, result: {n: node<4>}, fileName: "match_and_return.cypher"}>
Record<{row: 2, result: {n: node<6>}, fileName: "match_and_return.cypher"}>
Record<{row: 3, result: {n: node<16>}, fileName: "match_and_return.cypher"}>] (1 failure)
-- failure 1 --expected:<{id=0}> but was:<{id=1}>
...
```