### PR TITLE
Add commit SHA's to the github actions versions

### DIFF
--- a/.github/actions/setup-gradle-cache/action.yaml
+++ b/.github/actions/setup-gradle-cache/action.yaml
@@ -4,7 +4,7 @@ description: "Setups cache for Gradle"
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v3
+    - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
       with:
         path: |
           ~/.gradle/caches

--- a/.github/actions/setup-jdk/action.yaml
+++ b/.github/actions/setup-jdk/action.yaml
@@ -9,7 +9,7 @@ runs:
   using: "composite"
   steps:
     - name: Set up JDK 21
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
       with:
         java-version: ${{ inputs.java-version }}
         distribution: 'temurin'

--- a/.github/actions/test-gradle-project/action.yml
+++ b/.github/actions/test-gradle-project/action.yml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       run: ./gradlew --info -Pneo4jVersionOverride=$NEO4JVERSION -Pneo4jDockerEeOverride=$NEO4J_DOCKER_EE_OVERRIDE -Pneo4jDockerCeOverride=$NEO4J_DOCKER_CE_OVERRIDE :${{inputs.project-name}}:check --parallel
     - name: Archive test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       if: always()
       with:
         name: ${{inputs.project-name}}-test-results

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -25,7 +25,7 @@ jobs:
         language: [ 'java', 'javascript' ]
     steps:
       - name: Configure AWS CLI
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@90a7a1fb1ee4e8d6a99f60d2fd22287e1657e51e # v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -41,7 +41,7 @@ jobs:
         run: |
           aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin $ECR_NEO4J_DOCKER_URL
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3
       - uses: ./.github/actions/setup-jdk
       - uses: ./.github/actions/setup-gradle-cache
 
@@ -78,7 +78,7 @@ jobs:
           ./gradlew --no-daemon --info -Pneo4jVersionOverride=$NEO4JVERSION --init-script init.gradle clean
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3.28.8
+        uses: github/codeql-action/init@8ff85221d12737ec1137e6a892722e5130f32d05 # v3.28.8
         with:
           languages: ${{ matrix.language }}
 
@@ -86,7 +86,7 @@ jobs:
         run: ./gradlew --info -Pneo4jVersionOverride=$NEO4JVERSION compileJava :extended:compileTestJava :extended-it:compileTestJava
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3.28.8
+        uses: github/codeql-action/analyze@8ff85221d12737ec1137e6a892722e5130f32d05 # v3.28.8
         with:
           category: "/language:${{matrix.language}}"
   
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS CLI
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@90a7a1fb1ee4e8d6a99f60d2fd22287e1657e51e # v2
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -114,13 +114,13 @@ jobs:
         run: |
           aws ecr get-login-password --region eu-west-1 | docker login --username AWS --password-stdin $ECR_NEO4J_DOCKER_URL
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
       - name: Set up JDK 21
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@91d3aa4956ec4a53e477c4907347b5e3481be8c9 # v2
         with:
           java-version: '21'
           distribution: 'temurin'
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: |
             ~/.gradle/caches

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ downloadLicenses {
 
 allprojects {
     group = 'org.neo4j.procedure'
-    version = '2026.06.0'
+    version = '2026.07.0'
     archivesBaseName = 'apoc'
     description = """neo4j-apoc-procedures"""
 }
@@ -92,8 +92,8 @@ subprojects {
         // neo4jDockerImage system property is used in TestContainerUtil
         systemProperties 'user.language' : 'en' ,
                 'user.country' : 'US',
-                'neo4jDockerImage': project.hasProperty("neo4jDockerEeOverride") ? project.getProperty("neo4jDockerEeOverride") : 'neo4j:2026.06.0-enterprise',
-                'neo4jCommunityDockerImage': project.hasProperty("neo4jDockerCeOverride") ? project.getProperty("neo4jDockerCeOverride") : 'neo4j:2026.06.0',
+                'neo4jDockerImage': project.hasProperty("neo4jDockerEeOverride") ? project.getProperty("neo4jDockerEeOverride") : 'neo4j:2026.07.0-enterprise',
+                'neo4jCommunityDockerImage': project.hasProperty("neo4jDockerCeOverride") ? project.getProperty("neo4jDockerCeOverride") : 'neo4j:2026.07.0',
                 'coreDir': 'apoc-core/core',
                 'testDockerBundle': false,
                 'org.neo4j.io.pagecache.tracing.cursor.DefaultPageCursorTracer.CHECK_REPORTED_COUNTERS': 'true' // Extra assertions in kernel
@@ -157,7 +157,7 @@ subprojects {
 
 ext {
     // NB: due to version.json generation by parsing this file, the next line must not have any if/then/else logic
-    neo4jVersion = "2026.06.0"
+    neo4jVersion = "2026.07.0"
     // instead we apply the override logic here
     neo4jVersionEffective = project.hasProperty("neo4jVersionOverride") ? project.getProperty("neo4jVersionOverride") : neo4jVersion
     testContainersVersion = '2.0.2'

--- a/docs/antora/publish.yml
+++ b/docs/antora/publish.yml
@@ -6,7 +6,7 @@ site:
 content:
   sources:
   - url: https://github.com/neo4j-contrib/neo4j-apoc-procedures
-    branches: ['2026.06.0', '5.26', '4.4', '4.3', '4.2', '4.1', '4.0']
+    branches: ['2026.07.0', '5.26', '4.4', '4.3', '4.2', '4.1', '4.0']
     start_path: docs/asciidoc
     exclude:
     - '!**/_includes/*'

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -30,7 +30,7 @@ plugins {
 }
 
 
-if (!project.hasProperty('apocVersion')) { ext.apocVersion = '2026.06.0' }
+if (!project.hasProperty('apocVersion')) { ext.apocVersion = '2026.07.0' }
 
 ext {
     versionParts = apocVersion.split('-')

--- a/extended/build.gradle
+++ b/extended/build.gradle
@@ -89,6 +89,11 @@ dependencies {
 
     // These will be dependencies packaged with the .jar
     implementation project(':common')
+    implementation(group: 'org.neo4j', name: 'neo4j-graph-algo', version: neo4jVersionEffective) {
+        exclude group: 'org.neo4j', module: 'neo4j-cypher-runtime-util'
+        exclude group: 'org.neo4j', module: 'neo4j-util'
+        exclude group: 'org.neo4j', module: 'neo4j-kernel'
+    }
     implementation group: 'com.unboundid', name: 'unboundid-ldapsdk', version: '6.0.11'
     implementation group: 'org.jsoup', name: 'jsoup', version: '1.15.3'
     implementation group: 'org.apache.commons', name: 'commons-csv', version: '1.10.0', {

--- a/extended/src/main/java/apoc/monitor/Store.java
+++ b/extended/src/main/java/apoc/monitor/Store.java
@@ -30,12 +30,12 @@ public class Store {
         RecordDatabaseLayout databaseLayout = RecordDatabaseLayout.convert( database.getDatabaseLayout() );
         return Stream.of(new StoreInfoResult(
                 getDirectorySize(databaseLayout.getTransactionLogsDirectory().toFile()),
-                databaseLayout.propertyStringStore().toFile().length(),
-                databaseLayout.propertyArrayStore().toFile().length(),
-                databaseLayout.relationshipStore().toFile().length(),
-                databaseLayout.propertyStore().toFile().length(),
+                databaseLayout.propertyStringStore().storeBaseFileName().toFile().length(),
+                databaseLayout.propertyArrayStore().storeBaseFileName().toFile().length(),
+                databaseLayout.relationshipStore().storeBaseFileName().toFile().length(),
+                databaseLayout.propertyStore().storeBaseFileName().toFile().length(),
                 getDirectorySize(databaseLayout.databaseDirectory().toFile()), //databaseLayout.storeFiles().stream().mapToLong(File::length).sum(),
-                databaseLayout.nodeStore().toFile().length()
+                databaseLayout.nodeStore().storeBaseFileName().toFile().length()
         ));
     }
 

--- a/extended/src/test/java/apoc/coll/CollExtendedTest.java
+++ b/extended/src/test/java/apoc/coll/CollExtendedTest.java
@@ -65,16 +65,19 @@ public class CollExtendedTest {
     public void testAvgDurationWrongType() {
         final String queryIntType = "WITH [1,2,3] AS dur " +
                 "RETURN apoc.coll.avgDuration(dur)";
-        testWrongType(queryIntType);
+        // Error comes from Cypher
+        try {
+            testCall(db, queryIntType, row -> fail("should fail due to Wrong argument type"));
+        } catch (RuntimeException e) {
+            String expected = "Type mismatch: expected List<Duration> but was List<Integer>";
+            MatcherAssert.assertThat(e.getMessage(), Matchers.containsString(expected));
+        }
 
         final String queryMixedType = "WITH [duration('P2DT4H1S'), duration('PT1H6S'), 1] AS dur " +
                 "RETURN apoc.coll.avgDuration(dur)";
-        testWrongType(queryMixedType);
-    }
-
-    private void testWrongType(String query) {
+        // Error comes from APOC as the list is represented as a LIST<ANY>
         try {
-            testCall(db, query, row -> fail("should fail due to Wrong argument type"));
+            testCall(db, queryMixedType, row -> fail("should fail due to Wrong argument type"));
         } catch (RuntimeException e) {
             String expected = "Can't coerce `Long(1)` to Duration";
             MatcherAssert.assertThat(e.getMessage(), Matchers.containsString(expected));

--- a/extra-dependencies/build.gradle
+++ b/extra-dependencies/build.gradle
@@ -108,7 +108,7 @@ ext {
 
 
 subprojects {
-    version = '2026.06.0'
+    version = '2026.07.0'
     group = 'org.neo4j.contrib'
 }
 


### PR DESCRIPTION
Pin the most recent SHA version for these actions instead of just relying on the less secure versions.